### PR TITLE
fix: correct channel list not updating when other users join/leave/switch channels

### DIFF
--- a/docs/plans/2026-02-20-mumble-event-audit-fixes.md
+++ b/docs/plans/2026-02-20-mumble-event-audit-fixes.md
@@ -1,0 +1,344 @@
+# Mumble Event Audit Fixes
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix all remaining bugs found in the Mumble event handler audit — channel state/remove handling, root channel user visibility, spurious channel-change events, permission denied forwarding, and cleanup of redundant code.
+
+**Architecture:** Six targeted fixes across MumbleAdapter.cs (C# bridge layer), App.tsx (frontend event listeners), and ChannelTree.tsx (channel tree rendering). Each fix is independent and can be verified individually. No new infrastructure — just correcting existing event wiring.
+
+**Tech Stack:** C# (.NET 10), React/TypeScript, WebView2 bridge
+
+---
+
+### Task 1: Fix ChannelState to read from Channel model instead of raw protobuf
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:705-714`
+
+**Step 1: Replace raw protobuf reads with Channel model lookups**
+
+After `base.ChannelState(channelState)` runs, the Channel object in `ChannelDictionary` has the correct merged state. Replace the current code:
+
+Before:
+```csharp
+public override void ChannelState(ChannelState channelState)
+{
+    base.ChannelState(channelState);
+    _bridge?.Send("voice.channelJoined", new
+    {
+        id = channelState.ChannelId,
+        name = channelState.Name,
+        parent = channelState.Parent
+    });
+}
+```
+
+After:
+```csharp
+public override void ChannelState(ChannelState channelState)
+{
+    base.ChannelState(channelState);
+
+    if (ChannelDictionary.TryGetValue(channelState.ChannelId, out var channel))
+    {
+        _bridge?.Send("voice.channelJoined", new
+        {
+            id = channel.Id,
+            name = channel.Name,
+            parent = channel.Parent
+        });
+    }
+}
+```
+
+**Step 2: Build**
+
+Run: `dotnet build`
+Expected: 0 compilation errors (file-lock warning on running client is OK)
+
+**Step 3: Commit**
+
+```
+fix: read channel state from model instead of raw protobuf for bridge messages
+```
+
+---
+
+### Task 2: Add ChannelRemove override to forward channel deletions to frontend
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` (add override after ChannelState)
+- Modify: `src/Brmble.Web/src/App.tsx` (add event listener)
+
+**Step 1: Add ChannelRemove override in MumbleAdapter**
+
+Add this method right after the `ChannelState` override (after current line ~714, before `TextMessage`):
+
+```csharp
+public override void ChannelRemove(ChannelRemove channelRemove)
+{
+    var channelId = channelRemove.ChannelId;
+    base.ChannelRemove(channelRemove);
+    _bridge?.Send("voice.channelRemoved", new { id = channelId });
+}
+```
+
+Note: We capture `channelId` before `base.ChannelRemove()` because the base method removes the channel from `ChannelDictionary`.
+
+**Step 2: Add frontend listener in App.tsx**
+
+Add the handler function inside the `useEffect` block (after `onVoiceChannelJoined`, around line 251):
+
+```typescript
+const onVoiceChannelRemoved = ((data: unknown) => {
+    const d = data as { id: number } | undefined;
+    if (d?.id !== undefined) {
+        setChannels(prev => prev.filter(c => c.id !== d.id));
+    }
+});
+```
+
+Add the `bridge.on` registration (after `voice.channelJoined` line):
+
+```typescript
+bridge.on('voice.channelRemoved', onVoiceChannelRemoved);
+```
+
+Add the `bridge.off` cleanup (after `voice.channelJoined` off line):
+
+```typescript
+bridge.off('voice.channelRemoved', onVoiceChannelRemoved);
+```
+
+**Step 3: Build frontend and backend**
+
+Run: `dotnet build`
+Expected: 0 compilation errors
+
+Run: `cd src/Brmble.Web && npm run build`
+Expected: 0 errors
+
+**Step 4: Commit**
+
+```
+feat: forward channel deletions to frontend via voice.channelRemoved
+```
+
+---
+
+### Task 3: Fix ChannelTree dropping users in root channel (channelId=0)
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/ChannelTree.tsx:95`
+
+**Step 1: Fix the falsy check for channelId**
+
+Before (line 95):
+```typescript
+if (user.channelId && channelMap.has(user.channelId)) {
+```
+
+After:
+```typescript
+if (user.channelId !== undefined && channelMap.has(user.channelId)) {
+```
+
+JavaScript `0` is falsy, so `user.channelId && ...` drops users in the root channel (id=0). Using `!== undefined` correctly handles channel 0.
+
+**Step 2: Build frontend**
+
+Run: `cd src/Brmble.Web && npm run build`
+Expected: 0 errors
+
+**Step 3: Commit**
+
+```
+fix: show users in root channel (channelId=0) in channel tree
+```
+
+---
+
+### Task 4: Fix voice.channelChanged using raw protobuf channelId
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:605-607`
+
+**Step 1: Use User model for channel-change detection and event**
+
+Replace the raw protobuf `userState.ChannelId` reads with model-based reads. The `user` variable from Task 2 of the previous plan (the UserDictionary lookup) is already available at this point in the method.
+
+Before (line 605-607):
+```csharp
+if (previousChannel.HasValue && userState.ChannelId != previousChannel && isSelf)
+{
+    _bridge?.Send("voice.channelChanged", new { channelId = userState.ChannelId });
+```
+
+After:
+```csharp
+var currentChannelId = user?.Channel?.Id ?? userState.ChannelId;
+if (previousChannel.HasValue && currentChannelId != previousChannel && isSelf)
+{
+    _bridge?.Send("voice.channelChanged", new { channelId = currentChannelId });
+```
+
+Also fix line 636 which checks `userState.ChannelId == 0` — replace with `currentChannelId == 0`:
+
+Before (line 636):
+```csharp
+else if (userState.ChannelId == 0 && ReceivedServerSync && userState.ShouldSerializeChannelId())
+```
+
+After:
+```csharp
+else if (currentChannelId == 0 && ReceivedServerSync && userState.ShouldSerializeChannelId())
+```
+
+**Step 2: Build**
+
+Run: `dotnet build`
+Expected: 0 compilation errors
+
+**Step 3: Commit**
+
+```
+fix: use model channel ID for local user channel-change detection
+```
+
+---
+
+### Task 5: Relax frontend onVoiceChannelJoined guard
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx:242`
+
+**Step 1: Remove truthy name check**
+
+Before (line 242):
+```typescript
+if (d?.id !== undefined && d?.name) {
+```
+
+After:
+```typescript
+if (d?.id !== undefined) {
+```
+
+With Task 1 reading from the Channel model, `name` will always be present. But even without it, channels should still update — a channel's position in the tree is determined by `id` and `parent`, not `name`.
+
+**Step 2: Build frontend**
+
+Run: `cd src/Brmble.Web && npm run build`
+Expected: 0 errors
+
+**Step 3: Commit**
+
+```
+fix: allow voice.channelJoined updates without name field
+```
+
+---
+
+### Task 6: Forward PermissionDenied to frontend
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` (add override)
+
+**Step 1: Add PermissionDenied override**
+
+Add this method after the `Reject` override (after line ~732):
+
+```csharp
+public override void PermissionDenied(PermissionDenied permissionDenied)
+{
+    base.PermissionDenied(permissionDenied);
+
+    var reason = !string.IsNullOrEmpty(permissionDenied.Reason)
+        ? permissionDenied.Reason
+        : $"Permission denied: {permissionDenied.Type}";
+
+    _bridge?.Send("voice.error", new { message = reason, type = "permissionDenied" });
+}
+```
+
+**Step 2: Build**
+
+Run: `dotnet build`
+Expected: 0 compilation errors
+
+**Step 3: Commit**
+
+```
+fix: forward permission denied errors to frontend
+```
+
+---
+
+### Task 7: Remove redundant UserStateChannelChanged override
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:644-660`
+
+**Step 1: Remove the entire override**
+
+Delete the `UserStateChannelChanged` method (lines 644-660). The `UserState` override already sends `voice.userJoined` with the correct model data for ALL users (including local). This override only fires for `LocalUser` and sends a duplicate message.
+
+**Step 2: Build**
+
+Run: `dotnet build`
+Expected: 0 compilation errors
+
+**Step 3: Commit**
+
+```
+refactor: remove redundant UserStateChannelChanged override
+```
+
+---
+
+### Task 8: Fix debug log to use model name
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:582`
+
+**Step 1: Use model user name in debug log**
+
+Before (line 582):
+```csharp
+Debug.WriteLine($"[Mumble] UserState: {userState.Name} (session: {userState.Session}), isNew: {isNewUser}");
+```
+
+After:
+```csharp
+Debug.WriteLine($"[Mumble] UserState: {user?.Name ?? userState.Name} (session: {userState.Session}), isNew: {isNewUser}");
+```
+
+Note: The `user` variable from the `UserDictionary.TryGetValue` call is available here.
+
+**Step 2: Build**
+
+Run: `dotnet build`
+Expected: 0 compilation errors
+
+**Step 3: Commit**
+
+```
+fix: use model name in UserState debug log
+```
+
+---
+
+### Task 9: Build, test, and verify everything
+
+**Step 1: Full build**
+
+Run: `dotnet build`
+Run: `cd src/Brmble.Web && npm run build`
+Expected: 0 errors on both
+
+**Step 2: Run tests**
+
+Run: `dotnet test`
+Expected: 57 MumbleVoiceEngine tests pass, server tests same as before (3 pre-existing failures from Matrix config)
+
+---

--- a/docs/plans/2026-02-20-other-user-updates.md
+++ b/docs/plans/2026-02-20-other-user-updates.md
@@ -1,0 +1,221 @@
+# Other-User Channel Updates & ProcessLoop Throttling
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the channel tree not updating when other users join/leave/switch channels, and throttle ProcessLoop UI notifications to prevent audio choppiness.
+
+**Architecture:** Two C# fixes in MumbleAdapter (read User model instead of raw protobuf, throttle NotifyUiThread to 50ms), one frontend guard fix in App.tsx. All changes are small and targeted.
+
+**Tech Stack:** C# (.NET 10), React/TypeScript, WebView2 bridge
+
+---
+
+### Task 1: Throttle NotifyUiThread in ProcessLoop
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:20-33` (add field)
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:163-188` (throttle in ProcessLoop)
+
+**Step 1: Add throttle field to MumbleAdapter**
+
+Add a `Stopwatch` field alongside the other instance fields (after line 33):
+
+```csharp
+private readonly Stopwatch _notifyThrottle = Stopwatch.StartNew();
+```
+
+Add `using System.Diagnostics;` if not already present (it is — line 1).
+
+**Step 2: Throttle NotifyUiThread in ProcessLoop**
+
+Replace the ProcessLoop method (lines 163-188) with throttled version:
+
+```csharp
+private void ProcessLoop(CancellationToken ct)
+{
+    while (!ct.IsCancellationRequested
+           && Connection is { State: not ConnectionStates.Disconnected })
+    {
+        try
+        {
+            if (Connection.Process())
+            {
+                // Throttle UI notifications to at most once per 50ms (20/sec).
+                // Without this, UDP voice packets (20-50+/sec) flood the UI
+                // thread with WM_USER messages and cause choppy audio.
+                if (_notifyThrottle.ElapsedMilliseconds >= 50)
+                {
+                    _bridge?.NotifyUiThread();
+                    _notifyThrottle.Restart();
+                }
+                Thread.Yield();
+            }
+            else
+            {
+                // No packet — flush any pending messages before sleeping.
+                if (_notifyThrottle.ElapsedMilliseconds > 0 && !_pendingMessages_empty())
+                {
+                    _bridge?.NotifyUiThread();
+                    _notifyThrottle.Restart();
+                }
+                Thread.Sleep(1);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _bridge?.Send("voice.error", new { message = $"Process error: {ex.Message}" });
+            _bridge?.NotifyUiThread();
+        }
+    }
+}
+```
+
+Wait — we can't check `_pendingMessages_empty()` from here since the queue is on NativeBridge. Simplify: just always notify when transitioning from processing to idle (the `else` branch). Actually, the simplest correct approach:
+
+```csharp
+private void ProcessLoop(CancellationToken ct)
+{
+    while (!ct.IsCancellationRequested
+           && Connection is { State: not ConnectionStates.Disconnected })
+    {
+        try
+        {
+            if (Connection.Process())
+            {
+                if (_notifyThrottle.ElapsedMilliseconds >= 50)
+                {
+                    _bridge?.NotifyUiThread();
+                    _notifyThrottle.Restart();
+                }
+                Thread.Yield();
+            }
+            else
+            {
+                // No more packets — flush any queued messages before sleeping.
+                _bridge?.NotifyUiThread();
+                _notifyThrottle.Restart();
+                Thread.Sleep(1);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _bridge?.Send("voice.error", new { message = $"Process error: {ex.Message}" });
+            _bridge?.NotifyUiThread();
+        }
+    }
+}
+```
+
+The key insight: when `Process()` returns `false` (no packet), we're about to sleep, so flush anything pending. When `Process()` returns `true` (packet processed), only notify if 50ms has passed. This ensures messages are always delivered promptly (within 50ms or at idle) without flooding during voice.
+
+**Step 3: Build and run tests**
+
+Run: `dotnet build`
+Expected: 0 errors
+
+Run: `dotnet test`
+Expected: all 106 tests pass
+
+**Step 4: Commit**
+
+```
+fix: throttle ProcessLoop UI notifications to prevent audio choppiness
+```
+
+---
+
+### Task 2: Fix UserState to read from User model
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:566-585`
+
+**Step 1: Replace raw protobuf reads with User model lookups**
+
+After `base.UserState(userState)` runs (line 571), the User object in UserDictionary has the correct state. Replace lines 577-585:
+
+Before:
+```csharp
+_bridge?.Send("voice.userJoined", new
+{
+    session = userState.Session,
+    name = userState.Name,
+    channelId = userState.ChannelId,
+    muted = userState.Mute || userState.SelfMute,
+    deafened = userState.Deaf || userState.SelfDeaf,
+    self = isSelf
+});
+```
+
+After:
+```csharp
+UserDictionary.TryGetValue(userState.Session, out var user);
+
+_bridge?.Send("voice.userJoined", new
+{
+    session = userState.Session,
+    name = user?.Name ?? userState.Name,
+    channelId = user?.Channel?.Id ?? userState.ChannelId,
+    muted = user != null ? (user.Muted || user.SelfMuted) : (userState.Mute || userState.SelfMute),
+    deafened = user != null ? (user.Deaf || user.SelfDeaf) : (userState.Deaf || userState.SelfDeaf),
+    self = isSelf
+});
+```
+
+**Step 2: Build and run tests**
+
+Run: `dotnet build`
+Expected: 0 errors
+
+Run: `dotnet test`
+Expected: all tests pass
+
+**Step 3: Commit**
+
+```
+fix: read user state from model instead of raw protobuf for bridge messages
+```
+
+---
+
+### Task 3: Relax frontend guard for voice.userJoined
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx:228`
+
+**Step 1: Remove name requirement from guard**
+
+Before (line 228):
+```typescript
+if (d?.session && d?.name && d.channelId !== undefined) {
+```
+
+After:
+```typescript
+if (d?.session && d.channelId !== undefined) {
+```
+
+With Task 2, `name` will always be present from C#. But the guard shouldn't gate on it — a session + channelId is sufficient to update an existing user's position.
+
+**Step 2: Build frontend**
+
+Run: `cd src/Brmble.Web && npm run build`
+Expected: no errors
+
+**Step 3: Commit**
+
+```
+fix: allow voice.userJoined without name field for channel moves
+```
+
+---
+
+### Task 4: Manual verification
+
+Test with two users on the same Mumble server:
+1. Connect both users
+2. Have the other user switch channels — verify they move in the channel tree
+3. Have the other user disconnect — verify they disappear
+4. Have the other user reconnect — verify they appear
+5. During active voice, verify audio is not choppy
+
+---

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -31,6 +31,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private bool _canRejoin;
     private TransmissionMode _previousMode = TransmissionMode.Continuous;
     private string? _currentPttKey;
+    private readonly Stopwatch _notifyThrottle = Stopwatch.StartNew();
 
     public string ServiceName => "mumble";
 
@@ -169,13 +170,21 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             {
                 if (Connection.Process())
                 {
-                    // A server packet was processed — Send() calls have enqueued
-                    // messages. Post one WM_USER to flush the batch on the UI thread.
-                    _bridge?.NotifyUiThread();
+                    // Throttle UI notifications to at most once per 50ms (20/sec).
+                    // Without this, UDP voice packets (20-50+/sec) flood the UI
+                    // thread with WM_USER messages and cause choppy audio.
+                    if (_notifyThrottle.ElapsedMilliseconds >= 50)
+                    {
+                        _bridge?.NotifyUiThread();
+                        _notifyThrottle.Restart();
+                    }
                     Thread.Yield();
                 }
                 else
                 {
+                    // No more packets — flush any queued messages before sleeping.
+                    _bridge?.NotifyUiThread();
+                    _notifyThrottle.Restart();
                     Thread.Sleep(1);
                 }
             }
@@ -570,17 +579,19 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         base.UserState(userState);
 
-        Debug.WriteLine($"[Mumble] UserState: {userState.Name} (session: {userState.Session}), isNew: {isNewUser}");
+        UserDictionary.TryGetValue(userState.Session, out var user);
+
+        Debug.WriteLine($"[Mumble] UserState: {user?.Name ?? userState.Name} (session: {userState.Session}), isNew: {isNewUser}");
 
         var isSelf = LocalUser != null && userState.Session == LocalUser.Id;
 
         _bridge?.Send("voice.userJoined", new
         {
             session = userState.Session,
-            name = userState.Name,
-            channelId = userState.ChannelId,
-            muted = userState.Mute || userState.SelfMute,
-            deafened = userState.Deaf || userState.SelfDeaf,
+            name = user?.Name ?? userState.Name,
+            channelId = user?.Channel?.Id ?? userState.ChannelId,
+            muted = user != null ? (user.Muted || user.SelfMuted) : (userState.Mute || userState.SelfMute),
+            deafened = user != null ? (user.Deaf || user.SelfDeaf) : (userState.Deaf || userState.SelfDeaf),
             self = isSelf
         });
 
@@ -591,9 +602,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             SendSystemMessage($"{userName} connected to the server", "userJoined");
         }
 
-        if (previousChannel.HasValue && userState.ChannelId != previousChannel && isSelf)
+        var currentChannelId = user?.Channel?.Id ?? userState.ChannelId;
+        if (previousChannel.HasValue && currentChannelId != previousChannel && isSelf)
         {
-            _bridge?.Send("voice.channelChanged", new { channelId = userState.ChannelId });
+            _bridge?.Send("voice.channelChanged", new { channelId = currentChannelId });
 
             // If this channel change was initiated by LeaveVoice toggle, just clear the flag
             if (_leaveVoiceInProgress)
@@ -622,29 +634,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             // ReceivedServerSync guard prevents firing during the initial state-sync burst on connect.
             // ShouldSerializeChannelId guard prevents mute/deafen echoes (which have ChannelId=0 by
             // protobuf default but no explicit channel field) from being mistaken for a move to root.
-            else if (userState.ChannelId == 0 && ReceivedServerSync && userState.ShouldSerializeChannelId())
+            else if (currentChannelId == 0 && ReceivedServerSync && userState.ShouldSerializeChannelId())
             {
                 _previousChannelId = previousChannel;
                 ActivateLeaveVoice();
             }
-        }
-    }
-
-    protected override void UserStateChannelChanged(User user, uint oldChannelId)
-    {
-        base.UserStateChannelChanged(user, oldChannelId);
-
-        if (user == LocalUser && user.Channel != null)
-        {
-            _bridge?.Send("voice.userJoined", new
-            {
-                session = user.Id,
-                name = user.Name,
-                channelId = user.Channel.Id,
-                muted = user.Muted || user.SelfMuted,
-                deafened = user.Deaf || user.SelfDeaf,
-                self = true
-            });
         }
     }
 
@@ -694,12 +688,23 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     public override void ChannelState(ChannelState channelState)
     {
         base.ChannelState(channelState);
-        _bridge?.Send("voice.channelJoined", new
+
+        if (ChannelDictionary.TryGetValue(channelState.ChannelId, out var channel))
         {
-            id = channelState.ChannelId,
-            name = channelState.Name,
-            parent = channelState.Parent
-        });
+            _bridge?.Send("voice.channelJoined", new
+            {
+                id = channel.Id,
+                name = channel.Name,
+                parent = channel.Parent
+            });
+        }
+    }
+
+    public override void ChannelRemove(ChannelRemove channelRemove)
+    {
+        var channelId = channelRemove.ChannelId;
+        base.ChannelRemove(channelRemove);
+        _bridge?.Send("voice.channelRemoved", new { id = channelId });
     }
 
     public override void TextMessage(TextMessage textMessage)
@@ -718,6 +723,17 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     {
         base.Reject(reject);
         _bridge?.Send("voice.error", new { message = reject.Reason, type = reject.Type });
+    }
+
+    public override void PermissionDenied(PermissionDenied permissionDenied)
+    {
+        base.PermissionDenied(permissionDenied);
+
+        var reason = !string.IsNullOrEmpty(permissionDenied.Reason)
+            ? permissionDenied.Reason
+            : $"Permission denied: {permissionDenied.Type}";
+
+        _bridge?.Send("voice.error", new { message = reason, type = "permissionDenied" });
     }
 
     public override void EncodedVoice(byte[] data, uint userId, long sequence,

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -225,7 +225,7 @@ function App() {
 
     const onVoiceUserJoined = ((data: unknown) => {
       const d = data as { session: number; name: string; channelId?: number; muted?: boolean; deafened?: boolean; self?: boolean } | undefined;
-      if (d?.session && d?.name && d.channelId !== undefined) {
+      if (d?.session && d.channelId !== undefined) {
         setUsers(prev => {
           const existing = prev.find(u => u.session === d.session);
           if (existing) {
@@ -239,7 +239,7 @@ function App() {
 
     const onVoiceChannelJoined = ((data: unknown) => {
       const d = data as { id: number; name: string; parent?: number } | undefined;
-      if (d?.id !== undefined && d?.name) {
+      if (d?.id !== undefined) {
         setChannels(prev => {
           const existing = prev.find(c => c.id === d.id);
           if (existing) {
@@ -247,6 +247,13 @@ function App() {
           }
           return [...prev, d];
         });
+      }
+    });
+
+    const onVoiceChannelRemoved = ((data: unknown) => {
+      const d = data as { id: number } | undefined;
+      if (d?.id !== undefined) {
+        setChannels(prev => prev.filter(c => c.id !== d.id));
       }
     });
 
@@ -356,6 +363,7 @@ function App() {
     bridge.on('voice.system', onVoiceSystem);
     bridge.on('voice.userJoined', onVoiceUserJoined);
     bridge.on('voice.channelJoined', onVoiceChannelJoined);
+    bridge.on('voice.channelRemoved', onVoiceChannelRemoved);
     bridge.on('voice.userLeft', onVoiceUserLeft);
     bridge.on('voice.channelChanged', onVoiceChannelChanged);
     bridge.on('voice.selfMuteChanged', onSelfMuteChanged);
@@ -377,6 +385,7 @@ function App() {
       bridge.off('voice.system', onVoiceSystem);
       bridge.off('voice.userJoined', onVoiceUserJoined);
       bridge.off('voice.channelJoined', onVoiceChannelJoined);
+      bridge.off('voice.channelRemoved', onVoiceChannelRemoved);
       bridge.off('voice.userLeft', onVoiceUserLeft);
       bridge.off('voice.channelChanged', onVoiceChannelChanged);
       bridge.off('voice.selfMuteChanged', onSelfMuteChanged);

--- a/src/Brmble.Web/src/components/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/ChannelTree.tsx
@@ -92,7 +92,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     });
 
     users.forEach(user => {
-      if (user.channelId && channelMap.has(user.channelId)) {
+      if (user.channelId !== undefined && channelMap.has(user.channelId)) {
         channelMap.get(user.channelId)!.users.push(user);
       }
     });


### PR DESCRIPTION
## Summary

Fixes #48 — Channel list not updating when other users join/leave/switch channels.

A full Mumble event handler audit uncovered **11 bugs** across the C#/TypeScript bridge layer that caused missing or incorrect UI updates.

## Bugs Fixed

### C# Bridge (`MumbleAdapter.cs`)
1. **ProcessLoop flooding** — Unthrottled `NotifyUiThread()` on every `Connection.Process()` fired 20-50+ WM_USER messages/sec during voice, causing choppy audio. Added 50ms Stopwatch throttle.
2. **UserState raw protobuf reads** — Channel-move packets only contain Session + ChannelId (protobuf omits unchanged fields). Reading `userState.Name`/`Mute`/`Deaf` directly returned null/false. Fixed by reading from `UserDictionary` model after `base.UserState()`.
3. **ChannelState raw protobuf reads** — Same pattern as UserState for channel renames/moves. Fixed by reading from `ChannelDictionary` model.
4. **ChannelRemove not forwarded** — Deleted channels persisted as ghosts in the UI. Added `ChannelRemove` override + `voice.channelRemoved` event.
5. **voice.channelChanged raw protobuf channelId** — Mute/deaf echoes could trigger spurious channel-change to root. Fixed to use `user?.Channel?.Id`.
6. **PermissionDenied not forwarded** — Server-denied actions gave no UI feedback. Added override sending `voice.error`.
7. **Redundant UserStateChannelChanged override** — Sent duplicate `voice.userJoined` for local user. Removed entirely.
8. **Debug log raw protobuf name** — Showed empty name on mute/channel events. Fixed to use model name.

### Frontend (`App.tsx`, `ChannelTree.tsx`)
9. **userJoined guard too strict** — `if (d?.session && d?.name && ...)` dropped channel-move packets where `name` is null. Relaxed to `if (d?.session && ...)`.
10. **channelJoined guard too strict** — `if (d?.id !== undefined && d?.name)` dropped channel-move-only updates. Relaxed to `if (d?.id !== undefined)`.
11. **Root channel users invisible** — `if (user.channelId && ...)` in ChannelTree treated `0` as falsy. Users in root channel (id=0) never appeared. Fixed to `user.channelId !== undefined`.

## Testing
- `dotnet build` — 0 errors, 0 warnings
- `npm run build` — success
- 57/57 MumbleVoiceEngine tests pass
- 3 pre-existing Brmble.Server.Tests failures (unrelated `Matrix:HomeserverUrl` config issue)

## Files Changed
- `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` — All 8 C# fixes
- `src/Brmble.Web/src/App.tsx` — Guard relaxations + channelRemoved listener
- `src/Brmble.Web/src/components/ChannelTree.tsx` — Root channel falsy fix
- `docs/plans/` — Two implementation plan documents