### PR TITLE
fix: add jitter buffer to fix audio jitter on Mumble 1.5+ servers

### DIFF
--- a/src/Brmble.Client/Services/AppConfig/AppSettings.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppSettings.cs
@@ -6,6 +6,7 @@ public record AudioSettings(
     int InputVolume = 250,
     int MaxAmplification = 100,
     int OutputVolume = 250,
+    int JitterBufferMs = 30,
     string TransmissionMode = "voiceActivity",
     string? PushToTalkKey = null
 );

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -525,6 +525,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         _audioManager?.SetInputVolume(settings.Audio.InputVolume);
         _audioManager?.SetOutputVolume(settings.Audio.OutputVolume);
         _audioManager?.SetMaxAmplification(settings.Audio.MaxAmplification);
+        _audioManager?.SetJitterBuffer(settings.Audio.JitterBufferMs);
 
         var modelVariant = settings.SpeechEnhancement.Model?.ToLowerInvariant() switch
         {

--- a/src/Brmble.Web/src/components/SettingsModal/AudioSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/AudioSettingsTab.tsx
@@ -16,6 +16,7 @@ export interface AudioSettings {
   inputVolume: number;
   outputVolume: number;
   maxAmplification: number;
+  jitterBuffer: number;
   transmissionMode: TransmissionMode;
   pushToTalkKey: string | null;
 }
@@ -31,6 +32,7 @@ export const DEFAULT_SETTINGS: AudioSettings = {
   inputVolume: 250,
   outputVolume: 250,
   maxAmplification: 100,
+  jitterBuffer: 30,
   transmissionMode: 'pushToTalk',
   pushToTalkKey: null,
 };
@@ -146,6 +148,17 @@ export function AudioSettingsTab({ settings, speechEnhancement, onChange, onSpee
           max="250"
           value={localSettings.outputVolume}
           onChange={(e) => handleChange('outputVolume', parseInt(e.target.value, 10))}
+        />
+      </div>
+
+      <div className="settings-item settings-slider">
+        <label>Jitter Buffer: {localSettings.jitterBuffer}ms</label>
+        <input
+          type="range"
+          min="0"
+          max="100"
+          value={localSettings.jitterBuffer}
+          onChange={(e) => handleChange('jitterBuffer', parseInt(e.target.value, 10))}
         />
       </div>
 


### PR DESCRIPTION
## Summary

- Add configurable jitter buffer (default 30ms) to fix audio jitter caused by UDP packet reordering
- Issue occurred on Mumble 1.5+ servers where voice packets could arrive out of order

## Changes

- `UserAudioPipeline.cs`: Implement jitter buffer that buffers encoded packets by sequence number and releases them in order
- `AppSettings.cs`: Add `JitterBufferMs` setting (default 30ms)
- `AudioManager.cs`: Add `SetJitterBuffer()` method to update pipelines
- `AudioSettingsTab.tsx`: Add jitter buffer slider (0-100ms)

## Testing

- Built successfully
- All tests pass
- User confirmed the fix resolves the jitter issue on Mumble 1.5.8 server

## Notes

- Users who prioritize lowest latency can set jitter buffer to 0
- Users with network jitter issues can increase up to 100ms
- Default of 30ms provides good balance for most users