### PR TITLE
feat: multi-profile system with cert management, registration detection, and per-profile state

### DIFF
--- a/docs/plans/2026-03-20-multi-profile-design.md
+++ b/docs/plans/2026-03-20-multi-profile-design.md
@@ -1,0 +1,131 @@
+# Multi-Profile System Design
+
+**Issues:** #277 (certificate reset & multi-cert), #358 (registration status UI)
+**Date:** 2026-03-20
+
+## Overview
+
+Introduce a **Profile** concept that pairs a certificate (.pfx) with a user-chosen profile name. Users can create multiple profiles, switch between them, and each profile's name serves as the default username when connecting to servers.
+
+## Data Model
+
+### config.json additions
+
+```json
+{
+  "profiles": [
+    { "id": "abc-123", "name": "Roan" }
+  ],
+  "activeProfileId": "abc-123",
+  "servers": [...],
+  "settings": {...}
+}
+```
+
+- `profiles` — ordered list of profile entries
+- `activeProfileId` — UUID of the currently active profile (null if no profiles)
+- Each profile's cert file lives at `%APPDATA%/Brmble/certs/{id}.pfx`
+- No separate `certFile` field — the ID is the filename
+
+### Certificate storage
+
+- Directory: `%APPDATA%/Brmble/certs/`
+- Files: `{profile-id}.pfx` per profile
+- Files are **never deleted** by the app — even when a profile is removed
+- Orphaned cert files stay on disk; no automatic cleanup
+
+## Migration
+
+On startup, if `identity.pfx` exists at the old location and `profiles` is empty/missing:
+
+1. Create `%APPDATA%/Brmble/certs/` directory
+2. Move `identity.pfx` → `certs/{new-uuid}.pfx`
+3. Add profile `{ id: uuid, name: "Default" }` to config
+4. Set `activeProfileId` to that UUID
+5. Delete old `identity.pfx`
+
+Seamless — existing users see no difference.
+
+## Bridge Protocol
+
+### New messages (ProfileService or extended AppConfigService)
+
+| Message | Direction | Payload |
+|---------|-----------|---------|
+| `profiles.list` | JS → C# → JS | `{ profiles: [...], activeProfileId }` |
+| `profiles.add` | JS → C# | `{ name }` — generates cert, creates profile |
+| `profiles.import` | JS → C# | `{ name, data }` (base64 pfx) — creates profile with imported cert |
+| `profiles.remove` | JS → C# | `{ id }` — removes from config, cert file stays |
+| `profiles.rename` | JS → C# | `{ id, name }` |
+| `profiles.setActive` | JS → C# | `{ id }` — switches active profile, reloads cert |
+| `profiles.added` | C# → JS | New profile entry with fingerprint |
+| `profiles.removed` | C# → JS | `{ id }` |
+| `profiles.renamed` | C# → JS | Updated profile entry |
+| `profiles.activeChanged` | C# → JS | `{ id, name, fingerprint }` |
+| `profiles.error` | C# → JS | `{ message }` |
+
+### Existing messages (unchanged)
+
+- `cert.requestStatus` / `cert.status` — still work, reflect the active profile's cert
+- `cert.export` — exports the active profile's cert
+- `cert.generate`, `cert.import` — used internally by `profiles.add` / `profiles.import`
+
+## Constraints
+
+- `profiles.setActive` fails with `profiles.error` if currently connected to a server
+- All profiles can be deleted — deleting the last profile sets `activeProfileId: null` and `certExists: false`, which triggers the CertWizard overlay
+- Deleting the active profile when others exist: auto-switch to another profile first, then delete
+- Profile name uniqueness is NOT enforced
+- If a cert file is missing/corrupt: show error state on that profile row, allow delete but not set-active
+
+## Frontend UI
+
+### Settings > Profiles tab
+
+Mirrors the ServerList layout and follows `docs/UI_GUIDE.md`:
+
+**List layout:**
+- `div.profiles-section` with `h3.heading-section.profiles-section-title` — "Profiles"
+- `div.profiles-items` — flex column, `gap: var(--space-sm)`
+
+**Profile row** (same pattern as `.server-list-item`):
+- `div.profiles-item` — flex row, `--bg-surface`, `--radius-lg`, `padding: var(--space-md)`
+- **Icon:** 44px gradient square, first letter of profile name (same pattern as server icon)
+- **Info:** Profile name + truncated fingerprint (mono font)
+- **Active badge:** "Active" indicator on the current profile
+- **Actions:** Set Active (secondary, hidden on active, disabled when connected), Edit (secondary), Export cert (ghost), Delete (ghost danger)
+
+**Inline form** (same pattern as server add/edit form):
+- `form.profiles-form` with `formSlideIn` animation
+- Fields: Profile Name (`brmble-input`)
+- For new profiles: Generate / Import choice
+- If importing: file picker for `.pfx/.p12`
+- Cancel / Save buttons, `flex: 1` each
+
+**Add button:** Full-width dashed border ghost button: `+ Add Profile`
+
+**Delete prompt:** Uses `confirm()` from `usePrompt` hook (themed modal dialog, never `window.confirm`)
+
+### CertWizard extension
+
+- Add a "Profile Name" text input to the `choose` step (or new step between `welcome` and `choose`)
+- This name becomes the first profile's name and default server username
+- Rest of wizard flow unchanged
+
+### App.tsx state changes
+
+- `certExists` / `certFingerprint` — unchanged, reflect active profile's cert
+- New: `activeProfileName: string` — updated on `profiles.activeChanged`
+- When `activeProfileId` is null (no profiles): `certExists = false` → CertWizard overlay
+
+### Server connection
+
+- When connecting, if server entry's `username` is empty → use `activeProfileName` as default
+- Existing per-server usernames take priority (not overwritten)
+
+## Out of scope (future work)
+
+- Per-server username changes (issue #358 registration status UI will be addressed separately)
+- Orphaned cert file cleanup UI
+- Per-profile server lists (server list is shared)
+- Password protection on .pfx files

--- a/docs/plans/2026-03-20-multi-profile-implementation.md
+++ b/docs/plans/2026-03-20-multi-profile-implementation.md
@@ -1,0 +1,1440 @@
+# Multi-Profile System Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add multi-profile support so users can manage multiple certificates, each with a profile name that serves as the default server username.
+
+**Architecture:** Profiles are stored in `config.json` alongside the existing server list. Each profile has an ID, name, and a cert file at `%APPDATA%/Brmble/certs/{id}.pfx`. The backend exposes `profiles.*` bridge messages. The frontend adds a Profiles tab in Settings, mirroring the ServerList layout.
+
+**Tech Stack:** C# (AppConfigService, CertificateService), React + TypeScript (Settings UI, CertWizard), MSTest (backend tests)
+
+---
+
+### Task 1: Add Profile Data Model to AppConfigService
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/AppConfig/AppConfigService.cs`
+- Modify: `src/Brmble.Client/Services/AppConfig/IAppConfigService.cs`
+- Test: `tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs`
+
+**Step 1: Write the failing tests**
+
+Add these tests to `AppConfigServiceTests.cs`:
+
+```csharp
+[TestMethod]
+public void LoadsEmptyProfiles_WhenNoFileExists()
+{
+    var svc = new AppConfigService(_tempDir);
+    Assert.AreEqual(0, svc.GetProfiles().Count);
+    Assert.IsNull(svc.GetActiveProfileId());
+}
+
+[TestMethod]
+public void SavesAndReloads_Profiles()
+{
+    var svc = new AppConfigService(_tempDir);
+    var profile = new ProfileEntry("p1", "Roan");
+    svc.AddProfile(profile);
+    svc.SetActiveProfileId("p1");
+
+    var svc2 = new AppConfigService(_tempDir);
+    Assert.AreEqual(1, svc2.GetProfiles().Count);
+    Assert.AreEqual("Roan", svc2.GetProfiles()[0].Name);
+    Assert.AreEqual("p1", svc2.GetActiveProfileId());
+}
+
+[TestMethod]
+public void RemoveProfile_RemovesFromConfig_ButNotCertFile()
+{
+    var svc = new AppConfigService(_tempDir);
+    var certsDir = Path.Combine(_tempDir, "certs");
+    Directory.CreateDirectory(certsDir);
+    File.WriteAllBytes(Path.Combine(certsDir, "p1.pfx"), new byte[] { 1, 2, 3 });
+
+    svc.AddProfile(new ProfileEntry("p1", "Test"));
+    svc.RemoveProfile("p1");
+
+    Assert.AreEqual(0, svc.GetProfiles().Count);
+    Assert.IsTrue(File.Exists(Path.Combine(certsDir, "p1.pfx")), "Cert file should NOT be deleted");
+}
+
+[TestMethod]
+public void RemoveActiveProfile_ClearsActiveId_WhenLastProfile()
+{
+    var svc = new AppConfigService(_tempDir);
+    svc.AddProfile(new ProfileEntry("p1", "Only"));
+    svc.SetActiveProfileId("p1");
+
+    svc.RemoveProfile("p1");
+
+    Assert.IsNull(svc.GetActiveProfileId());
+}
+
+[TestMethod]
+public void RemoveActiveProfile_SwitchesToAnother_WhenOthersExist()
+{
+    var svc = new AppConfigService(_tempDir);
+    svc.AddProfile(new ProfileEntry("p1", "First"));
+    svc.AddProfile(new ProfileEntry("p2", "Second"));
+    svc.SetActiveProfileId("p1");
+
+    svc.RemoveProfile("p1");
+
+    Assert.AreEqual("p2", svc.GetActiveProfileId());
+}
+
+[TestMethod]
+public void RenameProfile_UpdatesName()
+{
+    var svc = new AppConfigService(_tempDir);
+    svc.AddProfile(new ProfileEntry("p1", "Old Name"));
+
+    svc.RenameProfile("p1", "New Name");
+    var svc2 = new AppConfigService(_tempDir);
+
+    Assert.AreEqual("New Name", svc2.GetProfiles()[0].Name);
+}
+
+[TestMethod]
+public void MigratesIdentityPfx_ToProfileOnLoad()
+{
+    // Create a legacy identity.pfx
+    File.WriteAllBytes(Path.Combine(_tempDir, "identity.pfx"), new byte[] { 1, 2, 3 });
+
+    var svc = new AppConfigService(_tempDir);
+
+    Assert.AreEqual(1, svc.GetProfiles().Count);
+    Assert.IsNotNull(svc.GetActiveProfileId());
+    var profile = svc.GetProfiles()[0];
+    Assert.AreEqual("Default", profile.Name);
+    Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "certs", profile.Id + ".pfx")));
+    Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "identity.pfx")), "Old file should be moved");
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "ClassName~AppConfigServiceTests" -v n`
+Expected: FAIL — `ProfileEntry` type doesn't exist, methods don't exist.
+
+**Step 3: Add ProfileEntry record and IAppConfigService interface changes**
+
+In `IAppConfigService.cs`, add at the bottom of the interface:
+
+```csharp
+IReadOnlyList<ProfileEntry> GetProfiles();
+void AddProfile(ProfileEntry profile);
+void RemoveProfile(string id);
+void RenameProfile(string id, string newName);
+string? GetActiveProfileId();
+void SetActiveProfileId(string? id);
+string GetCertsDir();
+```
+
+Add above the interface (same file, same namespace):
+
+```csharp
+public record ProfileEntry(string Id, string Name);
+```
+
+**Step 4: Implement profile methods in AppConfigService**
+
+Add fields alongside existing ones (after line 24):
+
+```csharp
+private List<ProfileEntry> _profiles = new();
+private string? _activeProfileId;
+```
+
+Add a `_dir` field set from the constructor's `dir` parameter (store it so we can compute certs path):
+
+```csharp
+private readonly string _dir;
+```
+
+Set `_dir = dir;` in the constructor (line 35).
+
+Add `GetCertsDir()`:
+
+```csharp
+public string GetCertsDir()
+{
+    var certsDir = Path.Combine(_dir, "certs");
+    Directory.CreateDirectory(certsDir);
+    return certsDir;
+}
+```
+
+Add profile methods:
+
+```csharp
+public IReadOnlyList<ProfileEntry> GetProfiles() { lock (_lock) return _profiles.ToList(); }
+
+public void AddProfile(ProfileEntry profile)
+{
+    lock (_lock)
+    {
+        _profiles.Add(profile);
+        Save();
+    }
+}
+
+public void RemoveProfile(string id)
+{
+    lock (_lock)
+    {
+        _profiles.RemoveAll(p => p.Id == id);
+        if (_activeProfileId == id)
+            _activeProfileId = _profiles.FirstOrDefault()?.Id;
+        Save();
+    }
+}
+
+public void RenameProfile(string id, string newName)
+{
+    lock (_lock)
+    {
+        var idx = _profiles.FindIndex(p => p.Id == id);
+        if (idx >= 0)
+        {
+            _profiles[idx] = _profiles[idx] with { Name = newName };
+            Save();
+        }
+    }
+}
+
+public string? GetActiveProfileId() { lock (_lock) return _activeProfileId; }
+
+public void SetActiveProfileId(string? id)
+{
+    lock (_lock)
+    {
+        _activeProfileId = id;
+        Save();
+    }
+}
+```
+
+Update `ConfigData` record to include profiles:
+
+```csharp
+private record ConfigData
+{
+    public List<ServerEntry> Servers { get; init; } = [];
+    public AppSettings Settings { get; init; } = AppSettings.Default;
+    public WindowState? Window { get; init; } = null;
+    public string? ClosePreference { get; init; } = null;
+    public string? LastConnectedServerId { get; init; } = null;
+    public double? ZoomFactor { get; init; } = null;
+    public List<ProfileEntry> Profiles { get; init; } = [];
+    public string? ActiveProfileId { get; init; } = null;
+}
+```
+
+Update `Load()` to read profiles:
+
+```csharp
+_profiles = data?.Profiles ?? new List<ProfileEntry>();
+_activeProfileId = data?.ActiveProfileId;
+```
+
+Update `Save()` to include profiles:
+
+```csharp
+var data = new ConfigData {
+    Servers = _servers, Settings = _settings, Window = _windowState,
+    ClosePreference = _closePreference, LastConnectedServerId = _lastConnectedServerId,
+    ZoomFactor = _zoomFactor, Profiles = _profiles, ActiveProfileId = _activeProfileId
+};
+```
+
+Add migration in `Load()` — after loading config (or after legacy migration), before the method returns, add:
+
+```csharp
+MigrateIdentityPfx();
+```
+
+Add the migration method:
+
+```csharp
+private void MigrateIdentityPfx()
+{
+    if (_profiles.Count > 0) return;
+
+    var oldCertPath = Path.Combine(_dir, "identity.pfx");
+    if (!File.Exists(oldCertPath)) return;
+
+    var id = Guid.NewGuid().ToString();
+    var certsDir = Path.Combine(_dir, "certs");
+    Directory.CreateDirectory(certsDir);
+    File.Move(oldCertPath, Path.Combine(certsDir, id + ".pfx"));
+
+    _profiles.Add(new ProfileEntry(id, "Default"));
+    _activeProfileId = id;
+    Save();
+}
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "ClassName~AppConfigServiceTests" -v n`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/Brmble.Client/Services/AppConfig/ tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+git commit -m "feat: add profile data model to AppConfigService with migration"
+```
+
+---
+
+### Task 2: Update CertificateService to Support Profiles
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Certificate/CertificateService.cs`
+- Modify: `src/Brmble.Client/Program.cs`
+
+**Step 1: Refactor CertificateService to accept a dynamic cert path**
+
+Replace the static `CertPath` property with a method that takes a profile ID:
+
+```csharp
+private readonly IAppConfigService _config;
+
+private string GetCertPath(string profileId) =>
+    Path.Combine(_config.GetCertsDir(), profileId + ".pfx");
+
+private string? ActiveCertPath =>
+    _config.GetActiveProfileId() is string id ? GetCertPath(id) : null;
+```
+
+Update the constructor to accept `IAppConfigService`:
+
+```csharp
+public CertificateService(NativeBridge bridge, IAppConfigService config)
+{
+    _bridge = bridge;
+    _config = config;
+}
+```
+
+**Step 2: Update all methods that reference `CertPath`**
+
+- `SendStatus()`: Replace `File.Exists(CertPath)` with `ActiveCertPath is string path && File.Exists(path)`, use `path` throughout.
+- `GenerateCertificate()`: This is now called only via `profiles.add` (Task 3). For now, add a `GenerateCertificate(string certPath)` overload that takes an explicit path. Keep the old `GenerateCertificate()` using `ActiveCertPath`.
+- `ImportCertificate(string base64Data)`: Same pattern — add `ImportCertificate(string base64Data, string certPath)` overload.
+- `ExportCertificate()`: Use `ActiveCertPath`.
+- `GetExportableCertificate()`: Use `ActiveCertPath`.
+
+Add public methods for profile-specific cert operations:
+
+```csharp
+internal void GenerateCertificateForProfile(string certPath)
+{
+    // Same as GenerateCertificate but writes to certPath instead of CertPath
+}
+
+internal void ImportCertificateForProfile(string base64Data, string certPath)
+{
+    // Same as ImportCertificate but writes to certPath instead of CertPath
+}
+```
+
+**Step 3: Update Program.cs**
+
+Change line 236:
+
+```csharp
+_certService = new CertificateService(_bridge, _appConfigService);
+```
+
+**Step 4: Run build to verify no compilation errors**
+
+Run: `dotnet build src/Brmble.Client/Brmble.Client.csproj`
+Expected: Build succeeded
+
+**Step 5: Run existing tests to verify no regressions**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj -v n`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Certificate/CertificateService.cs src/Brmble.Client/Program.cs
+git commit -m "refactor: make CertificateService profile-aware with dynamic cert paths"
+```
+
+---
+
+### Task 3: Add Profile Bridge Handlers
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Certificate/CertificateService.cs` (add `profiles.*` handlers)
+
+**Step 1: Add profiles bridge handlers in RegisterHandlers**
+
+Add these handlers alongside the existing `cert.*` handlers:
+
+```csharp
+bridge.RegisterHandler("profiles.list", _ =>
+{
+    var profiles = _config.GetProfiles().Select(p =>
+    {
+        var certPath = GetCertPath(p.Id);
+        string? fingerprint = null;
+        bool certValid = false;
+        if (File.Exists(certPath))
+        {
+            try
+            {
+                using var cert = X509CertificateLoader.LoadPkcs12FromFile(certPath, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                fingerprint = cert.Thumbprint;
+                certValid = true;
+            }
+            catch { }
+        }
+        return new { id = p.Id, name = p.Name, fingerprint, certValid };
+    }).ToList();
+    bridge.Send("profiles.list", new { profiles, activeProfileId = _config.GetActiveProfileId() });
+    return Task.CompletedTask;
+});
+
+bridge.RegisterHandler("profiles.add", data =>
+{
+    var name = data.TryGetProperty("name", out var n) ? n.GetString() ?? "Unnamed" : "Unnamed";
+    Task.Run(() =>
+    {
+        try
+        {
+            var id = Guid.NewGuid().ToString();
+            var certPath = GetCertPath(id);
+            Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
+
+            using var ecdsa = System.Security.Cryptography.ECDsa.Create(
+                System.Security.Cryptography.ECCurve.NamedCurves.nistP256);
+            var req = new System.Security.Cryptography.X509Certificates.CertificateRequest(
+                "CN=Brmble User", ecdsa, System.Security.Cryptography.HashAlgorithmName.SHA256);
+            var now = DateTimeOffset.UtcNow;
+            using var cert = req.CreateSelfSigned(now, now.AddYears(100));
+            File.WriteAllBytes(certPath, cert.Export(X509ContentType.Pfx));
+
+            var profile = new ProfileEntry(id, name);
+            _config.AddProfile(profile);
+
+            // If this is the first profile, make it active
+            if (_config.GetActiveProfileId() == null)
+            {
+                _config.SetActiveProfileId(id);
+                LoadActiveCertificate();
+                bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
+            }
+
+            bridge.Send("profiles.added", new { id, name, fingerprint = cert.Thumbprint, certValid = true });
+        }
+        catch (Exception ex)
+        {
+            bridge.Send("profiles.error", new { message = $"Failed to create profile: {ex.Message}" });
+        }
+    });
+    return Task.CompletedTask;
+});
+
+bridge.RegisterHandler("profiles.import", data =>
+{
+    var name = data.TryGetProperty("name", out var n) ? n.GetString() ?? "Unnamed" : "Unnamed";
+    var base64 = data.TryGetProperty("data", out var d) ? d.GetString() : null;
+    if (base64 == null)
+    {
+        bridge.Send("profiles.error", new { message = "No certificate data provided." });
+        return Task.CompletedTask;
+    }
+    Task.Run(() =>
+    {
+        try
+        {
+            var bytes = Convert.FromBase64String(base64);
+            var testCert = X509CertificateLoader.LoadPkcs12(bytes, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+
+            var id = Guid.NewGuid().ToString();
+            var certPath = GetCertPath(id);
+            Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
+            File.WriteAllBytes(certPath, bytes);
+
+            var profile = new ProfileEntry(id, name);
+            _config.AddProfile(profile);
+
+            if (_config.GetActiveProfileId() == null)
+            {
+                _config.SetActiveProfileId(id);
+                LoadActiveCertificate();
+                bridge.Send("profiles.activeChanged", new { id, name, fingerprint = testCert.Thumbprint });
+            }
+
+            bridge.Send("profiles.added", new { id, name, fingerprint = testCert.Thumbprint, certValid = true });
+        }
+        catch (Exception ex)
+        {
+            bridge.Send("profiles.error", new { message = $"Failed to import profile: {ex.Message}" });
+        }
+    });
+    return Task.CompletedTask;
+});
+
+bridge.RegisterHandler("profiles.remove", data =>
+{
+    var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+    if (id == null) return Task.CompletedTask;
+
+    var wasActive = _config.GetActiveProfileId() == id;
+    _config.RemoveProfile(id);
+    bridge.Send("profiles.removed", new { id });
+
+    if (wasActive)
+    {
+        var newActiveId = _config.GetActiveProfileId();
+        if (newActiveId != null)
+        {
+            var newProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == newActiveId);
+            LoadActiveCertificate();
+            bridge.Send("profiles.activeChanged", new { id = newActiveId, name = newProfile?.Name, fingerprint = ActiveCertificate?.Thumbprint });
+        }
+        else
+        {
+            ActiveCertificate = null;
+            bridge.Send("profiles.activeChanged", new { id = (string?)null, name = (string?)null, fingerprint = (string?)null });
+            bridge.Send("cert.status", new { exists = false });
+        }
+    }
+    return Task.CompletedTask;
+});
+
+bridge.RegisterHandler("profiles.rename", data =>
+{
+    var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+    var name = data.TryGetProperty("name", out var n) ? n.GetString() : null;
+    if (id == null || name == null) return Task.CompletedTask;
+
+    _config.RenameProfile(id, name);
+    bridge.Send("profiles.renamed", new { id, name });
+
+    if (_config.GetActiveProfileId() == id)
+        bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
+
+    return Task.CompletedTask;
+});
+
+bridge.RegisterHandler("profiles.setActive", data =>
+{
+    var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+    if (id == null) return Task.CompletedTask;
+
+    // TODO: Check connection status — for now, trust the frontend to disable this when connected
+    _config.SetActiveProfileId(id);
+    LoadActiveCertificate();
+
+    var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+    bridge.Send("profiles.activeChanged", new { id, name = profile?.Name, fingerprint = ActiveCertificate?.Thumbprint });
+    bridge.Send("cert.status", new { exists = ActiveCertificate != null, fingerprint = ActiveCertificate?.Thumbprint, subject = ActiveCertificate?.Subject });
+    return Task.CompletedTask;
+});
+```
+
+**Step 2: Add LoadActiveCertificate helper**
+
+```csharp
+private void LoadActiveCertificate()
+{
+    ActiveCertificate = null;
+    if (ActiveCertPath is string path && File.Exists(path))
+    {
+        try
+        {
+            ActiveCertificate = X509CertificateLoader.LoadPkcs12FromFile(path, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+        }
+        catch { }
+    }
+}
+```
+
+**Step 3: Update SendStatus to use LoadActiveCertificate**
+
+```csharp
+private void SendStatus()
+{
+    LoadActiveCertificate();
+    if (ActiveCertificate != null)
+    {
+        _bridge.Send("cert.status", new
+        {
+            exists = true,
+            fingerprint = ActiveCertificate.Thumbprint,
+            subject = ActiveCertificate.Subject
+        });
+    }
+    else
+    {
+        _bridge.Send("cert.status", new { exists = false });
+    }
+}
+```
+
+**Step 4: Run build**
+
+Run: `dotnet build src/Brmble.Client/Brmble.Client.csproj`
+Expected: Build succeeded
+
+**Step 5: Run all tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj -v n`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Certificate/CertificateService.cs
+git commit -m "feat: add profiles.* bridge handlers for multi-profile management"
+```
+
+---
+
+### Task 4: Add useProfiles Hook (Frontend)
+
+**Files:**
+- Create: `src/Brmble.Web/src/hooks/useProfiles.ts`
+
+**Step 1: Create the hook**
+
+Model after `useServerlist.ts`. The hook manages profile state via bridge messages:
+
+```typescript
+import { useState, useEffect } from 'react';
+import bridge from '../bridge';
+
+export interface Profile {
+  id: string;
+  name: string;
+  fingerprint: string | null;
+  certValid: boolean;
+}
+
+export function useProfiles() {
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const onList = (data: unknown) => {
+      const d = data as { profiles: Profile[]; activeProfileId: string | null };
+      setProfiles(d.profiles ?? []);
+      setActiveProfileId(d.activeProfileId ?? null);
+      setLoading(false);
+    };
+
+    const onAdded = (data: unknown) => {
+      const d = data as Profile;
+      setProfiles(prev => [...prev, d]);
+    };
+
+    const onRemoved = (data: unknown) => {
+      const d = data as { id: string };
+      setProfiles(prev => prev.filter(p => p.id !== d.id));
+    };
+
+    const onRenamed = (data: unknown) => {
+      const d = data as { id: string; name: string };
+      setProfiles(prev => prev.map(p => p.id === d.id ? { ...p, name: d.name } : p));
+    };
+
+    const onActiveChanged = (data: unknown) => {
+      const d = data as { id: string | null; name: string | null; fingerprint: string | null };
+      setActiveProfileId(d.id);
+    };
+
+    bridge.on('profiles.list', onList);
+    bridge.on('profiles.added', onAdded);
+    bridge.on('profiles.removed', onRemoved);
+    bridge.on('profiles.renamed', onRenamed);
+    bridge.on('profiles.activeChanged', onActiveChanged);
+    bridge.send('profiles.list');
+
+    return () => {
+      bridge.off('profiles.list', onList);
+      bridge.off('profiles.added', onAdded);
+      bridge.off('profiles.removed', onRemoved);
+      bridge.off('profiles.renamed', onRenamed);
+      bridge.off('profiles.activeChanged', onActiveChanged);
+    };
+  }, []);
+
+  const addProfile = (name: string) => {
+    bridge.send('profiles.add', { name });
+  };
+
+  const importProfile = (name: string, data: string) => {
+    bridge.send('profiles.import', { name, data });
+  };
+
+  const removeProfile = (id: string) => {
+    bridge.send('profiles.remove', { id });
+  };
+
+  const renameProfile = (id: string, name: string) => {
+    bridge.send('profiles.rename', { id, name });
+  };
+
+  const setActive = (id: string) => {
+    bridge.send('profiles.setActive', { id });
+  };
+
+  const exportCert = () => {
+    bridge.send('cert.export');
+  };
+
+  return { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert };
+}
+```
+
+**Step 2: Build frontend to verify no TS errors**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useProfiles.ts
+git commit -m "feat: add useProfiles hook for profile management bridge communication"
+```
+
+---
+
+### Task 5: Create ProfilesSettingsTab Component
+
+**Files:**
+- Create: `src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.tsx`
+- Create: `src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css`
+
+**Step 1: Create the CSS file**
+
+Follow ServerList.css patterns. Use design tokens from UI_GUIDE.md:
+
+```css
+/* Profile list items */
+.profiles-items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.profiles-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  transition: all var(--transition-fast);
+  animation: profileItemFadeIn 0.3s ease-out both;
+}
+
+.profiles-item:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent-primary);
+  transform: translateX(4px);
+}
+
+.profiles-item-active {
+  border-color: var(--accent-primary);
+  box-shadow: inset 0 0 0 1px var(--accent-primary-ghost);
+}
+
+/* Profile icon (first letter) */
+.profiles-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+/* Profile info */
+.profiles-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.profiles-name {
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.profiles-fingerprint {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.profiles-active-badge {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  color: var(--accent-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.profiles-cert-error {
+  font-size: var(--text-2xs);
+  color: var(--accent-danger);
+}
+
+/* Profile actions */
+.profiles-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+/* Inline form (mirrors server-list-form) */
+.profiles-form {
+  margin-top: var(--space-lg);
+  padding: var(--space-lg);
+  background: var(--bg-deep-glass);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  animation: formSlideIn 0.25s ease-out;
+}
+
+.profiles-form-title {
+  margin-bottom: var(--space-md) !important;
+}
+
+.profiles-form-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.profiles-form-actions {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.profiles-form-actions .btn {
+  flex: 1;
+}
+
+.profiles-form-mode-buttons {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.profiles-form-mode-buttons .btn {
+  flex: 1;
+}
+
+/* Add button (mirrors server-list-add-btn) */
+.profiles-add-btn {
+  width: 100%;
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  border: 2px dashed var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: transparent;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+}
+
+.profiles-add-btn:hover {
+  border-color: var(--accent-primary);
+  border-style: solid;
+  color: var(--accent-primary);
+  background: var(--accent-primary-ghost);
+}
+
+.profiles-add-icon {
+  color: var(--accent-primary);
+  font-size: var(--text-lg);
+}
+
+/* Empty state */
+.profiles-empty {
+  text-align: center;
+  padding: var(--space-xl) var(--space-md);
+  color: var(--text-muted);
+}
+
+.profiles-empty-hint {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin-top: var(--space-xs);
+}
+
+@keyframes profileItemFadeIn {
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+```
+
+**Step 2: Create the component**
+
+```tsx
+import { useState, useEffect } from 'react';
+import './ProfilesSettingsTab.css';
+import { useProfiles } from '../../hooks/useProfiles';
+import type { Profile } from '../../hooks/useProfiles';
+import { Tooltip } from '../Tooltip/Tooltip';
+import { usePrompt } from '../../hooks/usePrompt';
+
+interface ProfilesSettingsTabProps {
+  connected: boolean;
+}
+
+export function ProfilesSettingsTab({ connected }: ProfilesSettingsTabProps) {
+  const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert } = useProfiles();
+  const { confirm } = usePrompt();
+  const [isAdding, setIsAdding] = useState(false);
+  const [editing, setEditing] = useState<Profile | null>(null);
+  const [formName, setFormName] = useState('');
+  const [formMode, setFormMode] = useState<'generate' | 'import' | null>(null);
+  const [importData, setImportData] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsAdding(false);
+        setEditing(null);
+        resetForm();
+      }
+    };
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, []);
+
+  const resetForm = () => {
+    setFormName('');
+    setFormMode(null);
+    setImportData(null);
+  };
+
+  const handleStartAdd = () => {
+    setEditing(null);
+    setIsAdding(true);
+    resetForm();
+  };
+
+  const handleStartEdit = (profile: Profile) => {
+    setIsAdding(false);
+    setEditing(profile);
+    setFormName(profile.name);
+  };
+
+  const handleCancel = () => {
+    setIsAdding(false);
+    setEditing(null);
+    resetForm();
+  };
+
+  const handleSaveNew = () => {
+    if (!formName.trim()) return;
+    if (formMode === 'import' && importData) {
+      importProfile(formName.trim(), importData);
+    } else if (formMode === 'generate') {
+      addProfile(formName.trim());
+    }
+    setIsAdding(false);
+    resetForm();
+  };
+
+  const handleSaveEdit = () => {
+    if (!editing || !formName.trim()) return;
+    renameProfile(editing.id, formName.trim());
+    setEditing(null);
+    resetForm();
+  };
+
+  const handleDelete = async (profile: Profile) => {
+    const confirmed = await confirm(
+      `Delete profile "${profile.name}"?`,
+      'The certificate file will remain on disk and can be re-imported later.'
+    );
+    if (confirmed) {
+      removeProfile(profile.id);
+      if (editing?.id === profile.id) {
+        setEditing(null);
+        resetForm();
+      }
+    }
+  };
+
+  const handleImportFile = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.pfx,.p12';
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64 = (reader.result as string).split(',')[1];
+        setImportData(base64);
+        setFormMode('import');
+      };
+      reader.readAsDataURL(file);
+    };
+    input.click();
+  };
+
+  const truncateFingerprint = (fp: string | null) => {
+    if (!fp) return 'No certificate';
+    return fp.substring(0, 16).toUpperCase() + '...';
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="settings-section">
+      <h3 className="heading-section settings-section-title">Profiles</h3>
+
+      {profiles.length > 0 ? (
+        <div className="profiles-items">
+          {profiles.map((profile, index) => (
+            <div
+              key={profile.id}
+              className={`profiles-item ${profile.id === activeProfileId ? 'profiles-item-active' : ''}`}
+              style={{ animationDelay: `${index * 50}ms` }}
+            >
+              <div className="profiles-icon">
+                {profile.name.charAt(0).toUpperCase()}
+              </div>
+              <div className="profiles-info">
+                <span className="profiles-name">{profile.name}</span>
+                {profile.certValid ? (
+                  <span className="profiles-fingerprint">{truncateFingerprint(profile.fingerprint)}</span>
+                ) : (
+                  <span className="profiles-cert-error">Certificate missing or invalid</span>
+                )}
+                {profile.id === activeProfileId && (
+                  <span className="profiles-active-badge">Active</span>
+                )}
+              </div>
+              <div className="profiles-actions">
+                {profile.id !== activeProfileId && (
+                  <Tooltip content={connected ? 'Disconnect first' : 'Set as active profile'} position="top">
+                    <button
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => setActive(profile.id)}
+                      disabled={connected || !profile.certValid}
+                    >
+                      Activate
+                    </button>
+                  </Tooltip>
+                )}
+                <Tooltip content="Edit profile name" position="top">
+                  <button
+                    className="btn btn-secondary btn-sm"
+                    onClick={() => handleStartEdit(profile)}
+                  >
+                    Edit
+                  </button>
+                </Tooltip>
+                {profile.id === activeProfileId && (
+                  <Tooltip content="Export certificate" position="top">
+                    <button
+                      className="btn btn-ghost btn-sm"
+                      onClick={() => exportCert()}
+                    >
+                      Export
+                    </button>
+                  </Tooltip>
+                )}
+                <Tooltip content="Delete profile" position="top">
+                  <button
+                    className="btn btn-ghost btn-sm btn-danger"
+                    onClick={() => handleDelete(profile)}
+                    style={{ width: 32, height: 32 }}
+                  >
+                    ×
+                  </button>
+                </Tooltip>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="profiles-empty">
+          <p>No profiles yet</p>
+          <p className="profiles-empty-hint">Create a profile to get started</p>
+        </div>
+      )}
+
+      {(isAdding || editing) && (
+        <form className="profiles-form" onSubmit={(e) => { e.preventDefault(); isAdding ? handleSaveNew() : handleSaveEdit(); }}>
+          <h3 className="heading-section profiles-form-title">
+            {isAdding ? 'New Profile' : 'Edit Profile'}
+          </h3>
+          <div className="profiles-form-fields">
+            <label>
+              Profile Name
+              <input
+                className="brmble-input"
+                type="text"
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+                placeholder="e.g. Personal, Work"
+                autoFocus
+              />
+            </label>
+
+            {isAdding && !formMode && (
+              <div className="profiles-form-mode-buttons">
+                <button type="button" className="btn btn-primary" onClick={() => setFormMode('generate')}>
+                  Generate New Certificate
+                </button>
+                <button type="button" className="btn btn-secondary" onClick={handleImportFile}>
+                  Import Certificate
+                </button>
+              </div>
+            )}
+
+            {isAdding && formMode === 'import' && (
+              <p style={{ color: 'var(--text-secondary)', fontSize: 'var(--text-xs)' }}>
+                Certificate loaded. Click Save to create the profile.
+              </p>
+            )}
+          </div>
+
+          <div className="profiles-form-actions">
+            <button type="button" className="btn btn-secondary" onClick={handleCancel}>
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={!formName.trim() || (isAdding && !formMode)}
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      )}
+
+      {!isAdding && !editing && (
+        <button className="btn btn-ghost profiles-add-btn" onClick={handleStartAdd}>
+          <span className="profiles-add-icon">+</span> Add Profile
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+**Step 3: Build frontend**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.tsx src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
+git commit -m "feat: add ProfilesSettingsTab component with ServerList-style layout"
+```
+
+---
+
+### Task 6: Wire ProfilesSettingsTab into SettingsModal
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx`
+
+**Step 1: Add the import**
+
+At the top of the file (after line 11):
+
+```typescript
+import { ProfilesSettingsTab } from './ProfilesSettingsTab';
+```
+
+**Step 2: Add 'profiles' to the tab type**
+
+Find the `activeTab` useState (line 75) and update the type union to include `'profiles'`:
+
+```typescript
+const [activeTab, setActiveTab] = useState<'profile' | 'profiles' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection'>('profile');
+```
+
+**Step 3: Add the Profiles tab button**
+
+After the Profile tab button (after the `</button>` closing tag around line 306), add:
+
+```tsx
+<button
+  className={`settings-tab ${activeTab === 'profiles' ? 'active' : ''}`}
+  onClick={() => setActiveTab('profiles')}
+>
+  Profiles
+</button>
+```
+
+**Step 4: Add the Profiles tab content**
+
+In the settings-content div (after the profile tab rendering, around line 350), add:
+
+```tsx
+{activeTab === 'profiles' && (
+  <ProfilesSettingsTab connected={props.connected ?? false} />
+)}
+```
+
+**Step 5: Build frontend**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+git commit -m "feat: wire ProfilesSettingsTab into SettingsModal as new tab"
+```
+
+---
+
+### Task 7: Update App.tsx for Profile-Aware State
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+
+**Step 1: Add activeProfileName state**
+
+Near the existing cert state (around line 135), add:
+
+```typescript
+const [activeProfileName, setActiveProfileName] = useState('');
+```
+
+**Step 2: Add profiles.activeChanged listener**
+
+In the useEffect where bridge listeners are set up (near the cert handlers around line 901-919), add:
+
+```typescript
+const onProfilesActiveChanged = (data: unknown) => {
+  const d = data as { id: string | null; name: string | null; fingerprint: string | null };
+  if (d.id) {
+    setCertExists(true);
+    setCertFingerprint(d.fingerprint ?? '');
+    setActiveProfileName(d.name ?? '');
+  } else {
+    setCertExists(false);
+    setCertFingerprint('');
+    setActiveProfileName('');
+  }
+};
+bridge.on('profiles.activeChanged', onProfilesActiveChanged);
+```
+
+And in the cleanup return, add:
+
+```typescript
+bridge.off('profiles.activeChanged', onProfilesActiveChanged);
+```
+
+**Step 3: Request profiles on mount**
+
+In the cert.requestStatus useEffect (around line 1058-1060), also request profiles:
+
+```typescript
+useEffect(() => {
+  bridge.send('cert.requestStatus');
+  bridge.send('profiles.list');
+}, []);
+```
+
+Add a listener for the initial profiles.list response to set activeProfileName:
+
+```typescript
+const onInitialProfilesList = (data: unknown) => {
+  const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null };
+  if (d.activeProfileId) {
+    const active = d.profiles.find(p => p.id === d.activeProfileId);
+    if (active) setActiveProfileName(active.name);
+  }
+};
+bridge.on('profiles.list', onInitialProfilesList);
+// Clean up after first response — handled by the useProfiles hook in settings
+```
+
+**Step 4: Use activeProfileName as fallback username for server connection**
+
+In the `handleServerConnect` function (or `handleConnect`), when building the connection params, if the server's `username` is empty, use `activeProfileName`:
+
+Find the server connect handler and update:
+
+```typescript
+const connectUsername = server.username || activeProfileName || 'Brmble User';
+```
+
+**Step 5: Build frontend**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx
+git commit -m "feat: add profile-aware state and activeProfileName fallback for connections"
+```
+
+---
+
+### Task 8: Extend CertWizard with Profile Name Field
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/CertWizard/CertWizard.tsx`
+
+**Step 1: Add profileName state**
+
+After the existing state declarations (around line 12-15):
+
+```typescript
+const [profileName, setProfileName] = useState('');
+```
+
+**Step 2: Add a name input to the 'choose' step**
+
+In the `choose` step rendering (around line 150-171), add a text input before the generate/import buttons:
+
+```tsx
+<label>
+  Profile Name
+  <input
+    className="brmble-input"
+    type="text"
+    value={profileName}
+    onChange={(e) => setProfileName(e.target.value)}
+    placeholder="e.g. Your Name"
+    autoFocus
+  />
+</label>
+```
+
+Disable the generate/import buttons when `profileName` is empty.
+
+**Step 3: Change cert.generate to profiles.add**
+
+Replace the `bridge.send('cert.generate')` call (around line 60-63) with:
+
+```typescript
+bridge.send('profiles.add', { name: profileName });
+```
+
+And the import path to use:
+
+```typescript
+bridge.send('profiles.import', { name: profileName, data: base64Data });
+```
+
+**Step 4: Listen for profiles.added instead of cert.generated/cert.imported**
+
+Update the bridge listeners in the useEffect:
+
+```typescript
+const onProfileAdded = (data: unknown) => {
+  const d = data as { fingerprint?: string };
+  setFingerprint(d?.fingerprint ?? '');
+  setStep('backup');
+  setLoading(false);
+};
+bridge.on('profiles.added', onProfileAdded);
+```
+
+Clean up the old `cert.generated` and `cert.imported` listeners (they are no longer needed for the wizard flow).
+
+**Step 5: Build frontend**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
+git commit -m "feat: extend CertWizard to create profile with name on first launch"
+```
+
+---
+
+### Task 9: Build, Verify, and Final Commit
+
+**Files:**
+- All modified files
+
+**Step 1: Build backend**
+
+Run: `dotnet build src/Brmble.Client/Brmble.Client.csproj`
+Expected: Build succeeded
+
+**Step 2: Run all backend tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj -v n`
+Expected: ALL PASS
+
+**Step 3: Build frontend**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Build frontend assets**
+
+Run: `cd src/Brmble.Web && npm run build`
+Expected: Build succeeded
+
+**Step 5: Verify no uncommitted changes**
+
+Run: `git status`
+Expected: Clean working tree
+
+**Step 6: Done**
+
+All tasks complete. The multi-profile system is implemented with:
+- Profile data model in AppConfigService with migration from identity.pfx
+- Profile-aware CertificateService with dynamic cert paths
+- Full profiles.* bridge protocol
+- useProfiles hook for frontend state management
+- ProfilesSettingsTab in Settings with ServerList-style layout
+- Profile-aware App.tsx with activeProfileName fallback
+- CertWizard extended to create first profile with a name

--- a/docs/plans/2026-03-20-mumble-registration-detection-design.md
+++ b/docs/plans/2026-03-20-mumble-registration-detection-design.md
@@ -1,0 +1,68 @@
+# Mumble Registration Detection Design
+
+## Problem
+
+When a user is registered on a Mumble server, the server overrides whatever username the client sends and uses the registered name instead. The client currently has no way to know this happened (except through the Brmble Server API, which only works for servers running Brmble Server). We need to detect registration status from the Mumble protocol itself and display the registered name in the server edit form.
+
+## Approach
+
+Read `UserState.user_id` and `UserState.hash` from the Mumble protocol — fields that are already deserialized by MumbleSharp but currently discarded. This works with any Mumble server, not just ones running Brmble Server. The existing Brmble Server API check remains as the primary source; protocol-level detection serves as a fallback for plain Mumble servers.
+
+## Design
+
+### Layer 1: MumbleSharp User Model
+
+Add properties to the `User` model in `lib/MumbleSharp/`:
+
+- `RegisteredUserId` (`uint?`) — from `UserState.user_id`. Null means not registered.
+- `CertificateHash` (`string?`) — from `UserState.hash`.
+- `IsRegistered` (`bool`, computed) — returns `RegisteredUserId != null`.
+
+Update `BasicMumbleProtocol.UserState()` to read these two fields from incoming messages and store them on the `User` object. The protobuf fields are already deserialized; the handler just ignores them today.
+
+These properties apply to all users, not just the local user. For now we only use `LocalUser`'s values.
+
+### Layer 2: MumbleAdapter Bridge Messages
+
+After connecting (and after auto-registration completes), MumbleAdapter checks `LocalUser.IsRegistered` and sends:
+
+```
+voice.registrationStatus → {
+  registered: bool,
+  registeredName: string | null   // LocalUser.Name when registered
+}
+```
+
+Timing:
+1. After initial connection completes (within the `voice.connected` flow).
+2. After auto-registration completes — hook into the `UserState` update that sets `LocalUser.RegisteredUserId`.
+
+MumbleAdapter also persists the registration info to the server entry config via `servers.update`, so the data is available even when disconnected. Values refresh on each new connection.
+
+### Layer 3: Frontend — Username Field in Server Edit Form
+
+**When registered (`registered === true`):**
+- Username field shows `registeredName` (the server-assigned name).
+- Field is disabled (non-editable) — already implemented.
+- A checkmark icon (SVG) appears inside the input on the right side.
+- Tooltip: "Registered as [name] on this server".
+
+**When not registered:**
+- Username field is editable, no checkmark.
+- Falls back to active profile name if empty (existing behavior).
+
+CSS: Wrap the input in a container with a positioned checkmark icon when `registered` is true. Use design tokens for the checkmark color.
+
+No changes to the server list card view — registration status only appears in the edit form.
+
+### Data Persistence
+
+The `ServerEntry` TypeScript interface already has an optional `registered` field. We add `registeredName` (optional string) alongside it. Both are persisted to config.json and refreshed on each connection.
+
+The C# `ServerEntry` record does not currently have these fields — they are stored as extra properties in the JSON and handled by the bridge message layer. No C# record change needed if the existing config serialization is flexible enough; otherwise add `Registered` and `RegisteredName` fields.
+
+## Out of Scope
+
+- Showing registration status for other users (possible with the same data, deferred).
+- Showing registration status on the server list card (user chose edit form only).
+- Removing the Brmble Server API registration check (kept as primary source).

--- a/docs/plans/2026-03-20-mumble-registration-detection-implementation.md
+++ b/docs/plans/2026-03-20-mumble-registration-detection-implementation.md
@@ -1,0 +1,293 @@
+# Mumble Registration Detection Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Detect Mumble registration status from the protocol and display the registered name (with checkmark) in the server edit form's username field.
+
+**Architecture:** Patch MumbleSharp's User model and BasicMumbleProtocol to read `UserState.user_id` and `UserState.hash` from incoming messages. MumbleAdapter sends registration status to the frontend after connection and after auto-registration. The frontend persists it to config and shows the registered name in a disabled username field with a checkmark icon.
+
+**Tech Stack:** C# (MumbleSharp, Brmble.Client), TypeScript/React (Brmble.Web), CSS
+
+---
+
+### Task 1: Add Registration Properties to MumbleSharp User Model
+
+**Files:**
+- Modify: `lib/MumbleSharp/MumbleSharp/Model/User.cs:24` (after ListeningVolumeAdjustments)
+
+**Step 1: Add the three new properties**
+
+After line 24 (`ListeningVolumeAdjustments`), before line 26 (`_channel`), add:
+
+```csharp
+public uint? RegisteredUserId { get; set; }
+public string CertificateHash { get; set; }
+public bool IsRegistered => RegisteredUserId.HasValue;
+```
+
+**Step 2: Build to verify compilation**
+
+Run: `dotnet build lib/MumbleSharp/MumbleSharp/MumbleSharp.csproj`
+Expected: Build succeeded.
+
+**Step 3: Commit**
+
+```bash
+git add lib/MumbleSharp/MumbleSharp/Model/User.cs
+git commit -m "feat: add RegisteredUserId, CertificateHash, IsRegistered to MumbleSharp User model"
+```
+
+---
+
+### Task 2: Read Registration Fields in BasicMumbleProtocol.UserState()
+
+**Files:**
+- Modify: `lib/MumbleSharp/MumbleSharp/BasicMumbleProtocol.cs:414` (after Comment handling, before ChannelId handling)
+
+**Step 1: Add UserId and Hash reading**
+
+After line 414 (the closing brace of the Comment block) and before line 416 (the ChannelId block), insert:
+
+```csharp
+                if (userState.ShouldSerializeUserId())
+                {
+                    user.RegisteredUserId = userState.UserId;
+                }
+                if (userState.ShouldSerializeHash())
+                {
+                    user.CertificateHash = userState.Hash;
+                }
+```
+
+This follows the exact same pattern as all the other field reads in this method (`ShouldSerializeX()` → set property).
+
+**Step 2: Build to verify compilation**
+
+Run: `dotnet build lib/MumbleSharp/MumbleSharp/MumbleSharp.csproj`
+Expected: Build succeeded.
+
+**Step 3: Commit**
+
+```bash
+git add lib/MumbleSharp/MumbleSharp/BasicMumbleProtocol.cs
+git commit -m "feat: read UserState.user_id and hash in BasicMumbleProtocol"
+```
+
+---
+
+### Task 3: Send Registration Status from MumbleAdapter
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`
+  - In `SendVoiceConnected()` (line ~2003): add registration fields to the payload
+  - In `UserState` override or callback: detect registration changes for the local user
+
+**Step 1: Add registration fields to `voice.connected` payload**
+
+In `SendVoiceConnected()` at line ~2021, update the `_bridge?.Send("voice.connected", ...)` call. Add `registered` and `registeredName` to the anonymous object:
+
+```csharp
+_bridge?.Send("voice.connected", new
+{
+    username = LocalUser?.Name,
+    channelId,
+    channels,
+    users,
+    registered = LocalUser?.IsRegistered ?? false,
+    registeredName = LocalUser?.IsRegistered == true ? LocalUser.Name : (string)null
+});
+```
+
+**Step 2: Send registration update when UserState changes for local user**
+
+Override `UserStateChanged` (or use the existing override) to detect when `LocalUser` becomes registered after auto-registration. Find the existing `UserStateChanged` or `UserStateNameChanged` override in MumbleAdapter.
+
+When `LocalUser.IsRegistered` becomes true, send a bridge message to update the server entry:
+
+```csharp
+// Inside the UserState change handler for the local user:
+if (user == LocalUser && user.IsRegistered && _activeServerId != null)
+{
+    _bridge?.Send("voice.registrationStatus", new
+    {
+        serverId = _activeServerId,
+        registered = true,
+        registeredName = user.Name
+    });
+}
+```
+
+Note: `_activeServerId` is already set in the `voice.connect` handler (line ~1479).
+
+**Step 3: Build to verify compilation**
+
+Run: `dotnet build src/Brmble.Client/Brmble.Client.csproj`
+Expected: Build succeeded.
+
+**Step 4: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+git commit -m "feat: send registration status in voice.connected and on UserState changes"
+```
+
+---
+
+### Task 4: Add `registeredName` to Frontend ServerEntry and Handle Bridge Messages
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useServerlist.ts:11` (add `registeredName` to interface)
+- Modify: `src/Brmble.Web/src/App.tsx` (add `voice.registrationStatus` handler, update `voice.connected` handler)
+
+**Step 1: Add `registeredName` to ServerEntry interface**
+
+In `useServerlist.ts` at line 11, after `registered?: boolean;` add:
+
+```typescript
+registeredName?: string;
+```
+
+**Step 2: Also update the `SavedServer` interface in App.tsx**
+
+In `App.tsx` at line ~101, after `registered?: boolean;` add:
+
+```typescript
+registeredName?: string;
+```
+
+**Step 3: Update `voice.connected` handler in App.tsx**
+
+In the existing `voice.connected` handler (lines ~514-546), read the new `registered` and `registeredName` fields from the payload and persist them to the server entry:
+
+```typescript
+// After setting username, channels, users:
+const reg = d as { registered?: boolean; registeredName?: string };
+if (reg?.registered && savedServer?.id) {
+  const updated = { ...savedServer, registered: true, username: reg.registeredName ?? savedServer.username, registeredName: reg.registeredName };
+  bridge.send('servers.update', updated);
+  // Also update localStorage
+  localStorage.setItem('brmble-server', JSON.stringify(updated));
+}
+```
+
+**Step 4: Add `voice.registrationStatus` handler**
+
+Register a new bridge handler for `voice.registrationStatus` that updates the server entry when registration status changes mid-session (e.g., after auto-registration):
+
+```typescript
+const onRegistrationStatus = (data: unknown) => {
+  const d = data as { serverId?: string; registered?: boolean; registeredName?: string } | undefined;
+  if (!d?.registered || !d.serverId) return;
+  // Update via servers.update bridge message
+  bridge.send('servers.update', { id: d.serverId, registered: true, registeredName: d.registeredName });
+};
+bridge.on('voice.registrationStatus', onRegistrationStatus);
+// cleanup: bridge.off('voice.registrationStatus', onRegistrationStatus);
+```
+
+**Step 5: Build to verify**
+
+Run from `src/Brmble.Web`: `npm run build`
+Expected: Build succeeded.
+
+**Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useServerlist.ts src/Brmble.Web/src/App.tsx
+git commit -m "feat: handle registration status in frontend and persist to server entries"
+```
+
+---
+
+### Task 5: Update ServerList Username Field UI with Checkmark
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/ServerList/ServerList.tsx:240-247` (username input)
+- Modify: `src/Brmble.Web/src/components/ServerList/ServerList.css` (add checkmark styles)
+
+**Step 1: Update the username field to show registeredName and checkmark**
+
+Replace the username input block (lines 240-247) with:
+
+```tsx
+<div className="server-list-username-wrapper">
+  <input
+    className={`brmble-input server-list-input${editing?.registered ? ' server-list-input-registered' : ''}`}
+    placeholder="Username"
+    value={editing?.registered ? (editing.registeredName ?? form.username) : form.username}
+    onChange={e => setForm(f => ({ ...f, username: e.target.value }))}
+    disabled={editing?.registered === true}
+    title={editing?.registered ? `Registered as "${editing.registeredName}" on this server` : undefined}
+  />
+  {editing?.registered && (
+    <svg className="server-list-registered-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-label="Registered">
+      <polyline points="3.5 8 6.5 11 12.5 5" />
+    </svg>
+  )}
+</div>
+```
+
+Note: The `editing` object needs to carry `registeredName`. Check the `handleEdit` function (lines 41-53) to make sure it passes the full server entry including `registeredName`. The `editing` state type may need updating.
+
+**Step 2: Add CSS for the username wrapper and checkmark icon**
+
+Add to `ServerList.css`:
+
+```css
+.server-list-username-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.server-list-input-registered {
+  padding-right: var(--space-xl) !important;
+}
+
+.server-list-registered-icon {
+  position: absolute;
+  right: var(--space-sm);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--accent-success, #4ade80);
+  pointer-events: none;
+}
+```
+
+This follows the same pattern as `.server-list-password-wrapper` and `.server-list-password-toggle` already in the CSS (lines 292-319).
+
+**Step 3: Ensure `editing` state includes `registeredName`**
+
+The `editing` state (line ~15) is set from the servers array. Make sure the `ServerEntry` type flowing through includes `registeredName`. If the `handleEdit` function (line ~41) spreads the server object, it should already pass through `registeredName` since it's on the `ServerEntry` interface. Verify this.
+
+**Step 4: Build to verify**
+
+Run from `src/Brmble.Web`: `npm run build`
+Expected: Build succeeded.
+
+**Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/ServerList/ServerList.tsx src/Brmble.Web/src/components/ServerList/ServerList.css
+git commit -m "feat: show registered name with checkmark icon in server edit form"
+```
+
+---
+
+### Task 6: Full Build Verification
+
+**Step 1: Run all .NET tests**
+
+Run: `dotnet test`
+Expected: All tests pass (52 client + 68 voice engine + server tests).
+
+**Step 2: Run frontend build**
+
+Run from `src/Brmble.Web`: `npm run build`
+Expected: Build succeeded, no TypeScript errors.
+
+**Step 3: Manual testing checklist**
+
+- Connect to a Mumble server where you ARE registered → username field should show the registered name, be disabled, and display a checkmark icon
+- Connect to a Mumble server where you are NOT registered → username field should be editable, no checkmark
+- Disconnect and reopen edit form → persisted `registered` + `registeredName` should still show
+- After auto-registration completes on a new server → registration status should update via `voice.registrationStatus` bridge message

--- a/docs/plans/2026-03-20-profile-tab-consolidation-design.md
+++ b/docs/plans/2026-03-20-profile-tab-consolidation-design.md
@@ -1,0 +1,37 @@
+# Profile Tab Consolidation Design
+
+Merge the separate "Profile" and "Profiles" settings tabs into a single "Profile" tab.
+
+## Current State
+
+- **Profile tab** (`ProfileSettingsTab`): Avatar section, Certificate section (fingerprint + server username), Manage section (global export/import)
+- **Profiles tab** (`ProfilesSettingsTab`): Profile list with per-profile activate/edit/export/delete, inline add form
+
+## New Layout (single "Profile" tab)
+
+### Section 1: Avatar (unchanged)
+Avatar display, name, upload/remove buttons. No changes.
+
+### Section 2: Profile (replaces "Certificate")
+- Dropdown/select to switch active profile (disabled when connected)
+- Removes fingerprint display and "current server username"
+
+### Section 3: Manage Profiles (replaces "Manage")
+- Full profile list from ProfilesSettingsTab: items with icon, name, fingerprint, activate/edit/export/delete
+- Inline add form (name + generate/import)
+- Dashed "+ Add Profile" button
+- Per-profile export already handled via Export button on each item
+- Old global export/import buttons removed (redundant)
+
+## Removals
+- "Profiles" tab button from tab bar
+- `ProfilesSettingsTab` as standalone tab (content migrates into `ProfileSettingsTab`)
+- Fingerprint display from old Certificate section
+- "Current server username" display
+- Old global Export/Import certificate buttons
+
+## Changes
+- "Certificate" header -> "Profile" with dropdown
+- "Manage" header -> "Manage Profiles" with profile list
+- `ProfileSettingsTab` imports `useProfiles` hook
+- `SettingsModal` removes 'profiles' tab type and button

--- a/docs/plans/2026-03-20-profile-tab-consolidation-implementation.md
+++ b/docs/plans/2026-03-20-profile-tab-consolidation-implementation.md
@@ -1,0 +1,582 @@
+# Profile Tab Consolidation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Merge the separate "Profile" and "Profiles" settings tabs into a single unified "Profile" tab with avatar, profile dropdown, and profile management sections.
+
+**Architecture:** Rewrite `ProfileSettingsTab` to incorporate `useProfiles` hook and absorb all profile management UI from `ProfilesSettingsTab`. Remove the standalone Profiles tab from `SettingsModal`. Pure frontend refactor — no backend changes.
+
+**Tech Stack:** React, TypeScript, CSS (design tokens from `docs/UI_GUIDE.md`)
+
+---
+
+### Task 1: Rewrite ProfileSettingsTab to Consolidated Layout
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx`
+- Modify: `src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.css`
+
+**Step 1: Rewrite ProfileSettingsTab.tsx**
+
+Replace the entire file with the consolidated component. The new component has three sections:
+
+1. **Avatar** — kept from current ProfileSettingsTab (unchanged)
+2. **Profile** — dropdown to switch active profile (replaces old Certificate section)
+3. **Manage Profiles** — profile list, inline add/edit forms, per-profile actions (migrated from ProfilesSettingsTab)
+
+```tsx
+import { useState, useEffect, useRef } from 'react';
+import Avatar from '../Avatar/Avatar';
+import AvatarUpload from '../AvatarUpload/AvatarUpload';
+import bridge from '../../bridge';
+import { useProfiles } from '../../hooks/useProfiles';
+import { confirm } from '../../hooks/usePrompt';
+import { Tooltip } from '../Tooltip/Tooltip';
+import './ProfileSettingsTab.css';
+
+interface ProfileSettingsTabProps {
+  currentUser: {
+    name: string;
+    matrixUserId?: string;
+    avatarUrl?: string;
+  };
+  onUploadAvatar: (blob: Blob, contentType: string) => void;
+  onRemoveAvatar: () => void;
+  connected: boolean;
+}
+
+function getAvatarStatusText(user: ProfileSettingsTabProps['currentUser']): string {
+  if (!user.avatarUrl) return 'Default';
+  if (user.avatarUrl.startsWith('mxc://') || user.avatarUrl.includes('/_matrix/')) {
+    return 'Uploaded';
+  }
+  return 'From Mumble';
+}
+
+function triggerBlobDownload(base64: string, filename: string) {
+  const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+  const blob = new Blob([bytes], { type: 'application/x-pkcs12' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar, connected }: ProfileSettingsTabProps) {
+  const [showUpload, setShowUpload] = useState(false);
+  const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert } = useProfiles();
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [addName, setAddName] = useState('');
+  const [editName, setEditName] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const statusText = getAvatarStatusText(currentUser);
+
+  // Certificate export handler
+  useEffect(() => {
+    const onExportData = (data: unknown) => {
+      const d = data as { data: string; filename: string } | undefined;
+      if (d?.data) triggerBlobDownload(d.data, d.filename ?? 'brmble-identity.pfx');
+    };
+    bridge.on('cert.exportData', onExportData);
+    return () => bridge.off('cert.exportData', onExportData);
+  }, []);
+
+  // Cancel forms on Escape
+  useEffect(() => {
+    if (!isAdding && !editingId) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsAdding(false);
+        setEditingId(null);
+        setAddName('');
+        setEditName('');
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isAdding, editingId]);
+
+  const getInitial = (name: string) => (name?.charAt(0) || '?').toUpperCase();
+
+  const truncateFingerprint = (fp: string | null) => {
+    if (!fp) return 'No certificate';
+    if (fp.length <= 20) return fp;
+    return fp.slice(0, 8) + '...' + fp.slice(-8);
+  };
+
+  const handleAddGenerate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = addName.trim();
+    if (!name) return;
+    addProfile(name);
+    setAddName('');
+    setIsAdding(false);
+  };
+
+  const handleAddImport = () => {
+    const name = addName.trim();
+    if (!name) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const name = addName.trim();
+    if (!name) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const buffer = ev.target?.result as ArrayBuffer;
+      const bytes = new Uint8Array(buffer);
+      let binary = '';
+      bytes.forEach(b => (binary += String.fromCharCode(b)));
+      importProfile(name, btoa(binary));
+      setAddName('');
+      setIsAdding(false);
+    };
+    reader.readAsArrayBuffer(file);
+    e.target.value = '';
+  };
+
+  const handleEditSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editingId) return;
+    const name = editName.trim();
+    if (!name) return;
+    renameProfile(editingId, name);
+    setEditingId(null);
+    setEditName('');
+  };
+
+  const handleEditStart = (profile: { id: string; name: string }) => {
+    setEditingId(profile.id);
+    setEditName(profile.name);
+    setIsAdding(false);
+  };
+
+  const handleDelete = async (profile: { id: string; name: string }) => {
+    const confirmed = await confirm({
+      title: 'Delete profile',
+      message: `Remove "${profile.name}"? The certificate file will remain on disk and can be re-imported later.`,
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+    });
+    if (confirmed) removeProfile(profile.id);
+  };
+
+  const handleCancel = () => {
+    setIsAdding(false);
+    setEditingId(null);
+    setAddName('');
+    setEditName('');
+  };
+
+  return (
+    <div className="profile-settings-tab">
+      {/* Avatar section */}
+      <div className="settings-section">
+        <h3 className="heading-section settings-section-title">Avatar</h3>
+        <div className="profile-avatar-section">
+          <Avatar user={currentUser} size={80} />
+          <div className="profile-avatar-info">
+            <span className="profile-display-name">{currentUser.name}</span>
+            <span className="profile-display-name-hint">Set by Mumble registration</span>
+            <span className="profile-avatar-status">{statusText}</span>
+          </div>
+          {connected ? (
+            <div className="profile-avatar-actions">
+              <button className="btn btn-primary" onClick={() => setShowUpload(true)}>Upload</button>
+              {currentUser.avatarUrl && (
+                <button className="btn btn-secondary" onClick={onRemoveAvatar}>Remove</button>
+              )}
+            </div>
+          ) : (
+            <span className="profile-avatar-hint">Connect to a server to change your avatar</span>
+          )}
+        </div>
+      </div>
+
+      {/* Profile dropdown section */}
+      <div className="settings-section">
+        <h3 className="heading-section settings-section-title">Profile</h3>
+        <div className="settings-item">
+          <label>Active Profile</label>
+          <Tooltip content={connected ? 'Disconnect to switch profiles' : 'Select your active profile'}>
+            <select
+              className="brmble-input profile-select"
+              value={activeProfileId ?? ''}
+              onChange={(e) => setActive(e.target.value)}
+              disabled={connected || loading || profiles.length === 0}
+            >
+              {profiles.map(p => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+              {profiles.length === 0 && (
+                <option value="">No profiles</option>
+              )}
+            </select>
+          </Tooltip>
+        </div>
+      </div>
+
+      {/* Manage Profiles section */}
+      <div className="settings-section">
+        <h3 className="heading-section settings-section-title">Manage Profiles</h3>
+
+        {/* Hidden file input for certificate import */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".pfx,.p12"
+          style={{ display: 'none' }}
+          onChange={handleFileChange}
+        />
+
+        {!loading && profiles.length > 0 ? (
+          <div className="profiles-items">
+            {profiles.map((profile, index) => {
+              const isActive = profile.id === activeProfileId;
+
+              if (editingId === profile.id) {
+                return (
+                  <form key={profile.id} className="profiles-form" onSubmit={handleEditSubmit}>
+                    <h3 className="heading-section profiles-form-title">Rename Profile</h3>
+                    <div className="profiles-form-fields">
+                      <input
+                        className="brmble-input profiles-input"
+                        placeholder="Profile Name"
+                        value={editName}
+                        onChange={e => setEditName(e.target.value)}
+                        autoFocus
+                      />
+                    </div>
+                    <div className="profiles-form-actions">
+                      <button type="button" className="btn btn-secondary" onClick={handleCancel}>
+                        Cancel
+                      </button>
+                      <button type="submit" className="btn btn-primary" disabled={!editName.trim()}>
+                        Save
+                      </button>
+                    </div>
+                  </form>
+                );
+              }
+
+              return (
+                <div
+                  key={profile.id}
+                  className={`profiles-item${isActive ? ' profiles-item-active' : ''}`}
+                  style={{ animationDelay: `${index * 50}ms` }}
+                >
+                  <div className="profiles-icon">
+                    {getInitial(profile.name)}
+                  </div>
+                  <div className="profiles-info">
+                    <span className="profiles-name">{profile.name}</span>
+                    <span className="profiles-fingerprint">{truncateFingerprint(profile.fingerprint)}</span>
+                    {isActive && <span className="profiles-active-badge">Active</span>}
+                  </div>
+                  <div className="profiles-actions">
+                    <Tooltip content="Rename profile">
+                      <button
+                        className="btn btn-secondary profiles-action-btn"
+                        onClick={() => handleEditStart(profile)}
+                      >
+                        Edit
+                      </button>
+                    </Tooltip>
+                    <Tooltip content="Export certificate">
+                      <button
+                        className="btn btn-secondary profiles-action-btn"
+                        onClick={() => exportCert()}
+                      >
+                        Export
+                      </button>
+                    </Tooltip>
+                    <Tooltip content="Delete profile">
+                      <button
+                        className="btn btn-ghost profiles-delete-btn"
+                        onClick={() => handleDelete(profile)}
+                      >
+                        ✕
+                      </button>
+                    </Tooltip>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : !loading ? (
+          <div className="profiles-empty">
+            <div className="profiles-empty-icon">
+              <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true" focusable="false">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+            </div>
+            <p>No profiles yet</p>
+            <p className="profiles-empty-hint">Create a profile to manage multiple identities</p>
+          </div>
+        ) : null}
+
+        {isAdding && (
+          <form className="profiles-form" onSubmit={handleAddGenerate}>
+            <h3 className="heading-section profiles-form-title">Add New Profile</h3>
+            <div className="profiles-form-fields">
+              <input
+                className="brmble-input profiles-input"
+                placeholder="Profile Name"
+                value={addName}
+                onChange={e => setAddName(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <div className="profiles-form-actions">
+              <button type="button" className="btn btn-secondary" onClick={handleCancel}>
+                Cancel
+              </button>
+              <button type="button" className="btn btn-secondary" onClick={handleAddImport} disabled={!addName.trim()}>
+                Import Certificate
+              </button>
+              <button type="submit" className="btn btn-primary" disabled={!addName.trim()}>
+                Generate New Certificate
+              </button>
+            </div>
+          </form>
+        )}
+
+        {!isAdding && !editingId && (
+          <button className="btn btn-ghost profiles-add-btn" onClick={() => setIsAdding(true)}>
+            <span className="profiles-add-icon">+</span>
+            Add Profile
+          </button>
+        )}
+      </div>
+
+      {showUpload && (
+        <AvatarUpload
+          onUpload={(blob, contentType) => {
+            onUploadAvatar(blob, contentType);
+            setShowUpload(false);
+          }}
+          onCancel={() => setShowUpload(false)}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+Key changes from current `ProfileSettingsTab`:
+- Removed `fingerprint` and `connectedUsername` props (no longer needed)
+- Removed Certificate section (fingerprint display, server username)
+- Removed old Manage section (global export/import)
+- Added `useProfiles` hook import and usage
+- Added profile dropdown in new "Profile" section
+- Added full profile list + forms in new "Manage Profiles" section (migrated from `ProfilesSettingsTab`)
+- Removed `Activate` button from profile items (dropdown handles switching now)
+- `Export` button shown on all profiles (not just active — user may want to export any cert)
+
+**Step 2: Update ProfileSettingsTab.css**
+
+Add the profile dropdown style. The profiles-* CSS classes are already in `ProfilesSettingsTab.css` which we'll import:
+
+Add to the end of `ProfileSettingsTab.css`:
+
+```css
+.profile-select {
+  min-width: 200px;
+}
+```
+
+**Step 3: Import ProfilesSettingsTab.css into ProfileSettingsTab.tsx**
+
+Add this import at the top of the rewritten `ProfileSettingsTab.tsx` (already included in the code above — but we need to add the CSS import):
+
+```tsx
+import '../SettingsModal/ProfilesSettingsTab.css';
+```
+
+Wait — since both files are in the same directory, this is simply:
+
+```tsx
+import './ProfilesSettingsTab.css';
+```
+
+Add this import alongside the existing `./ProfileSettingsTab.css` import.
+
+**Step 4: Build frontend to verify no TS errors**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.css
+git commit -m "refactor: consolidate Profile and Profiles tabs into single Profile tab"
+```
+
+---
+
+### Task 2: Remove Profiles Tab from SettingsModal
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx`
+
+**Step 1: Remove ProfilesSettingsTab import**
+
+Remove line 12:
+```tsx
+import { ProfilesSettingsTab } from './ProfilesSettingsTab';
+```
+
+**Step 2: Remove 'profiles' from tab type**
+
+Change line 76 from:
+```tsx
+const [activeTab, setActiveTab] = useState<'profile' | 'profiles' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection'>('profile');
+```
+to:
+```tsx
+const [activeTab, setActiveTab] = useState<'profile' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection'>('profile');
+```
+
+**Step 3: Remove Profiles tab button**
+
+Remove the Profiles tab button (lines 308-313):
+```tsx
+          <button
+            className={`settings-tab ${activeTab === 'profiles' ? 'active' : ''}`}
+            onClick={() => setActiveTab('profiles')}
+          >
+            Profiles
+          </button>
+```
+
+**Step 4: Remove Profiles tab content**
+
+Remove the profiles tab content rendering (lines 358-360):
+```tsx
+          {activeTab === 'profiles' && (
+            <ProfilesSettingsTab connected={props.connected ?? false} />
+          )}
+```
+
+**Step 5: Update ProfileSettingsTab props**
+
+The ProfileSettingsTab no longer needs `fingerprint` and `connectedUsername` props. Update the rendering:
+
+Change from:
+```tsx
+            <ProfileSettingsTab
+              currentUser={props.currentUser ?? { name: props.username ?? 'Unknown' }}
+              onUploadAvatar={props.onUploadAvatar ?? (() => {})}
+              onRemoveAvatar={props.onRemoveAvatar ?? (() => {})}
+              fingerprint={props.certFingerprint ?? ''}
+              connectedUsername={props.username ?? ''}
+              connected={props.connected ?? false}
+            />
+```
+
+To:
+```tsx
+            <ProfileSettingsTab
+              currentUser={props.currentUser ?? { name: props.username ?? 'Unknown' }}
+              onUploadAvatar={props.onUploadAvatar ?? (() => {})}
+              onRemoveAvatar={props.onRemoveAvatar ?? (() => {})}
+              connected={props.connected ?? false}
+            />
+```
+
+**Step 6: Build frontend**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 7: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+git commit -m "refactor: remove standalone Profiles tab from SettingsModal"
+```
+
+---
+
+### Task 3: Clean Up Unused Props from SettingsModalProps
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx`
+
+**Step 1: Remove `certFingerprint` from SettingsModalProps**
+
+The `certFingerprint` prop is no longer consumed by any child. Check if it's still used elsewhere in the component before removing.
+
+If it's only used for the old `ProfileSettingsTab` fingerprint prop (which was removed in Task 2), remove it from the interface:
+
+```tsx
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  username?: string;
+  // certFingerprint removed
+  connected?: boolean;
+  currentUser?: {
+    name: string;
+    matrixUserId?: string;
+    avatarUrl?: string;
+  };
+  onUploadAvatar?: (blob: Blob, contentType: string) => void;
+  onRemoveAvatar?: () => void;
+}
+```
+
+**Step 2: Find and update all call sites passing certFingerprint**
+
+Search for `certFingerprint` in the codebase. Update any `<SettingsModal>` usage in `App.tsx` or elsewhere to stop passing this prop.
+
+**Step 3: Build frontend**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: remove unused certFingerprint prop from SettingsModal"
+```
+
+---
+
+### Task 4: Build Verification
+
+**Step 1: TypeScript check**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No errors
+
+**Step 2: Vite build**
+
+Run: `cd src/Brmble.Web && npm run build`
+Expected: Build succeeded
+
+**Step 3: Backend build (sanity check)**
+
+Run: `dotnet build src/Brmble.Client/Brmble.Client.csproj`
+Expected: Build succeeded
+
+**Step 4: Run all tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj -v n`
+Expected: 52 tests pass
+
+**Step 5: Verify clean git status**
+
+Run: `git status`
+Expected: Clean working tree

--- a/docs/plans/2026-03-21-audit-bugfixes-design.md
+++ b/docs/plans/2026-03-21-audit-bugfixes-design.md
@@ -1,0 +1,95 @@
+# Audit Bugfixes Design
+
+**Goal:** Fix high-severity data loss bugs, medium-severity robustness/UX issues, and one low-severity CSS inconsistency found during the multi-profile branch audit.
+
+**Branch:** `feature/profile-data-model`
+
+---
+
+## H1: Migration Timing — Data Loss on First Profile
+
+**Problem:** `migrateLocalStorage` runs in a parent `useEffect` in `App.tsx`. React fires child effects before parent effects. When `certFingerprint` changes from `''` to a real value, the game and brmblegotchi fingerprint-change effects fire first, find no scoped localStorage key, and reset to `INITIAL_STATE`. Then migration runs and copies old data to the scoped key — but it's too late. The auto-save intervals overwrite the migrated data with defaults.
+
+**Fix:** Call `migrateLocalStorage(fingerprint)` synchronously inside the bridge event handlers (`onCertStatus`, `onCertGenerated`, `onCertImported`, `onProfilesActiveChanged`) before calling `setCertFingerprint`. Remove the `useEffect`-based migration entirely. This guarantees scoped keys exist before React re-renders children.
+
+**Files:** `App.tsx`
+
+---
+
+## H2: Stale State Cross-Write During Profile Switch
+
+**Problem:** When switching profiles, `storageKey` updates immediately but `stateRef.current` still holds the old profile's data. If the auto-save interval fires in that window, it writes Profile A's state to Profile B's storage key.
+
+**Fix:** Change the fingerprint-reload effects in `useGameState.ts` and `Brmblegotchi.tsx` from `useEffect` to `useLayoutEffect`. This ensures state is reloaded synchronously before paint, before the auto-save `useEffect` re-establishes its interval with the new `storageKey`. The `stateRef` is updated as part of `setState`, so by the time the auto-save interval fires, it references the correct state.
+
+**Files:** `useGameState.ts`, `Brmblegotchi.tsx`
+
+---
+
+## H3: `profiles.setActive` No-Op Guard
+
+**Problem:** `AppConfigService.SetActiveProfileId` silently no-ops for non-existent profile IDs, but the `profiles.setActive` bridge handler unconditionally swaps registrations, reloads certs, and sends events.
+
+**Fix:** After calling `_config.SetActiveProfileId(id)`, check `_config.GetActiveProfileId() == id`. If they differ (ID was invalid), return early without side effects.
+
+**Files:** `CertificateService.cs`
+
+---
+
+## M1: Duplicate Name Guard in C# Backend
+
+**Problem:** `AppConfigService.AddProfile` and `RenameProfile` accept any name. Frontend validates, but the domain layer has no defense.
+
+**Fix:** In `AddProfile`, check `_profiles.Any(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase))` and return `null` if duplicate. In `RenameProfile`, same check excluding the profile's own ID. Return `false` on failure. Bridge handlers already validate at the frontend layer; this is defense-in-depth.
+
+**Files:** `AppConfigService.cs`, `IAppConfigService.cs` (return type changes)
+
+---
+
+## M2: `ActiveCertificate` Thread Safety
+
+**Problem:** `profiles.add` and `profiles.import` use `Task.Run`, while `profiles.setActive` runs on the UI thread. Both read/write `ActiveCertificate` without synchronization.
+
+**Fix:** Add a `private readonly object _certLock = new()` to `CertificateService`. Wrap all reads/writes of `ActiveCertificate` and calls to `LoadActiveCertificate` in `lock(_certLock)`.
+
+**Files:** `CertificateService.cs`
+
+---
+
+## M3: Tooltips on Disabled Buttons
+
+**Problem:** Disabled `<button>` elements don't fire hover events, so the informational tooltips ("Disconnect to delete/rename") never appear when they're most useful.
+
+**Fix:** Wrap disabled buttons in a `<span>` and attach the `Tooltip` to the wrapper, per the UI guide's rule for disabled elements. Applies to Delete and Edit buttons in `ProfileSettingsTab.tsx`.
+
+**Files:** `ProfileSettingsTab.tsx`
+
+---
+
+## M4: Export Button Exports Wrong Profile
+
+**Problem:** `exportCert()` sends `cert.export` with no profile ID. Clicking Export on a non-active profile exports the active profile's cert.
+
+**Fix:** Pass the profile ID from the UI: `bridge.send('cert.export', { profileId })`. On the C# side, look up the cert path for that specific profile. Fall back to active profile when no ID is provided (backward compat).
+
+**Files:** `useProfiles.ts`, `ProfileSettingsTab.tsx`, `CertificateService.cs`
+
+---
+
+## M5: Missing try/catch in Bridge Handlers
+
+**Problem:** `profiles.remove`, `profiles.rename`, and `profiles.setActive` have no try/catch. Exceptions leave the frontend with no response.
+
+**Fix:** Wrap each handler body in try/catch, send `profiles.error` with the exception message on failure. Matches the pattern already used in `profiles.add` and `profiles.import`.
+
+**Files:** `CertificateService.cs`
+
+---
+
+## L3: CertWizard Button CSS Classes
+
+**Problem:** Import step buttons use `cert-wizard-btn ghost/primary` instead of `btn btn-ghost/btn btn-primary`.
+
+**Fix:** Replace the incorrect classes with the standard button classes.
+
+**Files:** `CertWizard.tsx`

--- a/docs/plans/2026-03-21-audit-bugfixes-implementation.md
+++ b/docs/plans/2026-03-21-audit-bugfixes-implementation.md
@@ -1,0 +1,771 @@
+# Audit Bugfixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix data loss bugs (H1-H3), robustness/UX issues (M1-M5), and one CSS inconsistency (L3) found during the multi-profile branch audit.
+
+**Architecture:** All fixes are isolated — no cross-task dependencies. Frontend fixes are in React (App.tsx, useGameState, Brmblegotchi, ProfileSettingsTab, CertWizard). Backend fixes are in C# (CertificateService, AppConfigService). Each task is independently buildable and testable.
+
+**Tech Stack:** React, TypeScript, C# (.NET 10), WebView2 bridge
+
+---
+
+### Task 1: H1 — Fix Migration Timing (Data Loss on First Profile)
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx:35,141-146,921-953`
+
+**Step 1: Move migration into bridge event handlers**
+
+In `App.tsx`, find the four handlers that set `certFingerprint` and call `migrateLocalStorage` synchronously before `setCertFingerprint`:
+
+```tsx
+    const onCertStatus = (data: unknown) => {
+      const d = data as { exists: boolean; fingerprint?: string } | undefined;
+      if (d?.exists) {
+        setCertExists(true);
+        const fp = d.fingerprint ?? '';
+        if (fp) migrateLocalStorage(fp);
+        setCertFingerprint(fp);
+      } else {
+        setCertExists(false);
+      }
+    };
+    const onCertGenerated = (data: unknown) => {
+      const d = data as { fingerprint?: string } | undefined;
+      setCertExists(true);
+      const fp = d?.fingerprint ?? '';
+      if (fp) migrateLocalStorage(fp);
+      setCertFingerprint(fp);
+    };
+    const onCertImported = (data: unknown) => {
+      const d = data as { fingerprint?: string } | undefined;
+      setCertExists(true);
+      const fp = d?.fingerprint ?? '';
+      if (fp) migrateLocalStorage(fp);
+      setCertFingerprint(fp);
+    };
+
+    const onProfilesActiveChanged = (data: unknown) => {
+      const d = data as { id: string | null; name: string | null; fingerprint: string | null };
+      resetMarkersCache();
+      if (d.id) {
+        setCertExists(true);
+        const fp = d.fingerprint ?? '';
+        if (fp) migrateLocalStorage(fp);
+        setCertFingerprint(fp);
+        setActiveProfileName(d.name ?? '');
+      } else {
+        setCertExists(false);
+        setCertFingerprint('');
+        setActiveProfileName('');
+        setShowSettings(false);
+      }
+    };
+```
+
+**Step 2: Remove the useEffect migration**
+
+Delete lines 141-146:
+```tsx
+  // Migrate global localStorage keys to per-profile scoped keys
+  useEffect(() => {
+    if (certFingerprint) {
+      migrateLocalStorage(certFingerprint);
+    }
+  }, [certFingerprint]);
+```
+
+**Step 3: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success, no type errors
+
+**Step 4: Commit**
+
+```
+git add src/Brmble.Web/src/App.tsx
+git commit -m "fix: run localStorage migration synchronously before setting fingerprint to prevent data loss"
+```
+
+---
+
+### Task 2: H2 — Fix Stale State Cross-Write During Profile Switch
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Game/useGameState.ts:111-127`
+- Modify: `src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx:261-295`
+
+**Step 1: Change useGameState fingerprint reload to useLayoutEffect**
+
+In `useGameState.ts`, add `useLayoutEffect` to the import from React (it already imports `useEffect`, `useState`, `useRef`, `useMemo`, `useCallback`). Then change the fingerprint reload effect from `useEffect` to `useLayoutEffect`:
+
+```ts
+  // Reload state when profile fingerprint changes
+  const fingerprintRef = useRef(fingerprint);
+  useLayoutEffect(() => {
+    if (fingerprint && fingerprint !== fingerprintRef.current) {
+      fingerprintRef.current = fingerprint;
+      const key = `${STORAGE_KEY}_${fingerprint}`;
+      const saved = localStorage.getItem(key);
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          if (hasInfrastructure(parsed) && hasServices(parsed)) {
+            setState(parsed);
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+      setState(INITIAL_STATE);
+    }
+  }, [fingerprint]);
+```
+
+**Step 2: Change Brmblegotchi fingerprint reload to useLayoutEffect**
+
+In `Brmblegotchi.tsx`, add `useLayoutEffect` to the React import. Then change the fingerprint reload effect from `useEffect` to `useLayoutEffect`:
+
+```tsx
+  // Reload state when profile fingerprint changes
+  const fingerprintRef = useRef(fingerprint);
+  useLayoutEffect(() => {
+    if (fingerprint && fingerprint !== fingerprintRef.current) {
+      fingerprintRef.current = fingerprint;
+      // Reload pet state
+      try {
+        const stored = localStorage.getItem(`${STATE_KEY}_${fingerprint}`);
+        if (stored) {
+          const saved = JSON.parse(stored) as PetState;
+          const elapsed = (Date.now() - saved.lastUpdate) / 1000;
+          setPetState({
+            hunger: Math.max(0, saved.hunger - elapsed * 0.0069),
+            happiness: Math.max(0, saved.happiness - elapsed * 0.0139),
+            cleanliness: Math.max(0, saved.cleanliness - elapsed * 0.0278),
+            lastUpdate: Date.now(),
+            lastActionTime: saved.lastActionTime ?? 0,
+          });
+        } else {
+          setPetState({ hunger: 80, happiness: 75, cleanliness: 85, lastUpdate: Date.now(), lastActionTime: 0 });
+        }
+      } catch {
+        setPetState({ hunger: 80, happiness: 75, cleanliness: 85, lastUpdate: Date.now(), lastActionTime: 0 });
+      }
+      // Reload position
+      try {
+        const stored = localStorage.getItem(`${POSITION_KEY}_${fingerprint}`);
+        if (stored) {
+          setPosition(JSON.parse(stored));
+        } else {
+          setPosition({ bottom: 150, right: 24 });
+        }
+      } catch {
+        setPosition({ bottom: 150, right: 24 });
+      }
+    }
+  }, [fingerprint]);
+```
+
+**Step 3: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success
+
+**Step 4: Commit**
+
+```
+git add src/Brmble.Web/src/components/Game/useGameState.ts src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx
+git commit -m "fix: use useLayoutEffect for profile switch state reload to prevent cross-profile data corruption"
+```
+
+---
+
+### Task 3: H3 — Guard `profiles.setActive` Against No-Op
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Certificate/CertificateService.cs:532-551`
+
+**Step 1: Add guard after SetActiveProfileId**
+
+Replace the `profiles.setActive` handler body with a guard that verifies the switch succeeded:
+
+```csharp
+        bridge.RegisterHandler("profiles.setActive", data =>
+        {
+            var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+            if (id == null) return Task.CompletedTask;
+
+            var oldProfileId = _config.GetActiveProfileId();
+
+            _config.SetActiveProfileId(id);
+
+            // Verify the switch actually happened (SetActiveProfileId is a no-op for non-existent IDs)
+            if (_config.GetActiveProfileId() != id) return Task.CompletedTask;
+
+            lock (_certLock) { LoadActiveCertificate(); }
+
+            // Swap registration data — save old profile's, load new profile's cached registrations
+            _config.SwapProfileRegistrations(oldProfileId, id);
+
+            var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+            bridge.Send("profiles.activeChanged", new { id, name = profile?.Name, fingerprint = GetCertHash() });
+            bridge.Send("cert.status", new { exists = ActiveCertificate != null, fingerprint = GetCertHash(), subject = ActiveCertificate?.Subject });
+            // Re-send server list so frontend picks up swapped registration fields
+            bridge.Send("servers.list", new { servers = _config.GetServers() });
+            return Task.CompletedTask;
+        });
+```
+
+Note: This uses `_certLock` and `GetCertHash()` which will be added in Task 6 (M2). If implementing sequentially, add the `_certLock` field first (Task 6) or use `LoadActiveCertificate()` without the lock temporarily and add it in Task 6.
+
+**Step 2: Build to verify**
+
+Run: `dotnet build`
+Expected: Success
+
+**Step 3: Commit**
+
+```
+git add src/Brmble.Client/Services/Certificate/CertificateService.cs
+git commit -m "fix: guard profiles.setActive against no-op when profile ID doesn't exist"
+```
+
+---
+
+### Task 4: M1 — Add Duplicate Name Guard in C# Backend
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/AppConfig/IAppConfigService.cs:25-27`
+- Modify: `src/Brmble.Client/Services/AppConfig/AppConfigService.cs:262-294`
+- Modify: `tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs`
+
+**Step 1: Change return types in interface**
+
+In `IAppConfigService.cs`, change:
+```csharp
+    bool AddProfile(ProfileEntry profile);
+    void RemoveProfile(string id);
+    bool RenameProfile(string id, string newName);
+```
+
+**Step 2: Update AddProfile with duplicate guard**
+
+In `AppConfigService.cs`:
+```csharp
+    public bool AddProfile(ProfileEntry profile)
+    {
+        lock (_lock)
+        {
+            if (_profiles.Any(p => p.Id == profile.Id)) return false;
+            if (_profiles.Any(p => p.Name.Equals(profile.Name, StringComparison.OrdinalIgnoreCase))) return false;
+            _profiles.Add(profile);
+            Save();
+            return true;
+        }
+    }
+```
+
+**Step 3: Update RenameProfile with duplicate guard**
+
+In `AppConfigService.cs`:
+```csharp
+    public bool RenameProfile(string id, string newName)
+    {
+        lock (_lock)
+        {
+            if (_profiles.Any(p => p.Id != id && p.Name.Equals(newName, StringComparison.OrdinalIgnoreCase))) return false;
+            var idx = _profiles.FindIndex(p => p.Id == id);
+            if (idx >= 0)
+            {
+                _profiles[idx] = _profiles[idx] with { Name = newName };
+                Save();
+                return true;
+            }
+            return false;
+        }
+    }
+```
+
+**Step 4: Add tests**
+
+Add these test methods to `AppConfigServiceTests.cs`:
+
+```csharp
+    [TestMethod]
+    public void AddProfile_RejectsDuplicateName()
+    {
+        var svc = CreateService();
+        svc.AddProfile(new ProfileEntry("id1", "MyProfile"));
+        var result = svc.AddProfile(new ProfileEntry("id2", "myprofile"));
+        Assert.IsFalse(result);
+        Assert.AreEqual(1, svc.GetProfiles().Count);
+    }
+
+    [TestMethod]
+    public void RenameProfile_RejectsDuplicateName()
+    {
+        var svc = CreateService();
+        svc.AddProfile(new ProfileEntry("id1", "Alpha"));
+        svc.AddProfile(new ProfileEntry("id2", "Beta"));
+        var result = svc.RenameProfile("id2", "alpha");
+        Assert.IsFalse(result);
+        Assert.AreEqual("Beta", svc.GetProfiles().First(p => p.Id == "id2").Name);
+    }
+
+    [TestMethod]
+    public void RenameProfile_AllowsSameNameForSameProfile()
+    {
+        var svc = CreateService();
+        svc.AddProfile(new ProfileEntry("id1", "Alpha"));
+        var result = svc.RenameProfile("id1", "Alpha");
+        Assert.IsTrue(result);
+    }
+```
+
+**Step 5: Fix any compilation errors from return type change**
+
+The `CertificateService.cs` calls `_config.AddProfile(...)` and `_config.RenameProfile(...)`. Since these previously returned `void`, callers that ignore the return value will still compile fine (C# allows discarding return values). No changes needed there.
+
+**Step 6: Build and test**
+
+Run: `dotnet build && dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj`
+Expected: All tests pass (including new ones)
+
+**Step 7: Commit**
+
+```
+git add src/Brmble.Client/Services/AppConfig/IAppConfigService.cs src/Brmble.Client/Services/AppConfig/AppConfigService.cs tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+git commit -m "fix: add duplicate name guard to AddProfile and RenameProfile in AppConfigService"
+```
+
+---
+
+### Task 5: M5 — Add try/catch to Bridge Handlers
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Certificate/CertificateService.cs:389-455,532-551`
+
+**Step 1: Wrap profiles.remove handler**
+
+```csharp
+        bridge.RegisterHandler("profiles.remove", data =>
+        {
+            try
+            {
+                var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+                if (id == null) return Task.CompletedTask;
+
+                var wasActive = _config.GetActiveProfileId() == id;
+                _config.RemoveProfile(id);
+                bridge.Send("profiles.removed", new { id });
+
+                if (wasActive)
+                {
+                    var newActiveId = _config.GetActiveProfileId();
+                    if (newActiveId != null)
+                    {
+                        var newProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == newActiveId);
+                        lock (_certLock) { LoadActiveCertificate(); }
+                        bridge.Send("profiles.activeChanged", new { id = newActiveId, name = newProfile?.Name, fingerprint = GetCertHash() });
+                    }
+                    else
+                    {
+                        lock (_certLock)
+                        {
+                            var old = ActiveCertificate;
+                            ActiveCertificate = null;
+                            old?.Dispose();
+                        }
+                        bridge.Send("profiles.activeChanged", new { id = (string?)null, name = (string?)null, fingerprint = (string?)null });
+                        bridge.Send("cert.status", new { exists = false });
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                bridge.Send("profiles.error", new { message = $"Failed to remove profile: {ex.Message}" });
+            }
+            return Task.CompletedTask;
+        });
+```
+
+**Step 2: Wrap profiles.rename handler**
+
+```csharp
+        bridge.RegisterHandler("profiles.rename", data =>
+        {
+            try
+            {
+                var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+                var name = data.TryGetProperty("name", out var n) ? n.GetString()?.Trim() : null;
+                if (id == null || name == null) return Task.CompletedTask;
+
+                var validationError = ValidateProfileName(name);
+                if (validationError != null)
+                {
+                    bridge.Send("profiles.error", new { message = validationError });
+                    return Task.CompletedTask;
+                }
+
+                // Find the current cert file before renaming the profile
+                var oldProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+                var oldCertPath = oldProfile != null ? FindCertPath(id, oldProfile.Name) : null;
+
+                _config.RenameProfile(id, name);
+
+                // Rename the cert file on disk to match the new profile name
+                if (oldCertPath != null && File.Exists(oldCertPath))
+                {
+                    var newCertPath = GetCertPath(id, name);
+                    if (!string.Equals(oldCertPath, newCertPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        try { File.Move(oldCertPath, newCertPath); }
+                        catch { /* best-effort; FindCertPath fallback will still locate it */ }
+                    }
+                }
+
+                bridge.Send("profiles.renamed", new { id, name });
+
+                if (_config.GetActiveProfileId() == id)
+                    bridge.Send("profiles.activeChanged", new { id, name, fingerprint = GetCertHash() });
+            }
+            catch (Exception ex)
+            {
+                bridge.Send("profiles.error", new { message = $"Failed to rename profile: {ex.Message}" });
+            }
+            return Task.CompletedTask;
+        });
+```
+
+**Step 3: Wrap profiles.setActive handler**
+
+(Already partially done in Task 3. Add the try/catch around the whole body.)
+
+```csharp
+        bridge.RegisterHandler("profiles.setActive", data =>
+        {
+            try
+            {
+                var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+                if (id == null) return Task.CompletedTask;
+
+                var oldProfileId = _config.GetActiveProfileId();
+
+                _config.SetActiveProfileId(id);
+
+                // Verify the switch actually happened
+                if (_config.GetActiveProfileId() != id) return Task.CompletedTask;
+
+                lock (_certLock) { LoadActiveCertificate(); }
+
+                _config.SwapProfileRegistrations(oldProfileId, id);
+
+                var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+                bridge.Send("profiles.activeChanged", new { id, name = profile?.Name, fingerprint = GetCertHash() });
+                bridge.Send("cert.status", new { exists = ActiveCertificate != null, fingerprint = GetCertHash(), subject = ActiveCertificate?.Subject });
+                bridge.Send("servers.list", new { servers = _config.GetServers() });
+            }
+            catch (Exception ex)
+            {
+                bridge.Send("profiles.error", new { message = $"Failed to switch profile: {ex.Message}" });
+            }
+            return Task.CompletedTask;
+        });
+```
+
+**Step 4: Build to verify**
+
+Run: `dotnet build`
+Expected: Success
+
+**Step 5: Commit**
+
+```
+git add src/Brmble.Client/Services/Certificate/CertificateService.cs
+git commit -m "fix: add try/catch to profiles.remove, profiles.rename, profiles.setActive handlers"
+```
+
+---
+
+### Task 6: M2 — Add Thread Safety to CertificateService
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Certificate/CertificateService.cs:12,17-18,298,353,404,409-411,540,565-578`
+
+**Step 1: Add the lock field**
+
+After line 12 (`public X509Certificate2? ActiveCertificate { get; private set; }`), add:
+
+```csharp
+    private readonly object _certLock = new();
+```
+
+**Step 2: Wrap all ActiveCertificate reads/writes in lock**
+
+Every location where `ActiveCertificate` is read or written outside of already-locked code needs `lock (_certLock)`. Key locations:
+
+- `LoadActiveCertificate()` (line 565-578) — the method body should be called inside `lock (_certLock)` at every call site (already done in Tasks 3 and 5 above)
+- `profiles.remove` handler (line 409-411) — the `ActiveCertificate = null; old?.Dispose()` block (already wrapped in Task 5)
+- `profiles.add` handler (inside `Task.Run` at ~line 298) — wrap `LoadActiveCertificate()` call
+- `profiles.import` handler (inside `Task.Run` at ~line 353) — wrap `LoadActiveCertificate()` call
+- `GetCertHash()` (line 14-15) — wrap the read
+- `GetExportableCertificate()` (line 560-563) — wrap the `ActiveCertificate` read
+- `SendStatus()` — wrap `ActiveCertificate` reads
+- `cert.export` handler — wrap `ActiveCertificate` reads (via `ActiveCertPath` which reads `ActiveCertificate` indirectly)
+
+For `GetCertHash()`:
+```csharp
+    public string? GetCertHash()
+    {
+        lock (_certLock) return ActiveCertificate?.Thumbprint?.ToLowerInvariant();
+    }
+```
+
+For each `Task.Run` call site that calls `LoadActiveCertificate()`:
+```csharp
+lock (_certLock) { LoadActiveCertificate(); }
+```
+
+For `GetExportableCertificate()`:
+```csharp
+    internal X509Certificate2? GetExportableCertificate()
+    {
+        lock (_certLock)
+        {
+            return ActiveCertificate is not null && ActiveCertPath is string path && File.Exists(path)
+                ? X509CertificateLoader.LoadPkcs12FromFile(path, password: null, keyStorageFlags: X509KeyStorageFlags.Exportable)
+                : null;
+        }
+    }
+```
+
+**Step 3: Build to verify**
+
+Run: `dotnet build`
+Expected: Success
+
+**Step 4: Run tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj`
+Expected: All pass
+
+**Step 5: Commit**
+
+```
+git add src/Brmble.Client/Services/Certificate/CertificateService.cs
+git commit -m "fix: add _certLock to CertificateService for thread-safe ActiveCertificate access"
+```
+
+---
+
+### Task 7: M3 — Fix Tooltips on Disabled Buttons
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx:352-370`
+
+**Step 1: Wrap disabled buttons in span for Tooltip**
+
+Replace the Delete and Edit button sections:
+
+```tsx
+                    <Tooltip content={connected && isActive ? 'Disconnect to delete this profile' : 'Delete profile'}>
+                      <span>
+                        <button
+                          className="btn btn-ghost profiles-delete-btn"
+                          onClick={() => handleDelete(profile)}
+                          disabled={connected && isActive}
+                        >
+                          ✕
+                        </button>
+                      </span>
+                    </Tooltip>
+                    <Tooltip content={connected ? 'Disconnect to rename profiles' : 'Rename profile'}>
+                      <span>
+                        <button
+                          className="btn btn-secondary profiles-action-btn"
+                          onClick={() => handleEditStart(profile)}
+                          disabled={connected}
+                        >
+                          Edit
+                        </button>
+                      </span>
+                    </Tooltip>
+```
+
+**Step 2: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success
+
+**Step 3: Commit**
+
+```
+git add src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+git commit -m "fix: wrap disabled profile buttons in span so Tooltip shows on hover"
+```
+
+---
+
+### Task 8: M4 — Fix Export Button to Export Correct Profile
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useProfiles.ts:85-87`
+- Modify: `src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx:374`
+- Modify: `src/Brmble.Client/Services/Certificate/CertificateService.cs:676-702`
+
+**Step 1: Pass profile ID in useProfiles.ts**
+
+```ts
+  const exportCert = useCallback((profileId?: string) => {
+    bridge.send('cert.export', profileId ? { profileId } : {});
+  }, []);
+```
+
+**Step 2: Pass profile.id in ProfileSettingsTab.tsx**
+
+Change line 374 from:
+```tsx
+onClick={() => exportCert()}
+```
+to:
+```tsx
+onClick={() => exportCert(profile.id)}
+```
+
+**Step 3: Update cert.export handler in C#**
+
+In the `ExportCertificate` method (or wherever `cert.export` is handled), accept an optional `profileId`:
+
+Find where `cert.export` is registered. Looking at the handler registration (it should use `bridge.RegisterHandler("cert.export", ...)`). The actual export logic is in `ExportCertificate()` at line 676. Find how it's called:
+
+Update the `cert.export` handler to pass the `profileId` from the message data, and update `ExportCertificate` to accept it:
+
+```csharp
+    private void ExportCertificate(string? profileId = null)
+    {
+        try
+        {
+            string? certPath;
+            string exportName;
+
+            if (profileId != null)
+            {
+                var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == profileId);
+                if (profile == null)
+                {
+                    _bridge.Send("cert.error", new { message = "Profile not found." });
+                    return;
+                }
+                certPath = FindCertPath(profileId, profile.Name);
+                exportName = $"{SanitizeFileName(profile.Name)}.pfx";
+            }
+            else
+            {
+                certPath = ActiveCertPath;
+                var activeId = _config.GetActiveProfileId();
+                var activeProfile = activeId != null ? _config.GetProfiles().FirstOrDefault(p => p.Id == activeId) : null;
+                exportName = activeProfile != null ? $"{SanitizeFileName(activeProfile.Name)}.pfx" : "brmble-identity.pfx";
+            }
+
+            if (certPath is not string cp || !File.Exists(cp))
+            {
+                _bridge.Send("cert.error", new { message = "No certificate to export." });
+                return;
+            }
+
+            var bytes = File.ReadAllBytes(cp);
+            var base64 = Convert.ToBase64String(bytes);
+            _bridge.Send("cert.exportData", new { data = base64, filename = exportName });
+            _bridge.NotifyUiThread();
+        }
+        catch (Exception ex)
+        {
+            _bridge.Send("cert.error", new { message = $"Failed to export certificate: {ex.Message}" });
+            _bridge.NotifyUiThread();
+        }
+    }
+```
+
+Also update the bridge handler registration to pass the profileId:
+
+```csharp
+        bridge.RegisterHandler("cert.export", data =>
+        {
+            var profileId = data.TryGetProperty("profileId", out var pidEl) ? pidEl.GetString() : null;
+            ExportCertificate(profileId);
+            return Task.CompletedTask;
+        });
+```
+
+**Step 4: Build to verify**
+
+Run: `dotnet build && cd src/Brmble.Web && npm run build`
+Expected: Success
+
+**Step 5: Commit**
+
+```
+git add src/Brmble.Web/src/hooks/useProfiles.ts src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx src/Brmble.Client/Services/Certificate/CertificateService.cs
+git commit -m "fix: export correct profile's cert instead of always exporting active profile"
+```
+
+---
+
+### Task 9: L3 — Fix CertWizard Button CSS Classes
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/CertWizard/CertWizard.tsx:318,321`
+
+**Step 1: Replace CSS classes**
+
+Change line 318:
+```tsx
+<button className="cert-wizard-btn ghost" onClick={() => setStep('warning')}>
+```
+to:
+```tsx
+<button className="btn btn-ghost" onClick={() => setStep('warning')}>
+```
+
+Change line 321:
+```tsx
+<button className="cert-wizard-btn primary" onClick={handleImportClick}>
+```
+to:
+```tsx
+<button className="btn btn-primary" onClick={handleImportClick}>
+```
+
+**Step 2: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success
+
+**Step 3: Commit**
+
+```
+git add src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
+git commit -m "fix: use correct btn CSS classes on CertWizard import step buttons"
+```
+
+---
+
+### Task 10: Final Build & Test Verification
+
+**Files:**
+- None (verification only)
+
+**Step 1: Full frontend build**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success
+
+**Step 2: Full dotnet build**
+
+Run: `dotnet build`
+Expected: Success (pre-existing CS8604 warning only)
+
+**Step 3: Run all tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj && dotnet test tests/MumbleVoiceEngine.Tests/MumbleVoiceEngine.Tests.csproj`
+Expected: All pass (55+ client tests including new ones, 68 voice engine tests)

--- a/docs/plans/2026-03-21-per-profile-state-scoping-design.md
+++ b/docs/plans/2026-03-21-per-profile-state-scoping-design.md
@@ -1,0 +1,132 @@
+# Per-Profile State Scoping — Design
+
+**Date:** 2026-03-21
+**Status:** Approved
+**Related:** Multi-profile system (`2026-03-20-multi-profile-design.md`)
+
+## Problem
+
+Several pieces of client-side state are stored globally when they should be scoped per-profile. When a user switches profiles, they see stale data from the previous profile:
+
+1. **Stale registration status** — If Profile A is registered on a server but Profile B is not, the server entry still shows `registered=true` after switching to Profile B and connecting.
+2. **Idle game state** — Progress in the "Hosting Empire" game carries across profiles.
+3. **Brmblegotchi state** — Virtual pet stats and position carry across profiles.
+4. **Read markers** — Unread indicators for chat rooms carry across profiles (each profile has a different Matrix identity server-side).
+
+## Scope
+
+### In Scope (Critical + High Priority)
+
+| Item | Storage | Current Key | Priority |
+|---|---|---|---|
+| Registration status (clear on connect) | config.json via bridge | Server entry fields | Critical |
+| Idle game save | localStorage | `idle-farm-save` | High |
+| Idle game theme | localStorage | `idle-farm-theme` | High |
+| Brmblegotchi state | localStorage | `brmblegotchi-state` | High |
+| Brmblegotchi position | localStorage | `brmblegotchi-position` | High |
+| Read markers | localStorage | `brmble-read-markers` | High |
+
+### Out of Scope (Deferred)
+
+| Item | Reason |
+|---|---|
+| DM contacts (`brmble_dm_contacts_*`) | DM system will be refactored separately |
+| Auto-connect settings | Medium priority — GitHub issue to be filed |
+| Last connected server (`brmble-server`) | Medium priority — GitHub issue to be filed |
+| Chat history (`brmble_chat_*`) | Already server-scoped by room ID |
+| Volume/mute settings (`volume_*`, `localMute_*`) | Hardware settings, not identity-bound |
+| App settings (`brmble-settings`) | User preferences, not identity-bound |
+| Screenshare split (`brmble-screenshare-split`) | UI preference, not identity-bound |
+
+## Design
+
+### 1. Registration Status — Clear on Connect
+
+**Problem:** The `voice.connected` handler in `App.tsx` (line 548) only processes registration when `reg?.registered` is truthy. It never clears stale `registered`/`registeredName` when a server reports the user is NOT registered.
+
+**Solution:** Add an `else` branch to the existing `if (reg?.registered)` block. When the server reports `registered=false` (or omits registration data), clear `registered` to `false` and `registeredName` to `null` on the server entry. Persist via `servers.update` bridge call.
+
+**No schema change needed.** The `ServerEntry` already has optional `registered?: boolean` and `registeredName?: string` fields.
+
+### 2. localStorage Scoping by Cert Fingerprint
+
+**Keying strategy:** Append the full 40-character SHA1 certificate thumbprint to each localStorage key using an underscore separator.
+
+| Old Key | New Key Pattern |
+|---|---|
+| `idle-farm-save` | `idle-farm-save_{fingerprint}` |
+| `idle-farm-theme` | `idle-farm-theme_{fingerprint}` |
+| `brmblegotchi-state` | `brmblegotchi-state_{fingerprint}` |
+| `brmblegotchi-position` | `brmblegotchi-position_{fingerprint}` |
+| `brmble-read-markers` | `brmble-read-markers_{fingerprint}` |
+
+**Why fingerprint?** The cert fingerprint is the true identity — it's what the Mumble server and Matrix homeserver use to identify the user. Profile names can be renamed; fingerprints are immutable.
+
+### 3. ProfileContext for Fingerprint Distribution
+
+**Problem:** Components that need the fingerprint (`useGameState`, `Brmblegotchi`, `useUnreadTracker`) are deep in the component tree. Threading props would be invasive.
+
+**Solution:** Create a `ProfileContext` React context that provides `certFingerprint`.
+
+- `certFingerprint` is already maintained as React state in `App.tsx` (set from `cert.status`, `cert.generated`, `cert.imported`, `profiles.activeChanged`).
+- Currently the state value is destructured away: `const [, setCertFingerprint] = useState('')`. Change to `const [certFingerprint, setCertFingerprint]`.
+- Wrap the app content in `<ProfileContext.Provider value={certFingerprint}>`.
+- Consumers call `useProfileFingerprint()` to get the value.
+
+### 4. Component Changes
+
+#### `useGameState.ts`
+- Accept `fingerprint` parameter (from context, passed by caller).
+- Derive scoped keys: `idle-farm-save_{fingerprint}`, `idle-farm-theme_{fingerprint}`.
+- When `fingerprint` is empty string (no profile loaded), use the old unscoped key as fallback for backward compatibility.
+- All 6 localStorage access points updated to use scoped keys.
+
+#### `Brmblegotchi.tsx`
+- Read `certFingerprint` from `ProfileContext`.
+- Derive scoped keys: `brmblegotchi-state_{fingerprint}`, `brmblegotchi-position_{fingerprint}`.
+- When fingerprint changes (profile switch), re-initialize state from the new scoped keys.
+- All 7 localStorage access points updated.
+
+#### `useUnreadTracker.ts`
+- Module-level `markersCache` must be invalidated on profile switch.
+- Add a `resetMarkersCache()` export function.
+- `loadMarkers()` and `saveMarker()` accept a `fingerprint` parameter to build the scoped key.
+- Callers pass fingerprint from context.
+- When fingerprint is empty, fall back to the unscoped key.
+
+### 5. Migration
+
+Create a `migrateLocalStorage(fingerprint: string)` utility function:
+
+```
+For each old global key:
+  1. If old key exists in localStorage AND new scoped key does NOT exist:
+     - Copy value from old key to new scoped key
+     - Delete old key
+  2. If both exist, do nothing (scoped key takes precedence)
+  3. If only scoped key exists, do nothing (already migrated)
+```
+
+**Properties:**
+- Idempotent — safe to run multiple times
+- Non-destructive — only migrates if the scoped key doesn't already exist
+- Runs once on app startup after fingerprint is known
+
+**Trigger:** Call `migrateLocalStorage(fingerprint)` in `App.tsx` when `certFingerprint` is first set (or changes).
+
+### 6. Profile Switch Behavior
+
+When the active profile changes (`profiles.activeChanged`):
+1. `certFingerprint` state updates (already happens).
+2. `migrateLocalStorage(newFingerprint)` runs for the new profile.
+3. `resetMarkersCache()` is called to invalidate the unread tracker cache.
+4. Components re-render with the new fingerprint via context, loading their state from new scoped keys.
+
+**Note:** `useGameState` and `Brmblegotchi` use `useState` lazy initializers, which only run on mount. On profile switch, these components need to detect the fingerprint change and re-load state. This is handled by `useEffect` watching the fingerprint value.
+
+## Non-Goals
+
+- No changes to `config.json` schema
+- No changes to C# backend
+- No changes to bridge protocol
+- No server-side changes

--- a/docs/plans/2026-03-21-per-profile-state-scoping-implementation.md
+++ b/docs/plans/2026-03-21-per-profile-state-scoping-implementation.md
@@ -1,0 +1,581 @@
+# Per-Profile State Scoping Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Scope localStorage-backed state (idle game, brmblegotchi, read markers) per-profile using the cert fingerprint, clear stale registration on connect, and migrate existing data.
+
+**Architecture:** Create a `ProfileContext` providing `certFingerprint` to the component tree. Each component reads its scoped localStorage key (`{baseKey}_{fingerprint}`). A one-time migration copies old global keys to scoped keys. The `voice.connected` handler gets an `else` branch to clear stale registration.
+
+**Tech Stack:** React (context, hooks), TypeScript, localStorage
+
+---
+
+### Task 1: Clear Stale Registration on Connect
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx:548-563`
+
+**Step 1: Add else branch to clear stale registration**
+
+In the `onVoiceConnected` handler, after the existing `if (reg?.registered) { ... }` block (line 550-562), add an `else` branch that clears `registered` and `registeredName` on the saved server entry:
+
+```typescript
+      // Persist Mumble registration status to the saved server entry
+      const reg = data as { registered?: boolean; registeredName?: string } | undefined;
+      if (reg?.registered) {
+        try {
+          const stored = localStorage.getItem('brmble-server');
+          if (stored) {
+            const savedServer = JSON.parse(stored) as SavedServer;
+            if (savedServer.id) {
+              const updated = { ...savedServer, registered: true, username: reg.registeredName ?? savedServer.username, registeredName: reg.registeredName };
+              bridge.send('servers.update', updated);
+              localStorage.setItem('brmble-server', JSON.stringify(updated));
+            }
+          }
+        } catch { /* ignore parse errors */ }
+      } else {
+        // Clear stale registration when server reports not-registered
+        try {
+          const stored = localStorage.getItem('brmble-server');
+          if (stored) {
+            const savedServer = JSON.parse(stored) as SavedServer;
+            if (savedServer.id && savedServer.registered) {
+              const updated = { ...savedServer, registered: false, registeredName: undefined };
+              bridge.send('servers.update', updated);
+              localStorage.setItem('brmble-server', JSON.stringify(updated));
+            }
+          }
+        } catch { /* ignore parse errors */ }
+      }
+```
+
+Note: The `else` branch only sends updates when `savedServer.registered` is currently truthy, avoiding unnecessary writes when the server was already marked as not-registered.
+
+**Step 2: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success, no type errors
+
+**Step 3: Commit**
+
+```
+git add src/Brmble.Web/src/App.tsx
+git commit -m "fix: clear stale registration status when server reports not-registered"
+```
+
+---
+
+### Task 2: Create ProfileContext
+
+**Files:**
+- Create: `src/Brmble.Web/src/contexts/ProfileContext.tsx`
+- Modify: `src/Brmble.Web/src/App.tsx:1,136`
+
+**Step 1: Create the ProfileContext file**
+
+Create `src/Brmble.Web/src/contexts/ProfileContext.tsx`:
+
+```typescript
+import { createContext, useContext } from 'react';
+
+const ProfileContext = createContext<string>('');
+
+export const ProfileProvider = ProfileContext.Provider;
+
+export function useProfileFingerprint(): string {
+  return useContext(ProfileContext);
+}
+```
+
+**Step 2: Expose certFingerprint in App.tsx**
+
+In `App.tsx` line 136, change:
+```typescript
+const [, setCertFingerprint] = useState('');
+```
+to:
+```typescript
+const [certFingerprint, setCertFingerprint] = useState('');
+```
+
+**Step 3: Import ProfileProvider in App.tsx**
+
+Add to imports at top of `App.tsx`:
+```typescript
+import { ProfileProvider } from './contexts/ProfileContext';
+```
+
+**Step 4: Wrap app content with ProfileProvider**
+
+In the `return` statement of `App()`, wrap the outermost `<div className="app">` children with the provider. Find the opening `<div className="app">` (should be around line 1656) and wrap the content:
+
+```tsx
+return (
+  <div className="app">
+    <ProfileProvider value={certFingerprint}>
+      {/* ...existing content... */}
+    </ProfileProvider>
+  </div>
+);
+```
+
+Note: The `<ProfileProvider>` should go just inside `<div className="app">`, wrapping everything until the closing `</div>`. This ensures all child components can access the fingerprint.
+
+**Step 5: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success, no type errors
+
+**Step 6: Commit**
+
+```
+git add src/Brmble.Web/src/contexts/ProfileContext.tsx src/Brmble.Web/src/App.tsx
+git commit -m "feat: add ProfileContext to provide cert fingerprint to component tree"
+```
+
+---
+
+### Task 3: Create localStorage Migration Utility
+
+**Files:**
+- Create: `src/Brmble.Web/src/utils/migrateLocalStorage.ts`
+- Modify: `src/Brmble.Web/src/App.tsx` (call migration on fingerprint set)
+
+**Step 1: Create the migration utility**
+
+Create `src/Brmble.Web/src/utils/migrateLocalStorage.ts`:
+
+```typescript
+/**
+ * Migrate global localStorage keys to per-profile scoped keys.
+ *
+ * For each key, if the old global key exists AND the new scoped key
+ * does NOT exist, copies the value and deletes the old key.
+ * Idempotent — safe to run multiple times.
+ */
+
+const KEYS_TO_MIGRATE = [
+  'idle-farm-save',
+  'idle-farm-theme',
+  'brmblegotchi-state',
+  'brmblegotchi-position',
+  'brmble-read-markers',
+];
+
+export function migrateLocalStorage(fingerprint: string): void {
+  if (!fingerprint) return;
+
+  for (const key of KEYS_TO_MIGRATE) {
+    const scopedKey = `${key}_${fingerprint}`;
+    const oldValue = localStorage.getItem(key);
+    if (oldValue !== null && localStorage.getItem(scopedKey) === null) {
+      localStorage.setItem(scopedKey, oldValue);
+      localStorage.removeItem(key);
+    }
+  }
+}
+```
+
+**Step 2: Call migration in App.tsx when fingerprint is set**
+
+Add import at top of `App.tsx`:
+```typescript
+import { migrateLocalStorage } from './utils/migrateLocalStorage';
+```
+
+Add a `useEffect` in `App()` (after the `certFingerprint` state declaration, around line 138) that runs migration when fingerprint changes:
+
+```typescript
+useEffect(() => {
+  if (certFingerprint) {
+    migrateLocalStorage(certFingerprint);
+  }
+}, [certFingerprint]);
+```
+
+**Step 3: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success
+
+**Step 4: Commit**
+
+```
+git add src/Brmble.Web/src/utils/migrateLocalStorage.ts src/Brmble.Web/src/App.tsx
+git commit -m "feat: add localStorage migration utility for per-profile state scoping"
+```
+
+---
+
+### Task 4: Scope useGameState to Profile Fingerprint
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Game/useGameState.ts`
+- Modify: `src/Brmble.Web/src/components/Game/GameUI.tsx`
+
+**Step 1: Add fingerprint parameter to useGameState**
+
+In `useGameState.ts`, import `useProfileFingerprint`:
+
+```typescript
+import { useProfileFingerprint } from '../../contexts/ProfileContext';
+```
+
+Change the hook signature and add scoped key derivation. At line 61:
+
+```typescript
+export function useGameState() {
+  const fingerprint = useProfileFingerprint();
+  const storageKey = fingerprint ? `${STORAGE_KEY}_${fingerprint}` : STORAGE_KEY;
+  const themeKey = fingerprint ? `idle-farm-theme_${fingerprint}` : 'idle-farm-theme';
+```
+
+**Step 2: Replace all STORAGE_KEY references with storageKey**
+
+Replace every `STORAGE_KEY` usage inside the hook body with `storageKey`, and `'idle-farm-theme'` with `themeKey`. There are 6 locations:
+
+1. Line 63 (useState initializer): `localStorage.getItem(storageKey)`
+2. Line 98 (auto-save interval): `localStorage.setItem(storageKey, ...)`
+3. Line 230 (theme save): `localStorage.setItem(themeKey, theme)`
+4. Line 234 (manual save): `localStorage.setItem(storageKey, ...)`
+5. Line 238 (manual load): `localStorage.getItem(storageKey)`
+6. Line 254 (reset): `localStorage.removeItem(storageKey)`
+
+**Step 3: Re-load state when fingerprint changes**
+
+The `useState` lazy initializer only runs on mount. Add a `useEffect` to reload state when fingerprint changes:
+
+```typescript
+const fingerprintRef = useRef(fingerprint);
+useEffect(() => {
+  if (fingerprint && fingerprint !== fingerprintRef.current) {
+    fingerprintRef.current = fingerprint;
+    const key = `${STORAGE_KEY}_${fingerprint}`;
+    const saved = localStorage.getItem(key);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (hasInfrastructure(parsed) && hasServices(parsed)) {
+          setState(parsed);
+          return;
+        }
+      } catch { /* ignore */ }
+    }
+    setState(INITIAL_STATE);
+  }
+}, [fingerprint]);
+```
+
+**Step 4: Add storageKey to auto-save dependency array**
+
+The auto-save `useEffect` (line 96-101) uses `[]` dependency. Since `storageKey` can change, update it:
+
+```typescript
+useEffect(() => {
+  const interval = setInterval(() => {
+    localStorage.setItem(storageKey, JSON.stringify({ ...stateRef.current, lastSaved: Date.now() }));
+  }, 30000);
+  return () => clearInterval(interval);
+}, [storageKey]);
+```
+
+**Step 5: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success
+
+**Step 6: Commit**
+
+```
+git add src/Brmble.Web/src/components/Game/useGameState.ts
+git commit -m "feat: scope idle game state to active profile fingerprint"
+```
+
+---
+
+### Task 5: Scope Brmblegotchi to Profile Fingerprint
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx`
+
+**Step 1: Import useProfileFingerprint and derive scoped keys**
+
+Add import:
+```typescript
+import { useProfileFingerprint } from '../../contexts/ProfileContext';
+```
+
+At the start of `BrmblegotchiWidget()` (line 88), add:
+```typescript
+export function BrmblegotchiWidget() {
+  const fingerprint = useProfileFingerprint();
+  const stateKey = fingerprint ? `${STATE_KEY}_${fingerprint}` : STATE_KEY;
+  const positionKey = fingerprint ? `${POSITION_KEY}_${fingerprint}` : POSITION_KEY;
+```
+
+**Step 2: Replace all STATE_KEY / POSITION_KEY with scoped versions**
+
+Replace every usage in the component body:
+
+- `STATE_KEY` → `stateKey` (lines 105, 163, 203)
+- `POSITION_KEY` → `positionKey` (lines 94, 251)
+
+The `SETTINGS_KEY` references stay global (settings are shared).
+
+**Step 3: Re-initialize state when fingerprint changes**
+
+Add a `useEffect` to reload state and position when fingerprint changes:
+
+```typescript
+const fingerprintRef = useRef(fingerprint);
+useEffect(() => {
+  if (fingerprint && fingerprint !== fingerprintRef.current) {
+    fingerprintRef.current = fingerprint;
+    // Reload pet state
+    try {
+      const stored = localStorage.getItem(`${STATE_KEY}_${fingerprint}`);
+      if (stored) {
+        const saved = JSON.parse(stored) as PetState;
+        const elapsed = (Date.now() - saved.lastUpdate) / 1000;
+        setPetState({
+          hunger: Math.max(0, saved.hunger - elapsed * 0.0069),
+          happiness: Math.max(0, saved.happiness - elapsed * 0.0139),
+          cleanliness: Math.max(0, saved.cleanliness - elapsed * 0.0278),
+          lastUpdate: Date.now(),
+          lastActionTime: saved.lastActionTime ?? 0,
+        });
+      } else {
+        setPetState({ hunger: 80, happiness: 75, cleanliness: 85, lastUpdate: Date.now(), lastActionTime: 0 });
+      }
+    } catch {
+      setPetState({ hunger: 80, happiness: 75, cleanliness: 85, lastUpdate: Date.now(), lastActionTime: 0 });
+    }
+    // Reload position
+    try {
+      const stored = localStorage.getItem(`${POSITION_KEY}_${fingerprint}`);
+      if (stored) {
+        setPosition(JSON.parse(stored));
+      } else {
+        setPosition({ bottom: 150, right: 24 });
+      }
+    } catch {
+      setPosition({ bottom: 150, right: 24 });
+    }
+  }
+}, [fingerprint]);
+```
+
+**Step 4: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success
+
+**Step 5: Commit**
+
+```
+git add src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx
+git commit -m "feat: scope brmblegotchi state to active profile fingerprint"
+```
+
+---
+
+### Task 6: Scope Read Markers to Profile Fingerprint
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useUnreadTracker.ts`
+- Modify: `src/Brmble.Web/src/App.tsx` (call resetMarkersCache on profile switch)
+
+**Step 1: Add fingerprint parameter to module-level functions**
+
+In `useUnreadTracker.ts`, change the module-level functions to accept a fingerprint parameter:
+
+Change `STORAGE_KEY` usage to be dynamic. Add a helper:
+
+```typescript
+function getStorageKey(fingerprint: string): string {
+  return fingerprint ? `${STORAGE_KEY}_${fingerprint}` : STORAGE_KEY;
+}
+```
+
+Update `loadMarkers` to accept fingerprint and use scoped key:
+```typescript
+let markersCacheFingerprint: string | null = null;
+
+function loadMarkers(fingerprint: string): Record<string, StoredMarker> {
+  if (markersCache && markersCacheFingerprint === fingerprint) return markersCache;
+  const key = getStorageKey(fingerprint);
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) {
+      markersCache = {};
+      markersCacheFingerprint = fingerprint;
+      return markersCache;
+    }
+    const parsed = JSON.parse(raw);
+    const result: Record<string, StoredMarker> = {};
+    for (const [roomId, value] of Object.entries(parsed)) {
+      if (typeof value === 'string') {
+        result[roomId] = { eventId: value, ts: Date.now() };
+      } else {
+        result[roomId] = value as StoredMarker;
+      }
+    }
+    markersCache = result;
+    markersCacheFingerprint = fingerprint;
+    return markersCache;
+  } catch {
+    markersCache = {};
+    markersCacheFingerprint = fingerprint;
+    return markersCache;
+  }
+}
+```
+
+Update `saveMarker`:
+```typescript
+function saveMarker(roomId: string, eventId: string, ts: number, fingerprint: string): void {
+  const markers = loadMarkers(fingerprint);
+  markers[roomId] = { eventId, ts };
+  try {
+    localStorage.setItem(getStorageKey(fingerprint), JSON.stringify(markers));
+  } catch { /* localStorage may be full */ }
+}
+```
+
+Update `getMarker`:
+```typescript
+function getMarker(roomId: string, fingerprint: string): StoredMarker | null {
+  return loadMarkers(fingerprint)[roomId] ?? null;
+}
+```
+
+Add `resetMarkersCache` export:
+```typescript
+export function resetMarkersCache(): void {
+  markersCache = null;
+  markersCacheFingerprint = null;
+}
+```
+
+**Step 2: Thread fingerprint through useUnreadTracker hook**
+
+Add fingerprint parameter to the hook:
+```typescript
+export function useUnreadTracker(
+  client: MatrixClient | null,
+  dmRoomIds: Set<string>,
+  activeRoomId: string | null,
+  currentDisplayName?: string | null,
+  fingerprint?: string,
+): UnreadTracker {
+```
+
+Use `fingerprint ?? ''` in all calls to `loadMarkers`, `saveMarker`, `getMarker` within the hook body. There are 5 call sites:
+
+1. `buildRoomUnread` — `getMarker(room.roomId, fp)` (2 occurrences, lines ~206, ~253)
+2. `markRoomRead` — `saveMarker(roomId, messageEventId, markerTs, fp)` (line ~359)
+3. `getMarkerTimestamp` — `getMarker(roomId, fp)` (line ~430)
+4. `refreshAll` — `getMarker(room.roomId, fp)` (line ~253)
+
+Store fingerprint in a local variable:
+```typescript
+const fp = fingerprint ?? '';
+```
+
+**Step 3: Pass fingerprint to useUnreadTracker call in App.tsx**
+
+In `App.tsx` around line 330, update the call:
+```typescript
+const unreadTracker = useUnreadTracker(
+  matrixClient?.client ?? null,
+  dmRoomIds,
+  activeMatrixRoomId,
+  username || null,
+  certFingerprint,
+);
+```
+
+**Step 4: Call resetMarkersCache on profile switch in App.tsx**
+
+Import `resetMarkersCache`:
+```typescript
+import { useUnreadTracker, resetMarkersCache } from './hooks/useUnreadTracker';
+```
+
+In the `onProfilesActiveChanged` handler (line 918-929), add `resetMarkersCache()` call:
+```typescript
+const onProfilesActiveChanged = (data: unknown) => {
+  const d = data as { id: string | null; name: string | null; fingerprint: string | null };
+  resetMarkersCache();
+  if (d.id) {
+    // ...existing code...
+```
+
+**Step 5: Build to verify**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success
+
+**Step 6: Commit**
+
+```
+git add src/Brmble.Web/src/hooks/useUnreadTracker.ts src/Brmble.Web/src/App.tsx
+git commit -m "feat: scope read markers to active profile fingerprint"
+```
+
+---
+
+### Task 7: Build Verification & Final Commit
+
+**Files:**
+- None (verification only)
+
+**Step 1: Run full frontend build**
+
+Run: `npm run build` (in `src/Brmble.Web`)
+Expected: Success with zero errors
+
+**Step 2: Run dotnet build**
+
+Run: `dotnet build`
+Expected: Success (no C# changes in this plan, but verify nothing is broken)
+
+**Step 3: Run tests**
+
+Run: `dotnet test`
+Expected: All tests pass
+
+---
+
+### Task 8: Create GitHub Issue for Medium-Priority Items
+
+**Files:**
+- None (GitHub issue only)
+
+**Step 1: Create the issue**
+
+Use `gh issue create` with the following content:
+
+Title: `Per-profile scoping for auto-connect and last-connected-server settings`
+
+Body:
+```
+## Context
+
+With the multi-profile system, several settings are currently shared globally but should be scoped per-profile in a future iteration.
+
+## Items
+
+- [ ] `autoConnectEnabled` / `autoConnectServerId` — auto-connect preferences should be per-profile
+- [ ] `lastConnectedServerId` — last connected server should track per-profile
+- [ ] `brmble-server` localStorage key — stores the last connected server entry, should be per-profile
+
+## Notes
+
+These are medium priority because they don't cause data corruption or incorrect behavior — they just mean preferences leak between profiles. The critical items (game state, brmblegotchi, read markers, registration status) were fixed in the per-profile state scoping implementation.
+
+## Related
+
+- Part of the multi-profile system (feature/profile-data-model branch)
+```

--- a/lib/MumbleSharp/MumbleSharp/BasicMumbleProtocol.cs
+++ b/lib/MumbleSharp/MumbleSharp/BasicMumbleProtocol.cs
@@ -412,6 +412,14 @@ namespace MumbleSharp
                     user.Comment = userState.Comment;
                     triggerUserStateCommentChanged = true;
                 }
+                if (userState.ShouldSerializeUserId())
+                {
+                    user.RegisteredUserId = userState.UserId;
+                }
+                if (userState.ShouldSerializeHash())
+                {
+                    user.CertificateHash = userState.Hash;
+                }
 
                 if (userState.ShouldSerializeChannelId())
                 {

--- a/lib/MumbleSharp/MumbleSharp/Model/User.cs
+++ b/lib/MumbleSharp/MumbleSharp/Model/User.cs
@@ -23,6 +23,10 @@ namespace MumbleSharp.Model
         public System.Collections.Generic.List<uint> ListeningChannels { get; } = new System.Collections.Generic.List<uint>();
         public System.Collections.Generic.Dictionary<uint, float> ListeningVolumeAdjustments { get; } = new System.Collections.Generic.Dictionary<uint, float>();
 
+        public uint? RegisteredUserId { get; set; }
+        public string CertificateHash { get; set; }
+        public bool IsRegistered => RegisteredUserId.HasValue;
+
         private Channel _channel;
         public Channel Channel
         {

--- a/lib/MumbleSharp/MumbleSharp/Model/User.cs
+++ b/lib/MumbleSharp/MumbleSharp/Model/User.cs
@@ -24,7 +24,7 @@ namespace MumbleSharp.Model
         public System.Collections.Generic.Dictionary<uint, float> ListeningVolumeAdjustments { get; } = new System.Collections.Generic.Dictionary<uint, float>();
 
         public uint? RegisteredUserId { get; set; }
-        public string CertificateHash { get; set; }
+        public string CertificateHash { get; set; } = string.Empty;
         public bool IsRegistered => RegisteredUserId.HasValue;
 
         private Channel _channel;

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -233,7 +233,7 @@ static class Program
             _appConfigService!.OnSettingsChanged = settings => _mumbleClient?.ApplySettings(settings);
             _appConfigService!.RegisterHandlers(_bridge);
 
-            _certService = new CertificateService(_bridge);
+            _certService = new CertificateService(_bridge, _appConfigService);
             _certService.RegisterHandlers(_bridge);
 
             _mumbleClient = new MumbleAdapter(_bridge, _hwnd, _certService, _appConfigService);

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -234,6 +234,7 @@ static class Program
             _appConfigService!.RegisterHandlers(_bridge);
 
             _certService = new CertificateService(_bridge, _appConfigService);
+            _certService.Initialize(_bridge);
             _certService.RegisterHandlers(_bridge);
 
             _mumbleClient = new MumbleAdapter(_bridge, _hwnd, _certService, _appConfigService);

--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -81,8 +81,9 @@ internal sealed class AppConfigService : IAppConfigService
             var entry = ParseServerEntry(data);
             if (entry != null)
             {
-                UpdateServer(entry);
-                bridge.Send("servers.updated", new { server = entry });
+                var merged = UpdateServer(entry);
+                if (merged != null)
+                    bridge.Send("servers.updated", new { server = merged });
             }
             await Task.CompletedTask;
         });
@@ -133,12 +134,30 @@ internal sealed class AppConfigService : IAppConfigService
         lock (_lock) { _servers.Add(server); Save(); }
     }
 
-    public void UpdateServer(ServerEntry server)
+    public ServerEntry? UpdateServer(ServerEntry server)
     {
         lock (_lock)
         {
             var i = _servers.FindIndex(s => s.Id == server.Id);
-            if (i >= 0) { _servers[i] = server; Save(); }
+            if (i >= 0)
+            {
+                var existing = _servers[i];
+                // Merge: only overwrite fields that have non-default values in the incoming entry
+                _servers[i] = existing with
+                {
+                    Label = !string.IsNullOrEmpty(server.Label) ? server.Label : existing.Label,
+                    ApiUrl = server.ApiUrl ?? existing.ApiUrl,
+                    Host = server.Host ?? existing.Host,
+                    Port = server.Port ?? existing.Port,
+                    Username = !string.IsNullOrEmpty(server.Username) ? server.Username : existing.Username,
+                    Password = !string.IsNullOrEmpty(server.Password) ? server.Password : existing.Password,
+                    Registered = server.Registered || existing.Registered,
+                    RegisteredName = server.RegisteredName ?? existing.RegisteredName,
+                };
+                Save();
+                return _servers[i];
+            }
+            return null;
         }
     }
 
@@ -306,25 +325,30 @@ internal sealed class AppConfigService : IAppConfigService
 
     private static ServerEntry? ParseServerEntry(System.Text.Json.JsonElement data)
     {
-        if (!data.TryGetProperty("label", out var label) ||
-            !data.TryGetProperty("username", out var username))
+        if (!data.TryGetProperty("id", out var idEl))
             return null;
 
-        var id = data.TryGetProperty("id", out var idEl)
-            ? idEl.GetString()
-            : Guid.NewGuid().ToString();
+        var id = idEl.GetString();
+        if (string.IsNullOrEmpty(id))
+            return null;
 
+        var label = data.TryGetProperty("label", out var labelEl) ? labelEl.GetString() ?? "" : "";
+        var username = data.TryGetProperty("username", out var usernameEl) ? usernameEl.GetString() ?? "" : "";
         var apiUrl = data.TryGetProperty("apiUrl", out var apiEl) ? apiEl.GetString() : null;
         var password = data.TryGetProperty("password", out var pwEl) ? pwEl.GetString() ?? "" : "";
+        var registered = data.TryGetProperty("registered", out var regEl) && regEl.ValueKind == System.Text.Json.JsonValueKind.True;
+        var registeredName = data.TryGetProperty("registeredName", out var rnEl) ? rnEl.GetString() : null;
 
         return new ServerEntry(
             id!,
-            label.GetString() ?? "",
+            label,
             apiUrl,
             data.TryGetProperty("host", out var hostEl) ? hostEl.GetString() : null,
             data.TryGetProperty("port", out var portEl) && portEl.ValueKind == System.Text.Json.JsonValueKind.Number ? portEl.GetInt32() : null,
-            username.GetString() ?? "",
-            password);
+            username,
+            password,
+            registered,
+            registeredName);
     }
 
     private record ConfigData

--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -259,13 +259,15 @@ internal sealed class AppConfigService : IAppConfigService
 
     public IReadOnlyList<ProfileEntry> GetProfiles() { lock (_lock) return _profiles.ToList(); }
 
-    public void AddProfile(ProfileEntry profile)
+    public bool AddProfile(ProfileEntry profile)
     {
         lock (_lock)
         {
-            if (_profiles.Any(p => p.Id == profile.Id)) return;
+            if (_profiles.Any(p => p.Id == profile.Id)) return false;
+            if (_profiles.Any(p => p.Name.Equals(profile.Name, StringComparison.OrdinalIgnoreCase))) return false;
             _profiles.Add(profile);
             Save();
+            return true;
         }
     }
 
@@ -280,16 +282,19 @@ internal sealed class AppConfigService : IAppConfigService
         }
     }
 
-    public void RenameProfile(string id, string newName)
+    public bool RenameProfile(string id, string newName)
     {
         lock (_lock)
         {
+            if (_profiles.Any(p => p.Id != id && p.Name.Equals(newName, StringComparison.OrdinalIgnoreCase))) return false;
             var idx = _profiles.FindIndex(p => p.Id == id);
             if (idx >= 0)
             {
                 _profiles[idx] = _profiles[idx] with { Name = newName };
                 Save();
+                return true;
             }
+            return false;
         }
     }
 

--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -142,19 +142,9 @@ internal sealed class AppConfigService : IAppConfigService
             var i = _servers.FindIndex(s => s.Id == server.Id);
             if (i >= 0)
             {
-                var existing = _servers[i];
-                // Merge: only overwrite fields that have non-default values in the incoming entry
-                _servers[i] = existing with
-                {
-                    Label = !string.IsNullOrEmpty(server.Label) ? server.Label : existing.Label,
-                    ApiUrl = server.ApiUrl ?? existing.ApiUrl,
-                    Host = server.Host ?? existing.Host,
-                    Port = server.Port ?? existing.Port,
-                    Username = !string.IsNullOrEmpty(server.Username) ? server.Username : existing.Username,
-                    Password = !string.IsNullOrEmpty(server.Password) ? server.Password : existing.Password,
-                    Registered = server.Registered,
-                    RegisteredName = server.Registered ? (server.RegisteredName ?? existing.RegisteredName) : null,
-                };
+                // Replace the existing entry wholesale with the incoming server entry.
+                // The frontend sends a full ServerEntry on edit, so this allows fields to be cleared.
+                _servers[i] = server;
                 Save();
                 return _servers[i];
             }

--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -25,6 +25,7 @@ internal sealed class AppConfigService : IAppConfigService
     private double? _zoomFactor;
     private List<ProfileEntry> _profiles = new();
     private string? _activeProfileId;
+    private Dictionary<string, Dictionary<string, RegistrationInfo>> _profileRegistrations = new();
     private readonly string _certsDir;
     private readonly object _lock = new();
 
@@ -151,8 +152,8 @@ internal sealed class AppConfigService : IAppConfigService
                     Port = server.Port ?? existing.Port,
                     Username = !string.IsNullOrEmpty(server.Username) ? server.Username : existing.Username,
                     Password = !string.IsNullOrEmpty(server.Password) ? server.Password : existing.Password,
-                    Registered = server.Registered || existing.Registered,
-                    RegisteredName = server.RegisteredName ?? existing.RegisteredName,
+                    Registered = server.Registered,
+                    RegisteredName = server.Registered ? (server.RegisteredName ?? existing.RegisteredName) : null,
                 };
                 Save();
                 return _servers[i];
@@ -164,6 +165,43 @@ internal sealed class AppConfigService : IAppConfigService
     public void RemoveServer(string id)
     {
         lock (_lock) { _servers.RemoveAll(s => s.Id == id); Save(); }
+    }
+
+    public void SwapProfileRegistrations(string? oldProfileId, string? newProfileId)
+    {
+        lock (_lock)
+        {
+            // Save current registrations under old profile
+            if (!string.IsNullOrEmpty(oldProfileId))
+            {
+                var regs = new Dictionary<string, RegistrationInfo>();
+                foreach (var s in _servers)
+                {
+                    if (s.Registered || s.RegisteredName != null)
+                        regs[s.Id] = new RegistrationInfo(s.Registered, s.RegisteredName);
+                }
+                _profileRegistrations[oldProfileId!] = regs;
+            }
+
+            // Load new profile's cached registrations (or clear if none cached)
+            Dictionary<string, RegistrationInfo>? newRegs = null;
+            if (!string.IsNullOrEmpty(newProfileId))
+                _profileRegistrations.TryGetValue(newProfileId!, out newRegs);
+
+            for (int i = 0; i < _servers.Count; i++)
+            {
+                RegistrationInfo? info = null;
+                if (newRegs != null && newRegs.TryGetValue(_servers[i].Id, out var found))
+                    info = found;
+                _servers[i] = _servers[i] with
+                {
+                    Registered = info?.Registered ?? false,
+                    RegisteredName = info?.RegisteredName
+                };
+            }
+
+            Save();
+        }
     }
 
     public AppSettings GetSettings()
@@ -283,6 +321,7 @@ internal sealed class AppConfigService : IAppConfigService
                 _zoomFactor = data?.ZoomFactor;
                 _profiles = data?.Profiles ?? new List<ProfileEntry>();
                 _activeProfileId = data?.ActiveProfileId;
+                _profileRegistrations = data?.ProfileRegistrations ?? new();
                 MigrateIdentityPfx();
                 return;
             }
@@ -308,6 +347,7 @@ internal sealed class AppConfigService : IAppConfigService
             _zoomFactor = null;
             _profiles = new List<ProfileEntry>();
             _activeProfileId = null;
+            _profileRegistrations = new();
         }
 
         MigrateIdentityPfx();
@@ -318,7 +358,8 @@ internal sealed class AppConfigService : IAppConfigService
         var data = new ConfigData {
             Servers = _servers, Settings = _settings, Window = _windowState,
             ClosePreference = _closePreference, LastConnectedServerId = _lastConnectedServerId,
-            ZoomFactor = _zoomFactor, Profiles = _profiles, ActiveProfileId = _activeProfileId
+            ZoomFactor = _zoomFactor, Profiles = _profiles, ActiveProfileId = _activeProfileId,
+            ProfileRegistrations = _profileRegistrations
         };
         File.WriteAllText(_configPath, JsonSerializer.Serialize(data, _jsonOptions));
     }
@@ -361,6 +402,7 @@ internal sealed class AppConfigService : IAppConfigService
         public double? ZoomFactor { get; init; } = null;
         public List<ProfileEntry> Profiles { get; init; } = [];
         public string? ActiveProfileId { get; init; } = null;
+        public Dictionary<string, Dictionary<string, RegistrationInfo>> ProfileRegistrations { get; init; } = new();
     }
 
     private void MigrateIdentityPfx()

--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -16,12 +16,16 @@ internal sealed class AppConfigService : IAppConfigService
 
     private readonly string _configPath;
     private readonly string _legacyServersPath;
+    private readonly string _dir;
     private List<ServerEntry> _servers = new();
     private AppSettings _settings = AppSettings.Default;
     private WindowState? _windowState;
     private string? _closePreference;
     private string? _lastConnectedServerId;
     private double? _zoomFactor;
+    private List<ProfileEntry> _profiles = new();
+    private string? _activeProfileId;
+    private readonly string _certsDir;
     private readonly object _lock = new();
 
     public string ServiceName => "appConfig";
@@ -33,8 +37,11 @@ internal sealed class AppConfigService : IAppConfigService
 
     internal AppConfigService(string dir)
     {
+        _dir = dir;
         _configPath = Path.Combine(dir, "config.json");
         _legacyServersPath = Path.Combine(dir, "servers.json");
+        _certsDir = Path.Combine(dir, "certs");
+        Directory.CreateDirectory(_certsDir);
         Load();
     }
 
@@ -191,6 +198,56 @@ internal sealed class AppConfigService : IAppConfigService
         lock (_lock) { _zoomFactor = factor; Save(); }
     }
 
+    public string GetCertsDir() => _certsDir;
+
+    public IReadOnlyList<ProfileEntry> GetProfiles() { lock (_lock) return _profiles.ToList(); }
+
+    public void AddProfile(ProfileEntry profile)
+    {
+        lock (_lock)
+        {
+            if (_profiles.Any(p => p.Id == profile.Id)) return;
+            _profiles.Add(profile);
+            Save();
+        }
+    }
+
+    public void RemoveProfile(string id)
+    {
+        lock (_lock)
+        {
+            _profiles.RemoveAll(p => p.Id == id);
+            if (_activeProfileId == id)
+                _activeProfileId = _profiles.FirstOrDefault()?.Id;
+            Save();
+        }
+    }
+
+    public void RenameProfile(string id, string newName)
+    {
+        lock (_lock)
+        {
+            var idx = _profiles.FindIndex(p => p.Id == id);
+            if (idx >= 0)
+            {
+                _profiles[idx] = _profiles[idx] with { Name = newName };
+                Save();
+            }
+        }
+    }
+
+    public string? GetActiveProfileId() { lock (_lock) return _activeProfileId; }
+
+    public void SetActiveProfileId(string? id)
+    {
+        lock (_lock)
+        {
+            if (id != null && !_profiles.Any(p => p.Id == id)) return;
+            _activeProfileId = id;
+            Save();
+        }
+    }
+
     private void Load()
     {
         try
@@ -205,6 +262,9 @@ internal sealed class AppConfigService : IAppConfigService
                 _closePreference = data?.ClosePreference;
                 _lastConnectedServerId = data?.LastConnectedServerId;
                 _zoomFactor = data?.ZoomFactor;
+                _profiles = data?.Profiles ?? new List<ProfileEntry>();
+                _activeProfileId = data?.ActiveProfileId;
+                MigrateIdentityPfx();
                 return;
             }
 
@@ -215,6 +275,7 @@ internal sealed class AppConfigService : IAppConfigService
                 var legacy = JsonSerializer.Deserialize<LegacyServerlistData>(json);
                 _servers = legacy?.Servers ?? new List<ServerEntry>();
                 Save(); // write config.json immediately
+                MigrateIdentityPfx();
                 return;
             }
         }
@@ -226,12 +287,20 @@ internal sealed class AppConfigService : IAppConfigService
             _closePreference = null;
             _lastConnectedServerId = null;
             _zoomFactor = null;
+            _profiles = new List<ProfileEntry>();
+            _activeProfileId = null;
         }
+
+        MigrateIdentityPfx();
     }
 
     private void Save()
     {
-        var data = new ConfigData { Servers = _servers, Settings = _settings, Window = _windowState, ClosePreference = _closePreference, LastConnectedServerId = _lastConnectedServerId, ZoomFactor = _zoomFactor };
+        var data = new ConfigData {
+            Servers = _servers, Settings = _settings, Window = _windowState,
+            ClosePreference = _closePreference, LastConnectedServerId = _lastConnectedServerId,
+            ZoomFactor = _zoomFactor, Profiles = _profiles, ActiveProfileId = _activeProfileId
+        };
         File.WriteAllText(_configPath, JsonSerializer.Serialize(data, _jsonOptions));
     }
 
@@ -266,6 +335,46 @@ internal sealed class AppConfigService : IAppConfigService
         public string? ClosePreference { get; init; } = null;
         public string? LastConnectedServerId { get; init; } = null;
         public double? ZoomFactor { get; init; } = null;
+        public List<ProfileEntry> Profiles { get; init; } = [];
+        public string? ActiveProfileId { get; init; } = null;
+    }
+
+    private void MigrateIdentityPfx()
+    {
+        if (_profiles.Count > 0) return;
+
+        var oldCertPath = Path.Combine(_dir, "identity.pfx");
+        if (!File.Exists(oldCertPath)) return;
+
+        var id = Guid.NewGuid().ToString();
+        var newCertPath = Path.Combine(_certsDir, id + ".pfx");
+
+        try
+        {
+            File.Move(oldCertPath, newCertPath);
+
+            _profiles.Add(new ProfileEntry(id, "Default"));
+            _activeProfileId = id;
+
+            try
+            {
+                Save();
+            }
+            catch
+            {
+                // Save() failed — roll back the file move and profile state
+                _profiles.RemoveAll(p => p.Id == id);
+                _activeProfileId = null;
+                File.Move(newCertPath, oldCertPath);
+                return;
+            }
+        }
+        catch
+        {
+            // File.Move or rollback failed — ensure profile state is clean
+            _profiles.RemoveAll(p => p.Id == id);
+            _activeProfileId = null;
+        }
     }
 
     private record LegacyServerlistData

--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -371,7 +371,8 @@ internal sealed class AppConfigService : IAppConfigService
         if (!File.Exists(oldCertPath)) return;
 
         var id = Guid.NewGuid().ToString();
-        var newCertPath = Path.Combine(_certsDir, id + ".pfx");
+        var profileName = "Default";
+        var newCertPath = Path.Combine(_certsDir, SanitizeForFileName(profileName) + "_" + id + ".pfx");
 
         try
         {
@@ -404,5 +405,28 @@ internal sealed class AppConfigService : IAppConfigService
     private record LegacyServerlistData
     {
         public List<ServerEntry> Servers { get; init; } = [];
+    }
+
+    private static string SanitizeForFileName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "profile";
+        var invalid = new HashSet<char>(Path.GetInvalidFileNameChars());
+        var sb = new System.Text.StringBuilder(name.Length);
+        bool lastWasUnderscore = false;
+        foreach (var c in name)
+        {
+            if (invalid.Contains(c) || c == ' ')
+            {
+                if (!lastWasUnderscore) { sb.Append('_'); lastWasUnderscore = true; }
+            }
+            else
+            {
+                sb.Append(c);
+                lastWasUnderscore = false;
+            }
+        }
+        var result = sb.ToString().Trim('_');
+        if (result.Length > 50) result = result[..50].TrimEnd('_');
+        return result.Length == 0 ? "profile" : result;
     }
 }

--- a/src/Brmble.Client/Services/AppConfig/IAppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/IAppConfigService.cs
@@ -22,9 +22,9 @@ public interface IAppConfigService
     double? GetZoomFactor();
     void SaveZoomFactor(double? factor);
     IReadOnlyList<ProfileEntry> GetProfiles();
-    void AddProfile(ProfileEntry profile);
+    bool AddProfile(ProfileEntry profile);
     void RemoveProfile(string id);
-    void RenameProfile(string id, string newName);
+    bool RenameProfile(string id, string newName);
     string? GetActiveProfileId();
     void SetActiveProfileId(string? id);
     string GetCertsDir();

--- a/src/Brmble.Client/Services/AppConfig/IAppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/IAppConfigService.cs
@@ -8,7 +8,7 @@ public interface IAppConfigService
 {
     IReadOnlyList<ServerEntry> GetServers();
     void AddServer(ServerEntry server);
-    void UpdateServer(ServerEntry server);
+    ServerEntry? UpdateServer(ServerEntry server);
     void RemoveServer(string id);
     AppSettings GetSettings();
     void SetSettings(AppSettings settings);

--- a/src/Brmble.Client/Services/AppConfig/IAppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/IAppConfigService.cs
@@ -2,6 +2,8 @@ using Brmble.Client.Services.Serverlist;
 
 namespace Brmble.Client.Services.AppConfig;
 
+public record ProfileEntry(string Id, string Name);
+
 public interface IAppConfigService
 {
     IReadOnlyList<ServerEntry> GetServers();
@@ -18,4 +20,11 @@ public interface IAppConfigService
     void SaveLastConnectedServerId(string? serverId);
     double? GetZoomFactor();
     void SaveZoomFactor(double? factor);
+    IReadOnlyList<ProfileEntry> GetProfiles();
+    void AddProfile(ProfileEntry profile);
+    void RemoveProfile(string id);
+    void RenameProfile(string id, string newName);
+    string? GetActiveProfileId();
+    void SetActiveProfileId(string? id);
+    string GetCertsDir();
 }

--- a/src/Brmble.Client/Services/AppConfig/IAppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/IAppConfigService.cs
@@ -3,6 +3,7 @@ using Brmble.Client.Services.Serverlist;
 namespace Brmble.Client.Services.AppConfig;
 
 public record ProfileEntry(string Id, string Name);
+public record RegistrationInfo(bool Registered, string? RegisteredName);
 
 public interface IAppConfigService
 {
@@ -27,4 +28,5 @@ public interface IAppConfigService
     string? GetActiveProfileId();
     void SetActiveProfileId(string? id);
     string GetCertsDir();
+    void SwapProfileRegistrations(string? oldProfileId, string? newProfileId);
 }

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography.X509Certificates;
 using Brmble.Client.Bridge;
+using Brmble.Client.Services.AppConfig;
 
 namespace Brmble.Client.Services.Certificate;
 
@@ -13,16 +14,18 @@ internal sealed class CertificateService : IService
         ActiveCertificate?.Thumbprint?.ToLowerInvariant();
 
     private readonly NativeBridge _bridge;
+    private readonly IAppConfigService _config;
 
-    private static string CertPath =>
-        Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Brmble",
-            "identity.pfx");
+    private string GetCertPath(string profileId) =>
+        Path.Combine(_config.GetCertsDir(), profileId + ".pfx");
 
-    public CertificateService(NativeBridge bridge)
+    private string? ActiveCertPath =>
+        _config.GetActiveProfileId() is string id ? GetCertPath(id) : null;
+
+    public CertificateService(NativeBridge bridge, IAppConfigService config)
     {
         _bridge = bridge;
+        _config = config;
     }
 
     public void Initialize(NativeBridge bridge) { }
@@ -63,36 +66,52 @@ internal sealed class CertificateService : IService
     /// Returns null if no certificate exists.
     /// </summary>
     internal X509Certificate2? GetExportableCertificate() =>
-        ActiveCertificate is not null && File.Exists(CertPath)
-            ? X509CertificateLoader.LoadPkcs12FromFile(CertPath, password: null, keyStorageFlags: X509KeyStorageFlags.Exportable)
+        ActiveCertificate is not null && ActiveCertPath is string path && File.Exists(path)
+            ? X509CertificateLoader.LoadPkcs12FromFile(path, password: null, keyStorageFlags: X509KeyStorageFlags.Exportable)
             : null;
 
-    private void SendStatus()
+    private void LoadActiveCertificate()
     {
-        if (File.Exists(CertPath))
+        ActiveCertificate = null;
+        if (ActiveCertPath is string path && File.Exists(path))
         {
             try
             {
-                ActiveCertificate = X509CertificateLoader.LoadPkcs12FromFile(CertPath, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
-                _bridge.Send("cert.status", new
-                {
-                    exists = true,
-                    fingerprint = ActiveCertificate.Thumbprint,
-                    subject = ActiveCertificate.Subject
-                });
-                return;
+                ActiveCertificate = X509CertificateLoader.LoadPkcs12FromFile(path, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
             }
-            catch { /* fall through to exists=false */ }
+            catch { }
         }
+    }
 
-        _bridge.Send("cert.status", new { exists = false });
+    private void SendStatus()
+    {
+        LoadActiveCertificate();
+        if (ActiveCertificate != null)
+        {
+            _bridge.Send("cert.status", new
+            {
+                exists = true,
+                fingerprint = ActiveCertificate.Thumbprint,
+                subject = ActiveCertificate.Subject
+            });
+        }
+        else
+        {
+            _bridge.Send("cert.status", new { exists = false });
+        }
     }
 
     private void GenerateCertificate()
     {
         try
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(CertPath)!);
+            if (ActiveCertPath is not string certPath)
+            {
+                _bridge.Send("cert.error", new { message = "No active profile selected." });
+                return;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
 
             using var ecdsa = System.Security.Cryptography.ECDsa.Create(
                 System.Security.Cryptography.ECCurve.NamedCurves.nistP256);
@@ -107,10 +126,10 @@ internal sealed class CertificateService : IService
 
             // Export WITH private key (PFX = PKCS#12)
             var pfxBytes = cert.Export(X509ContentType.Pfx);
-            File.WriteAllBytes(CertPath, pfxBytes);
+            File.WriteAllBytes(certPath, pfxBytes);
 
             // Reload from file to get a clean X509Certificate2 (DefaultKeySet — exportable not needed for status display)
-            ActiveCertificate = X509CertificateLoader.LoadPkcs12FromFile(CertPath, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+            ActiveCertificate = X509CertificateLoader.LoadPkcs12FromFile(certPath, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
 
             _bridge.Send("cert.generated", new
             {
@@ -123,17 +142,24 @@ internal sealed class CertificateService : IService
             _bridge.Send("cert.error", new { message = $"Failed to generate certificate: {ex.Message}" });
         }
     }
+
     private void ImportCertificate(string base64Data)
     {
         try
         {
+            if (ActiveCertPath is not string certPath)
+            {
+                _bridge.Send("cert.error", new { message = "No active profile selected." });
+                return;
+            }
+
             var bytes = Convert.FromBase64String(base64Data);
 
             // Validate it loads before overwriting (DefaultKeySet — no need for exportable during import validation)
             var testCert = X509CertificateLoader.LoadPkcs12(bytes, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
 
-            Directory.CreateDirectory(Path.GetDirectoryName(CertPath)!);
-            File.WriteAllBytes(CertPath, bytes);
+            Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
+            File.WriteAllBytes(certPath, bytes);
             ActiveCertificate = testCert;
 
             _bridge.Send("cert.imported", new
@@ -147,17 +173,18 @@ internal sealed class CertificateService : IService
             _bridge.Send("cert.error", new { message = $"Failed to import certificate: {ex.Message}" });
         }
     }
+
     private void ExportCertificate()
     {
         try
         {
-            if (!File.Exists(CertPath))
+            if (ActiveCertPath is not string certPath || !File.Exists(certPath))
             {
                 _bridge.Send("cert.error", new { message = "No certificate to export." });
                 return;
             }
 
-            var bytes = File.ReadAllBytes(CertPath);
+            var bytes = File.ReadAllBytes(certPath);
             var base64 = Convert.ToBase64String(bytes);
             _bridge.Send("cert.exportData", new { data = base64, filename = "brmble-identity.pfx" });
         }

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -137,7 +137,8 @@ internal sealed class CertificateService : IService
                 try
                 {
                     var bytes = Convert.FromBase64String(base64);
-                    var testCert = X509CertificateLoader.LoadPkcs12(bytes, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                    using var testCert = X509CertificateLoader.LoadPkcs12(bytes, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                    var fingerprint = testCert.Thumbprint;
 
                     var id = Guid.NewGuid().ToString();
                     var certPath = GetCertPath(id);
@@ -151,10 +152,10 @@ internal sealed class CertificateService : IService
                     {
                         _config.SetActiveProfileId(id);
                         LoadActiveCertificate();
-                        bridge.Send("profiles.activeChanged", new { id, name, fingerprint = testCert.Thumbprint });
+                        bridge.Send("profiles.activeChanged", new { id, name, fingerprint });
                     }
 
-                    bridge.Send("profiles.added", new { id, name, fingerprint = testCert.Thumbprint, certValid = true });
+                    bridge.Send("profiles.added", new { id, name, fingerprint, certValid = true });
                 }
                 catch (Exception ex)
                 {

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
 using Brmble.Client.Bridge;
 using Brmble.Client.Services.AppConfig;
 
@@ -73,6 +74,30 @@ internal sealed class CertificateService : IService
         var result = sb.ToString().Trim('_');
         if (result.Length > 50) result = result[..50].TrimEnd('_');
         return result.Length == 0 ? "profile" : result;
+    }
+
+    /// <summary>
+    /// Regex for valid profile names: Mumble's default allowed charset minus Windows-invalid
+    /// filename chars (only '|' is removed). Allows: word chars (\w), -, =, [], {}, (), @, .
+    /// No spaces (Mumble disallows them). Trimmed at edges, max 128 chars.
+    /// </summary>
+    private static readonly Regex ValidProfileNameRegex = new(@"^[-=\w\[\]\{\}\(\)\@\.]+$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Validates a profile name. Returns null if valid, or an error message if invalid.
+    /// </summary>
+    private static string? ValidateProfileName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return "Profile name cannot be empty.";
+        var trimmed = name.Trim();
+        if (trimmed.Length == 0)
+            return "Profile name cannot be empty.";
+        if (trimmed.Length > 128)
+            return "Profile name must be 128 characters or fewer.";
+        if (!ValidProfileNameRegex.IsMatch(trimmed))
+            return "Profile name can only contain letters, numbers, and - = _ . [ ] { } ( ) @";
+        return null;
     }
 
     public CertificateService(NativeBridge bridge, IAppConfigService config)
@@ -178,7 +203,13 @@ internal sealed class CertificateService : IService
         // Create a profile that reuses an existing cert file found by name prefix
         bridge.RegisterHandler("profiles.addFromExisting", data =>
         {
-            var name = data.TryGetProperty("name", out var n) ? n.GetString() ?? "Unnamed" : "Unnamed";
+            var name = data.TryGetProperty("name", out var n) ? n.GetString()?.Trim() ?? "" : "";
+            var validationError = ValidateProfileName(name);
+            if (validationError != null)
+            {
+                bridge.Send("profiles.error", new { message = validationError });
+                return Task.CompletedTask;
+            }
             var sanitized = SanitizeFileName(name);
             var certsDir = _config.GetCertsDir();
             var prefix = sanitized + "_";
@@ -257,7 +288,13 @@ internal sealed class CertificateService : IService
 
         bridge.RegisterHandler("profiles.add", data =>
         {
-            var name = data.TryGetProperty("name", out var n) ? n.GetString() ?? "Unnamed" : "Unnamed";
+            var name = data.TryGetProperty("name", out var n) ? n.GetString()?.Trim() ?? "" : "";
+            var validationError = ValidateProfileName(name);
+            if (validationError != null)
+            {
+                bridge.Send("profiles.error", new { message = validationError });
+                return Task.CompletedTask;
+            }
             Task.Run(() =>
             {
                 try
@@ -300,7 +337,13 @@ internal sealed class CertificateService : IService
 
         bridge.RegisterHandler("profiles.import", data =>
         {
-            var name = data.TryGetProperty("name", out var n) ? n.GetString() ?? "Unnamed" : "Unnamed";
+            var name = data.TryGetProperty("name", out var n) ? n.GetString()?.Trim() ?? "" : "";
+            var validationError = ValidateProfileName(name);
+            if (validationError != null)
+            {
+                bridge.Send("profiles.error", new { message = validationError });
+                return Task.CompletedTask;
+            }
             var base64 = data.TryGetProperty("data", out var d) ? d.GetString() : null;
             if (base64 == null)
             {
@@ -376,8 +419,15 @@ internal sealed class CertificateService : IService
         bridge.RegisterHandler("profiles.rename", data =>
         {
             var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
-            var name = data.TryGetProperty("name", out var n) ? n.GetString() : null;
+            var name = data.TryGetProperty("name", out var n) ? n.GetString()?.Trim() : null;
             if (id == null || name == null) return Task.CompletedTask;
+
+            var validationError = ValidateProfileName(name);
+            if (validationError != null)
+            {
+                bridge.Send("profiles.error", new { message = validationError });
+                return Task.CompletedTask;
+            }
 
             // Find the current cert file before renaming the profile
             var oldProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
@@ -408,8 +458,15 @@ internal sealed class CertificateService : IService
         bridge.RegisterHandler("profiles.renameSwapCert", data =>
         {
             var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
-            var name = data.TryGetProperty("name", out var n) ? n.GetString() : null;
+            var name = data.TryGetProperty("name", out var n) ? n.GetString()?.Trim() : null;
             if (id == null || name == null) return Task.CompletedTask;
+
+            var validationError = ValidateProfileName(name);
+            if (validationError != null)
+            {
+                bridge.Send("profiles.error", new { message = validationError });
+                return Task.CompletedTask;
+            }
 
             var sanitized = SanitizeFileName(name);
             var certsDir = _config.GetCertsDir();

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -534,12 +534,19 @@ internal sealed class CertificateService : IService
             var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
             if (id == null) return Task.CompletedTask;
 
+            var oldProfileId = _config.GetActiveProfileId();
+
             _config.SetActiveProfileId(id);
             LoadActiveCertificate();
+
+            // Swap registration data — save old profile's, load new profile's cached registrations
+            _config.SwapProfileRegistrations(oldProfileId, id);
 
             var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
             bridge.Send("profiles.activeChanged", new { id, name = profile?.Name, fingerprint = ActiveCertificate?.Thumbprint });
             bridge.Send("cert.status", new { exists = ActiveCertificate != null, fingerprint = ActiveCertificate?.Thumbprint, subject = ActiveCertificate?.Subject });
+            // Re-send server list so frontend picks up swapped registration fields
+            bridge.Send("servers.list", new { servers = _config.GetServers() });
             return Task.CompletedTask;
         });
     }

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -249,7 +249,11 @@ internal sealed class CertificateService : IService
                 var fingerprint = cert.Thumbprint;
 
                 var profile = new ProfileEntry(idPart, name);
-                _config.AddProfile(profile);
+                if (!_config.AddProfile(profile))
+                {
+                    bridge.Send("profiles.error", new { message = "A profile with that name already exists." });
+                    return Task.CompletedTask;
+                }
 
                 if (_config.GetActiveProfileId() == null)
                 {
@@ -316,7 +320,14 @@ internal sealed class CertificateService : IService
                     File.WriteAllBytes(certPath, cert.Export(X509ContentType.Pfx));
 
                     var profile = new ProfileEntry(id, name);
-                    _config.AddProfile(profile);
+                    if (!_config.AddProfile(profile))
+                    {
+                        // Duplicate name/id — clean up the orphaned cert file
+                        try { File.Delete(certPath); } catch { }
+                        bridge.Send("profiles.error", new { message = "A profile with that name already exists." });
+                        bridge.NotifyUiThread();
+                        return;
+                    }
 
                     // If this is the first profile, make it active
                     if (_config.GetActiveProfileId() == null)
@@ -368,7 +379,14 @@ internal sealed class CertificateService : IService
                     File.WriteAllBytes(certPath, bytes);
 
                     var profile = new ProfileEntry(id, name);
-                    _config.AddProfile(profile);
+                    if (!_config.AddProfile(profile))
+                    {
+                        // Duplicate name/id — clean up the orphaned cert file
+                        try { File.Delete(certPath); } catch { }
+                        bridge.Send("profiles.error", new { message = "A profile with that name already exists." });
+                        bridge.NotifyUiThread();
+                        return;
+                    }
 
                     if (_config.GetActiveProfileId() == null)
                     {
@@ -449,7 +467,11 @@ internal sealed class CertificateService : IService
                 var oldProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
                 var oldCertPath = oldProfile != null ? FindCertPath(id, oldProfile.Name) : null;
 
-                _config.RenameProfile(id, name);
+                if (!_config.RenameProfile(id, name))
+                {
+                    bridge.Send("profiles.error", new { message = "A profile with that name already exists." });
+                    return Task.CompletedTask;
+                }
 
                 // Rename the cert file on disk to match the new profile name
                 if (oldCertPath != null && File.Exists(oldCertPath))
@@ -523,7 +545,11 @@ internal sealed class CertificateService : IService
                 var oldProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
 
                 // Rename the profile in config
-                _config.RenameProfile(id, name);
+                if (!_config.RenameProfile(id, name))
+                {
+                    bridge.Send("profiles.error", new { message = "A profile with that name already exists." });
+                    return Task.CompletedTask;
+                }
 
                 // Rename the matched cert file to use this profile's ID: {name}_{id}.pfx
                 var targetPath = GetCertPath(id, name);

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -10,9 +10,12 @@ internal sealed class CertificateService : IService
     public string ServiceName => "cert";
 
     public X509Certificate2? ActiveCertificate { get; private set; }
+    private readonly object _certLock = new();
 
-    public string? GetCertHash() =>
-        ActiveCertificate?.Thumbprint?.ToLowerInvariant();
+    public string? GetCertHash()
+    {
+        lock (_certLock) return ActiveCertificate?.Thumbprint?.ToLowerInvariant();
+    }
 
     private readonly NativeBridge _bridge;
     private readonly IAppConfigService _config;
@@ -154,9 +157,10 @@ internal sealed class CertificateService : IService
             return Task.CompletedTask;
         });
 
-        bridge.RegisterHandler("cert.export", _ =>
+        bridge.RegisterHandler("cert.export", data =>
         {
-            Task.Run(ExportCertificate);
+            var profileId = data.TryGetProperty("profileId", out var pidEl) ? pidEl.GetString() : null;
+            Task.Run(() => ExportCertificate(profileId));
             return Task.CompletedTask;
         });
 
@@ -250,8 +254,8 @@ internal sealed class CertificateService : IService
                 if (_config.GetActiveProfileId() == null)
                 {
                     _config.SetActiveProfileId(idPart);
-                    LoadActiveCertificate();
-                    bridge.Send("profiles.activeChanged", new { id = idPart, name, fingerprint = ActiveCertificate?.Thumbprint });
+                    lock (_certLock) { LoadActiveCertificate(); }
+                    bridge.Send("profiles.activeChanged", new { id = idPart, name, fingerprint = GetCertHash() });
                 }
 
                 bridge.Send("profiles.added", new { id = idPart, name, fingerprint, certValid = true });
@@ -318,8 +322,8 @@ internal sealed class CertificateService : IService
                     if (_config.GetActiveProfileId() == null)
                     {
                         _config.SetActiveProfileId(id);
-                        LoadActiveCertificate();
-                        bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
+                        lock (_certLock) { LoadActiveCertificate(); }
+                        bridge.Send("profiles.activeChanged", new { id, name, fingerprint = GetCertHash() });
                         bridge.NotifyUiThread();
                     }
 
@@ -369,7 +373,7 @@ internal sealed class CertificateService : IService
                     if (_config.GetActiveProfileId() == null)
                     {
                         _config.SetActiveProfileId(id);
-                        LoadActiveCertificate();
+                        lock (_certLock) { LoadActiveCertificate(); }
                         bridge.Send("profiles.activeChanged", new { id, name, fingerprint });
                         bridge.NotifyUiThread();
                     }
@@ -388,69 +392,85 @@ internal sealed class CertificateService : IService
 
         bridge.RegisterHandler("profiles.remove", data =>
         {
-            var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
-            if (id == null) return Task.CompletedTask;
-
-            var wasActive = _config.GetActiveProfileId() == id;
-            _config.RemoveProfile(id);
-            bridge.Send("profiles.removed", new { id });
-
-            if (wasActive)
+            try
             {
-                var newActiveId = _config.GetActiveProfileId();
-                if (newActiveId != null)
+                var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+                if (id == null) return Task.CompletedTask;
+
+                var wasActive = _config.GetActiveProfileId() == id;
+                _config.RemoveProfile(id);
+                bridge.Send("profiles.removed", new { id });
+
+                if (wasActive)
                 {
-                    var newProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == newActiveId);
-                    LoadActiveCertificate();
-                    bridge.Send("profiles.activeChanged", new { id = newActiveId, name = newProfile?.Name, fingerprint = ActiveCertificate?.Thumbprint });
+                    var newActiveId = _config.GetActiveProfileId();
+                    if (newActiveId != null)
+                    {
+                        var newProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == newActiveId);
+                        lock (_certLock) { LoadActiveCertificate(); }
+                        bridge.Send("profiles.activeChanged", new { id = newActiveId, name = newProfile?.Name, fingerprint = GetCertHash() });
+                    }
+                    else
+                    {
+                        lock (_certLock)
+                        {
+                            var old = ActiveCertificate;
+                            ActiveCertificate = null;
+                            old?.Dispose();
+                        }
+                        bridge.Send("profiles.activeChanged", new { id = (string?)null, name = (string?)null, fingerprint = (string?)null });
+                        bridge.Send("cert.status", new { exists = false });
+                    }
                 }
-                else
-                {
-                    var old = ActiveCertificate;
-                    ActiveCertificate = null;
-                    old?.Dispose();
-                    bridge.Send("profiles.activeChanged", new { id = (string?)null, name = (string?)null, fingerprint = (string?)null });
-                    bridge.Send("cert.status", new { exists = false });
-                }
+            }
+            catch (Exception ex)
+            {
+                bridge.Send("profiles.error", new { message = $"Failed to remove profile: {ex.Message}" });
             }
             return Task.CompletedTask;
         });
 
         bridge.RegisterHandler("profiles.rename", data =>
         {
-            var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
-            var name = data.TryGetProperty("name", out var n) ? n.GetString()?.Trim() : null;
-            if (id == null || name == null) return Task.CompletedTask;
-
-            var validationError = ValidateProfileName(name);
-            if (validationError != null)
+            try
             {
-                bridge.Send("profiles.error", new { message = validationError });
-                return Task.CompletedTask;
-            }
+                var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+                var name = data.TryGetProperty("name", out var n) ? n.GetString()?.Trim() : null;
+                if (id == null || name == null) return Task.CompletedTask;
 
-            // Find the current cert file before renaming the profile
-            var oldProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
-            var oldCertPath = oldProfile != null ? FindCertPath(id, oldProfile.Name) : null;
-
-            _config.RenameProfile(id, name);
-
-            // Rename the cert file on disk to match the new profile name
-            if (oldCertPath != null && File.Exists(oldCertPath))
-            {
-                var newCertPath = GetCertPath(id, name);
-                if (!string.Equals(oldCertPath, newCertPath, StringComparison.OrdinalIgnoreCase))
+                var validationError = ValidateProfileName(name);
+                if (validationError != null)
                 {
-                    try { File.Move(oldCertPath, newCertPath); }
-                    catch { /* best-effort; FindCertPath fallback will still locate it */ }
+                    bridge.Send("profiles.error", new { message = validationError });
+                    return Task.CompletedTask;
                 }
+
+                // Find the current cert file before renaming the profile
+                var oldProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+                var oldCertPath = oldProfile != null ? FindCertPath(id, oldProfile.Name) : null;
+
+                _config.RenameProfile(id, name);
+
+                // Rename the cert file on disk to match the new profile name
+                if (oldCertPath != null && File.Exists(oldCertPath))
+                {
+                    var newCertPath = GetCertPath(id, name);
+                    if (!string.Equals(oldCertPath, newCertPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        try { File.Move(oldCertPath, newCertPath); }
+                        catch { /* best-effort; FindCertPath fallback will still locate it */ }
+                    }
+                }
+
+                bridge.Send("profiles.renamed", new { id, name });
+
+                if (_config.GetActiveProfileId() == id)
+                    bridge.Send("profiles.activeChanged", new { id, name, fingerprint = GetCertHash() });
             }
-
-            bridge.Send("profiles.renamed", new { id, name });
-
-            if (_config.GetActiveProfileId() == id)
-                bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
-
+            catch (Exception ex)
+            {
+                bridge.Send("profiles.error", new { message = $"Failed to rename profile: {ex.Message}" });
+            }
             return Task.CompletedTask;
         });
 
@@ -516,8 +536,8 @@ internal sealed class CertificateService : IService
                 // Reload active cert if this is the active profile
                 if (_config.GetActiveProfileId() == id)
                 {
-                    LoadActiveCertificate();
-                    bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
+                    lock (_certLock) { LoadActiveCertificate(); }
+                    bridge.Send("profiles.activeChanged", new { id, name, fingerprint = GetCertHash() });
                 }
 
                 bridge.Send("profiles.renamed", new { id, name, fingerprint, certValid = true });
@@ -531,22 +551,40 @@ internal sealed class CertificateService : IService
 
         bridge.RegisterHandler("profiles.setActive", data =>
         {
-            var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
-            if (id == null) return Task.CompletedTask;
+            try
+            {
+                var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+                if (id == null) return Task.CompletedTask;
 
-            var oldProfileId = _config.GetActiveProfileId();
+                var oldProfileId = _config.GetActiveProfileId();
 
-            _config.SetActiveProfileId(id);
-            LoadActiveCertificate();
+                _config.SetActiveProfileId(id);
+                // Verify the switch actually happened (SetActiveProfileId is a no-op for non-existent IDs)
+                if (_config.GetActiveProfileId() != id) return Task.CompletedTask;
 
-            // Swap registration data — save old profile's, load new profile's cached registrations
-            _config.SwapProfileRegistrations(oldProfileId, id);
+                lock (_certLock) { LoadActiveCertificate(); }
 
-            var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
-            bridge.Send("profiles.activeChanged", new { id, name = profile?.Name, fingerprint = ActiveCertificate?.Thumbprint });
-            bridge.Send("cert.status", new { exists = ActiveCertificate != null, fingerprint = ActiveCertificate?.Thumbprint, subject = ActiveCertificate?.Subject });
-            // Re-send server list so frontend picks up swapped registration fields
-            bridge.Send("servers.list", new { servers = _config.GetServers() });
+                // Swap registration data — save old profile's, load new profile's cached registrations
+                _config.SwapProfileRegistrations(oldProfileId, id);
+
+                var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+                var certHash = GetCertHash();
+                bool certExists;
+                string? certSubject;
+                lock (_certLock)
+                {
+                    certExists = ActiveCertificate != null;
+                    certSubject = ActiveCertificate?.Subject;
+                }
+                bridge.Send("profiles.activeChanged", new { id, name = profile?.Name, fingerprint = certHash });
+                bridge.Send("cert.status", new { exists = certExists, fingerprint = certHash, subject = certSubject });
+                // Re-send server list so frontend picks up swapped registration fields
+                bridge.Send("servers.list", new { servers = _config.GetServers() });
+            }
+            catch (Exception ex)
+            {
+                bridge.Send("profiles.error", new { message = $"Failed to switch profile: {ex.Message}" });
+            }
             return Task.CompletedTask;
         });
     }
@@ -557,10 +595,15 @@ internal sealed class CertificateService : IService
     /// Callers are responsible for disposing the returned instance.
     /// Returns null if no certificate exists.
     /// </summary>
-    internal X509Certificate2? GetExportableCertificate() =>
-        ActiveCertificate is not null && ActiveCertPath is string path && File.Exists(path)
-            ? X509CertificateLoader.LoadPkcs12FromFile(path, password: null, keyStorageFlags: X509KeyStorageFlags.Exportable)
-            : null;
+    internal X509Certificate2? GetExportableCertificate()
+    {
+        lock (_certLock)
+        {
+            return ActiveCertificate is not null && ActiveCertPath is string path && File.Exists(path)
+                ? X509CertificateLoader.LoadPkcs12FromFile(path, password: null, keyStorageFlags: X509KeyStorageFlags.Exportable)
+                : null;
+        }
+    }
 
     private void LoadActiveCertificate()
     {
@@ -579,14 +622,23 @@ internal sealed class CertificateService : IService
 
     private void SendStatus()
     {
-        LoadActiveCertificate();
-        if (ActiveCertificate != null)
+        lock (_certLock) { LoadActiveCertificate(); }
+        bool exists;
+        string? fingerprint;
+        string? subject;
+        lock (_certLock)
+        {
+            exists = ActiveCertificate != null;
+            fingerprint = ActiveCertificate?.Thumbprint;
+            subject = ActiveCertificate?.Subject;
+        }
+        if (exists)
         {
             _bridge.Send("cert.status", new
             {
                 exists = true,
-                fingerprint = ActiveCertificate.Thumbprint,
-                subject = ActiveCertificate.Subject
+                fingerprint,
+                subject
             });
         }
         else
@@ -623,14 +675,21 @@ internal sealed class CertificateService : IService
             File.WriteAllBytes(certPath, pfxBytes);
 
             // Reload from file to get a clean X509Certificate2 (DefaultKeySet — exportable not needed for status display)
-            var oldCert = ActiveCertificate;
-            ActiveCertificate = X509CertificateLoader.LoadPkcs12FromFile(certPath, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
-            oldCert?.Dispose();
+            string certFingerprint;
+            string certSubject;
+            lock (_certLock)
+            {
+                var oldCert = ActiveCertificate;
+                ActiveCertificate = X509CertificateLoader.LoadPkcs12FromFile(certPath, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                oldCert?.Dispose();
+                certFingerprint = ActiveCertificate.Thumbprint;
+                certSubject = ActiveCertificate.Subject;
+            }
 
             _bridge.Send("cert.generated", new
             {
-                fingerprint = ActiveCertificate.Thumbprint,
-                subject = ActiveCertificate.Subject
+                fingerprint = certFingerprint,
+                subject = certSubject
             });
             _bridge.NotifyUiThread();
         }
@@ -658,14 +717,21 @@ internal sealed class CertificateService : IService
 
             Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
             File.WriteAllBytes(certPath, bytes);
-            var oldCert = ActiveCertificate;
-            ActiveCertificate = testCert;
-            oldCert?.Dispose();
+            string certFingerprint;
+            string certSubject;
+            lock (_certLock)
+            {
+                var oldCert = ActiveCertificate;
+                ActiveCertificate = testCert;
+                oldCert?.Dispose();
+                certFingerprint = ActiveCertificate.Thumbprint;
+                certSubject = ActiveCertificate.Subject;
+            }
 
             _bridge.Send("cert.imported", new
             {
-                fingerprint = ActiveCertificate.Thumbprint,
-                subject = ActiveCertificate.Subject
+                fingerprint = certFingerprint,
+                subject = certSubject
             });
             _bridge.NotifyUiThread();
         }
@@ -676,21 +742,40 @@ internal sealed class CertificateService : IService
         }
     }
 
-    private void ExportCertificate()
+    private void ExportCertificate(string? profileId = null)
     {
         try
         {
-            if (ActiveCertPath is not string certPath || !File.Exists(certPath))
+            string? certPath;
+            string exportName;
+
+            if (profileId != null)
+            {
+                var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == profileId);
+                if (profile == null)
+                {
+                    _bridge.Send("cert.error", new { message = "Profile not found." });
+                    return;
+                }
+                certPath = FindCertPath(profileId, profile.Name);
+                exportName = $"{SanitizeFileName(profile.Name)}.pfx";
+            }
+            else
+            {
+                certPath = ActiveCertPath;
+                var activeId = _config.GetActiveProfileId();
+                var activeProfile = activeId != null ? _config.GetProfiles().FirstOrDefault(p => p.Id == activeId) : null;
+                exportName = activeProfile != null ? $"{SanitizeFileName(activeProfile.Name)}.pfx" : "brmble-identity.pfx";
+            }
+
+            if (certPath is not string cp || !File.Exists(cp))
             {
                 _bridge.Send("cert.error", new { message = "No certificate to export." });
                 return;
             }
 
-            var bytes = File.ReadAllBytes(certPath);
+            var bytes = File.ReadAllBytes(cp);
             var base64 = Convert.ToBase64String(bytes);
-            var activeId = _config.GetActiveProfileId();
-            var activeProfile = activeId != null ? _config.GetProfiles().FirstOrDefault(p => p.Id == activeId) : null;
-            var exportName = activeProfile != null ? $"{SanitizeFileName(activeProfile.Name)}.pfx" : "brmble-identity.pfx";
             _bridge.Send("cert.exportData", new { data = base64, filename = exportName });
             _bridge.NotifyUiThread();
         }

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -137,6 +137,101 @@ internal sealed class CertificateService : IService
 
         // ── Profile handlers ──────────────────────────────────────────
 
+        // Check if an existing cert file matches a given profile name
+        bridge.RegisterHandler("profiles.checkCert", data =>
+        {
+            var name = data.TryGetProperty("name", out var n) ? n.GetString() : null;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                bridge.Send("profiles.checkCertResult", new { exists = false });
+                return Task.CompletedTask;
+            }
+            var sanitized = SanitizeFileName(name!);
+            var certsDir = _config.GetCertsDir();
+            string? matchedFile = null;
+            string? matchedFingerprint = null;
+            if (Directory.Exists(certsDir))
+            {
+                // Look for any .pfx file starting with "{sanitizedName}_"
+                var prefix = sanitized + "_";
+                foreach (var file in Directory.EnumerateFiles(certsDir, "*.pfx"))
+                {
+                    var fileName = Path.GetFileName(file);
+                    if (fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Verify it's a valid cert before offering it
+                        try
+                        {
+                            using var cert = X509CertificateLoader.LoadPkcs12FromFile(file, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                            matchedFile = file;
+                            matchedFingerprint = cert.Thumbprint;
+                        }
+                        catch { /* skip invalid files */ }
+                        break;
+                    }
+                }
+            }
+            bridge.Send("profiles.checkCertResult", new { exists = matchedFile != null, fingerprint = matchedFingerprint });
+            return Task.CompletedTask;
+        });
+
+        // Create a profile that reuses an existing cert file found by name prefix
+        bridge.RegisterHandler("profiles.addFromExisting", data =>
+        {
+            var name = data.TryGetProperty("name", out var n) ? n.GetString() ?? "Unnamed" : "Unnamed";
+            var sanitized = SanitizeFileName(name);
+            var certsDir = _config.GetCertsDir();
+            var prefix = sanitized + "_";
+            string? matchedFile = null;
+
+            if (Directory.Exists(certsDir))
+            {
+                foreach (var file in Directory.EnumerateFiles(certsDir, "*.pfx"))
+                {
+                    var fileName = Path.GetFileName(file);
+                    if (fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matchedFile = file;
+                        break;
+                    }
+                }
+            }
+
+            if (matchedFile == null)
+            {
+                bridge.Send("profiles.error", new { message = "No matching certificate found." });
+                return Task.CompletedTask;
+            }
+
+            try
+            {
+                // Extract the profile ID from the existing filename: {sanitizedName}_{id}.pfx
+                var fileName = Path.GetFileNameWithoutExtension(matchedFile);
+                var idPart = fileName.Substring(prefix.Length);
+
+                // Verify the cert loads
+                using var cert = X509CertificateLoader.LoadPkcs12FromFile(matchedFile, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                var fingerprint = cert.Thumbprint;
+
+                var profile = new ProfileEntry(idPart, name);
+                _config.AddProfile(profile);
+
+                if (_config.GetActiveProfileId() == null)
+                {
+                    _config.SetActiveProfileId(idPart);
+                    LoadActiveCertificate();
+                    bridge.Send("profiles.activeChanged", new { id = idPart, name, fingerprint = ActiveCertificate?.Thumbprint });
+                }
+
+                bridge.Send("profiles.added", new { id = idPart, name, fingerprint, certValid = true });
+            }
+            catch (Exception ex)
+            {
+                bridge.Send("profiles.error", new { message = $"Failed to reuse certificate: {ex.Message}" });
+            }
+            return Task.CompletedTask;
+        });
+
         bridge.RegisterHandler("profiles.list", _ =>
         {
             var profiles = _config.GetProfiles().Select(p =>
@@ -188,13 +283,16 @@ internal sealed class CertificateService : IService
                         _config.SetActiveProfileId(id);
                         LoadActiveCertificate();
                         bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
+                        bridge.NotifyUiThread();
                     }
 
                     bridge.Send("profiles.added", new { id, name, fingerprint = cert.Thumbprint, certValid = true });
+                    bridge.NotifyUiThread();
                 }
                 catch (Exception ex)
                 {
                     bridge.Send("profiles.error", new { message = $"Failed to create profile: {ex.Message}" });
+                    bridge.NotifyUiThread();
                 }
             });
             return Task.CompletedTask;
@@ -230,13 +328,16 @@ internal sealed class CertificateService : IService
                         _config.SetActiveProfileId(id);
                         LoadActiveCertificate();
                         bridge.Send("profiles.activeChanged", new { id, name, fingerprint });
+                        bridge.NotifyUiThread();
                     }
 
                     bridge.Send("profiles.added", new { id, name, fingerprint, certValid = true });
+                    bridge.NotifyUiThread();
                 }
                 catch (Exception ex)
                 {
                     bridge.Send("profiles.error", new { message = $"Failed to import profile: {ex.Message}" });
+                    bridge.NotifyUiThread();
                 }
             });
             return Task.CompletedTask;
@@ -300,6 +401,74 @@ internal sealed class CertificateService : IService
             if (_config.GetActiveProfileId() == id)
                 bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
 
+            return Task.CompletedTask;
+        });
+
+        // Rename profile AND swap its cert to an existing cert file matching the new name
+        bridge.RegisterHandler("profiles.renameSwapCert", data =>
+        {
+            var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+            var name = data.TryGetProperty("name", out var n) ? n.GetString() : null;
+            if (id == null || name == null) return Task.CompletedTask;
+
+            var sanitized = SanitizeFileName(name);
+            var certsDir = _config.GetCertsDir();
+            var prefix = sanitized + "_";
+            string? matchedFile = null;
+
+            // Find the existing cert file for this name
+            if (Directory.Exists(certsDir))
+            {
+                foreach (var file in Directory.EnumerateFiles(certsDir, "*.pfx"))
+                {
+                    var fileName = Path.GetFileName(file);
+                    if (fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matchedFile = file;
+                        break;
+                    }
+                }
+            }
+
+            if (matchedFile == null)
+            {
+                bridge.Send("profiles.error", new { message = "No matching certificate found." });
+                return Task.CompletedTask;
+            }
+
+            try
+            {
+                // Validate the found cert
+                using var cert = X509CertificateLoader.LoadPkcs12FromFile(matchedFile, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                var fingerprint = cert.Thumbprint;
+
+                // Find and keep the profile's old cert file path (we won't delete it)
+                var oldProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+
+                // Rename the profile in config
+                _config.RenameProfile(id, name);
+
+                // Rename the matched cert file to use this profile's ID: {name}_{id}.pfx
+                var targetPath = GetCertPath(id, name);
+                if (!string.Equals(matchedFile, targetPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    try { File.Move(matchedFile, targetPath); }
+                    catch { /* best-effort; the file is still valid at its current path */ }
+                }
+
+                // Reload active cert if this is the active profile
+                if (_config.GetActiveProfileId() == id)
+                {
+                    LoadActiveCertificate();
+                    bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
+                }
+
+                bridge.Send("profiles.renamed", new { id, name, fingerprint, certValid = true });
+            }
+            catch (Exception ex)
+            {
+                bridge.Send("profiles.error", new { message = $"Failed to swap certificate: {ex.Message}" });
+            }
             return Task.CompletedTask;
         });
 
@@ -399,10 +568,12 @@ internal sealed class CertificateService : IService
                 fingerprint = ActiveCertificate.Thumbprint,
                 subject = ActiveCertificate.Subject
             });
+            _bridge.NotifyUiThread();
         }
         catch (Exception ex)
         {
             _bridge.Send("cert.error", new { message = $"Failed to generate certificate: {ex.Message}" });
+            _bridge.NotifyUiThread();
         }
     }
 
@@ -432,10 +603,12 @@ internal sealed class CertificateService : IService
                 fingerprint = ActiveCertificate.Thumbprint,
                 subject = ActiveCertificate.Subject
             });
+            _bridge.NotifyUiThread();
         }
         catch (Exception ex)
         {
             _bridge.Send("cert.error", new { message = $"Failed to import certificate: {ex.Message}" });
+            _bridge.NotifyUiThread();
         }
     }
 
@@ -455,10 +628,12 @@ internal sealed class CertificateService : IService
             var activeProfile = activeId != null ? _config.GetProfiles().FirstOrDefault(p => p.Id == activeId) : null;
             var exportName = activeProfile != null ? $"{SanitizeFileName(activeProfile.Name)}.pfx" : "brmble-identity.pfx";
             _bridge.Send("cert.exportData", new { data = base64, filename = exportName });
+            _bridge.NotifyUiThread();
         }
         catch (Exception ex)
         {
             _bridge.Send("cert.error", new { message = $"Failed to export certificate: {ex.Message}" });
+            _bridge.NotifyUiThread();
         }
     }
 }

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -72,7 +72,9 @@ internal sealed class CertificateService : IService
 
     private void LoadActiveCertificate()
     {
+        var old = ActiveCertificate;
         ActiveCertificate = null;
+        old?.Dispose();
         if (ActiveCertPath is string path && File.Exists(path))
         {
             try
@@ -129,7 +131,9 @@ internal sealed class CertificateService : IService
             File.WriteAllBytes(certPath, pfxBytes);
 
             // Reload from file to get a clean X509Certificate2 (DefaultKeySet — exportable not needed for status display)
+            var oldCert = ActiveCertificate;
             ActiveCertificate = X509CertificateLoader.LoadPkcs12FromFile(certPath, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+            oldCert?.Dispose();
 
             _bridge.Send("cert.generated", new
             {
@@ -160,7 +164,9 @@ internal sealed class CertificateService : IService
 
             Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
             File.WriteAllBytes(certPath, bytes);
+            var oldCert = ActiveCertificate;
             ActiveCertificate = testCert;
+            oldCert?.Dispose();
 
             _bridge.Send("cert.imported", new
             {

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -16,11 +16,64 @@ internal sealed class CertificateService : IService
     private readonly NativeBridge _bridge;
     private readonly IAppConfigService _config;
 
-    private string GetCertPath(string profileId) =>
+    /// <summary>Builds the canonical cert filename: {sanitizedName}_{id}.pfx</summary>
+    private string GetCertPath(string profileId, string profileName) =>
+        Path.Combine(_config.GetCertsDir(), $"{SanitizeFileName(profileName)}_{profileId}.pfx");
+
+    /// <summary>Legacy cert path using only the profile ID.</summary>
+    private string GetLegacyCertPath(string profileId) =>
         Path.Combine(_config.GetCertsDir(), profileId + ".pfx");
 
-    private string? ActiveCertPath =>
-        _config.GetActiveProfileId() is string id ? GetCertPath(id) : null;
+    /// <summary>
+    /// Returns the cert path, preferring the new {name}_{id}.pfx format.
+    /// Falls back to the legacy {id}.pfx if the new file doesn't exist.
+    /// </summary>
+    private string FindCertPath(string profileId, string profileName)
+    {
+        var preferred = GetCertPath(profileId, profileName);
+        if (File.Exists(preferred)) return preferred;
+        var legacy = GetLegacyCertPath(profileId);
+        if (File.Exists(legacy)) return legacy;
+        return preferred; // default to new format even if neither exists
+    }
+
+    private string? ActiveCertPath
+    {
+        get
+        {
+            var id = _config.GetActiveProfileId();
+            if (id == null) return null;
+            var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+            return profile != null ? FindCertPath(id, profile.Name) : FindCertPath(id, "");
+        }
+    }
+
+    /// <summary>
+    /// Sanitizes a profile name for use in a filename.
+    /// Replaces invalid chars with '_', collapses runs, trims, and caps length.
+    /// </summary>
+    private static string SanitizeFileName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return "profile";
+        var invalid = new HashSet<char>(Path.GetInvalidFileNameChars());
+        var sb = new System.Text.StringBuilder(name.Length);
+        bool lastWasUnderscore = false;
+        foreach (var c in name)
+        {
+            if (invalid.Contains(c) || c == ' ')
+            {
+                if (!lastWasUnderscore) { sb.Append('_'); lastWasUnderscore = true; }
+            }
+            else
+            {
+                sb.Append(c);
+                lastWasUnderscore = false;
+            }
+        }
+        var result = sb.ToString().Trim('_');
+        if (result.Length > 50) result = result[..50].TrimEnd('_');
+        return result.Length == 0 ? "profile" : result;
+    }
 
     public CertificateService(NativeBridge bridge, IAppConfigService config)
     {
@@ -28,7 +81,31 @@ internal sealed class CertificateService : IService
         _config = config;
     }
 
-    public void Initialize(NativeBridge bridge) { }
+    public void Initialize(NativeBridge bridge)
+    {
+        // Migrate legacy {id}.pfx cert files to {name}_{id}.pfx
+        MigrateCertFileNames();
+    }
+
+    /// <summary>
+    /// Renames any legacy {id}.pfx cert files to {name}_{id}.pfx format.
+    /// Best-effort; failures are silently ignored since FindCertPath falls back to legacy names.
+    /// </summary>
+    private void MigrateCertFileNames()
+    {
+        foreach (var profile in _config.GetProfiles())
+        {
+            var legacyPath = GetLegacyCertPath(profile.Id);
+            if (!File.Exists(legacyPath)) continue;
+
+            var newPath = GetCertPath(profile.Id, profile.Name);
+            if (string.Equals(legacyPath, newPath, StringComparison.OrdinalIgnoreCase)) continue;
+            if (File.Exists(newPath)) continue; // new-style file already exists
+
+            try { File.Move(legacyPath, newPath); }
+            catch { /* best-effort */ }
+        }
+    }
 
     public void RegisterHandlers(NativeBridge bridge)
     {
@@ -64,7 +141,7 @@ internal sealed class CertificateService : IService
         {
             var profiles = _config.GetProfiles().Select(p =>
             {
-                var certPath = GetCertPath(p.Id);
+                var certPath = FindCertPath(p.Id, p.Name);
                 string? fingerprint = null;
                 bool certValid = false;
                 if (File.Exists(certPath))
@@ -91,7 +168,7 @@ internal sealed class CertificateService : IService
                 try
                 {
                     var id = Guid.NewGuid().ToString();
-                    var certPath = GetCertPath(id);
+                    var certPath = GetCertPath(id, name);
                     Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
 
                     using var ecdsa = System.Security.Cryptography.ECDsa.Create(
@@ -141,7 +218,7 @@ internal sealed class CertificateService : IService
                     var fingerprint = testCert.Thumbprint;
 
                     var id = Guid.NewGuid().ToString();
-                    var certPath = GetCertPath(id);
+                    var certPath = GetCertPath(id, name);
                     Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
                     File.WriteAllBytes(certPath, bytes);
 
@@ -201,7 +278,23 @@ internal sealed class CertificateService : IService
             var name = data.TryGetProperty("name", out var n) ? n.GetString() : null;
             if (id == null || name == null) return Task.CompletedTask;
 
+            // Find the current cert file before renaming the profile
+            var oldProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+            var oldCertPath = oldProfile != null ? FindCertPath(id, oldProfile.Name) : null;
+
             _config.RenameProfile(id, name);
+
+            // Rename the cert file on disk to match the new profile name
+            if (oldCertPath != null && File.Exists(oldCertPath))
+            {
+                var newCertPath = GetCertPath(id, name);
+                if (!string.Equals(oldCertPath, newCertPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    try { File.Move(oldCertPath, newCertPath); }
+                    catch { /* best-effort; FindCertPath fallback will still locate it */ }
+                }
+            }
+
             bridge.Send("profiles.renamed", new { id, name });
 
             if (_config.GetActiveProfileId() == id)
@@ -358,7 +451,10 @@ internal sealed class CertificateService : IService
 
             var bytes = File.ReadAllBytes(certPath);
             var base64 = Convert.ToBase64String(bytes);
-            _bridge.Send("cert.exportData", new { data = base64, filename = "brmble-identity.pfx" });
+            var activeId = _config.GetActiveProfileId();
+            var activeProfile = activeId != null ? _config.GetProfiles().FirstOrDefault(p => p.Id == activeId) : null;
+            var exportName = activeProfile != null ? $"{SanitizeFileName(activeProfile.Name)}.pfx" : "brmble-identity.pfx";
+            _bridge.Send("cert.exportData", new { data = base64, filename = exportName });
         }
         catch (Exception ex)
         {

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -57,6 +57,171 @@ internal sealed class CertificateService : IService
             Task.Run(ExportCertificate);
             return Task.CompletedTask;
         });
+
+        // ── Profile handlers ──────────────────────────────────────────
+
+        bridge.RegisterHandler("profiles.list", _ =>
+        {
+            var profiles = _config.GetProfiles().Select(p =>
+            {
+                var certPath = GetCertPath(p.Id);
+                string? fingerprint = null;
+                bool certValid = false;
+                if (File.Exists(certPath))
+                {
+                    try
+                    {
+                        using var cert = X509CertificateLoader.LoadPkcs12FromFile(certPath, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                        fingerprint = cert.Thumbprint;
+                        certValid = true;
+                    }
+                    catch { }
+                }
+                return new { id = p.Id, name = p.Name, fingerprint, certValid };
+            }).ToList();
+            bridge.Send("profiles.list", new { profiles, activeProfileId = _config.GetActiveProfileId() });
+            return Task.CompletedTask;
+        });
+
+        bridge.RegisterHandler("profiles.add", data =>
+        {
+            var name = data.TryGetProperty("name", out var n) ? n.GetString() ?? "Unnamed" : "Unnamed";
+            Task.Run(() =>
+            {
+                try
+                {
+                    var id = Guid.NewGuid().ToString();
+                    var certPath = GetCertPath(id);
+                    Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
+
+                    using var ecdsa = System.Security.Cryptography.ECDsa.Create(
+                        System.Security.Cryptography.ECCurve.NamedCurves.nistP256);
+                    var req = new System.Security.Cryptography.X509Certificates.CertificateRequest(
+                        "CN=Brmble User", ecdsa, System.Security.Cryptography.HashAlgorithmName.SHA256);
+                    var now = DateTimeOffset.UtcNow;
+                    using var cert = req.CreateSelfSigned(now, now.AddYears(100));
+                    File.WriteAllBytes(certPath, cert.Export(X509ContentType.Pfx));
+
+                    var profile = new ProfileEntry(id, name);
+                    _config.AddProfile(profile);
+
+                    // If this is the first profile, make it active
+                    if (_config.GetActiveProfileId() == null)
+                    {
+                        _config.SetActiveProfileId(id);
+                        LoadActiveCertificate();
+                        bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
+                    }
+
+                    bridge.Send("profiles.added", new { id, name, fingerprint = cert.Thumbprint, certValid = true });
+                }
+                catch (Exception ex)
+                {
+                    bridge.Send("profiles.error", new { message = $"Failed to create profile: {ex.Message}" });
+                }
+            });
+            return Task.CompletedTask;
+        });
+
+        bridge.RegisterHandler("profiles.import", data =>
+        {
+            var name = data.TryGetProperty("name", out var n) ? n.GetString() ?? "Unnamed" : "Unnamed";
+            var base64 = data.TryGetProperty("data", out var d) ? d.GetString() : null;
+            if (base64 == null)
+            {
+                bridge.Send("profiles.error", new { message = "No certificate data provided." });
+                return Task.CompletedTask;
+            }
+            Task.Run(() =>
+            {
+                try
+                {
+                    var bytes = Convert.FromBase64String(base64);
+                    var testCert = X509CertificateLoader.LoadPkcs12(bytes, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+
+                    var id = Guid.NewGuid().ToString();
+                    var certPath = GetCertPath(id);
+                    Directory.CreateDirectory(Path.GetDirectoryName(certPath)!);
+                    File.WriteAllBytes(certPath, bytes);
+
+                    var profile = new ProfileEntry(id, name);
+                    _config.AddProfile(profile);
+
+                    if (_config.GetActiveProfileId() == null)
+                    {
+                        _config.SetActiveProfileId(id);
+                        LoadActiveCertificate();
+                        bridge.Send("profiles.activeChanged", new { id, name, fingerprint = testCert.Thumbprint });
+                    }
+
+                    bridge.Send("profiles.added", new { id, name, fingerprint = testCert.Thumbprint, certValid = true });
+                }
+                catch (Exception ex)
+                {
+                    bridge.Send("profiles.error", new { message = $"Failed to import profile: {ex.Message}" });
+                }
+            });
+            return Task.CompletedTask;
+        });
+
+        bridge.RegisterHandler("profiles.remove", data =>
+        {
+            var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+            if (id == null) return Task.CompletedTask;
+
+            var wasActive = _config.GetActiveProfileId() == id;
+            _config.RemoveProfile(id);
+            bridge.Send("profiles.removed", new { id });
+
+            if (wasActive)
+            {
+                var newActiveId = _config.GetActiveProfileId();
+                if (newActiveId != null)
+                {
+                    var newProfile = _config.GetProfiles().FirstOrDefault(p => p.Id == newActiveId);
+                    LoadActiveCertificate();
+                    bridge.Send("profiles.activeChanged", new { id = newActiveId, name = newProfile?.Name, fingerprint = ActiveCertificate?.Thumbprint });
+                }
+                else
+                {
+                    var old = ActiveCertificate;
+                    ActiveCertificate = null;
+                    old?.Dispose();
+                    bridge.Send("profiles.activeChanged", new { id = (string?)null, name = (string?)null, fingerprint = (string?)null });
+                    bridge.Send("cert.status", new { exists = false });
+                }
+            }
+            return Task.CompletedTask;
+        });
+
+        bridge.RegisterHandler("profiles.rename", data =>
+        {
+            var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+            var name = data.TryGetProperty("name", out var n) ? n.GetString() : null;
+            if (id == null || name == null) return Task.CompletedTask;
+
+            _config.RenameProfile(id, name);
+            bridge.Send("profiles.renamed", new { id, name });
+
+            if (_config.GetActiveProfileId() == id)
+                bridge.Send("profiles.activeChanged", new { id, name, fingerprint = ActiveCertificate?.Thumbprint });
+
+            return Task.CompletedTask;
+        });
+
+        bridge.RegisterHandler("profiles.setActive", data =>
+        {
+            var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+            if (id == null) return Task.CompletedTask;
+
+            _config.SetActiveProfileId(id);
+            LoadActiveCertificate();
+
+            var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+            bridge.Send("profiles.activeChanged", new { id, name = profile?.Name, fingerprint = ActiveCertificate?.Thumbprint });
+            bridge.Send("cert.status", new { exists = ActiveCertificate != null, fingerprint = ActiveCertificate?.Thumbprint, subject = ActiveCertificate?.Subject });
+            return Task.CompletedTask;
+        });
     }
 
     /// <summary>

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -655,7 +655,7 @@ internal sealed class CertificateService : IService
         lock (_certLock)
         {
             exists = ActiveCertificate != null;
-            fingerprint = ActiveCertificate?.Thumbprint;
+            fingerprint = ActiveCertificate?.Thumbprint?.ToLowerInvariant();
             subject = ActiveCertificate?.Subject;
         }
         if (exists)

--- a/src/Brmble.Client/Services/Serverlist/IServerlistService.cs
+++ b/src/Brmble.Client/Services/Serverlist/IServerlistService.cs
@@ -7,7 +7,9 @@ public record ServerEntry(
     string? Host,
     int? Port,
     string Username,
-    string Password = ""
+    string Password = "",
+    bool Registered = false,
+    string? RegisteredName = null
 );
 
 public interface IServerlistService
@@ -17,6 +19,6 @@ public interface IServerlistService
     void RegisterHandlers(Bridge.NativeBridge bridge);
     IReadOnlyList<ServerEntry> GetServers();
     void AddServer(ServerEntry server);
-    void UpdateServer(ServerEntry server);
+    ServerEntry? UpdateServer(ServerEntry server);
     void RemoveServer(string id);
 }

--- a/src/Brmble.Client/Services/Serverlist/ServerlistService.cs
+++ b/src/Brmble.Client/Services/Serverlist/ServerlistService.cs
@@ -81,7 +81,7 @@ internal sealed class ServerlistService : IServerlistService
         }
     }
 
-    public void UpdateServer(ServerEntry server)
+    public ServerEntry? UpdateServer(ServerEntry server)
     {
         lock (_lock)
         {
@@ -90,7 +90,9 @@ internal sealed class ServerlistService : IServerlistService
             {
                 _servers[index] = server;
                 Save();
+                return _servers[index];
             }
+            return null;
         }
     }
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -2023,7 +2023,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             username = LocalUser?.Name,
             channelId,
             channels,
-            users
+            users,
+            registered = LocalUser?.IsRegistered ?? false,
+            registeredName = LocalUser?.IsRegistered == true ? LocalUser.Name : (string?)null
         });
 
         Debug.WriteLine($"[Mumble] Sent {channels.Count} channels and {users.Count} users");
@@ -2057,9 +2059,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         // Track previous channel for all users to detect when they leave our channel
         uint? previousUserChannel = null;
+        bool wasRegistered = false;
         if (UserDictionary.TryGetValue(userState.Session, out var existingUser))
         {
             previousUserChannel = existingUser.Channel?.Id;
+            wasRegistered = existingUser.IsRegistered;
         }
 
         base.UserState(userState);
@@ -2076,6 +2080,18 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         var isSelf = LocalUser != null && userState.Session == LocalUser.Id;
         var currentChannelId = user?.Channel?.Id ?? userState.ChannelId;
+
+        // Detect registration change for local user (e.g. after auto-registration)
+        if (isSelf && !wasRegistered && user != null && user.IsRegistered && _activeServerId != null)
+        {
+            Debug.WriteLine($"[Mumble] Local user became registered: {user.Name} (userId: {user.RegisteredUserId})");
+            _bridge?.Send("voice.registrationStatus", new
+            {
+                serverId = _activeServerId,
+                registered = true,
+                registeredName = user.Name
+            });
+        }
 
         // Check if a user left our channel (moved from our channel to a different one)
         if (!isSelf && previousUserChannel.HasValue && previousChannel.HasValue && 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -31,6 +31,8 @@ import { usePrompt, confirm } from './hooks/usePrompt';
 import { Toast } from './components/Toast/Toast';
 import { GameUI } from './components/Game/GameUI';
 import { Brmblegotchi } from './components/Brmblegotchi/Brmblegotchi';
+import { ProfileProvider } from './contexts/ProfileContext';
+import { migrateLocalStorage } from './utils/migrateLocalStorage';
 import './App.css';
 
 const SETTINGS_STORAGE_KEY = 'brmble-settings';
@@ -133,8 +135,15 @@ const mapStoredContacts = (contacts: StoredDMContact[]) =>
 function App() {
   // null = status not yet received, false = no cert, true = cert exists
   const [certExists, setCertExists] = useState<boolean | null>(null);
-  const [, setCertFingerprint] = useState('');
+  const [certFingerprint, setCertFingerprint] = useState('');
   const [activeProfileName, setActiveProfileName] = useState('');
+
+  // Migrate global localStorage keys to per-profile scoped keys
+  useEffect(() => {
+    if (certFingerprint) {
+      migrateLocalStorage(certFingerprint);
+    }
+  }, [certFingerprint]);
 
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('idle');
   const { statuses, updateStatus, resetStatuses } = useServiceStatus();
@@ -1672,6 +1681,7 @@ const handleConnect = (serverData: SavedServer) => {
 
   return (
     <div className="app">
+      <ProfileProvider value={certFingerprint}>
       <ErrorBoundary label="Header">
       <Header
         username={username}
@@ -1867,6 +1877,7 @@ const handleConnect = (serverData: SavedServer) => {
       <ZoomIndicator />
       <Version />
       <Brmblegotchi />
+      </ProfileProvider>
     </div>
   );
 }

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -97,6 +97,7 @@ function speakText(text: string) {
 interface SavedServer {
   id?: string;
   label?: string;
+  apiUrl?: string;
   host: string;
   port: number;
   username: string;
@@ -969,6 +970,9 @@ function App() {
       if (server) {
         setServerLabel(server.label || `${server.host}:${server.port}`);
         handleConnect({
+          id: server.id,
+          label: server.label,
+          apiUrl: server.apiUrl,
           host: server.host || '',
           port: server.port || 0,
           username: server.username || activeProfileName || 'Brmble User',
@@ -1192,10 +1196,13 @@ const handleConnect = (serverData: SavedServer) => {
     handleConnect({
       id: server.id,
       label: server.label,
+      apiUrl: server.apiUrl,
       host: server.host,
       port: server.port,
       username: server.username || activeProfileName || 'Brmble User',
-      password: server.password || ''
+      password: server.password || '',
+      registered: server.registered,
+      registeredName: server.registeredName,
     });
   };
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1791,7 +1791,6 @@ const handleConnect = (serverData: SavedServer) => {
         isOpen={showSettings}
         onClose={() => setShowSettings(false)}
         username={username}
-        certFingerprint={certFingerprint}
         connected={connected}
         currentUser={{
           name: username ?? 'Unknown',

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -559,6 +559,19 @@ function App() {
             }
           }
         } catch { /* ignore parse errors */ }
+      } else {
+        // Clear stale registration when server reports not-registered
+        try {
+          const stored = localStorage.getItem('brmble-server');
+          if (stored) {
+            const savedServer = JSON.parse(stored) as SavedServer;
+            if (savedServer.id && savedServer.registered) {
+              const updated = { ...savedServer, registered: false, registeredName: undefined };
+              bridge.send('servers.update', updated);
+              localStorage.setItem('brmble-server', JSON.stringify(updated));
+            }
+          }
+        } catch { /* ignore parse errors */ }
       }
     });
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -949,6 +949,7 @@ function App() {
         setCertExists(false);
         setCertFingerprint('');
         setActiveProfileName('');
+        setShowSettings(false);
       }
     };
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -608,33 +608,12 @@ function App() {
 
     const onServerCredentials = (data: unknown) => {
       setConnectionError(null);
-      const wrapped = data as { matrix?: MatrixCredentials; registered?: boolean; registeredName?: string } | undefined;
+      const wrapped = data as { matrix?: MatrixCredentials } | undefined;
       const d = wrapped?.matrix;
       if (d?.homeserverUrl && d.accessToken && d.userId && d.roomMap) {
         // Clear stale chat data from previous sessions
         clearChatStorage();
         setMatrixCredentials(d);
-      }
-
-      // Persist registration status to the saved server entry
-      if (wrapped?.registered) {
-        try {
-          const stored = localStorage.getItem('brmble-server');
-          if (stored) {
-            const savedServer = JSON.parse(stored) as SavedServer;
-            const updatedServer = {
-              ...savedServer,
-              registered: true,
-              username: wrapped.registeredName ?? savedServer.username,
-            };
-            localStorage.setItem('brmble-server', JSON.stringify(updatedServer));
-
-            // Update server list entry if we have an ID
-            if (savedServer.id) {
-              bridge.send('servers.update', updatedServer);
-            }
-          }
-        } catch { /* ignore parse errors */ }
       }
     };
 
@@ -1025,7 +1004,17 @@ function App() {
     const onRegistrationStatus = (data: unknown) => {
       const d = data as { serverId?: string; registered?: boolean; registeredName?: string } | undefined;
       if (!d?.registered || !d.serverId) return;
-      bridge.send('servers.update', { id: d.serverId, registered: true, registeredName: d.registeredName });
+      try {
+        const stored = localStorage.getItem('brmble-server');
+        if (stored) {
+          const savedServer = JSON.parse(stored) as SavedServer;
+          if (savedServer.id === d.serverId) {
+            const updated = { ...savedServer, registered: true, registeredName: d.registeredName, username: d.registeredName ?? savedServer.username };
+            bridge.send('servers.update', updated);
+            localStorage.setItem('brmble-server', JSON.stringify(updated));
+          }
+        }
+      } catch { /* ignore parse errors */ }
     };
 
     bridge.on('voice.connected', onVoiceConnected);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -133,6 +133,7 @@ function App() {
   // null = status not yet received, false = no cert, true = cert exists
   const [certExists, setCertExists] = useState<boolean | null>(null);
   const [certFingerprint, setCertFingerprint] = useState('');
+  const [activeProfileName, setActiveProfileName] = useState('');
 
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('idle');
   const { statuses, updateStatus, resetStatuses } = useServiceStatus();
@@ -918,6 +919,27 @@ function App() {
       setCertFingerprint(d?.fingerprint ?? '');
     };
 
+    const onProfilesActiveChanged = (data: unknown) => {
+      const d = data as { id: string | null; name: string | null; fingerprint: string | null };
+      if (d.id) {
+        setCertExists(true);
+        setCertFingerprint(d.fingerprint ?? '');
+        setActiveProfileName(d.name ?? '');
+      } else {
+        setCertExists(false);
+        setCertFingerprint('');
+        setActiveProfileName('');
+      }
+    };
+
+    const onProfilesList = (data: unknown) => {
+      const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null };
+      if (d.activeProfileId) {
+        const active = d.profiles.find(p => p.id === d.activeProfileId);
+        if (active) setActiveProfileName(active.name);
+      }
+    };
+
     const onAutoConnect = (data: unknown) => {
       const server = data as { id: string; label: string; apiUrl?: string; host?: string; port?: number; username: string } | undefined;
       if (server) {
@@ -925,7 +947,7 @@ function App() {
         handleConnect({
           host: server.host || '',
           port: server.port || 0,
-          username: server.username,
+          username: server.username || activeProfileName || 'Brmble User',
           password: '',
         });
       }
@@ -1009,6 +1031,8 @@ function App() {
     bridge.on('cert.status', onCertStatus);
     bridge.on('cert.generated', onCertGenerated);
     bridge.on('cert.imported', onCertImported);
+    bridge.on('profiles.activeChanged', onProfilesActiveChanged);
+    bridge.on('profiles.list', onProfilesList);
     bridge.on('voice.autoConnect', onAutoConnect);
     bridge.on('voice.reconnecting', onVoiceReconnecting);
     bridge.on('voice.reconnectFailed', onVoiceReconnectFailed);
@@ -1044,6 +1068,8 @@ function App() {
       bridge.off('cert.status', onCertStatus);
       bridge.off('cert.generated', onCertGenerated);
       bridge.off('cert.imported', onCertImported);
+      bridge.off('profiles.activeChanged', onProfilesActiveChanged);
+      bridge.off('profiles.list', onProfilesList);
       bridge.off('voice.autoConnect', onAutoConnect);
       bridge.off('voice.reconnecting', onVoiceReconnecting);
       bridge.off('voice.reconnectFailed', onVoiceReconnectFailed);
@@ -1057,6 +1083,7 @@ function App() {
 
   useEffect(() => {
     bridge.send('cert.requestStatus');
+    bridge.send('profiles.list');
   }, []);
 
   useEffect(() => {
@@ -1124,7 +1151,7 @@ const handleConnect = (serverData: SavedServer) => {
       id: server.id,
       host: server.host,
       port: server.port,
-      username: server.username,
+      username: server.username || activeProfileName || 'Brmble User',
       password: server.password || ''
     });
   };

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4,7 +4,7 @@ import type { ConnectionStatus } from './types';
 import { useMatrixClient } from './hooks/useMatrixClient';
 import type { MatrixCredentials } from './hooks/useMatrixClient';
 import { useScreenShare } from './hooks/useScreenShare';
-import { useUnreadTracker } from './hooks/useUnreadTracker';
+import { useUnreadTracker, resetMarkersCache } from './hooks/useUnreadTracker';
 import { useServiceStatus } from './hooks/useServiceStatus';
 import { useServerHealth } from './hooks/useServerHealth';
 
@@ -341,6 +341,7 @@ function App() {
     dmRoomIds,
     activeMatrixRoomId,
     username || null,
+    certFingerprint,
   );
 
   const channelKey = currentChannelId === 'server-root' ? 'server-root' : currentChannelId ? `channel-${currentChannelId}` : 'no-channel';
@@ -939,6 +940,7 @@ function App() {
 
     const onProfilesActiveChanged = (data: unknown) => {
       const d = data as { id: string | null; name: string | null; fingerprint: string | null };
+      resetMarkersCache();
       if (d.id) {
         setCertExists(true);
         setCertFingerprint(d.fingerprint ?? '');

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -99,6 +99,7 @@ interface SavedServer {
   username: string;
   password: string;
   registered?: boolean;
+  registeredName?: string;
 }
 
 interface Channel {
@@ -542,6 +543,22 @@ function App() {
           setSelfDeafened(selfUser.deafened || false);
           setSelfSession(selfUser.session);
         }
+      }
+
+      // Persist Mumble registration status to the saved server entry
+      const reg = data as { registered?: boolean; registeredName?: string } | undefined;
+      if (reg?.registered) {
+        try {
+          const stored = localStorage.getItem('brmble-server');
+          if (stored) {
+            const savedServer = JSON.parse(stored) as SavedServer;
+            if (savedServer.id) {
+              const updated = { ...savedServer, registered: true, username: reg.registeredName ?? savedServer.username, registeredName: reg.registeredName };
+              bridge.send('servers.update', updated);
+              localStorage.setItem('brmble-server', JSON.stringify(updated));
+            }
+          }
+        } catch { /* ignore parse errors */ }
       }
     });
 
@@ -1005,6 +1022,12 @@ function App() {
       }
     };
 
+    const onRegistrationStatus = (data: unknown) => {
+      const d = data as { serverId?: string; registered?: boolean; registeredName?: string } | undefined;
+      if (!d?.registered || !d.serverId) return;
+      bridge.send('servers.update', { id: d.serverId, registered: true, registeredName: d.registeredName });
+    };
+
     bridge.on('voice.connected', onVoiceConnected);
     bridge.on('voice.disconnected', onVoiceDisconnected);
     bridge.on('voice.error', onVoiceError);
@@ -1040,6 +1063,7 @@ function App() {
     bridge.on('voice.authError', onVoiceAuthError);
     bridge.on('voice.userMappingUpdated', onUserMappingUpdated);
     bridge.on('voice.sessionMappingSnapshot', onSessionMappingSnapshot);
+    bridge.on('voice.registrationStatus', onRegistrationStatus);
 
     return () => {
       bridge.off('voice.connected', onVoiceConnected);
@@ -1077,6 +1101,7 @@ function App() {
       bridge.off('voice.authError', onVoiceAuthError);
       bridge.off('voice.userMappingUpdated', onUserMappingUpdated);
       bridge.off('voice.sessionMappingSnapshot', onSessionMappingSnapshot);
+      bridge.off('voice.registrationStatus', onRegistrationStatus);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1742,7 +1742,7 @@ const handleConnect = (serverData: SavedServer) => {
         <main className="main-content">
           {connectionStatus === 'idle' ? (
             certExists === true ? (
-              <ServerList onConnect={handleServerConnect} connectionError={connectionError} onClearError={() => setConnectionError(null)} />
+              <ServerList onConnect={handleServerConnect} connectionError={connectionError} onClearError={() => setConnectionError(null)} activeProfileName={activeProfileName} />
             ) : (
               <div className="connection-state">
                 <div className="connection-state-content">

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -138,12 +138,6 @@ function App() {
   const [certFingerprint, setCertFingerprint] = useState('');
   const [activeProfileName, setActiveProfileName] = useState('');
 
-  // Migrate global localStorage keys to per-profile scoped keys
-  useEffect(() => {
-    if (certFingerprint) {
-      migrateLocalStorage(certFingerprint);
-    }
-  }, [certFingerprint]);
 
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('idle');
   const { statuses, updateStatus, resetStatuses } = useServiceStatus();
@@ -922,7 +916,9 @@ function App() {
       const d = data as { exists: boolean; fingerprint?: string } | undefined;
       if (d?.exists) {
         setCertExists(true);
-        setCertFingerprint(d.fingerprint ?? '');
+        const fp = d.fingerprint ?? '';
+        if (fp) migrateLocalStorage(fp);
+        setCertFingerprint(fp);
       } else {
         setCertExists(false);
       }
@@ -930,12 +926,16 @@ function App() {
     const onCertGenerated = (data: unknown) => {
       const d = data as { fingerprint?: string } | undefined;
       setCertExists(true);
-      setCertFingerprint(d?.fingerprint ?? '');
+      const fp = d?.fingerprint ?? '';
+      if (fp) migrateLocalStorage(fp);
+      setCertFingerprint(fp);
     };
     const onCertImported = (data: unknown) => {
       const d = data as { fingerprint?: string } | undefined;
       setCertExists(true);
-      setCertFingerprint(d?.fingerprint ?? '');
+      const fp = d?.fingerprint ?? '';
+      if (fp) migrateLocalStorage(fp);
+      setCertFingerprint(fp);
     };
 
     const onProfilesActiveChanged = (data: unknown) => {
@@ -943,7 +943,9 @@ function App() {
       resetMarkersCache();
       if (d.id) {
         setCertExists(true);
-        setCertFingerprint(d.fingerprint ?? '');
+        const fp = d.fingerprint ?? '';
+        if (fp) migrateLocalStorage(fp);
+        setCertFingerprint(fp);
         setActiveProfileName(d.name ?? '');
       } else {
         setCertExists(false);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -132,7 +132,7 @@ const mapStoredContacts = (contacts: StoredDMContact[]) =>
 function App() {
   // null = status not yet received, false = no cert, true = cert exists
   const [certExists, setCertExists] = useState<boolean | null>(null);
-  const [certFingerprint, setCertFingerprint] = useState('');
+  const [, setCertFingerprint] = useState('');
   const [activeProfileName, setActiveProfileName] = useState('');
 
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('idle');

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -96,6 +96,7 @@ function speakText(text: string) {
 
 interface SavedServer {
   id?: string;
+  label?: string;
   host: string;
   port: number;
   username: string;
@@ -1190,6 +1191,7 @@ const handleConnect = (serverData: SavedServer) => {
     setServerLabel(server.label || `${server.host}:${server.port}`);
     handleConnect({
       id: server.id,
+      label: server.label,
       host: server.host,
       port: server.port,
       username: server.username || activeProfileName || 'Brmble User',

--- a/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx
+++ b/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { useProfileFingerprint } from '../../contexts/ProfileContext';
 import './Brmblegotchi.css';
 
 const STATE_KEY = 'brmblegotchi-state';
@@ -86,12 +87,16 @@ function CleanlinessIcon() {
 }
 
 export function BrmblegotchiWidget() {
+  const fingerprint = useProfileFingerprint();
+  const stateKey = fingerprint ? `${STATE_KEY}_${fingerprint}` : STATE_KEY;
+  const positionKey = fingerprint ? `${POSITION_KEY}_${fingerprint}` : POSITION_KEY;
+
   const [isEnabled, setIsEnabled] = useState(true);
   const [isVisible, setIsVisible] = useState(true);
   const [showActions, setShowActions] = useState(false);
   const [position, setPosition] = useState(() => {
     try {
-      const stored = localStorage.getItem(POSITION_KEY);
+      const stored = localStorage.getItem(positionKey);
       if (stored) {
         return JSON.parse(stored);
       }
@@ -102,7 +107,7 @@ export function BrmblegotchiWidget() {
   const [cooldownRemaining, setCooldownRemaining] = useState(0);
   const [petState, setPetState] = useState<PetState>(() => {
     try {
-      const stored = localStorage.getItem(STATE_KEY);
+      const stored = localStorage.getItem(stateKey);
       if (stored) {
         const saved = JSON.parse(stored) as PetState;
         const elapsed = (Date.now() - saved.lastUpdate) / 1000;
@@ -160,12 +165,12 @@ export function BrmblegotchiWidget() {
         const remaining = Math.max(0, 600 - elapsedSinceActionSeconds);
         setCooldownRemaining(remaining);
 
-        localStorage.setItem(STATE_KEY, JSON.stringify(newState));
+        localStorage.setItem(stateKey, JSON.stringify(newState));
         return newState;
       });
     }, 1000);
     return () => clearInterval(interval);
-  }, []);
+  }, [stateKey]);
 
   const handleDismiss = useCallback(() => {
     setIsVisible(false);
@@ -200,12 +205,12 @@ export function BrmblegotchiWidget() {
           newState = { ...prev, cleanliness: Math.min(100, prev.cleanliness + 30), lastUpdate: Date.now(), lastActionTime: now };
           break;
       }
-      localStorage.setItem(STATE_KEY, JSON.stringify(newState));
+      localStorage.setItem(stateKey, JSON.stringify(newState));
       setCooldownRemaining(600);
       return newState;
     });
     setShowActions(false);
-  }, [petState.lastActionTime]);
+  }, [petState.lastActionTime, stateKey]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if ((e.target as HTMLElement).closest('.brmblegotchi-actions') || 
@@ -248,8 +253,46 @@ export function BrmblegotchiWidget() {
   }, [isDragging, handleMouseMove, handleMouseUp]);
 
   useEffect(() => {
-    localStorage.setItem(POSITION_KEY, JSON.stringify(position));
-  }, [position]);
+    localStorage.setItem(positionKey, JSON.stringify(position));
+  }, [position, positionKey]);
+
+  // Reload state when profile fingerprint changes
+  const fingerprintRef = useRef(fingerprint);
+  useEffect(() => {
+    if (fingerprint && fingerprint !== fingerprintRef.current) {
+      fingerprintRef.current = fingerprint;
+      // Reload pet state
+      try {
+        const stored = localStorage.getItem(`${STATE_KEY}_${fingerprint}`);
+        if (stored) {
+          const saved = JSON.parse(stored) as PetState;
+          const elapsed = (Date.now() - saved.lastUpdate) / 1000;
+          setPetState({
+            hunger: Math.max(0, saved.hunger - elapsed * 0.0069),
+            happiness: Math.max(0, saved.happiness - elapsed * 0.0139),
+            cleanliness: Math.max(0, saved.cleanliness - elapsed * 0.0278),
+            lastUpdate: Date.now(),
+            lastActionTime: saved.lastActionTime ?? 0,
+          });
+        } else {
+          setPetState({ hunger: 80, happiness: 75, cleanliness: 85, lastUpdate: Date.now(), lastActionTime: 0 });
+        }
+      } catch {
+        setPetState({ hunger: 80, happiness: 75, cleanliness: 85, lastUpdate: Date.now(), lastActionTime: 0 });
+      }
+      // Reload position
+      try {
+        const stored = localStorage.getItem(`${POSITION_KEY}_${fingerprint}`);
+        if (stored) {
+          setPosition(JSON.parse(stored));
+        } else {
+          setPosition({ bottom: 150, right: 24 });
+        }
+      } catch {
+        setPosition({ bottom: 150, right: 24 });
+      }
+    }
+  }, [fingerprint]);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {

--- a/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx
+++ b/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react';
 import { useProfileFingerprint } from '../../contexts/ProfileContext';
 import './Brmblegotchi.css';
 
@@ -258,7 +258,7 @@ export function BrmblegotchiWidget() {
 
   // Reload state when profile fingerprint changes
   const fingerprintRef = useRef(fingerprint);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (fingerprint && fingerprint !== fingerprintRef.current) {
       fingerprintRef.current = fingerprint;
       // Reload pet state

--- a/src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
+++ b/src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
@@ -315,10 +315,10 @@ export function CertWizard({ onComplete }: CertWizardProps) {
             </p>
             {error && <p style={{ color: 'var(--accent-danger-text)', fontSize: '0.85rem', marginBottom: '1rem' }}>{error}</p>}
             <div className="cert-wizard-actions">
-              <button className="cert-wizard-btn ghost" onClick={() => setStep('warning')}>
+              <button className="btn btn-ghost" onClick={() => setStep('warning')}>
                 Back
               </button>
-              <button className="cert-wizard-btn primary" onClick={handleImportClick}>
+              <button className="btn btn-primary" onClick={handleImportClick}>
                 Choose File…
               </button>
             </div>

--- a/src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
+++ b/src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import bridge from '../../bridge';
 import { confirm } from '../../hooks/usePrompt';
+import { validateProfileName } from '../../utils/profileValidation';
 import './CertWizard.css';
 
 type WizardStep = 'welcome' | 'choose' | 'warning' | 'action' | 'backup';
@@ -202,14 +203,19 @@ export function CertWizard({ onComplete }: CertWizardProps) {
                 type="text"
                 value={profileName}
                 onChange={(e) => setProfileName(e.target.value)}
-                placeholder="e.g. Your Name"
+                placeholder="e.g. YourName"
                 autoFocus
               />
+              {profileName.trim() && validateProfileName(profileName.trim()) && (
+                <span style={{ display: 'block', fontSize: 'var(--text-xs)', color: 'var(--accent-danger-text)', marginTop: 'var(--space-xs)' }}>
+                  {validateProfileName(profileName.trim())}
+                </span>
+              )}
             </label>
             <div className="cert-wizard-choices">
               <button
                 className="cert-wizard-choice"
-                disabled={!profileName.trim()}
+                disabled={!profileName.trim() || !!validateProfileName(profileName.trim())}
                 onClick={handleChooseGenerate}
               >
                 <span className="cert-wizard-choice-icon">✨</span>
@@ -220,7 +226,7 @@ export function CertWizard({ onComplete }: CertWizardProps) {
               </button>
               <button
                 className="cert-wizard-choice"
-                disabled={!profileName.trim()}
+                disabled={!profileName.trim() || !!validateProfileName(profileName.trim())}
                 onClick={handleChooseImport}
               >
                 <span className="cert-wizard-choice-icon">📂</span>

--- a/src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
+++ b/src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import bridge from '../../bridge';
+import { confirm } from '../../hooks/usePrompt';
 import './CertWizard.css';
 
 type WizardStep = 'welcome' | 'choose' | 'warning' | 'action' | 'backup';
@@ -18,6 +19,18 @@ function triggerBlobDownload(base64: string, filename: string) {
   a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+function checkExistingCert(name: string): Promise<{ exists: boolean; fingerprint: string | null }> {
+  return new Promise((resolve) => {
+    const handler = (data: unknown) => {
+      bridge.off('profiles.checkCertResult', handler);
+      const d = data as { exists: boolean; fingerprint?: string | null };
+      resolve({ exists: d.exists, fingerprint: d.fingerprint ?? null });
+    };
+    bridge.on('profiles.checkCertResult', handler);
+    bridge.send('profiles.checkCert', { name });
+  });
 }
 
 export function CertWizard({ onComplete }: CertWizardProps) {
@@ -63,6 +76,44 @@ export function CertWizard({ onComplete }: CertWizardProps) {
       bridge.off('profiles.error', onError);
     };
   }, []);
+
+  const handleChooseGenerate = async () => {
+    const existing = await checkExistingCert(profileName);
+    if (existing.exists) {
+      const reuse = await confirm({
+        title: 'Certificate found',
+        message: `A certificate file for "${profileName}" already exists in Brmble. Would you like to use it instead of generating a new one?`,
+        confirmLabel: 'Use existing',
+        cancelLabel: 'Generate new',
+      });
+      if (reuse) {
+        setGenerating(true);
+        bridge.send('profiles.addFromExisting', { name: profileName });
+        return;
+      }
+    }
+    setMode('generate');
+    setStep('warning');
+  };
+
+  const handleChooseImport = async () => {
+    const existing = await checkExistingCert(profileName);
+    if (existing.exists) {
+      const reuse = await confirm({
+        title: 'Certificate found',
+        message: `A certificate file for "${profileName}" already exists in Brmble. Would you like to use it instead of importing a different one?`,
+        confirmLabel: 'Use existing',
+        cancelLabel: 'Import different',
+      });
+      if (reuse) {
+        setGenerating(true);
+        bridge.send('profiles.addFromExisting', { name: profileName });
+        return;
+      }
+    }
+    setMode('import');
+    setStep('warning');
+  };
 
   const handleGenerate = () => {
     setError('');
@@ -159,7 +210,7 @@ export function CertWizard({ onComplete }: CertWizardProps) {
               <button
                 className="cert-wizard-choice"
                 disabled={!profileName.trim()}
-                onClick={() => { setMode('generate'); setStep('warning'); }}
+                onClick={handleChooseGenerate}
               >
                 <span className="cert-wizard-choice-icon">✨</span>
                 <div>
@@ -170,7 +221,7 @@ export function CertWizard({ onComplete }: CertWizardProps) {
               <button
                 className="cert-wizard-choice"
                 disabled={!profileName.trim()}
-                onClick={() => { setMode('import'); setStep('warning'); }}
+                onClick={handleChooseImport}
               >
                 <span className="cert-wizard-choice-icon">📂</span>
                 <div>

--- a/src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
+++ b/src/Brmble.Web/src/components/CertWizard/CertWizard.tsx
@@ -23,6 +23,7 @@ function triggerBlobDownload(base64: string, filename: string) {
 export function CertWizard({ onComplete }: CertWizardProps) {
   const [step, setStep] = useState<WizardStep>('welcome');
   const [mode, setMode] = useState<WizardMode>('generate');
+  const [profileName, setProfileName] = useState('');
   const [acknowledged, setAcknowledged] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [fingerprint, setFingerprint] = useState('');
@@ -33,17 +34,9 @@ export function CertWizard({ onComplete }: CertWizardProps) {
   const stepIndex = STEPS.indexOf(step);
 
   useEffect(() => {
-    const onGenerated = (data: unknown) => {
-      const d = data as { fingerprint: string } | undefined;
+    const onProfileAdded = (data: unknown) => {
+      const d = data as { fingerprint?: string } | undefined;
       setGenerating(false);
-      if (d?.fingerprint) {
-        setFingerprint(d.fingerprint);
-        setStep('backup');
-      }
-    };
-
-    const onImported = (data: unknown) => {
-      const d = data as { fingerprint: string } | undefined;
       if (d?.fingerprint) {
         setFingerprint(d.fingerprint);
         setStep('backup');
@@ -61,22 +54,20 @@ export function CertWizard({ onComplete }: CertWizardProps) {
       setError(d?.message ?? 'An error occurred.');
     };
 
-    bridge.on('cert.generated', onGenerated);
-    bridge.on('cert.imported', onImported);
+    bridge.on('profiles.added', onProfileAdded);
     bridge.on('cert.exportData', onExportData);
-    bridge.on('cert.error', onError);
+    bridge.on('profiles.error', onError);
     return () => {
-      bridge.off('cert.generated', onGenerated);
-      bridge.off('cert.imported', onImported);
+      bridge.off('profiles.added', onProfileAdded);
       bridge.off('cert.exportData', onExportData);
-      bridge.off('cert.error', onError);
+      bridge.off('profiles.error', onError);
     };
   }, []);
 
   const handleGenerate = () => {
     setError('');
     setGenerating(true);
-    bridge.send('cert.generate');
+    bridge.send('profiles.add', { name: profileName });
   };
 
   const handleImportClick = () => {
@@ -94,7 +85,7 @@ export function CertWizard({ onComplete }: CertWizardProps) {
       let binary = '';
       bytes.forEach(b => binary += String.fromCharCode(b));
       const base64 = btoa(binary);
-      bridge.send('cert.import', { data: base64 });
+      bridge.send('profiles.import', { name: profileName, data: base64 });
     };
     reader.readAsArrayBuffer(file);
     // Reset so the same file can be re-selected if needed
@@ -151,15 +142,36 @@ export function CertWizard({ onComplete }: CertWizardProps) {
           <>
             <div className="cert-wizard-icon">🪪</div>
             <h2 className="heading-title cert-wizard-title">Set Up Your Identity</h2>
+            <label style={{ display: 'block', marginBottom: 'var(--space-md)' }}>
+              <span style={{ display: 'block', fontSize: 'var(--text-sm)', fontWeight: 600, color: 'var(--text-primary)', marginBottom: 'var(--space-xs)' }}>
+                Profile Name
+              </span>
+              <input
+                className="brmble-input"
+                type="text"
+                value={profileName}
+                onChange={(e) => setProfileName(e.target.value)}
+                placeholder="e.g. Your Name"
+                autoFocus
+              />
+            </label>
             <div className="cert-wizard-choices">
-              <button className="cert-wizard-choice" onClick={() => { setMode('generate'); setStep('warning'); }}>
+              <button
+                className="cert-wizard-choice"
+                disabled={!profileName.trim()}
+                onClick={() => { setMode('generate'); setStep('warning'); }}
+              >
                 <span className="cert-wizard-choice-icon">✨</span>
                 <div>
                   <div className="cert-wizard-choice-label">Generate a new certificate</div>
                   <div className="cert-wizard-choice-desc">First time on Brmble? Start here.</div>
                 </div>
               </button>
-              <button className="cert-wizard-choice" onClick={() => { setMode('import'); setStep('warning'); }}>
+              <button
+                className="cert-wizard-choice"
+                disabled={!profileName.trim()}
+                onClick={() => { setMode('import'); setStep('warning'); }}
+              >
                 <span className="cert-wizard-choice-icon">📂</span>
                 <div>
                   <div className="cert-wizard-choice-label">Import an existing certificate</div>

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -83,7 +83,7 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
         const members = room.getJoinedMembers();
         for (const member of members) {
           const userId = member.userId;
-          const displayName = member.name || member.rawDisplayName || userId;
+          const displayName = member.rawDisplayName || member.name || userId;
           if (seen.has(userId) || seen.has(displayName.toLowerCase())) continue;
           seen.add(userId);
           seen.add(displayName.toLowerCase());

--- a/src/Brmble.Web/src/components/Game/useGameState.ts
+++ b/src/Brmble.Web/src/components/Game/useGameState.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo } from 'react';
 import type { GameState, GameActions, Infrastructure, Service } from './types';
 import { INITIAL_STATE } from './types';
 import { applyTheme } from '../../themes/theme-loader';
@@ -108,7 +108,7 @@ export function useGameState() {
 
   // Reload state when profile fingerprint changes
   const fingerprintRef = useRef(fingerprint);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (fingerprint && fingerprint !== fingerprintRef.current) {
       fingerprintRef.current = fingerprint;
       const key = `${STORAGE_KEY}_${fingerprint}`;

--- a/src/Brmble.Web/src/components/Game/useGameState.ts
+++ b/src/Brmble.Web/src/components/Game/useGameState.ts
@@ -2,8 +2,10 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { GameState, GameActions, Infrastructure, Service } from './types';
 import { INITIAL_STATE } from './types';
 import { applyTheme } from '../../themes/theme-loader';
+import { useProfileFingerprint } from '../../contexts/ProfileContext';
 
 const STORAGE_KEY = 'idle-farm-save';
+const THEME_KEY = 'idle-farm-theme';
 
 function calculateBandwidth(infra: Infrastructure[]): number {
   return infra.reduce((total, item) => {
@@ -59,8 +61,12 @@ function hasServices(state: unknown): state is GameState {
 }
 
 export function useGameState() {
+  const fingerprint = useProfileFingerprint();
+  const storageKey = fingerprint ? `${STORAGE_KEY}_${fingerprint}` : STORAGE_KEY;
+  const themeKey = fingerprint ? `${THEME_KEY}_${fingerprint}` : THEME_KEY;
+
   const [state, setState] = useState<GameState>(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
+    const saved = localStorage.getItem(storageKey);
     if (saved) {
       try {
         const parsed = JSON.parse(saved);
@@ -95,10 +101,30 @@ export function useGameState() {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...stateRef.current, lastSaved: Date.now() }));
+      localStorage.setItem(storageKey, JSON.stringify({ ...stateRef.current, lastSaved: Date.now() }));
     }, 30000);
     return () => clearInterval(interval);
-  }, []);
+  }, [storageKey]);
+
+  // Reload state when profile fingerprint changes
+  const fingerprintRef = useRef(fingerprint);
+  useEffect(() => {
+    if (fingerprint && fingerprint !== fingerprintRef.current) {
+      fingerprintRef.current = fingerprint;
+      const key = `${STORAGE_KEY}_${fingerprint}`;
+      const saved = localStorage.getItem(key);
+      if (saved) {
+        try {
+          const parsed = JSON.parse(saved);
+          if (hasInfrastructure(parsed) && hasServices(parsed)) {
+            setState(parsed);
+            return;
+          }
+        } catch { /* ignore */ }
+      }
+      setState(INITIAL_STATE);
+    }
+  }, [fingerprint]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -227,15 +253,15 @@ export function useGameState() {
 
   const setTheme = useCallback((theme: string) => {
     applyTheme(theme);
-    localStorage.setItem('idle-farm-theme', theme);
-  }, []);
+    localStorage.setItem(themeKey, theme);
+  }, [themeKey]);
 
   const saveGame = useCallback(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...state, lastSaved: Date.now() }));
-  }, [state]);
+    localStorage.setItem(storageKey, JSON.stringify({ ...state, lastSaved: Date.now() }));
+  }, [state, storageKey]);
 
   const loadGame = useCallback(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
+    const saved = localStorage.getItem(storageKey);
     if (saved) {
       try {
         const parsed = JSON.parse(saved);
@@ -248,12 +274,12 @@ export function useGameState() {
         // Invalid save data
       }
     }
-  }, []);
+  }, [storageKey]);
 
   const resetGame = useCallback(() => {
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(storageKey);
     setState(INITIAL_STATE);
-  }, []);
+  }, [storageKey]);
 
   const exportSave = useCallback((): string => {
     return JSON.stringify(state);

--- a/src/Brmble.Web/src/components/ServerList/ServerList.css
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.css
@@ -337,6 +337,24 @@
   outline: none;
 }
 
+.server-list-username-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.server-list-input-registered {
+  padding-right: var(--space-xl) !important;
+}
+
+.server-list-registered-icon {
+  position: absolute;
+  right: var(--space-sm);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--accent-success, #4ade80);
+  pointer-events: none;
+}
+
 .server-list-input-host {
   flex: 2;
 }

--- a/src/Brmble.Web/src/components/ServerList/ServerList.tsx
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.tsx
@@ -237,6 +237,7 @@ export function ServerList({ onConnect, connectionError, onClearError }: ServerL
                     </button>
                   )}
                 </div>
+                <Tooltip content={editing?.registered ? `Registered as "${editing.registeredName}" on this server` : ''}>
                 <div className="server-list-username-wrapper">
                   <input
                     className={`brmble-input server-list-input${editing?.registered ? ' server-list-input-registered' : ''}`}
@@ -244,7 +245,6 @@ export function ServerList({ onConnect, connectionError, onClearError }: ServerL
                     value={editing?.registered ? (editing.registeredName ?? form.username) : form.username}
                     onChange={e => setForm(f => ({ ...f, username: e.target.value }))}
                     disabled={editing?.registered === true}
-                    title={editing?.registered ? `Registered as "${editing.registeredName}" on this server` : undefined}
                   />
                   {editing?.registered && (
                     <svg className="server-list-registered-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-label="Registered">
@@ -252,6 +252,7 @@ export function ServerList({ onConnect, connectionError, onClearError }: ServerL
                     </svg>
                   )}
                 </div>
+                </Tooltip>
               </div>
               <div className="server-list-form-actions">
                 <button type="button" className="btn btn-secondary server-list-cancel-btn" onClick={handleCancel}>

--- a/src/Brmble.Web/src/components/ServerList/ServerList.tsx
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.tsx
@@ -216,7 +216,7 @@ export function ServerList({ onConnect, connectionError, onClearError }: ServerL
                     <button
                       type="button"
                       className="server-list-password-toggle"
-                      onClick={() => setShowPassword(v => !v)}
+                      onMouseDown={e => { e.preventDefault(); setShowPassword(v => !v); }}
                       onFocus={() => setToggleFocused(true)}
                       onBlur={() => { setToggleFocused(false); setShowPassword(false); }}
                       aria-label={showPassword ? 'Hide password' : 'Show password'}

--- a/src/Brmble.Web/src/components/ServerList/ServerList.tsx
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.tsx
@@ -249,7 +249,7 @@ export function ServerList({ onConnect, connectionError, onClearError, activePro
                 </div>
                 {editing?.registered && (
                 <Tooltip content={`Registered as "${editing.registeredName}" on this server`}>
-                <div className="server-list-username-wrapper">
+                <div className="server-list-username-wrapper" tabIndex={0}>
                   <input
                     className="brmble-input server-list-input server-list-input-registered"
                     placeholder="Username"

--- a/src/Brmble.Web/src/components/ServerList/ServerList.tsx
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.tsx
@@ -10,9 +10,10 @@ interface ServerListProps {
   onConnect: (server: ServerEntry) => void;
   connectionError?: string | null;
   onClearError?: () => void;
+  activeProfileName?: string;
 }
 
-export function ServerList({ onConnect, connectionError, onClearError }: ServerListProps) {
+export function ServerList({ onConnect, connectionError, onClearError, activeProfileName }: ServerListProps) {
   const { servers, loading, addServer, updateServer, removeServer } = useServerlist();
   const [editing, setEditing] = useState<ServerEntry | null>(null);
   const [isAdding, setIsAdding] = useState(false);
@@ -86,6 +87,15 @@ export function ServerList({ onConnect, connectionError, onClearError }: ServerL
     return () => window.removeEventListener('keydown', handleKey);
   }, [isAdding, editing]);
 
+  // Sync editing state when servers update (e.g. profile switch swaps registration data)
+  useEffect(() => {
+    if (!editing) return;
+    const fresh = servers.find(s => s.id === editing.id);
+    if (fresh) {
+      setEditing(fresh);
+    }
+  }, [servers]); // eslint-disable-line react-hooks/exhaustive-deps
+
   if (loading) {
     return (
       <div className="server-list-overlay">
@@ -103,7 +113,7 @@ export function ServerList({ onConnect, connectionError, onClearError }: ServerL
           <BrmbleLogo size={192} heartbeat />
         </div>
         <div className="server-list-header">
-          <h2 className="heading-title server-list-title">Choose a Server</h2>
+          <h2 className="heading-title server-list-title">Choose a Server{activeProfileName ? `, ${activeProfileName}!` : ''}</h2>
           <p className="server-list-subtitle">Select a server to start talking and chatting</p>
         </div>
 
@@ -237,22 +247,22 @@ export function ServerList({ onConnect, connectionError, onClearError }: ServerL
                     </button>
                   )}
                 </div>
-                <Tooltip content={editing?.registered ? `Registered as "${editing.registeredName}" on this server` : ''}>
+                {editing?.registered && (
+                <Tooltip content={`Registered as "${editing.registeredName}" on this server`}>
                 <div className="server-list-username-wrapper">
                   <input
-                    className={`brmble-input server-list-input${editing?.registered ? ' server-list-input-registered' : ''}`}
+                    className="brmble-input server-list-input server-list-input-registered"
                     placeholder="Username"
-                    value={editing?.registered ? (editing.registeredName ?? form.username) : form.username}
+                    value={editing.registeredName ?? form.username}
                     onChange={e => setForm(f => ({ ...f, username: e.target.value }))}
-                    disabled={editing?.registered === true}
+                    disabled
                   />
-                  {editing?.registered && (
-                    <svg className="server-list-registered-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-label="Registered">
-                      <polyline points="3.5 8 6.5 11 12.5 5" />
-                    </svg>
-                  )}
+                  <svg className="server-list-registered-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-label="Registered">
+                    <polyline points="3.5 8 6.5 11 12.5 5" />
+                  </svg>
                 </div>
                 </Tooltip>
+                )}
               </div>
               <div className="server-list-form-actions">
                 <button type="button" className="btn btn-secondary server-list-cancel-btn" onClick={handleCancel}>

--- a/src/Brmble.Web/src/components/ServerList/ServerList.tsx
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.tsx
@@ -27,7 +27,7 @@ export function ServerList({ onConnect, connectionError, onClearError }: ServerL
     e.preventDefault();
     const server = { ...form, port: parseInt(form.port) };
     if (editing) {
-      updateServer({ ...server, id: editing.id, registered: editing.registered });
+      updateServer({ ...server, id: editing.id, registered: editing.registered, registeredName: editing.registeredName });
       setEditing(null);
     } else {
       addServer(server);
@@ -237,14 +237,21 @@ export function ServerList({ onConnect, connectionError, onClearError }: ServerL
                     </button>
                   )}
                 </div>
-                <input
-                  className="brmble-input server-list-input"
-                  placeholder="Username"
-                  value={form.username}
-                  onChange={e => setForm(f => ({ ...f, username: e.target.value }))}
-                  disabled={editing?.registered === true}
-                  title={editing?.registered ? 'Username is locked after registration' : undefined}
-                />
+                <div className="server-list-username-wrapper">
+                  <input
+                    className={`brmble-input server-list-input${editing?.registered ? ' server-list-input-registered' : ''}`}
+                    placeholder="Username"
+                    value={editing?.registered ? (editing.registeredName ?? form.username) : form.username}
+                    onChange={e => setForm(f => ({ ...f, username: e.target.value }))}
+                    disabled={editing?.registered === true}
+                    title={editing?.registered ? `Registered as "${editing.registeredName}" on this server` : undefined}
+                  />
+                  {editing?.registered && (
+                    <svg className="server-list-registered-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-label="Registered">
+                      <polyline points="3.5 8 6.5 11 12.5 5" />
+                    </svg>
+                  )}
+                </div>
               </div>
               <div className="server-list-form-actions">
                 <button type="button" className="btn btn-secondary server-list-cancel-btn" onClick={handleCancel}>

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.css
@@ -45,6 +45,6 @@
   color: var(--text-muted);
 }
 
-.profile-select {
+.profile-select-wrapper {
   min-width: 200px;
 }

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.css
@@ -48,3 +48,19 @@
 .profile-select-wrapper {
   min-width: 200px;
 }
+
+.profile-registered-name {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--space-xs);
+  min-width: 200px;
+  padding-left: var(--space-sm);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.profile-registered-icon {
+  color: var(--accent-primary);
+  flex-shrink: 0;
+}

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.css
@@ -44,3 +44,7 @@
   font-size: var(--text-xs);
   color: var(--text-muted);
 }
+
+.profile-select {
+  min-width: 200px;
+}

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -4,6 +4,7 @@ import AvatarUpload from '../AvatarUpload/AvatarUpload';
 import bridge from '../../bridge';
 import { useProfiles } from '../../hooks/useProfiles';
 import { confirm } from '../../hooks/usePrompt';
+import { Select } from '../Select/Select';
 import { Tooltip } from '../Tooltip/Tooltip';
 import './ProfileSettingsTab.css';
 import './ProfilesSettingsTab.css';
@@ -60,27 +61,28 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
     return () => bridge.off('cert.exportData', onExportData);
   }, []);
 
-  // Cancel forms on Escape
+  // Cancel forms on Escape — stop propagation so SettingsModal doesn't also close
   useEffect(() => {
     if (!isAdding && !editingId) return;
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        e.stopPropagation();
+        e.preventDefault();
         setIsAdding(false);
         setEditingId(null);
         setAddName('');
         setEditName('');
       }
     };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
+    window.addEventListener('keydown', handleKey, true);
+    return () => window.removeEventListener('keydown', handleKey, true);
   }, [isAdding, editingId]);
 
   const getInitial = (name: string) => (name?.charAt(0) || '?').toUpperCase();
 
-  const truncateFingerprint = (fp: string | null) => {
+  const formatFingerprint = (fp: string | null) => {
     if (!fp) return 'No certificate';
-    if (fp.length <= 20) return fp;
-    return fp.slice(0, 8) + '...' + fp.slice(-8);
+    return fp;
   };
 
   const handleAddGenerate = (e: React.FormEvent) => {
@@ -181,19 +183,15 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
         <div className="settings-item">
           <label>Active Profile</label>
           <Tooltip content={connected ? 'Disconnect to switch profiles' : 'Select your active profile'}>
-            <select
-              className="brmble-input profile-select"
-              value={activeProfileId ?? ''}
-              onChange={(e) => setActive(e.target.value)}
-              disabled={connected || loading || profiles.length === 0}
-            >
-              {profiles.map(p => (
-                <option key={p.id} value={p.id}>{p.name}</option>
-              ))}
-              {profiles.length === 0 && (
-                <option value="">No profiles</option>
-              )}
-            </select>
+            <div className="profile-select-wrapper">
+              <Select
+                value={activeProfileId ?? ''}
+                onChange={(val) => setActive(val)}
+                options={profiles.map(p => ({ value: p.id, label: p.name }))}
+                disabled={connected || loading || profiles.length === 0}
+                placeholder="No profiles"
+              />
+            </div>
           </Tooltip>
         </div>
       </div>
@@ -252,10 +250,18 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
                   </div>
                   <div className="profiles-info">
                     <span className="profiles-name">{profile.name}</span>
-                    <span className="profiles-fingerprint">{truncateFingerprint(profile.fingerprint)}</span>
-                    {isActive && <span className="profiles-active-badge">Active</span>}
+                    <span className="profiles-fingerprint">{formatFingerprint(profile.fingerprint)}</span>
+
                   </div>
                   <div className="profiles-actions">
+                    <Tooltip content="Delete profile">
+                      <button
+                        className="btn btn-ghost profiles-delete-btn"
+                        onClick={() => handleDelete(profile)}
+                      >
+                        ✕
+                      </button>
+                    </Tooltip>
                     <Tooltip content="Rename profile">
                       <button
                         className="btn btn-secondary profiles-action-btn"
@@ -266,18 +272,10 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
                     </Tooltip>
                     <Tooltip content="Export certificate">
                       <button
-                        className="btn btn-secondary profiles-action-btn"
+                        className="btn btn-primary profiles-action-btn"
                         onClick={() => exportCert()}
                       >
                         Export
-                      </button>
-                    </Tooltip>
-                    <Tooltip content="Delete profile">
-                      <button
-                        className="btn btn-ghost profiles-delete-btn"
-                        onClick={() => handleDelete(profile)}
-                      >
-                        ✕
                       </button>
                     </Tooltip>
                   </div>
@@ -311,14 +309,16 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
               />
             </div>
             <div className="profiles-form-actions">
-              <button type="button" className="btn btn-secondary" onClick={handleCancel}>
-                Cancel
-              </button>
               <button type="button" className="btn btn-secondary" onClick={handleAddImport} disabled={!addName.trim()}>
                 Import Certificate
               </button>
               <button type="submit" className="btn btn-primary" disabled={!addName.trim()}>
                 Generate New Certificate
+              </button>
+            </div>
+            <div className="profiles-form-actions">
+              <button type="button" className="btn btn-secondary" onClick={handleCancel}>
+                Cancel
               </button>
             </div>
           </form>

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -254,10 +254,11 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
 
                   </div>
                   <div className="profiles-actions">
-                    <Tooltip content="Delete profile">
+                    <Tooltip content={connected && isActive ? 'Disconnect to delete this profile' : 'Delete profile'}>
                       <button
                         className="btn btn-ghost profiles-delete-btn"
                         onClick={() => handleDelete(profile)}
+                        disabled={connected && isActive}
                       >
                         ✕
                       </button>

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -375,7 +375,7 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
                     <Tooltip content="Export certificate">
                       <button
                         className="btn btn-primary profiles-action-btn"
-                        onClick={() => exportCert()}
+                        onClick={() => exportCert(profile.id)}
                       >
                         Export
                       </button>

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -18,6 +18,7 @@ interface ProfileSettingsTabProps {
   onUploadAvatar: (blob: Blob, contentType: string) => void;
   onRemoveAvatar: () => void;
   connected: boolean;
+  registeredName?: string;
 }
 
 function getAvatarStatusText(user: ProfileSettingsTabProps['currentUser']): string {
@@ -39,7 +40,7 @@ function triggerBlobDownload(base64: string, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar, connected }: ProfileSettingsTabProps) {
+export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar, connected, registeredName }: ProfileSettingsTabProps) {
   const [showUpload, setShowUpload] = useState(false);
   const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert } = useProfiles();
 
@@ -194,6 +195,17 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
             </div>
           </Tooltip>
         </div>
+        {connected && registeredName && (
+          <div className="settings-item">
+            <label>Registered name on server</label>
+            <span className="profile-registered-name">
+              {registeredName}
+              <svg className="profile-registered-icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <polyline points="3.5 8 6.5 11 12.5 5" />
+              </svg>
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Manage Profiles section */}
@@ -263,10 +275,11 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
                         ✕
                       </button>
                     </Tooltip>
-                    <Tooltip content="Rename profile">
+                    <Tooltip content={connected ? 'Disconnect to rename profiles' : 'Rename profile'}>
                       <button
                         className="btn btn-secondary profiles-action-btn"
                         onClick={() => handleEditStart(profile)}
+                        disabled={connected}
                       >
                         Edit
                       </button>

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -2,7 +2,11 @@ import { useState, useEffect, useRef } from 'react';
 import Avatar from '../Avatar/Avatar';
 import AvatarUpload from '../AvatarUpload/AvatarUpload';
 import bridge from '../../bridge';
+import { useProfiles } from '../../hooks/useProfiles';
+import { confirm } from '../../hooks/usePrompt';
+import { Tooltip } from '../Tooltip/Tooltip';
 import './ProfileSettingsTab.css';
+import './ProfilesSettingsTab.css';
 
 interface ProfileSettingsTabProps {
   currentUser: {
@@ -12,8 +16,6 @@ interface ProfileSettingsTabProps {
   };
   onUploadAvatar: (blob: Blob, contentType: string) => void;
   onRemoveAvatar: () => void;
-  fingerprint: string;
-  connectedUsername: string;
   connected: boolean;
 }
 
@@ -36,8 +38,14 @@ function triggerBlobDownload(base64: string, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar, fingerprint, connectedUsername, connected }: ProfileSettingsTabProps) {
+export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar, connected }: ProfileSettingsTabProps) {
   const [showUpload, setShowUpload] = useState(false);
+  const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert } = useProfiles();
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [addName, setAddName] = useState('');
+  const [editName, setEditName] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const statusText = getAvatarStatusText(currentUser);
@@ -52,22 +60,94 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
     return () => bridge.off('cert.exportData', onExportData);
   }, []);
 
-  const handleExport = () => bridge.send('cert.export');
-  const handleImportClick = () => fileInputRef.current?.click();
+  // Cancel forms on Escape
+  useEffect(() => {
+    if (!isAdding && !editingId) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsAdding(false);
+        setEditingId(null);
+        setAddName('');
+        setEditName('');
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isAdding, editingId]);
+
+  const getInitial = (name: string) => (name?.charAt(0) || '?').toUpperCase();
+
+  const truncateFingerprint = (fp: string | null) => {
+    if (!fp) return 'No certificate';
+    if (fp.length <= 20) return fp;
+    return fp.slice(0, 8) + '...' + fp.slice(-8);
+  };
+
+  const handleAddGenerate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = addName.trim();
+    if (!name) return;
+    addProfile(name);
+    setAddName('');
+    setIsAdding(false);
+  };
+
+  const handleAddImport = () => {
+    const name = addName.trim();
+    if (!name) return;
+    fileInputRef.current?.click();
+  };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    const name = addName.trim();
+    if (!name) return;
     const reader = new FileReader();
     reader.onload = (ev) => {
       const buffer = ev.target?.result as ArrayBuffer;
       const bytes = new Uint8Array(buffer);
       let binary = '';
-      bytes.forEach(b => binary += String.fromCharCode(b));
-      bridge.send('cert.import', { data: btoa(binary) });
+      bytes.forEach(b => (binary += String.fromCharCode(b)));
+      importProfile(name, btoa(binary));
+      setAddName('');
+      setIsAdding(false);
     };
     reader.readAsArrayBuffer(file);
     e.target.value = '';
+  };
+
+  const handleEditSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editingId) return;
+    const name = editName.trim();
+    if (!name) return;
+    renameProfile(editingId, name);
+    setEditingId(null);
+    setEditName('');
+  };
+
+  const handleEditStart = (profile: { id: string; name: string }) => {
+    setEditingId(profile.id);
+    setEditName(profile.name);
+    setIsAdding(false);
+  };
+
+  const handleDelete = async (profile: { id: string; name: string }) => {
+    const confirmed = await confirm({
+      title: 'Delete profile',
+      message: `Remove "${profile.name}"? The certificate file will remain on disk and can be re-imported later.`,
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+    });
+    if (confirmed) removeProfile(profile.id);
+  };
+
+  const handleCancel = () => {
+    setIsAdding(false);
+    setEditingId(null);
+    setAddName('');
+    setEditName('');
   };
 
   return (
@@ -95,34 +175,34 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
         </div>
       </div>
 
-      {/* Certificate section */}
+      {/* Profile dropdown section */}
       <div className="settings-section">
-        <h3 className="heading-section settings-section-title">Certificate</h3>
-        <div className="settings-item" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: '0.5rem' }}>
-          <label>Fingerprint</label>
-          <span style={{
-            fontFamily: 'monospace',
-            fontSize: '0.75rem',
-            color: 'var(--text-muted)',
-            wordBreak: 'break-all',
-            background: 'var(--bg-glass)',
-            padding: '0.5rem 0.75rem',
-            borderRadius: '6px',
-            width: '100%',
-            boxSizing: 'border-box',
-          }}>
-            {fingerprint || '\u2014'}
-          </span>
-        </div>
+        <h3 className="heading-section settings-section-title">Profile</h3>
         <div className="settings-item">
-          <label>Current server username</label>
-          <span className="settings-value">{connectedUsername || 'Not connected'}</span>
+          <label>Active Profile</label>
+          <Tooltip content={connected ? 'Disconnect to switch profiles' : 'Select your active profile'}>
+            <select
+              className="brmble-input profile-select"
+              value={activeProfileId ?? ''}
+              onChange={(e) => setActive(e.target.value)}
+              disabled={connected || loading || profiles.length === 0}
+            >
+              {profiles.map(p => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+              {profiles.length === 0 && (
+                <option value="">No profiles</option>
+              )}
+            </select>
+          </Tooltip>
         </div>
       </div>
 
-      {/* Manage section */}
+      {/* Manage Profiles section */}
       <div className="settings-section">
-        <h3 className="heading-section settings-section-title">Manage</h3>
+        <h3 className="heading-section settings-section-title">Manage Profiles</h3>
+
+        {/* Hidden file input for certificate import */}
         <input
           ref={fileInputRef}
           type="file"
@@ -130,20 +210,126 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
           style={{ display: 'none' }}
           onChange={handleFileChange}
         />
-        <div className="settings-item">
-          <div>
-            <div style={{ fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Export Certificate</div>
-            <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Save a backup of your identity to a file</div>
+
+        {!loading && profiles.length > 0 ? (
+          <div className="profiles-items">
+            {profiles.map((profile, index) => {
+              const isActive = profile.id === activeProfileId;
+
+              if (editingId === profile.id) {
+                return (
+                  <form key={profile.id} className="profiles-form" onSubmit={handleEditSubmit}>
+                    <h3 className="heading-section profiles-form-title">Rename Profile</h3>
+                    <div className="profiles-form-fields">
+                      <input
+                        className="brmble-input profiles-input"
+                        placeholder="Profile Name"
+                        value={editName}
+                        onChange={e => setEditName(e.target.value)}
+                        autoFocus
+                      />
+                    </div>
+                    <div className="profiles-form-actions">
+                      <button type="button" className="btn btn-secondary" onClick={handleCancel}>
+                        Cancel
+                      </button>
+                      <button type="submit" className="btn btn-primary" disabled={!editName.trim()}>
+                        Save
+                      </button>
+                    </div>
+                  </form>
+                );
+              }
+
+              return (
+                <div
+                  key={profile.id}
+                  className={`profiles-item${isActive ? ' profiles-item-active' : ''}`}
+                  style={{ animationDelay: `${index * 50}ms` }}
+                >
+                  <div className="profiles-icon">
+                    {getInitial(profile.name)}
+                  </div>
+                  <div className="profiles-info">
+                    <span className="profiles-name">{profile.name}</span>
+                    <span className="profiles-fingerprint">{truncateFingerprint(profile.fingerprint)}</span>
+                    {isActive && <span className="profiles-active-badge">Active</span>}
+                  </div>
+                  <div className="profiles-actions">
+                    <Tooltip content="Rename profile">
+                      <button
+                        className="btn btn-secondary profiles-action-btn"
+                        onClick={() => handleEditStart(profile)}
+                      >
+                        Edit
+                      </button>
+                    </Tooltip>
+                    <Tooltip content="Export certificate">
+                      <button
+                        className="btn btn-secondary profiles-action-btn"
+                        onClick={() => exportCert()}
+                      >
+                        Export
+                      </button>
+                    </Tooltip>
+                    <Tooltip content="Delete profile">
+                      <button
+                        className="btn btn-ghost profiles-delete-btn"
+                        onClick={() => handleDelete(profile)}
+                      >
+                        ✕
+                      </button>
+                    </Tooltip>
+                  </div>
+                </div>
+              );
+            })}
           </div>
-          <button className="btn btn-primary" onClick={handleExport}>Export</button>
-        </div>
-        <div className="settings-item">
-          <div>
-            <div style={{ fontSize: '0.875rem', color: 'var(--text-secondary)' }}>Import Different Certificate</div>
-            <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Takes effect on next launch</div>
+        ) : !loading ? (
+          <div className="profiles-empty">
+            <div className="profiles-empty-icon">
+              <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true" focusable="false">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+            </div>
+            <p>No profiles yet</p>
+            <p className="profiles-empty-hint">Create a profile to manage multiple identities</p>
           </div>
-          <button className="btn btn-secondary" onClick={handleImportClick}>Import</button>
-        </div>
+        ) : null}
+
+        {isAdding && (
+          <form className="profiles-form" onSubmit={handleAddGenerate}>
+            <h3 className="heading-section profiles-form-title">Add New Profile</h3>
+            <div className="profiles-form-fields">
+              <input
+                className="brmble-input profiles-input"
+                placeholder="Profile Name"
+                value={addName}
+                onChange={e => setAddName(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <div className="profiles-form-actions">
+              <button type="button" className="btn btn-secondary" onClick={handleCancel}>
+                Cancel
+              </button>
+              <button type="button" className="btn btn-secondary" onClick={handleAddImport} disabled={!addName.trim()}>
+                Import Certificate
+              </button>
+              <button type="submit" className="btn btn-primary" disabled={!addName.trim()}>
+                Generate New Certificate
+              </button>
+            </div>
+          </form>
+        )}
+
+        {!isAdding && !editingId && (
+          <button className="btn btn-ghost profiles-add-btn" onClick={() => setIsAdding(true)}>
+            <span className="profiles-add-icon">+</span>
+            Add Profile
+          </button>
+        )}
       </div>
 
       {showUpload && (

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -4,6 +4,7 @@ import AvatarUpload from '../AvatarUpload/AvatarUpload';
 import bridge from '../../bridge';
 import { useProfiles } from '../../hooks/useProfiles';
 import { confirm } from '../../hooks/usePrompt';
+import { validateProfileName } from '../../utils/profileValidation';
 import { Select } from '../Select/Select';
 import { Tooltip } from '../Tooltip/Tooltip';
 import './ProfileSettingsTab.css';
@@ -50,6 +51,9 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
   const [editName, setEditName] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const addNameError = addName.trim() ? validateProfileName(addName.trim()) : null;
+  const editNameError = editName.trim() ? validateProfileName(editName.trim()) : null;
+
   const statusText = getAvatarStatusText(currentUser);
 
   // Certificate export handler
@@ -93,6 +97,11 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
     e.preventDefault();
     const name = addName.trim();
     if (!name) return;
+    const nameError = validateProfileName(name);
+    if (nameError) {
+      await confirm({ title: 'Invalid name', message: nameError, confirmLabel: 'OK' });
+      return;
+    }
     if (isDuplicateName(name)) {
       await confirm({ title: 'Duplicate name', message: `A profile named "${name}" already exists.`, confirmLabel: 'OK' });
       return;
@@ -120,6 +129,11 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
   const handleAddImport = async () => {
     const name = addName.trim();
     if (!name) return;
+    const nameError = validateProfileName(name);
+    if (nameError) {
+      await confirm({ title: 'Invalid name', message: nameError, confirmLabel: 'OK' });
+      return;
+    }
     if (isDuplicateName(name)) {
       await confirm({ title: 'Duplicate name', message: `A profile named "${name}" already exists.`, confirmLabel: 'OK' });
       return;
@@ -166,6 +180,11 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
     if (!editingId) return;
     const name = editName.trim();
     if (!name) return;
+    const nameError = validateProfileName(name);
+    if (nameError) {
+      await confirm({ title: 'Invalid name', message: nameError, confirmLabel: 'OK' });
+      return;
+    }
     if (isDuplicateName(name, editingId)) {
       await confirm({ title: 'Duplicate name', message: `A profile named "${name}" already exists.`, confirmLabel: 'OK' });
       return;
@@ -302,12 +321,13 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
                         onChange={e => setEditName(e.target.value)}
                         autoFocus
                       />
+                      {editNameError && <span className="profiles-form-error">{editNameError}</span>}
                     </div>
                     <div className="profiles-form-actions">
                       <button type="button" className="btn btn-secondary" onClick={handleCancel}>
                         Cancel
                       </button>
-                      <button type="submit" className="btn btn-primary" disabled={!editName.trim()}>
+                      <button type="submit" className="btn btn-primary" disabled={!editName.trim() || !!editNameError}>
                         Save
                       </button>
                     </div>
@@ -385,12 +405,13 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
                 onChange={e => setAddName(e.target.value)}
                 autoFocus
               />
+              {addNameError && <span className="profiles-form-error">{addNameError}</span>}
             </div>
             <div className="profiles-form-actions">
-              <button type="button" className="btn btn-secondary" onClick={handleAddImport} disabled={!addName.trim()}>
+              <button type="button" className="btn btn-secondary" onClick={handleAddImport} disabled={!addName.trim() || !!addNameError}>
                 Import Certificate
               </button>
-              <button type="submit" className="btn btn-primary" disabled={!addName.trim()}>
+              <button type="submit" className="btn btn-primary" disabled={!addName.trim() || !!addNameError}>
                 Generate New Certificate
               </button>
             </div>

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -42,7 +42,7 @@ function triggerBlobDownload(base64: string, filename: string) {
 
 export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar, connected, registeredName }: ProfileSettingsTabProps) {
   const [showUpload, setShowUpload] = useState(false);
-  const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert } = useProfiles();
+  const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert, checkExistingCert, addFromExisting, renameSwapCert } = useProfiles();
 
   const [isAdding, setIsAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -86,18 +86,59 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
     return fp;
   };
 
-  const handleAddGenerate = (e: React.FormEvent) => {
+  const isDuplicateName = (name: string, excludeId?: string) =>
+    profiles.some(p => p.name.toLowerCase() === name.toLowerCase() && p.id !== excludeId);
+
+  const handleAddGenerate = async (e: React.FormEvent) => {
     e.preventDefault();
     const name = addName.trim();
     if (!name) return;
+    if (isDuplicateName(name)) {
+      await confirm({ title: 'Duplicate name', message: `A profile named "${name}" already exists.`, confirmLabel: 'OK' });
+      return;
+    }
+    const existing = await checkExistingCert(name);
+    if (existing.exists) {
+      const reuse = await confirm({
+        title: 'Certificate found',
+        message: `A certificate file for "${name}" already exists in Brmble. Would you like to use it instead of generating a new one?`,
+        confirmLabel: 'Use existing',
+        cancelLabel: 'Generate new',
+      });
+      if (reuse) {
+        addFromExisting(name);
+        setAddName('');
+        setIsAdding(false);
+        return;
+      }
+    }
     addProfile(name);
     setAddName('');
     setIsAdding(false);
   };
 
-  const handleAddImport = () => {
+  const handleAddImport = async () => {
     const name = addName.trim();
     if (!name) return;
+    if (isDuplicateName(name)) {
+      await confirm({ title: 'Duplicate name', message: `A profile named "${name}" already exists.`, confirmLabel: 'OK' });
+      return;
+    }
+    const existing = await checkExistingCert(name);
+    if (existing.exists) {
+      const reuse = await confirm({
+        title: 'Certificate found',
+        message: `A certificate file for "${name}" already exists in Brmble. Would you like to use it instead of importing a different one?`,
+        confirmLabel: 'Use existing',
+        cancelLabel: 'Import different',
+      });
+      if (reuse) {
+        addFromExisting(name);
+        setAddName('');
+        setIsAdding(false);
+        return;
+      }
+    }
     fileInputRef.current?.click();
   };
 
@@ -120,11 +161,34 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
     e.target.value = '';
   };
 
-  const handleEditSubmit = (e: React.FormEvent) => {
+  const handleEditSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!editingId) return;
     const name = editName.trim();
     if (!name) return;
+    if (isDuplicateName(name, editingId)) {
+      await confirm({ title: 'Duplicate name', message: `A profile named "${name}" already exists.`, confirmLabel: 'OK' });
+      return;
+    }
+    const existing = await checkExistingCert(name);
+    if (existing.exists) {
+      const currentProfile = profiles.find(p => p.id === editingId);
+      // Only offer swap if the found cert is different from this profile's cert
+      if (!currentProfile || existing.fingerprint !== currentProfile.fingerprint) {
+        const swap = await confirm({
+          title: 'Certificate found',
+          message: `A certificate file for "${name}" already exists in Brmble. Would you like to use that certificate for this profile?`,
+          confirmLabel: 'Use existing',
+          cancelLabel: 'Keep current',
+        });
+        if (swap) {
+          renameSwapCert(editingId, name);
+          setEditingId(null);
+          setEditName('');
+          return;
+        }
+      }
+    }
     renameProfile(editingId, name);
     setEditingId(null);
     setEditName('');

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -351,22 +351,26 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
                   </div>
                   <div className="profiles-actions">
                     <Tooltip content={connected && isActive ? 'Disconnect to delete this profile' : 'Delete profile'}>
-                      <button
-                        className="btn btn-ghost profiles-delete-btn"
-                        onClick={() => handleDelete(profile)}
-                        disabled={connected && isActive}
-                      >
-                        ✕
-                      </button>
+                      <span>
+                        <button
+                          className="btn btn-ghost profiles-delete-btn"
+                          onClick={() => handleDelete(profile)}
+                          disabled={connected && isActive}
+                        >
+                          ✕
+                        </button>
+                      </span>
                     </Tooltip>
                     <Tooltip content={connected ? 'Disconnect to rename profiles' : 'Rename profile'}>
-                      <button
-                        className="btn btn-secondary profiles-action-btn"
-                        onClick={() => handleEditStart(profile)}
-                        disabled={connected}
-                      >
-                        Edit
-                      </button>
+                      <span>
+                        <button
+                          className="btn btn-secondary profiles-action-btn"
+                          onClick={() => handleEditStart(profile)}
+                          disabled={connected}
+                        >
+                          Edit
+                        </button>
+                      </span>
                     </Tooltip>
                     <Tooltip content="Export certificate">
                       <button

--- a/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
@@ -1,0 +1,214 @@
+.profiles-items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.profiles-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  transition: all var(--transition-normal);
+  animation: profileItemFadeIn var(--animation-normal) ease backwards;
+}
+
+@keyframes profileItemFadeIn {
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.profiles-item:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent-primary);
+  transform: translateX(4px);
+}
+
+.profiles-item-active {
+  border-color: var(--accent-primary);
+  box-shadow: inset 0 0 0 1px var(--accent-primary-ghost);
+}
+
+.profiles-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-primary-dark) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--text-primary);
+  flex-shrink: 0;
+  box-shadow: 0 4px 12px var(--accent-primary-glow);
+}
+
+.profiles-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.profiles-name {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.profiles-fingerprint {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.profiles-active-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--accent-primary);
+  margin-top: var(--space-2xs);
+}
+
+.profiles-active-badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+}
+
+.profiles-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+.profiles-action-btn {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--text-xs);
+}
+
+.profiles-delete-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  font-size: var(--text-xl);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  border: 1px solid var(--accent-danger-border);
+  transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.profiles-delete-btn:hover {
+  color: var(--accent-danger);
+  background: var(--accent-danger-subtle);
+  border-color: var(--accent-danger);
+}
+
+.profiles-delete-btn:active {
+  color: var(--accent-danger-strong);
+  background: var(--accent-danger-bg);
+  border-color: var(--accent-danger-strong);
+  transform: scale(0.95);
+}
+
+.profiles-form {
+  margin-top: var(--space-lg);
+  padding: var(--space-lg);
+  background: var(--bg-deep-glass);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  animation: formSlideIn var(--animation-normal) ease backwards;
+}
+
+.profiles-form-title {
+  margin-bottom: var(--space-lg);
+  text-align: center;
+}
+
+.profiles-form-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.profiles-form-actions {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-lg);
+}
+
+.profiles-form-actions .btn {
+  flex: 1;
+}
+
+.profiles-add-btn {
+  width: 100%;
+  margin-top: var(--space-lg);
+  padding: var(--space-md);
+  border: 2px dashed var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.profiles-add-btn:hover {
+  border-color: var(--accent-primary);
+  border-style: solid;
+}
+
+.profiles-add-icon {
+  font-size: var(--text-xl);
+  font-weight: 300;
+  color: var(--accent-primary);
+}
+
+.profiles-empty {
+  text-align: center;
+  padding: var(--space-2xl) var(--space-md);
+}
+
+.profiles-empty-icon {
+  font-size: var(--text-4xl);
+  margin-bottom: var(--space-md);
+  opacity: 0.6;
+}
+
+.profiles-empty p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+}
+
+.profiles-empty-hint {
+  margin-top: var(--space-xs) !important;
+  color: var(--text-muted) !important;
+  font-size: var(--text-sm) !important;
+}
+
+.profiles-input {
+  width: 100%;
+}

--- a/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
@@ -81,24 +81,6 @@
   text-overflow: ellipsis;
 }
 
-.profiles-active-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2xs);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  color: var(--accent-primary);
-  margin-top: var(--space-2xs);
-}
-
-.profiles-active-badge::before {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent-primary);
-}
-
 .profiles-actions {
   display: flex;
   align-items: center;

--- a/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
@@ -194,3 +194,9 @@
 .profiles-input {
   width: 100%;
 }
+
+.profiles-form-error {
+  font-size: var(--text-xs);
+  color: var(--accent-danger-text);
+  margin-top: var(--space-xs);
+}

--- a/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.tsx
@@ -93,7 +93,7 @@ export function ProfilesSettingsTab({ connected }: ProfilesSettingsTabProps) {
   const handleDelete = async (profile: { id: string; name: string }) => {
     const confirmed = await confirm({
       title: 'Delete profile',
-      message: `Remove "${profile.name}" and its certificate? This cannot be undone.`,
+      message: `Remove "${profile.name}"? The certificate file will be kept on disk.`,
       confirmLabel: 'Delete',
       cancelLabel: 'Cancel',
     });

--- a/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.tsx
@@ -1,0 +1,266 @@
+import { useState, useEffect, useRef } from 'react';
+import { useProfiles } from '../../hooks/useProfiles';
+import { confirm } from '../../hooks/usePrompt';
+import { Tooltip } from '../Tooltip/Tooltip';
+import './ProfilesSettingsTab.css';
+
+interface ProfilesSettingsTabProps {
+  connected: boolean;
+}
+
+export function ProfilesSettingsTab({ connected }: ProfilesSettingsTabProps) {
+  const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert } = useProfiles();
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [addName, setAddName] = useState('');
+  const [editName, setEditName] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const getInitial = (name: string) => (name?.charAt(0) || '?').toUpperCase();
+
+  const truncateFingerprint = (fp: string | null) => {
+    if (!fp) return 'No certificate';
+    if (fp.length <= 20) return fp;
+    return fp.slice(0, 8) + '...' + fp.slice(-8);
+  };
+
+  // Cancel forms on Escape
+  useEffect(() => {
+    if (!isAdding && !editingId) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsAdding(false);
+        setEditingId(null);
+        setAddName('');
+        setEditName('');
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isAdding, editingId]);
+
+  const handleAddGenerate = (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = addName.trim();
+    if (!name) return;
+    addProfile(name);
+    setAddName('');
+    setIsAdding(false);
+  };
+
+  const handleAddImport = () => {
+    const name = addName.trim();
+    if (!name) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const name = addName.trim();
+    if (!name) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const buffer = ev.target?.result as ArrayBuffer;
+      const bytes = new Uint8Array(buffer);
+      let binary = '';
+      bytes.forEach(b => (binary += String.fromCharCode(b)));
+      importProfile(name, btoa(binary));
+      setAddName('');
+      setIsAdding(false);
+    };
+    reader.readAsArrayBuffer(file);
+    e.target.value = '';
+  };
+
+  const handleEditSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editingId) return;
+    const name = editName.trim();
+    if (!name) return;
+    renameProfile(editingId, name);
+    setEditingId(null);
+    setEditName('');
+  };
+
+  const handleEditStart = (profile: { id: string; name: string }) => {
+    setEditingId(profile.id);
+    setEditName(profile.name);
+    setIsAdding(false);
+  };
+
+  const handleDelete = async (profile: { id: string; name: string }) => {
+    const confirmed = await confirm({
+      title: 'Delete profile',
+      message: `Remove "${profile.name}" and its certificate? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+    });
+    if (confirmed) removeProfile(profile.id);
+  };
+
+  const handleCancel = () => {
+    setIsAdding(false);
+    setEditingId(null);
+    setAddName('');
+    setEditName('');
+  };
+
+  if (loading) {
+    return (
+      <div className="settings-section">
+        <h3 className="heading-section settings-section-title">Profiles</h3>
+        <div className="profiles-empty">
+          <p>Loading profiles...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-section">
+      <h3 className="heading-section settings-section-title">Profiles</h3>
+
+      {profiles.length > 0 ? (
+        <div className="profiles-items">
+          {profiles.map((profile, index) => {
+            const isActive = profile.id === activeProfileId;
+
+            if (editingId === profile.id) {
+              return (
+                <form key={profile.id} className="profiles-form" onSubmit={handleEditSubmit}>
+                  <h3 className="heading-section profiles-form-title">Rename Profile</h3>
+                  <div className="profiles-form-fields">
+                    <input
+                      className="brmble-input profiles-input"
+                      placeholder="Profile Name"
+                      value={editName}
+                      onChange={e => setEditName(e.target.value)}
+                      autoFocus
+                    />
+                  </div>
+                  <div className="profiles-form-actions">
+                    <button type="button" className="btn btn-secondary" onClick={handleCancel}>
+                      Cancel
+                    </button>
+                    <button type="submit" className="btn btn-primary" disabled={!editName.trim()}>
+                      Save
+                    </button>
+                  </div>
+                </form>
+              );
+            }
+
+            return (
+              <div
+                key={profile.id}
+                className={`profiles-item${isActive ? ' profiles-item-active' : ''}`}
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <div className="profiles-icon">
+                  {getInitial(profile.name)}
+                </div>
+                <div className="profiles-info">
+                  <span className="profiles-name">{profile.name}</span>
+                  <span className="profiles-fingerprint">{truncateFingerprint(profile.fingerprint)}</span>
+                  {isActive && <span className="profiles-active-badge">Active</span>}
+                </div>
+                <div className="profiles-actions">
+                  <Tooltip content={connected ? 'Disconnect to switch profiles' : isActive ? 'Already active' : 'Set as active profile'}>
+                    <button
+                      className="btn btn-primary profiles-action-btn"
+                      onClick={() => setActive(profile.id)}
+                      disabled={connected || isActive}
+                    >
+                      Activate
+                    </button>
+                  </Tooltip>
+                  <Tooltip content="Rename profile">
+                    <button
+                      className="btn btn-secondary profiles-action-btn"
+                      onClick={() => handleEditStart(profile)}
+                    >
+                      Edit
+                    </button>
+                  </Tooltip>
+                  {isActive && (
+                    <Tooltip content="Export certificate">
+                      <button
+                        className="btn btn-secondary profiles-action-btn"
+                        onClick={() => exportCert()}
+                      >
+                        Export
+                      </button>
+                    </Tooltip>
+                  )}
+                  <Tooltip content="Delete profile">
+                    <button
+                      className="btn btn-ghost profiles-delete-btn"
+                      onClick={() => handleDelete(profile)}
+                    >
+                      ✕
+                    </button>
+                  </Tooltip>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="profiles-empty">
+          <div className="profiles-empty-icon">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true" focusable="false">
+              <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+              <circle cx="12" cy="7" r="4" />
+            </svg>
+          </div>
+          <p>No profiles yet</p>
+          <p className="profiles-empty-hint">Create a profile to manage multiple identities</p>
+        </div>
+      )}
+
+      {/* Hidden file input for certificate import */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".pfx,.p12"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
+
+      {isAdding && (
+        <form className="profiles-form" onSubmit={handleAddGenerate}>
+          <h3 className="heading-section profiles-form-title">Add New Profile</h3>
+          <div className="profiles-form-fields">
+            <input
+              className="brmble-input profiles-input"
+              placeholder="Profile Name"
+              value={addName}
+              onChange={e => setAddName(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <div className="profiles-form-actions">
+            <button type="button" className="btn btn-secondary" onClick={handleCancel}>
+              Cancel
+            </button>
+            <button type="button" className="btn btn-secondary" onClick={handleAddImport} disabled={!addName.trim()}>
+              Import Certificate
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={!addName.trim()}>
+              Generate New Certificate
+            </button>
+          </div>
+        </form>
+      )}
+
+      {!isAdding && !editingId && (
+        <button className="btn btn-ghost profiles-add-btn" onClick={() => setIsAdding(true)}>
+          <span className="profiles-add-icon">+</span>
+          Add Profile
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -9,6 +9,7 @@ import { InterfaceSettingsTab } from './InterfaceSettingsTab';
 import { type AppearanceSettings, type OverlaySettings, type BrmblegotchiSettings, DEFAULT_APPEARANCE, DEFAULT_OVERLAY, DEFAULT_BRMBLEGOTCHI } from './InterfaceSettingsTypes';
 import { ConnectionSettingsTab, type ConnectionSettings } from './ConnectionSettingsTab';
 import { ProfileSettingsTab } from './ProfileSettingsTab';
+import { ProfilesSettingsTab } from './ProfilesSettingsTab';
 import { useServerlist } from '../../hooks/useServerlist';
 
 /** A flat map of every key binding in the app: bindingId → bound key code (or null). */
@@ -72,7 +73,7 @@ const DEFAULT_SETTINGS: AppSettings = {
 
 export function SettingsModal(props: SettingsModalProps) {
   const { isOpen, onClose } = props;
-  const [activeTab, setActiveTab] = useState<'profile' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection'>('profile');
+  const [activeTab, setActiveTab] = useState<'profile' | 'profiles' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection'>('profile');
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const { servers } = useServerlist();
 
@@ -304,6 +305,12 @@ export function SettingsModal(props: SettingsModalProps) {
           >
             Profile
           </button>
+          <button
+            className={`settings-tab ${activeTab === 'profiles' ? 'active' : ''}`}
+            onClick={() => setActiveTab('profiles')}
+          >
+            Profiles
+          </button>
           <button 
             className={`settings-tab ${activeTab === 'audio' ? 'active' : ''}`}
             onClick={() => setActiveTab('audio')}
@@ -347,6 +354,9 @@ export function SettingsModal(props: SettingsModalProps) {
               connectedUsername={props.username ?? ''}
               connected={props.connected ?? false}
             />
+          )}
+          {activeTab === 'profiles' && (
+            <ProfilesSettingsTab connected={props.connected ?? false} />
           )}
           {activeTab === 'audio' && <AudioSettingsTab settings={settings.audio} onChange={handleAudioChange} speechDenoise={settings.speechDenoise} onSpeechDenoiseChange={handleSpeechDenoiseChange} allBindings={allBindings} onClearBinding={handleClearBinding} />}
           {activeTab === 'shortcuts' && <ShortcutsSettingsTab settings={settings.shortcuts} onChange={handleShortcutsChange} allBindings={allBindings} onClearBinding={handleClearBinding} />}

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -9,7 +9,6 @@ import { InterfaceSettingsTab } from './InterfaceSettingsTab';
 import { type AppearanceSettings, type OverlaySettings, type BrmblegotchiSettings, DEFAULT_APPEARANCE, DEFAULT_OVERLAY, DEFAULT_BRMBLEGOTCHI } from './InterfaceSettingsTypes';
 import { ConnectionSettingsTab, type ConnectionSettings } from './ConnectionSettingsTab';
 import { ProfileSettingsTab } from './ProfileSettingsTab';
-import { ProfilesSettingsTab } from './ProfilesSettingsTab';
 import { useServerlist } from '../../hooks/useServerlist';
 
 /** A flat map of every key binding in the app: bindingId → bound key code (or null). */
@@ -73,7 +72,7 @@ const DEFAULT_SETTINGS: AppSettings = {
 
 export function SettingsModal(props: SettingsModalProps) {
   const { isOpen, onClose } = props;
-  const [activeTab, setActiveTab] = useState<'profile' | 'profiles' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection'>('profile');
+  const [activeTab, setActiveTab] = useState<'profile' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection'>('profile');
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const { servers } = useServerlist();
 
@@ -305,12 +304,6 @@ export function SettingsModal(props: SettingsModalProps) {
           >
             Profile
           </button>
-          <button
-            className={`settings-tab ${activeTab === 'profiles' ? 'active' : ''}`}
-            onClick={() => setActiveTab('profiles')}
-          >
-            Profiles
-          </button>
           <button 
             className={`settings-tab ${activeTab === 'audio' ? 'active' : ''}`}
             onClick={() => setActiveTab('audio')}
@@ -350,13 +343,8 @@ export function SettingsModal(props: SettingsModalProps) {
               currentUser={props.currentUser ?? { name: props.username ?? 'Unknown' }}
               onUploadAvatar={props.onUploadAvatar ?? (() => {})}
               onRemoveAvatar={props.onRemoveAvatar ?? (() => {})}
-              fingerprint={props.certFingerprint ?? ''}
-              connectedUsername={props.username ?? ''}
               connected={props.connected ?? false}
             />
-          )}
-          {activeTab === 'profiles' && (
-            <ProfilesSettingsTab connected={props.connected ?? false} />
           )}
           {activeTab === 'audio' && <AudioSettingsTab settings={settings.audio} onChange={handleAudioChange} speechDenoise={settings.speechDenoise} onSpeechDenoiseChange={handleSpeechDenoiseChange} allBindings={allBindings} onClearBinding={handleClearBinding} />}
           {activeTab === 'shortcuts' && <ShortcutsSettingsTab settings={settings.shortcuts} onChange={handleShortcutsChange} allBindings={allBindings} onClearBinding={handleClearBinding} />}

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -75,6 +75,19 @@ export function SettingsModal(props: SettingsModalProps) {
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const { servers } = useServerlist();
 
+  // Resolve registration name for the currently connected server
+  const connectedRegisteredName = (() => {
+    if (!props.connected) return undefined;
+    try {
+      const stored = localStorage.getItem('brmble-server');
+      if (!stored) return undefined;
+      const savedServer = JSON.parse(stored) as { id?: string };
+      if (!savedServer.id) return undefined;
+      const match = servers.find(s => s.id === savedServer.id);
+      return match?.registered ? match.registeredName : undefined;
+    } catch { return undefined; }
+  })();
+
   // Close on Escape key (skip if a key-binding button is recording)
   useEffect(() => {
     if (!isOpen) return;
@@ -343,6 +356,7 @@ export function SettingsModal(props: SettingsModalProps) {
               onUploadAvatar={props.onUploadAvatar ?? (() => {})}
               onRemoveAvatar={props.onRemoveAvatar ?? (() => {})}
               connected={props.connected ?? false}
+              registeredName={connectedRegisteredName}
             />
           )}
           {activeTab === 'audio' && <AudioSettingsTab settings={settings.audio} onChange={handleAudioChange} speechDenoise={settings.speechDenoise} onSpeechDenoiseChange={handleSpeechDenoiseChange} allBindings={allBindings} onClearBinding={handleClearBinding} />}

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -31,7 +31,6 @@ interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   username?: string;
-  certFingerprint?: string;
   connected?: boolean;
   currentUser?: {
     name: string;

--- a/src/Brmble.Web/src/contexts/ProfileContext.tsx
+++ b/src/Brmble.Web/src/contexts/ProfileContext.tsx
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+const ProfileContext = createContext<string>('');
+
+export const ProfileProvider = ProfileContext.Provider;
+
+export function useProfileFingerprint(): string {
+  return useContext(ProfileContext);
+}

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -83,7 +83,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       if (channelId) {
         const senderId = event.getSender() ?? 'Unknown';
         const senderMember = room?.getMember(senderId);
-        const displayName = senderMember?.name || senderMember?.rawDisplayName || senderId;
+        const displayName = senderMember?.rawDisplayName || senderMember?.name || senderId;
 
         const content = event.getContent() as {
           body?: string;
@@ -143,7 +143,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
 
       const dmSenderId = event.getSender() ?? 'Unknown';
       const dmSenderMember = room?.getMember(dmSenderId);
-      const dmDisplayName = dmSenderMember?.name || dmSenderMember?.rawDisplayName || dmSenderId;
+      const dmDisplayName = dmSenderMember?.rawDisplayName || dmSenderMember?.name || dmSenderId;
 
       const dmContent = event.getContent() as {
         body?: string;

--- a/src/Brmble.Web/src/hooks/useProfiles.ts
+++ b/src/Brmble.Web/src/hooks/useProfiles.ts
@@ -82,8 +82,8 @@ export function useProfiles() {
     bridge.send('profiles.setActive', { id });
   }, []);
 
-  const exportCert = useCallback(() => {
-    bridge.send('cert.export');
+  const exportCert = useCallback((profileId?: string) => {
+    bridge.send('cert.export', profileId ? { profileId } : {});
   }, []);
 
   const checkExistingCert = useCallback((name: string): Promise<{ exists: boolean; fingerprint: string | null }> => {

--- a/src/Brmble.Web/src/hooks/useProfiles.ts
+++ b/src/Brmble.Web/src/hooks/useProfiles.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import bridge from '../bridge';
+import { confirm } from './usePrompt';
 
 export interface Profile {
   id: string;
@@ -46,11 +47,19 @@ export function useProfiles() {
       setActiveProfileId(d.id);
     };
 
+    const onError = (data: unknown) => {
+      const d = data as { message?: string };
+      if (d.message) {
+        confirm({ title: 'Profile Error', message: d.message, confirmLabel: 'OK', cancelLabel: 'Dismiss' });
+      }
+    };
+
     bridge.on('profiles.list', onList);
     bridge.on('profiles.added', onAdded);
     bridge.on('profiles.removed', onRemoved);
     bridge.on('profiles.renamed', onRenamed);
     bridge.on('profiles.activeChanged', onActiveChanged);
+    bridge.on('profiles.error', onError);
     bridge.send('profiles.list');
 
     return () => {
@@ -59,6 +68,7 @@ export function useProfiles() {
       bridge.off('profiles.removed', onRemoved);
       bridge.off('profiles.renamed', onRenamed);
       bridge.off('profiles.activeChanged', onActiveChanged);
+      bridge.off('profiles.error', onError);
     };
   }, []);
 

--- a/src/Brmble.Web/src/hooks/useProfiles.ts
+++ b/src/Brmble.Web/src/hooks/useProfiles.ts
@@ -32,8 +32,13 @@ export function useProfiles() {
     };
 
     const onRenamed = (data: unknown) => {
-      const d = data as { id: string; name: string };
-      setProfiles(prev => prev.map(p => p.id === d.id ? { ...p, name: d.name } : p));
+      const d = data as { id: string; name: string; fingerprint?: string | null; certValid?: boolean };
+      setProfiles(prev => prev.map(p => p.id === d.id ? {
+        ...p,
+        name: d.name,
+        ...(d.fingerprint !== undefined ? { fingerprint: d.fingerprint } : {}),
+        ...(d.certValid !== undefined ? { certValid: d.certValid } : {}),
+      } : p));
     };
 
     const onActiveChanged = (data: unknown) => {
@@ -81,5 +86,25 @@ export function useProfiles() {
     bridge.send('cert.export');
   }, []);
 
-  return { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert };
+  const checkExistingCert = useCallback((name: string): Promise<{ exists: boolean; fingerprint: string | null }> => {
+    return new Promise((resolve) => {
+      const handler = (data: unknown) => {
+        bridge.off('profiles.checkCertResult', handler);
+        const d = data as { exists: boolean; fingerprint?: string | null };
+        resolve({ exists: d.exists, fingerprint: d.fingerprint ?? null });
+      };
+      bridge.on('profiles.checkCertResult', handler);
+      bridge.send('profiles.checkCert', { name });
+    });
+  }, []);
+
+  const addFromExisting = useCallback((name: string) => {
+    bridge.send('profiles.addFromExisting', { name });
+  }, []);
+
+  const renameSwapCert = useCallback((id: string, name: string) => {
+    bridge.send('profiles.renameSwapCert', { id, name });
+  }, []);
+
+  return { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert, checkExistingCert, addFromExisting, renameSwapCert };
 }

--- a/src/Brmble.Web/src/hooks/useProfiles.ts
+++ b/src/Brmble.Web/src/hooks/useProfiles.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect, useCallback } from 'react';
+import bridge from '../bridge';
+
+export interface Profile {
+  id: string;
+  name: string;
+  fingerprint: string | null;
+  certValid: boolean;
+}
+
+export function useProfiles() {
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const onList = (data: unknown) => {
+      const d = data as { profiles: Profile[]; activeProfileId: string | null };
+      setProfiles(d.profiles ?? []);
+      setActiveProfileId(d.activeProfileId ?? null);
+      setLoading(false);
+    };
+
+    const onAdded = (data: unknown) => {
+      const d = data as Profile;
+      setProfiles(prev => [...prev, d]);
+    };
+
+    const onRemoved = (data: unknown) => {
+      const d = data as { id: string };
+      setProfiles(prev => prev.filter(p => p.id !== d.id));
+    };
+
+    const onRenamed = (data: unknown) => {
+      const d = data as { id: string; name: string };
+      setProfiles(prev => prev.map(p => p.id === d.id ? { ...p, name: d.name } : p));
+    };
+
+    const onActiveChanged = (data: unknown) => {
+      const d = data as { id: string | null; name: string | null; fingerprint: string | null };
+      setActiveProfileId(d.id);
+    };
+
+    bridge.on('profiles.list', onList);
+    bridge.on('profiles.added', onAdded);
+    bridge.on('profiles.removed', onRemoved);
+    bridge.on('profiles.renamed', onRenamed);
+    bridge.on('profiles.activeChanged', onActiveChanged);
+    bridge.send('profiles.list');
+
+    return () => {
+      bridge.off('profiles.list', onList);
+      bridge.off('profiles.added', onAdded);
+      bridge.off('profiles.removed', onRemoved);
+      bridge.off('profiles.renamed', onRenamed);
+      bridge.off('profiles.activeChanged', onActiveChanged);
+    };
+  }, []);
+
+  const addProfile = useCallback((name: string) => {
+    bridge.send('profiles.add', { name });
+  }, []);
+
+  const importProfile = useCallback((name: string, data: string) => {
+    bridge.send('profiles.import', { name, data });
+  }, []);
+
+  const removeProfile = useCallback((id: string) => {
+    bridge.send('profiles.remove', { id });
+  }, []);
+
+  const renameProfile = useCallback((id: string, name: string) => {
+    bridge.send('profiles.rename', { id, name });
+  }, []);
+
+  const setActive = useCallback((id: string) => {
+    bridge.send('profiles.setActive', { id });
+  }, []);
+
+  const exportCert = useCallback(() => {
+    bridge.send('cert.export');
+  }, []);
+
+  return { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert };
+}

--- a/src/Brmble.Web/src/hooks/useServerlist.ts
+++ b/src/Brmble.Web/src/hooks/useServerlist.ts
@@ -9,6 +9,7 @@ export interface ServerEntry {
   username: string;
   password: string;
   registered?: boolean;
+  registeredName?: string;
 }
 
 export function useServerlist() {

--- a/src/Brmble.Web/src/hooks/useServerlist.ts
+++ b/src/Brmble.Web/src/hooks/useServerlist.ts
@@ -4,6 +4,7 @@ import bridge from '../bridge';
 export interface ServerEntry {
   id: string;
   label: string;
+  apiUrl?: string;
   host: string;
   port: number;
   username: string;

--- a/src/Brmble.Web/src/hooks/useUnreadTracker.ts
+++ b/src/Brmble.Web/src/hooks/useUnreadTracker.ts
@@ -65,13 +65,25 @@ interface StoredMarker {
 // In-memory cache of markers. Loaded once from localStorage; all subsequent
 // reads use this cache to avoid JSON.parse on every timeline event / refresh.
 let markersCache: Record<string, StoredMarker> | null = null;
+let markersCacheFingerprint: string | null = null;
 
-function loadMarkers(): Record<string, StoredMarker> {
-  if (markersCache) return markersCache;
+function getStorageKey(fingerprint: string): string {
+  return fingerprint ? `${STORAGE_KEY}_${fingerprint}` : STORAGE_KEY;
+}
+
+export function resetMarkersCache(): void {
+  markersCache = null;
+  markersCacheFingerprint = null;
+}
+
+function loadMarkers(fingerprint: string): Record<string, StoredMarker> {
+  if (markersCache && markersCacheFingerprint === fingerprint) return markersCache;
+  const key = getStorageKey(fingerprint);
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(key);
     if (!raw) {
       markersCache = {};
+      markersCacheFingerprint = fingerprint;
       return markersCache;
     }
     const parsed = JSON.parse(raw);
@@ -87,25 +99,27 @@ function loadMarkers(): Record<string, StoredMarker> {
       }
     }
     markersCache = result;
+    markersCacheFingerprint = fingerprint;
     return markersCache;
   } catch {
     markersCache = {};
+    markersCacheFingerprint = fingerprint;
     return markersCache;
   }
 }
 
-function saveMarker(roomId: string, eventId: string, ts: number): void {
-  const markers = loadMarkers();
+function saveMarker(roomId: string, eventId: string, ts: number, fingerprint: string): void {
+  const markers = loadMarkers(fingerprint);
   markers[roomId] = { eventId, ts };
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(markers));
+    localStorage.setItem(getStorageKey(fingerprint), JSON.stringify(markers));
   } catch {
     // localStorage may be full or unavailable
   }
 }
 
-function getMarker(roomId: string): StoredMarker | null {
-  return loadMarkers()[roomId] ?? null;
+function getMarker(roomId: string, fingerprint: string): StoredMarker | null {
+  return loadMarkers(fingerprint)[roomId] ?? null;
 }
 
 // ── Timeline counting ─────────────────────────────────────────────────
@@ -192,7 +206,9 @@ export function useUnreadTracker(
   dmRoomIds: Set<string>,
   activeRoomId: string | null,
   currentDisplayName?: string | null,
+  fingerprint?: string,
 ): UnreadTracker {
+  const fp = fingerprint ?? '';
   const [roomUnreads, setRoomUnreads] = useState<Map<string, RoomUnreadState>>(new Map());
   const activeRoomIdRef = useRef(activeRoomId);
   activeRoomIdRef.current = activeRoomId;
@@ -203,7 +219,7 @@ export function useUnreadTracker(
   const pendingMarkRef = useRef<Map<string, string>>(new Map());
 
   const buildRoomUnread = useCallback((room: Room): RoomUnreadState => {
-    const localMarker = getMarker(room.roomId);
+    const localMarker = getMarker(room.roomId, fp);
     const sdkMarkerId = room.getAccountData('m.fully_read')?.getContent()?.event_id ?? null;
     const fullyReadEventId = localMarker?.eventId ?? sdkMarkerId;
 
@@ -240,7 +256,7 @@ export function useUnreadTracker(
       highlightCount: serverHighlight + mentionCount,
       fullyReadEventId,
     };
-  }, [client, currentDisplayName]);
+  }, [client, currentDisplayName, fp]);
 
   const refreshAll = useCallback(() => {
     if (!client) return;
@@ -250,7 +266,7 @@ export function useUnreadTracker(
     for (const room of rooms) {
       if (room.roomId === activeId) {
         // Active room always shows 0 unreads — the user is looking at it.
-        const localMarker = getMarker(room.roomId);
+        const localMarker = getMarker(room.roomId, fp);
         const sdkMarkerId = room.getAccountData('m.fully_read')?.getContent()?.event_id ?? null;
         newMap.set(room.roomId, {
           notificationCount: 0,
@@ -356,7 +372,7 @@ export function useUnreadTracker(
     }
 
     // Persist locally (authoritative source)
-    saveMarker(roomId, messageEventId, markerTs);
+    saveMarker(roomId, messageEventId, markerTs, fp);
 
     // Update React state immediately
     setRoomUnreads(prev => {
@@ -385,7 +401,7 @@ export function useUnreadTracker(
       }
       markReadTimerRef.current.delete(roomId);
     }, 1000));
-  }, [client, flushMarkToServer]);
+  }, [client, flushMarkToServer, fp]);
 
   // Auto-mark active room as read when new m.room.message events arrive
   useEffect(() => {
@@ -427,9 +443,9 @@ export function useUnreadTracker(
   }, [roomUnreads]);
 
   const getMarkerTimestamp = useCallback((roomId: string): number | null => {
-    const marker = getMarker(roomId);
+    const marker = getMarker(roomId, fp);
     return marker?.ts ?? null;
-  }, []);
+  }, [fp]);
 
   // Compute totals from the current state (derived, not stored)
   let totalUnreadCount = 0;

--- a/src/Brmble.Web/src/hooks/useUnreadTracker.ts
+++ b/src/Brmble.Web/src/hooks/useUnreadTracker.ts
@@ -213,6 +213,19 @@ export function useUnreadTracker(
   const activeRoomIdRef = useRef(activeRoomId);
   activeRoomIdRef.current = activeRoomId;
 
+  // Track the fingerprint so we can detect profile switches.
+  const prevFpRef = useRef(fp);
+
+  // When the fingerprint changes (profile switch), immediately clear stale
+  // unread state from the previous profile so the UI never flashes the old
+  // profile's badges. The next refreshAll (triggered by the useEffect below
+  // re-running due to the dependency on fp) will repopulate with correct data.
+  if (fp !== prevFpRef.current) {
+    prevFpRef.current = fp;
+    // Synchronously clear — React will commit this before painting.
+    setRoomUnreads(new Map());
+  }
+
   // Debounce timer for the server-side markRoomRead HTTP call.
   // We batch rapid-fire calls (e.g. multiple messages arriving at once).
   const markReadTimerRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());

--- a/src/Brmble.Web/src/hooks/useUnreadTracker.ts
+++ b/src/Brmble.Web/src/hooks/useUnreadTracker.ts
@@ -261,6 +261,26 @@ export function useUnreadTracker(
   const refreshAll = useCallback(() => {
     if (!client) return;
     const rooms = client.getRooms();
+
+    // When switching to a profile that has no markers at all (e.g. a brand-new
+    // profile or first switch), bootstrap markers for every room so that
+    // future messages correctly show as unread.  Without this, the
+    // `!localMarker → 0` guard in buildRoomUnread would suppress all unreads.
+    const markers = loadMarkers(fp);
+    if (Object.keys(markers).length === 0 && rooms.length > 0) {
+      const now = Date.now();
+      for (const room of rooms) {
+        const timeline = room.getLiveTimeline().getEvents();
+        if (timeline.length > 0) {
+          const lastEvent = timeline[timeline.length - 1];
+          const lastEventId = lastEvent.getId();
+          if (lastEventId) {
+            saveMarker(room.roomId, lastEventId, now, fp);
+          }
+        }
+      }
+    }
+
     const newMap = new Map<string, RoomUnreadState>();
     const activeId = activeRoomIdRef.current;
     for (const room of rooms) {
@@ -278,7 +298,7 @@ export function useUnreadTracker(
       }
     }
     setRoomUnreads(newMap);
-  }, [client, buildRoomUnread]);
+  }, [client, buildRoomUnread, fp]);
 
   const refreshRoom = useCallback((roomId: string) => {
     if (!client) return;

--- a/src/Brmble.Web/src/utils/migrateLocalStorage.ts
+++ b/src/Brmble.Web/src/utils/migrateLocalStorage.ts
@@ -2,7 +2,8 @@
  * Migrate global localStorage keys to per-profile scoped keys.
  *
  * For each key, if the old global key exists AND the new scoped key
- * does NOT exist, copies the value and deletes the old key.
+ * does NOT exist, copies the value to the scoped key.
+ * The old key is kept so other profiles can also migrate from it.
  * Idempotent — safe to run multiple times.
  */
 
@@ -22,7 +23,6 @@ export function migrateLocalStorage(fingerprint: string): void {
     const oldValue = localStorage.getItem(key);
     if (oldValue !== null && localStorage.getItem(scopedKey) === null) {
       localStorage.setItem(scopedKey, oldValue);
-      localStorage.removeItem(key);
     }
   }
 }

--- a/src/Brmble.Web/src/utils/migrateLocalStorage.ts
+++ b/src/Brmble.Web/src/utils/migrateLocalStorage.ts
@@ -4,6 +4,13 @@
  * For each key, if the old global key exists AND the new scoped key
  * does NOT exist, copies the value to the scoped key.
  * The old key is kept so other profiles can also migrate from it.
+ *
+ * Also migrates uppercase-fingerprint scoped keys to lowercase.
+ * Before the fingerprint casing fix, cert.status sent the raw
+ * Thumbprint (uppercase) while GetCertHash() returned lowercase.
+ * Data saved under the uppercase key needs to be carried over.
+ * If the lowercase key already exists (from a stale global migration),
+ * we compare lastSaved timestamps and keep whichever is newer.
  * Idempotent — safe to run multiple times.
  */
 
@@ -15,11 +22,59 @@ const KEYS_TO_MIGRATE = [
   'brmble-read-markers',
 ];
 
+/** Extract a lastSaved / ts timestamp from a JSON string, if present. */
+function getTimestamp(json: string): number {
+  try {
+    const parsed = JSON.parse(json);
+    // Game state uses lastSaved, read markers use per-room ts values
+    if (typeof parsed === 'object' && parsed !== null) {
+      if (typeof parsed.lastSaved === 'number') return parsed.lastSaved;
+      // For read markers, find the max ts across all rooms
+      let maxTs = 0;
+      for (const val of Object.values(parsed)) {
+        const v = val as { ts?: number };
+        if (typeof v?.ts === 'number' && v.ts > maxTs) maxTs = v.ts;
+      }
+      if (maxTs > 0) return maxTs;
+    }
+  } catch { /* not JSON or no timestamp */ }
+  return 0;
+}
+
 export function migrateLocalStorage(fingerprint: string): void {
   if (!fingerprint) return;
 
+  // Fingerprint should already be lowercase, but ensure it.
+  const lowerFp = fingerprint.toLowerCase();
+  const upperFp = fingerprint.toUpperCase();
+
   for (const key of KEYS_TO_MIGRATE) {
-    const scopedKey = `${key}_${fingerprint}`;
+    const scopedKey = `${key}_${lowerFp}`;
+    const upperKey = `${key}_${upperFp}`;
+
+    // Migrate from uppercase-scoped key (pre-fix data) to lowercase.
+    // Compare timestamps: the uppercase key may have newer progress than
+    // a lowercase key that was populated from stale global data.
+    if (lowerFp !== upperFp) {
+      const upperValue = localStorage.getItem(upperKey);
+      if (upperValue !== null) {
+        const currentValue = localStorage.getItem(scopedKey);
+        if (currentValue === null) {
+          // No lowercase key yet — copy uppercase data
+          localStorage.setItem(scopedKey, upperValue);
+          continue;
+        }
+        // Both exist — keep the one with the newer timestamp
+        const upperTs = getTimestamp(upperValue);
+        const currentTs = getTimestamp(currentValue);
+        if (upperTs > currentTs) {
+          localStorage.setItem(scopedKey, upperValue);
+        }
+        continue;
+      }
+    }
+
+    // Migrate from global (unscoped) key
     const oldValue = localStorage.getItem(key);
     if (oldValue !== null && localStorage.getItem(scopedKey) === null) {
       localStorage.setItem(scopedKey, oldValue);

--- a/src/Brmble.Web/src/utils/migrateLocalStorage.ts
+++ b/src/Brmble.Web/src/utils/migrateLocalStorage.ts
@@ -1,0 +1,28 @@
+/**
+ * Migrate global localStorage keys to per-profile scoped keys.
+ *
+ * For each key, if the old global key exists AND the new scoped key
+ * does NOT exist, copies the value and deletes the old key.
+ * Idempotent — safe to run multiple times.
+ */
+
+const KEYS_TO_MIGRATE = [
+  'idle-farm-save',
+  'idle-farm-theme',
+  'brmblegotchi-state',
+  'brmblegotchi-position',
+  'brmble-read-markers',
+];
+
+export function migrateLocalStorage(fingerprint: string): void {
+  if (!fingerprint) return;
+
+  for (const key of KEYS_TO_MIGRATE) {
+    const scopedKey = `${key}_${fingerprint}`;
+    const oldValue = localStorage.getItem(key);
+    if (oldValue !== null && localStorage.getItem(scopedKey) === null) {
+      localStorage.setItem(scopedKey, oldValue);
+      localStorage.removeItem(key);
+    }
+  }
+}

--- a/src/Brmble.Web/src/utils/profileValidation.ts
+++ b/src/Brmble.Web/src/utils/profileValidation.ts
@@ -1,0 +1,35 @@
+/**
+ * Profile name validation matching Mumble's default username charset
+ * minus Windows-invalid filename characters (only '|' removed).
+ *
+ * Allowed: word chars (letters, digits, _), - = [ ] { } ( ) @ .
+ * Disallowed: spaces, |, and all other special characters.
+ * Max length: 128 characters.
+ */
+const VALID_PROFILE_NAME_REGEX = /^[-=\w[\]{}()@.]+$/;
+
+const MAX_PROFILE_NAME_LENGTH = 128;
+
+/**
+ * Validates a profile name. Returns null if valid, or an error message string if invalid.
+ */
+export function validateProfileName(name: string | undefined | null): string | null {
+  if (!name || name.trim().length === 0) {
+    return 'Profile name cannot be empty.';
+  }
+  const trimmed = name.trim();
+  if (trimmed.length > MAX_PROFILE_NAME_LENGTH) {
+    return 'Profile name must be 128 characters or fewer.';
+  }
+  if (!VALID_PROFILE_NAME_REGEX.test(trimmed)) {
+    return 'Only letters, numbers, and - = _ . [ ] { } ( ) @ are allowed.';
+  }
+  return null;
+}
+
+/**
+ * Returns true if the trimmed name is a valid profile name.
+ */
+export function isValidProfileName(name: string): boolean {
+  return validateProfileName(name) === null;
+}

--- a/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
@@ -307,4 +307,36 @@ public class AppConfigServiceTests
         Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "certs", "Default_" + profile.Id + ".pfx")));
         Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "identity.pfx")), "Old file should be moved");
     }
+
+    [TestMethod]
+    public void AddProfile_RejectsDuplicateName()
+    {
+        var svc = CreateService();
+        svc.AddProfile(new ProfileEntry("id1", "MyProfile"));
+        var result = svc.AddProfile(new ProfileEntry("id2", "myprofile"));
+        Assert.IsFalse(result);
+        Assert.AreEqual(1, svc.GetProfiles().Count);
+    }
+
+    [TestMethod]
+    public void RenameProfile_RejectsDuplicateName()
+    {
+        var svc = CreateService();
+        svc.AddProfile(new ProfileEntry("id1", "Alpha"));
+        svc.AddProfile(new ProfileEntry("id2", "Beta"));
+        var result = svc.RenameProfile("id2", "alpha");
+        Assert.IsFalse(result);
+        Assert.AreEqual("Beta", svc.GetProfiles().First(p => p.Id == "id2").Name);
+    }
+
+    [TestMethod]
+    public void RenameProfile_AllowsSameNameForSameProfile()
+    {
+        var svc = CreateService();
+        svc.AddProfile(new ProfileEntry("id1", "Alpha"));
+        var result = svc.RenameProfile("id1", "Alpha");
+        Assert.IsTrue(result);
+    }
+
+    private AppConfigService CreateService() => new AppConfigService(_tempDir);
 }

--- a/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
@@ -217,4 +217,94 @@ public class AppConfigServiceTests
 
         Assert.AreEqual("blue-lagoon", svc2.GetSettings().Appearance.Theme);
     }
+
+    [TestMethod]
+    public void LoadsEmptyProfiles_WhenNoFileExists()
+    {
+        var svc = new AppConfigService(_tempDir);
+        Assert.AreEqual(0, svc.GetProfiles().Count);
+        Assert.IsNull(svc.GetActiveProfileId());
+    }
+
+    [TestMethod]
+    public void SavesAndReloads_Profiles()
+    {
+        var svc = new AppConfigService(_tempDir);
+        var profile = new ProfileEntry("p1", "Roan");
+        svc.AddProfile(profile);
+        svc.SetActiveProfileId("p1");
+
+        var svc2 = new AppConfigService(_tempDir);
+        Assert.AreEqual(1, svc2.GetProfiles().Count);
+        Assert.AreEqual("Roan", svc2.GetProfiles()[0].Name);
+        Assert.AreEqual("p1", svc2.GetActiveProfileId());
+    }
+
+    [TestMethod]
+    public void RemoveProfile_RemovesFromConfig_ButNotCertFile()
+    {
+        var svc = new AppConfigService(_tempDir);
+        var certsDir = Path.Combine(_tempDir, "certs");
+        Directory.CreateDirectory(certsDir);
+        File.WriteAllBytes(Path.Combine(certsDir, "p1.pfx"), new byte[] { 1, 2, 3 });
+
+        svc.AddProfile(new ProfileEntry("p1", "Test"));
+        svc.RemoveProfile("p1");
+
+        Assert.AreEqual(0, svc.GetProfiles().Count);
+        Assert.IsTrue(File.Exists(Path.Combine(certsDir, "p1.pfx")), "Cert file should NOT be deleted");
+    }
+
+    [TestMethod]
+    public void RemoveActiveProfile_ClearsActiveId_WhenLastProfile()
+    {
+        var svc = new AppConfigService(_tempDir);
+        svc.AddProfile(new ProfileEntry("p1", "Only"));
+        svc.SetActiveProfileId("p1");
+
+        svc.RemoveProfile("p1");
+
+        Assert.IsNull(svc.GetActiveProfileId());
+    }
+
+    [TestMethod]
+    public void RemoveActiveProfile_SwitchesToAnother_WhenOthersExist()
+    {
+        var svc = new AppConfigService(_tempDir);
+        svc.AddProfile(new ProfileEntry("p1", "First"));
+        svc.AddProfile(new ProfileEntry("p2", "Second"));
+        svc.SetActiveProfileId("p1");
+
+        svc.RemoveProfile("p1");
+
+        Assert.AreEqual("p2", svc.GetActiveProfileId());
+    }
+
+    [TestMethod]
+    public void RenameProfile_UpdatesName()
+    {
+        var svc = new AppConfigService(_tempDir);
+        svc.AddProfile(new ProfileEntry("p1", "Old Name"));
+
+        svc.RenameProfile("p1", "New Name");
+        var svc2 = new AppConfigService(_tempDir);
+
+        Assert.AreEqual("New Name", svc2.GetProfiles()[0].Name);
+    }
+
+    [TestMethod]
+    public void MigratesIdentityPfx_ToProfileOnLoad()
+    {
+        // Create a legacy identity.pfx
+        File.WriteAllBytes(Path.Combine(_tempDir, "identity.pfx"), new byte[] { 1, 2, 3 });
+
+        var svc = new AppConfigService(_tempDir);
+
+        Assert.AreEqual(1, svc.GetProfiles().Count);
+        Assert.IsNotNull(svc.GetActiveProfileId());
+        var profile = svc.GetProfiles()[0];
+        Assert.AreEqual("Default", profile.Name);
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "certs", profile.Id + ".pfx")));
+        Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "identity.pfx")), "Old file should be moved");
+    }
 }

--- a/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
@@ -304,7 +304,7 @@ public class AppConfigServiceTests
         Assert.IsNotNull(svc.GetActiveProfileId());
         var profile = svc.GetProfiles()[0];
         Assert.AreEqual("Default", profile.Name);
-        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "certs", profile.Id + ".pfx")));
+        Assert.IsTrue(File.Exists(Path.Combine(_tempDir, "certs", "Default_" + profile.Id + ".pfx")));
         Assert.IsFalse(File.Exists(Path.Combine(_tempDir, "identity.pfx")), "Old file should be moved");
     }
 }


### PR DESCRIPTION
## Summary

- **Multi-profile system** — Users can create, rename, delete, import, and export multiple identity profiles, each with its own certificate (.pfx). Profile names are validated against Mumble's username charset. Cert files use human-readable `{name}_{id}.pfx` naming with automatic migration from legacy format.
- **Mumble registration detection** — Reads `UserState.user_id` from Mumble protocol to detect server-side registration, persists registered name per server entry, and displays a checkmark in the server edit form.
- **Per-profile state scoping** — localStorage keys for idle game, Brmblegotchi, and unread markers are scoped by certificate fingerprint so each profile has independent state. Migration preserves old keys for cross-profile access.
- **Audit bugfixes** — Fixes data-loss bugs (migration timing, stale state cross-write during profile switch, setActive no-op guard), adds thread safety (`_certLock`), error handling (try/catch on profile handlers), tooltip accessibility on disabled buttons, per-profile cert export, and CertWizard CSS consistency.

## What Changed

### Backend (C#)
- `AppConfigService` — Profile CRUD with duplicate name guards, per-profile registration caching (`SwapProfileRegistrations`), cert directory management
- `CertificateService` — Profile-aware cert paths, `_certLock` thread safety, cert file rename on profile rename, existing cert reuse/swap, per-profile export, try/catch error handling on all profile handlers
- `MumbleAdapter` / `MumbleSharp` — `UserState.user_id` and certificate hash reading for registration detection
- 55 client tests passing (including 3 new duplicate-name guard tests)

### Frontend (React/TypeScript)
- `ProfileSettingsTab` — Consolidated profile + cert management tab with add/edit/delete/export/import, existing cert detection, registration display
- `useProfiles` hook — Bridge communication for all profile operations
- `ProfileContext` — Cert fingerprint context for per-profile state scoping
- `migrateLocalStorage` — Migrates global keys to fingerprint-scoped keys
- Per-profile state in `useGameState`, `Brmblegotchi`, `useUnreadTracker`
- CertWizard profile-aware first-launch flow

### Stats
- 39 files changed, +6,556 / -207 lines
- 46 commits
- 68 voice engine tests + 55 client tests all passing
- Frontend and backend builds clean (0 errors)

## Design Documents
- `docs/plans/2026-03-20-multi-profile-design.md`
- `docs/plans/2026-03-20-profile-tab-consolidation-design.md`
- `docs/plans/2026-03-20-mumble-registration-detection-design.md`
- `docs/plans/2026-03-21-per-profile-state-scoping-design.md`
- `docs/plans/2026-03-21-audit-bugfixes-design.md`

## Issues
Closes #277, closes #358