### PR TITLE
fix: correct username tracking for registered Mumble users

### DIFF
--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1884,6 +1884,12 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     {
         base.ServerSync(serverSync);
 
+        // Update _reconnectUsername to the Mumble-confirmed name so that
+        // credential fetch and future reconnects use the registered name
+        // instead of whatever the user originally typed.
+        if (LocalUser?.Name != null)
+            _reconnectUsername = LocalUser.Name;
+
         if (_activeServerId is not null)
         {
             _appConfigService?.SaveLastConnectedServerId(_activeServerId);

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -42,7 +42,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private volatile CancellationTokenSource? _reconnectCts;
     private string? _reconnectHost;
     private int _reconnectPort;
-    private string? _reconnectUsername;
+    private volatile string? _reconnectUsername;
     private string? _reconnectPassword;
     private string? _currentPttKey;
     private readonly Stopwatch _notifyThrottle = Stopwatch.StartNew();

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -72,20 +72,25 @@ public static class AuthEndpoints
                 return Results.StatusCode(500);
             }
 
-            if (!string.IsNullOrEmpty(mumbleUsername))
-                authService.TrackMumbleName(mumbleUsername);
+            // Use the authoritative display name from auth (which resolves
+            // the Mumble-registered name via ICE) rather than the raw
+            // mumbleUsername from the request body, which may differ for
+            // registered users who connected with a different name.
+            var resolvedName = result.DisplayName;
+            if (!string.IsNullOrEmpty(resolvedName))
+                authService.TrackMumbleName(resolvedName);
 
-            if (!string.IsNullOrEmpty(mumbleUsername) &&
-                sessionMapping.TryGetSessionId(mumbleUsername, out var sid))
+            if (!string.IsNullOrEmpty(resolvedName) &&
+                sessionMapping.TryGetSessionId(resolvedName, out var sid))
             {
-                if (sessionMapping.TryAddMatrixUser(sid, result.MatrixUserId, mumbleUsername, result.UserId))
+                if (sessionMapping.TryAddMatrixUser(sid, result.MatrixUserId, resolvedName, result.UserId))
                 {
                     await eventBus.BroadcastAsync(new
                     {
                         type = "userMappingAdded",
                         sessionId = sid,
                         matrixUserId = result.MatrixUserId,
-                        mumbleName = mumbleUsername
+                        mumbleName = resolvedName
                     });
                 }
             }
@@ -94,7 +99,7 @@ public static class AuthEndpoints
                 "Auth succeeded: CertHash={CertHash}, MatrixUserId={MatrixUserId}, MumbleName={MumbleName}",
                 certHash,
                 result.MatrixUserId,
-                mumbleUsername ?? "(none)");
+                resolvedName ?? "(none)");
 
             var roomMap = (await channelRepository.GetAllAsync())
                 .ToDictionary(m => m.MumbleChannelId.ToString(), m => m.MatrixRoomId);

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -78,7 +78,7 @@ public static class AuthEndpoints
             // registered users who connected with a different name.
             var resolvedName = result.DisplayName;
             if (!string.IsNullOrEmpty(resolvedName))
-                authService.TrackMumbleName(resolvedName);
+                authService.TrackMumbleName(resolvedName, certHash);
 
             if (!string.IsNullOrEmpty(resolvedName) &&
                 sessionMapping.TryGetSessionId(resolvedName, out var sid))

--- a/src/Brmble.Server/Auth/AuthService.cs
+++ b/src/Brmble.Server/Auth/AuthService.cs
@@ -23,7 +23,7 @@ public interface IActiveBrmbleSessions
 {
     bool IsBrmbleClient(string certHash);
     bool IsBrmbleClientByName(string mumbleName);
-    void TrackMumbleName(string mumbleName);
+    void TrackMumbleName(string mumbleName, string? certHash = null);
     void UntrackMumbleName(string mumbleName);
 }
 
@@ -67,9 +67,14 @@ public class AuthService : IActiveBrmbleSessions
     {
         lock (_lock) { return _activeNames.Contains(mumbleName); }
     }
-    public void TrackMumbleName(string mumbleName)
+    public void TrackMumbleName(string mumbleName, string? certHash = null)
     {
-        lock (_lock) { _activeNames.Add(mumbleName); }
+        lock (_lock)
+        {
+            _activeNames.Add(mumbleName);
+            if (certHash is not null)
+                _certToName[certHash] = mumbleName;
+        }
     }
     public void UntrackMumbleName(string mumbleName)
     {

--- a/src/Brmble.Server/Auth/AuthService.cs
+++ b/src/Brmble.Server/Auth/AuthService.cs
@@ -71,9 +71,17 @@ public class AuthService : IActiveBrmbleSessions
     {
         lock (_lock)
         {
-            _activeNames.Add(mumbleName);
             if (certHash is not null)
+            {
+                if (_certToName.TryGetValue(certHash, out var existingName) && existingName != mumbleName)
+                {
+                    _activeNames.Remove(existingName);
+                }
+
                 _certToName[certHash] = mumbleName;
+            }
+
+            _activeNames.Add(mumbleName);
         }
     }
     public void UntrackMumbleName(string mumbleName)

--- a/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
@@ -170,4 +170,33 @@ public class AuthServiceTests
         Assert.AreEqual("syt_refresh_token", result.MatrixAccessToken);
         _mockMatrix!.Verify(m => m.LoginUser(It.IsAny<string>()), Times.Once);
     }
