### PR TITLE
fix: idle game bugs - income calculation and save on close

### DIFF
--- a/src/Brmble.Web/src/components/Game/GameUI.tsx
+++ b/src/Brmble.Web/src/components/Game/GameUI.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { Infrastructure, Service } from './types';
 import { useGameState } from './useGameState';
 import { confirm } from '../../hooks/usePrompt';
@@ -14,6 +14,12 @@ type TabId = 'infrastructure' | 'upgrades' | 'hosting' | 'options';
 export function GameUI({ onClose }: GameUIProps) {
   const { state, actions } = useGameState();
   const [activeTab, setActiveTab] = useState<TabId>('infrastructure');
+
+  useEffect(() => {
+    return () => {
+      actions.saveGame();
+    };
+  }, [actions]);
   
   const handleClose = useCallback(() => {
     actions.saveGame();

--- a/src/Brmble.Web/src/components/Game/useGameState.ts
+++ b/src/Brmble.Web/src/components/Game/useGameState.ts
@@ -18,10 +18,16 @@ function calculateBandwidth(infra: Infrastructure[]): number {
 }
 
 function calculateIncome(services: Service[], bandwidth: number): { income: number; bandwidthUsed: number } {
+  const sortedServices = [...services].sort((a, b) => {
+    const efficiencyA = a.baseIncomePerSecond / a.baseBandwidthRequired;
+    const efficiencyB = b.baseIncomePerSecond / b.baseBandwidthRequired;
+    return efficiencyB - efficiencyA;
+  });
+  
   let bandwidthUsed = 0;
   let income = 0;
   
-  for (const service of services) {
+  for (const service of sortedServices) {
     if (!service.unlocked || service.owned === 0) continue;
     
     const serviceBandwidth = service.baseBandwidthRequired;


### PR DESCRIPTION
## Summary

- **Income calculation bug**: Services are now sorted by efficiency (income per bandwidth) before calculating which services get activated. This prevents buying less efficient services (like File Hosting at $0.75/KB) from pushing out more efficient services (Personal Website at $1/KB) and decreasing total income.

- **Save on close bug**: Added a `useEffect` cleanup in GameUI that auto-saves when the component unmounts. This fixes progress not being saved when clicking the Brmble icon to hide the game (vs using the Close button).

## Changes

1. `useGameState.ts`: Sort services by efficiency before bandwidth allocation
2. `GameUI.tsx`: Add `useEffect` to save game on unmount

## Testing

- Built successfully with `npm run build`
- All tests pass with `npm run test`