### PR TITLE
fix(game): fix broken JSX nesting in GameUI causing build failure

### DIFF
--- a/src/Brmble.Web/src/components/Game/GameUI.tsx
+++ b/src/Brmble.Web/src/components/Game/GameUI.tsx
@@ -87,7 +87,7 @@ export function GameUI({ onClose }: GameUIProps) {
         <button className="game-close-btn" onClick={handleClose} aria-label="Close">×</button>
         <div className="game-ui">
           <Header money={state.money} income={state.incomePerSecond} />
-          <div className="game-body" id="game-title"></div>
+          <div className="game-body" id="game-title">
             <TabNav activeTab={activeTab} onTabChange={setActiveTab} />
             <div className="game-content">
               {activeTab === 'crops' && (


### PR DESCRIPTION
## Summary
- The `game-body` div in `GameUI.tsx` was self-closing (`<div ...></div>`) on line 90, causing `TabNav` and `game-content` to render as siblings outside it instead of children
- This produced TS1005/TS1109 errors and broke `npm run build`
- One-character fix: removed the premature `</div>` so the tag opens properly