+
+    [TestMethod]
+    public async Task TrackMumbleName_AfterAuthenticate_IsBrmbleClientByName()
+    {
+        await _svc!.Authenticate("tracktest");
+        _svc.TrackMumbleName("TrackedUser");
+        Assert.IsTrue(_svc.IsBrmbleClientByName("TrackedUser"));
+    }
+
+    [TestMethod]
+    public async Task TrackMumbleName_WrongName_IsNotBrmbleClientByCorrectName()
+    {
+        // Simulates the bug scenario: tracking "WrongName" means
+        // IsBrmbleClientByName("RealName") returns false
+        await _svc!.Authenticate("mismatchtest");
+        _svc.TrackMumbleName("WrongName");
+        Assert.IsTrue(_svc.IsBrmbleClientByName("WrongName"));
+        Assert.IsFalse(_svc.IsBrmbleClientByName("RealName"));
+    }
+
+    [TestMethod]
+    public async Task Deactivate_RemovesTrackedName()
+    {
+        await _svc!.Authenticate("deactivatetrack");
+        _svc.TrackMumbleName("TrackedDeactivate", "deactivatetrack");
+        Assert.IsTrue(_svc.IsBrmbleClientByName("TrackedDeactivate"));
+        _svc.Deactivate("deactivatetrack");
+        Assert.IsFalse(_svc.IsBrmbleClientByName("TrackedDeactivate"));
+    }
 }

--- a/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
@@ -199,4 +199,20 @@ public class AuthServiceTests
         _svc.Deactivate("deactivatetrack");
         Assert.IsFalse(_svc.IsBrmbleClientByName("TrackedDeactivate"));
     }
+
+    [TestMethod]
+    public async Task TrackMumbleName_RetrackWithCertHash_RemovesStaleName()
+    {
+        // Simulates: user first tracked under raw name, then re-tracked
+        // under the resolved registered name with the same certHash.
+        // The old name must be removed from _activeNames.
+        await _svc!.Authenticate("retrackhash");
+        _svc.TrackMumbleName("RawName", "retrackhash");
+        Assert.IsTrue(_svc.IsBrmbleClientByName("RawName"));
+
+        _svc.TrackMumbleName("RegisteredName", "retrackhash");
+        Assert.IsTrue(_svc.IsBrmbleClientByName("RegisteredName"));
+        Assert.IsFalse(_svc.IsBrmbleClientByName("RawName"),
+            "Stale name should be removed when re-tracked under same certHash");
+    }
 }


### PR DESCRIPTION
## Summary

When a registered Mumble user connects with a different username than their registered name, the server resolves them to their registered name after ServerSync. However, several parts of the codebase were using the raw user-typed name instead of the authoritative Mumble-confirmed name, causing:

- **Reconnects** using the wrong username forever (`_reconnectUsername` was never updated)
- **Auth token requests** sending the wrong `mumbleUsername` to `/auth/token`
- **Session tracking** (`TrackMumbleName`, `TryGetSessionId`, `TryAddMatrixUser`) using the raw request name instead of the resolved display name

## Changes

### Client (`MumbleAdapter.cs`)
- Update `_reconnectUsername` to `LocalUser.Name` after `ServerSync` so reconnects and credential fetches use the Mumble-confirmed name
- Mark `_reconnectUsername` as `volatile` for thread-safety (written on network thread, read during reconnect)

### Server (`AuthEndpoints.cs`)
- Use `result.DisplayName` (the resolved authoritative name from auth/ICE) instead of raw `mumbleUsername` for `TrackMumbleName`, session mapping, Matrix user tracking, and broadcast logging

### Server (`AuthService.cs`)
- Add optional `certHash` parameter to `TrackMumbleName` so `Deactivate` can properly clean up tracked names via `_certToName` mapping
- Update `IActiveBrmbleSessions` interface accordingly

### Tests (`AuthServiceTests.cs`)
- 3 new tests: tracked names recognized by `IsBrmbleClientByName`, mismatch scenario verification, and `Deactivate` cleanup via `certHash`

## Testing

All 298 tests pass (68 MumbleVoiceEngine + 55 Brmble.Client + 175 Brmble.Server).

## Related Issues

- Helps with #272 (unify username display) but does not fully resolve it
- #326 (mid-session name change dedup) is a separate issue — findings were posted as a comment there