### PR TITLE
fix: use EventType.Direct instead of string literal for m.direct

### DIFF
--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -197,10 +197,10 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       roomId = createResult.room_id;
 
       // Update m.direct account data
-      const directEvent = client.getAccountData('m.direct');
+      const directEvent = client.getAccountData(EventType.Direct);
       const directContent = (directEvent?.getContent() ?? {}) as Record<string, string[]>;
       directContent[targetMatrixUserId] = [roomId, ...(directContent[targetMatrixUserId] ?? [])];
-      await client.setAccountData('m.direct', directContent);
+      await client.setAccountData(EventType.Direct, directContent);
 
       // Update local state
       setDmRoomMap(prev => new Map(prev).set(targetMatrixUserId, roomId!));


### PR DESCRIPTION
## Summary
- Replace `'m.direct'` string literal with `EventType.Direct` in `useMatrixClient.ts`
- Fixes TypeScript build error: `Argument of type '"m.direct"' is not assignable to parameter of type 'keyof AccountDataEvents'`

## Test plan
- [ ] `npm run build` in `src/Brmble.Web` passes without TS errors
- [ ] Production client builds and runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)