### PR TITLE
fix: improve idle game resource tab styling

### DIFF
--- a/src/Brmble.Web/src/components/Game/GameUI.css
+++ b/src/Brmble.Web/src/components/Game/GameUI.css
@@ -130,7 +130,7 @@
 }
 
 .header-value.free {
-  color: var(--text-muted);
+  color: var(--accent-success);
 }
 
 .header-value.overage {
@@ -658,6 +658,25 @@
 
 .service-name {
   font-weight: 600;
+}
+
+.infra-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.infra-stats {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.service-row {
+  position: relative;
 }
 
 .service-bandwidth,

--- a/src/Brmble.Web/src/components/Game/GameUI.tsx
+++ b/src/Brmble.Web/src/components/Game/GameUI.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import type { Infrastructure, Service } from './types';
 import { useGameState } from './useGameState';
 import { confirm } from '../../hooks/usePrompt';


### PR DESCRIPTION
## Summary

- Fixes the FREE: indicator to display in green instead of gray
- Centers the "Owned: X | Y/unit" stats in the infrastructure service rows

## Changes

### GameUI.css
- Changed `.header-value.free` color from `var(--text-muted)` to `var(--accent-success)` to match the green color scheme
- Added CSS rules to center `.infra-stats` within the service row using absolute positioning with `left: 50%` and `transform: translateX(-50%)`
- Added `.infra-info` styling for flexbox layout
- Added `.service-row` with `position: relative` to enable absolute positioning of stats

### Visual Before/After

**Before:**
- FREE: appeared in gray/muted color
- "Owned: 2 | 1.00 KB/s/unit" was left-aligned next to the server name

**After:**
- FREE: now displays in green (matching the success accent color)
- "Owned: X | Y/unit" is centered in the middle of the server row for better visual balance

## Testing

Built and ran the client to verify:
- FREE: shows in green when bandwidth is under capacity
- OVER: still shows in red when over capacity  
- Owned/stats line is properly centered in the service row