### PR TITLE
fix: format soil/fertilizer/seeds upgrade prices with K/B/M/T suffixes

### DIFF
--- a/src/Brmble.Web/src/components/Game/GameUI.css
+++ b/src/Brmble.Web/src/components/Game/GameUI.css
@@ -214,7 +214,7 @@
 }
 
 .upgrade-btn {
-  min-width: 100px;
+  min-width: 120px;
 }
 
 .upgrade-btn:disabled {

--- a/src/Brmble.Web/src/components/Game/GameUI.tsx
+++ b/src/Brmble.Web/src/components/Game/GameUI.tsx
@@ -258,7 +258,7 @@ function CropsTab({ crops, onBuy, onUpgradeSoil, onUpgradeFertilizer, onUpgradeS
                       disabled={!nextUpgrade.canBuy}
                       onClick={nextUpgrade.action}
                     >
-                      {nextUpgrade.name === 'MAX' ? 'MAXED' : `${nextUpgrade.name}+ $${nextUpgrade.cost.toLocaleString()}`}
+                      {nextUpgrade.name === 'MAX' ? 'MAXED' : `${nextUpgrade.name}+ $${formatNumber(nextUpgrade.cost)}`}
                     </button>
                   ) : '-'}
                 </td>

--- a/src/Brmble.Web/src/components/Prompt/Prompt.css
+++ b/src/Brmble.Web/src/components/Prompt/Prompt.css
@@ -1,7 +1,8 @@
 .prompt {
   width: 100%;
-  max-width: 380px;
+  max-width: 420px;
   padding: var(--space-xl) var(--space-lg) var(--space-lg);
+  word-wrap: break-word;
 }
 
 .prompt .modal-header {


### PR DESCRIPTION
## Summary
- Fixed issue #293 where soil/fertilizer/seeds upgrade prices showed raw numbers instead of K/B/M/T suffixes
- Updated upgrade button and confirmation dialog to handle larger formatted numbers

## Changes

### GameUI.tsx (line 261)
- Changed upgrade price display from `.toLocaleString()` to `formatNumber()` to show K/B/M/T suffixes for larger numbers

### GameUI.css (line 217)
- Increased upgrade button min-width from 100px to 120px to fit larger formatted numbers

### Prompt.css (line 3)
- Increased prompt dialog max-width from 380px to 420px
- Added `word-wrap: break-word` to prevent overflow when prices are displayed in confirm dialogs

## Testing
Build verified successfully with `npm run build` in Brmble.Web