### PR TITLE
feat: rebuild DM subsystem — Matrix DMs, Mumble DMs, and Brmble client detection

### DIFF
--- a/docs/plans/2026-03-22-dm-subsystem-rebuild-design.md
+++ b/docs/plans/2026-03-22-dm-subsystem-rebuild-design.md
@@ -1,0 +1,215 @@
+# DM Subsystem Rebuild Design
+
+**Date:** 2026-03-22
+**Status:** Approved
+
+## Problem
+
+The DM system has 6 significant bugs and architectural debt that make it unreliable:
+
+1. **No auto-join for DM invites (Critical):** When User A creates a DM room and invites User B, nothing auto-joins B. B never receives messages.
+2. **Race condition in room creation (High):** Rapid sends create duplicate DM rooms — no mutex guards concurrent `createRoom` calls.
+3. **DM contacts keyed by ephemeral session ID (High):** Mumble session IDs change on reconnect, orphaning all DM contacts.
+4. **`clearChatStorage()` wipes all servers' DM contacts (High):** Fires on every reconnect when Matrix credentials arrive, destroying the contact list.
+5. **No local echo for Matrix DMs (Medium):** Sent messages don't appear until the Matrix sync round-trip completes.
+6. **Initial sync timing (Medium):** DM room mapping may not exist when initial sync timeline events fire, causing missed messages.
+
+DM state is spread across ~150 lines in `App.tsx` with no dedicated hook. The `useDMStore` refactor proposed in the March 1st robustness design was never completed.
+
+## Scope
+
+- **In scope:** Clean rebuild of the DM subsystem for Brmble-to-Brmble Matrix DMs. Fix all 6 bugs.
+- **Deprioritized:** Mumble-only DMs remain as-is (ephemeral fallback), shown in mixed contact list with warning badges.
+- **Out of scope:** Server-side DM bridging for OG Mumble clients (Phase 4 of architecture doc).
+
+## Architecture
+
+Matrix is the single source of truth for Brmble-to-Brmble DMs. localStorage is eliminated as a DM data store.
+
+```
+┌─────────────────────────────────────────┐
+│  UI Layer (ChatPanel, DMContactList)     │
+├─────────────────────────────────────────┤
+│  useDMStore hook (state + actions)       │  <-- NEW: single owner of all DM state
+│  ├── contacts: derived from m.direct     │
+│  ├── messages: from Matrix sync/timeline │
+│  ├── selectedUser: by Matrix user ID     │
+│  └── mumbleDMs: ephemeral fallback       │
+├─────────────────────────────────────────┤
+│  useMatrixClient (transport)             │  <-- EXISTS: cleaned up
+│  Mumble bridge (fallback transport)      │  <-- EXISTS: unchanged
+└─────────────────────────────────────────┘
+```
+
+## Identity Model
+
+DM contacts are keyed by Matrix user ID (`@user:server`). Mumble-only contacts use a synthetic key (`mumble:session:{id}`) and are marked as ephemeral with a warning badge in the UI.
+
+## useDMStore Hook API
+
+```typescript
+interface DMStore {
+  // State
+  contacts: DMContact[];           // Sorted by lastMessageTime, derived from m.direct
+  selectedContact: DMContact | null;
+  messages: ChatMessage[];         // Messages for selected contact
+  appMode: 'channels' | 'dm';
+
+  // Actions
+  selectContact(matrixUserId: string): void;
+  sendMessage(content: string): Promise<void>;
+  startDM(matrixUserId: string, displayName: string): void;
+  clearSelection(): void;
+
+  // Derived
+  totalUnreadCount: number;
+}
+
+interface DMContact {
+  matrixUserId: string;            // Primary key
+  displayName: string;
+  avatarUrl?: string;
+  lastMessage?: string;
+  lastMessageTime?: number;
+  unreadCount: number;
+  isEphemeral: boolean;            // true for Mumble-only contacts
+}
+```
+
+### Contact Population
+
+1. On Matrix sync `PREPARED`: read `m.direct` account data, extract all user IDs with DM rooms, create `DMContact` entries.
+2. Enrich with live data: match `matrixUserId` against the `users` array for current `displayName`, `avatarUrl`, online status.
+3. For each contact's room, get the last event from the timeline for `lastMessage`/`lastMessageTime`.
+4. Mumble-only contacts are added when a private message arrives from a user with no `matrixUserId`.
+
+### Room Creation Mutex
+
+```typescript
+const pendingRoomCreations = useRef(new Map<string, Promise<string>>());
+
+// In sendMessage:
+let roomId = dmRoomMap.get(targetUserId);
+if (!roomId) {
+  const existing = pendingRoomCreations.current.get(targetUserId);
+  if (existing) {
+    roomId = await existing;
+  } else {
+    const promise = createDMRoom(targetUserId);
+    pendingRoomCreations.current.set(targetUserId, promise);
+    roomId = await promise;
+    pendingRoomCreations.current.delete(targetUserId);
+  }
+}
+```
+
+## Bug Fix Strategies
+
+### Bug 1: No auto-join for DM invites
+
+Add an invite handler in `useMatrixClient` that auto-accepts room invites for DM rooms:
+
+```
+Matrix sync delivers invite event -> check if room is 1:1 direct -> auto-join via client.joinRoom(roomId)
+```
+
+Fires on the recipient's client when online. If offline, the invite waits until next connect and sync.
+
+### Bug 2: Race condition / duplicate rooms
+
+Solved by the `pendingRoomCreations` mutex. Only one `createRoom` call can be in-flight per target user.
+
+### Bug 3: Session ID keying
+
+Eliminated. Contacts keyed by `matrixUserId`. Session ID is only used for lookup to find `matrixUserId` from the live `users` array, never as a storage key.
+
+### Bug 4: `clearChatStorage()` wiping everything
+
+`clearChatStorage()` no longer touches DM data because DM contacts come from Matrix `m.direct` and DM messages come from the Matrix timeline. Modified to only clear channel localStorage caches.
+
+### Bug 5: No local echo
+
+Insert optimistic message with `pending: true` flag immediately on send. When the real event arrives via sync, match by transaction ID and replace.
+
+### Bug 6: Initial sync timing
+
+Process DM room maps from `m.direct` before processing timeline events. Call `refreshDMRoomMaps()` synchronously during the sync callback. Buffer timeline events for unknown rooms and replay after `PREPARED`.
+
+## Data Flow
+
+### Brmble-to-Brmble (Matrix)
+
+```
+SENDING:
+User types message -> useDMStore.sendMessage(content)
+  -> Insert optimistic message (pending: true)
+  -> Get/create room via mutex
+  -> client.sendMessage(roomId, content)
+  -> On sync: replace optimistic with confirmed message
+
+RECEIVING:
+Matrix sync -> timeline event for DM room
+  -> useMatrixClient identifies room as DM (via roomIdToDMUserId map)
+  -> Emits event/callback to useDMStore
+  -> useDMStore appends message, updates contact lastMessage/unreadCount
+```
+
+### Mumble Fallback (ephemeral)
+
+```
+SENDING:
+useDMStore.sendMessage(content)
+  -> Insert message locally (in-memory Map)
+  -> bridge.send('voice.sendPrivateMessage', { message, targetSession })
+
+RECEIVING:
+bridge 'voice.message' with sessions field
+  -> App.tsx routes to useDMStore.receiveMumbleDM(senderSession, text)
+  -> useDMStore creates/finds ephemeral contact
+  -> Appends message to in-memory Map
+```
+
+## Room Uniqueness
+
+Matrix `m.direct` account data ensures one DM room per user pair regardless of who initiates. When User A creates a DM room with User B, both users' `m.direct` maps the other's ID to the same room. Subsequent DM attempts from either side discover the existing room.
+
+Edge case: if A and B both send their first DM simultaneously (within the same sync cycle), two rooms could be created. This is extremely unlikely and both rooms would work — the first one in the `m.direct` array is always used.
+
+## State Removal from App.tsx
+
+The following are extracted to `useDMStore`:
+
+- `dmContacts` state and all `upsertDMContact` calls
+- `selectedDMUserId` state
+- `handleSendDMMessage` function
+- `handleSelectDMUser` function
+- DM-related `useEffect` hooks
+- DM message routing in `onVoiceMessage`
+- `appMode` state
+
+## State Removal from useChatStore.ts
+
+- `DM_CONTACTS_KEY_PREFIX` and related localStorage operations
+- DM-related keys from `clearChatStorage()`
+
+## Migration
+
+No data migration needed. Old localStorage DM data is orphaned and ignored. Matrix DM rooms already exist on the server and are rediscovered via `m.direct` sync.
+
+## Testing
+
+### Manual Scenarios (priority order)
+
+1. **Happy path:** A sends DM to B. B receives it. B replies. A receives reply. Both see full conversation.
+2. **Reconnect persistence:** A sends DM to B. Both disconnect and reconnect. Both see DM history.
+3. **Offline recipient:** A sends DM to B while B is offline. B connects later, auto-joins room, sees message.
+4. **Rapid sends:** A sends 5 messages quickly to B. Only 1 room is created.
+5. **Mumble fallback:** A sends DM to OG Mumble user. Message goes via Mumble TextMessage. Badge shows ephemeral indicator.
+6. **Unread tracking:** A sends DM to B while B is viewing channels. B sees unread badge. B opens DM, badge clears.
+7. **Multi-server:** A connects to Server 1, DMs User B. A connects to Server 2. Server 2 DM list is independent.
+
+### Unit-testable Logic
+
+- Room creation mutex behavior
+- Contact derivation from `m.direct` data
+- Optimistic message insertion and replacement

--- a/docs/plans/2026-03-22-dm-subsystem-rebuild-implementation.md
+++ b/docs/plans/2026-03-22-dm-subsystem-rebuild-implementation.md
@@ -1,0 +1,1124 @@
+# DM Subsystem Rebuild Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rebuild the DM subsystem so Matrix is the single source of truth for Brmble-to-Brmble DMs, fix 6 known bugs, and extract all DM state from App.tsx into a dedicated `useDMStore` hook.
+
+**Architecture:** New `useDMStore` hook owns all DM state (contacts from `m.direct`, messages from Matrix timeline, Mumble fallback in-memory). `useMatrixClient` is cleaned up to expose DM invite auto-join and a room creation mutex. `App.tsx` delegates all DM logic to the new hook.
+
+**Tech Stack:** React 18, TypeScript, matrix-js-sdk, WebView2 bridge
+
+**Design doc:** `docs/plans/2026-03-22-dm-subsystem-rebuild-design.md`
+
+---
+
+### Task 1: Add DM invite auto-join to useMatrixClient
+
+Fixes Bug 1 (Critical): recipients never join DM rooms because invite events are ignored.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.ts:219-251` (sync handler area)
+
+**Step 1: Add invite handler in the useEffect that creates the Matrix client**
+
+In `useMatrixClient.ts`, inside the `useEffect` that sets up the client (around line 56-270), add a `Room.myMembership` listener after the existing `onSync` and `onTimeline` handlers. This listener fires when the local user's membership in any room changes:
+
+```typescript
+// Add after line 256 (after onAccountData handler setup)
+const onMyMembership = (room: Room, membership: string) => {
+  if (membership === 'invite') {
+    // Auto-join DM room invites
+    const isDirect = room.getDMInviter() !== null;
+    if (isDirect) {
+      client.joinRoom(room.roomId).catch(err => {
+        console.error(`[Matrix] Failed to auto-join DM room ${room.roomId}:`, err);
+      });
+    }
+  }
+};
+client.on(RoomMemberEvent.MyMembership as any, onMyMembership);
+```
+
+Note: `Room.getDMInviter()` is a matrix-js-sdk helper that returns the user ID of the inviter if the room was marked as a DM invite. If it returns `null`, the room is not a DM. If `getDMInviter` is not available in the SDK version, fall back to checking invite membership count <= 2.
+
+Also add to cleanup on line 261-268:
+```typescript
+client.removeListener(RoomMemberEvent.MyMembership as any, onMyMembership);
+```
+
+**Step 2: Add necessary import**
+
+At the top of `useMatrixClient.ts`, add `Room` to the matrix-js-sdk imports if not already imported, and add `RoomMemberEvent`:
+```typescript
+import { RoomMemberEvent } from 'matrix-js-sdk';
+```
+
+Check the existing imports first -- `Room` may already be imported.
+
+**Step 3: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No new errors
+
+**Step 4: Commit**
+
+```
+feat: auto-join incoming DM room invites
+
+When a Matrix user receives an invite to a direct message room,
+the client now automatically joins the room so messages are received.
+Fixes the critical bug where DM recipients never joined created rooms.
+```
+
+---
+
+### Task 2: Add room creation mutex to useMatrixClient
+
+Fixes Bug 2 (High): rapid sends can create duplicate DM rooms.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.ts:288-316` (`sendDMMessage` function)
+
+**Step 1: Add pending-creation ref**
+
+After the existing refs (around line 48), add:
+```typescript
+const pendingRoomCreations = useRef(new Map<string, Promise<string>>());
+```
+
+**Step 2: Wrap room creation in sendDMMessage with mutex**
+
+Replace the `sendDMMessage` function (lines 288-316) with:
+
+```typescript
+const sendDMMessage = useCallback(async (targetMatrixUserId: string, text: string) => {
+  const client = clientRef.current;
+  if (!client || !credentials) return;
+
+  let roomId = dmRoomMapRef.current.get(targetMatrixUserId);
+
+  if (!roomId) {
+    // Check if a room creation is already in flight for this user
+    const pending = pendingRoomCreations.current.get(targetMatrixUserId);
+    if (pending) {
+      roomId = await pending;
+    } else {
+      // Create room with mutex
+      const createPromise = (async () => {
+        const createResult = await client.createRoom({
+          is_direct: true,
+          invite: [targetMatrixUserId],
+          preset: Preset.TrustedPrivateChat,
+        });
+        const newRoomId = createResult.room_id;
+
+        // Update m.direct account data
+        const directEvent = client.getAccountData(EventType.Direct);
+        const directContent = (directEvent?.getContent() ?? {}) as Record<string, string[]>;
+        directContent[targetMatrixUserId] = [newRoomId, ...(directContent[targetMatrixUserId] ?? [])];
+        await client.setAccountData(EventType.Direct, directContent);
+
+        // Update local maps
+        setDmRoomMap(prev => new Map(prev).set(targetMatrixUserId, newRoomId));
+        dmRoomMapRef.current = new Map(dmRoomMapRef.current).set(targetMatrixUserId, newRoomId);
+        roomIdToDMUserIdRef.current = new Map(roomIdToDMUserIdRef.current).set(newRoomId, targetMatrixUserId);
+
+        return newRoomId;
+      })();
+
+      pendingRoomCreations.current.set(targetMatrixUserId, createPromise);
+      try {
+        roomId = await createPromise;
+      } finally {
+        pendingRoomCreations.current.delete(targetMatrixUserId);
+      }
+    }
+  }
+
+  await client.sendMessage(roomId, { msgtype: MsgType.Text, body: text });
+}, [credentials]);
+```
+
+**Step 3: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No new errors
+
+**Step 4: Commit**
+
+```
+fix: prevent duplicate DM room creation on rapid sends
+
+Adds a mutex (pendingRoomCreations ref) so concurrent sendDMMessage calls
+for the same target user wait for the first createRoom call to complete
+instead of each creating their own room.
+```
+
+---
+
+### Task 3: Create the useDMStore hook skeleton
+
+This is the core of the rebuild. Create the new hook that will own all DM state.
+
+**Files:**
+- Create: `src/Brmble.Web/src/hooks/useDMStore.ts`
+
+**Step 1: Create the hook file with types and skeleton**
+
+```typescript
+import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
+import type { ChatMessage, User } from '../types';
+
+// --- Types ---
+
+export interface DMContact {
+  /** Primary key: Matrix user ID for Brmble users, "mumble:session:{id}" for Mumble-only */
+  id: string;
+  displayName: string;
+  avatarUrl?: string;
+  lastMessage?: string;
+  lastMessageTime?: number;
+  unreadCount: number;
+  /** true for Mumble-only contacts (no Matrix ID, ephemeral session) */
+  isEphemeral: boolean;
+  /** Mumble session ID, used for Mumble fallback sends */
+  sessionId?: number;
+}
+
+export interface DMStoreOptions {
+  /** Matrix DM messages from useMatrixClient, keyed by matrixUserId */
+  matrixDmMessages: Map<string, ChatMessage[]> | undefined;
+  /** Matrix DM room map from useMatrixClient, keyed by matrixUserId -> roomId */
+  matrixDmRoomMap: Map<string, string> | undefined;
+  /** Send a Matrix DM */
+  sendMatrixDM: ((targetMatrixUserId: string, text: string) => Promise<void>) | undefined;
+  /** Fetch DM history from Matrix */
+  fetchDMHistory: ((targetMatrixUserId: string) => Promise<void>) | undefined;
+  /** Current live users list */
+  users: User[];
+  /** Current username (self) */
+  username: string;
+  /** Bridge send function for Mumble fallback */
+  bridgeSend: (event: string, data: unknown) => void;
+  /** Matrix unread count for DM rooms */
+  matrixDmUnreadCount: number;
+}
+
+export interface DMStore {
+  // State
+  contacts: DMContact[];
+  selectedContact: DMContact | null;
+  messages: ChatMessage[];
+  appMode: 'channels' | 'dm';
+
+  // Actions
+  selectContact: (id: string) => void;
+  sendMessage: (content: string) => void;
+  startDM: (matrixUserId: string, displayName: string) => void;
+  clearSelection: () => void;
+  toggleMode: () => void;
+  closeDM: (id: string) => void;
+
+  // For bridge handler: receive a Mumble private message
+  receiveMumbleDM: (senderSession: number, senderName: string, text: string, media?: ChatMessage['media']) => void;
+
+  // Derived
+  totalUnreadCount: number;
+
+  // For components that need the raw appMode ref
+  appModeRef: React.RefObject<'channels' | 'dm'>;
+  selectedContactIdRef: React.RefObject<string | null>;
+}
+
+export function useDMStore(options: DMStoreOptions): DMStore {
+  const {
+    matrixDmMessages,
+    matrixDmRoomMap,
+    sendMatrixDM,
+    fetchDMHistory,
+    users,
+    username,
+    bridgeSend,
+    matrixDmUnreadCount,
+  } = options;
+
+  // --- Core state ---
+  const [appMode, setAppMode] = useState<'channels' | 'dm'>('channels');
+  const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
+  const [mumbleDmMessages, setMumbleDmMessages] = useState<Map<string, ChatMessage[]>>(new Map());
+  const [mumbleContacts, setMumbleContacts] = useState<DMContact[]>([]);
+
+  // --- Refs for bridge callbacks ---
+  const appModeRef = useRef<'channels' | 'dm'>('channels');
+  const selectedContactIdRef = useRef<string | null>(null);
+
+  useEffect(() => { appModeRef.current = appMode; }, [appMode]);
+  useEffect(() => { selectedContactIdRef.current = selectedContactId; }, [selectedContactId]);
+
+  // --- Derive Matrix contacts from m.direct (matrixDmRoomMap) ---
+  const matrixContacts: DMContact[] = useMemo(() => {
+    if (!matrixDmRoomMap || matrixDmRoomMap.size === 0) return [];
+
+    return Array.from(matrixDmRoomMap.keys()).map(matrixUserId => {
+      const user = users.find(u => u.matrixUserId === matrixUserId);
+      const msgs = matrixDmMessages?.get(matrixUserId);
+      const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
+
+      return {
+        id: matrixUserId,
+        displayName: user?.name ?? matrixUserId.split(':')[0].replace('@', ''),
+        avatarUrl: user?.avatarUrl,
+        lastMessage: lastMsg?.content,
+        lastMessageTime: lastMsg?.timestamp ? lastMsg.timestamp.getTime() : undefined,
+        unreadCount: 0, // Will be filled by unread tracker integration
+        isEphemeral: false,
+        sessionId: user?.session,
+      };
+    });
+  }, [matrixDmRoomMap, matrixDmMessages, users]);
+
+  // --- Combine Matrix + Mumble contacts, sorted by most recent ---
+  const contacts: DMContact[] = useMemo(() => {
+    const all = [...matrixContacts, ...mumbleContacts];
+    all.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
+    return all;
+  }, [matrixContacts, mumbleContacts]);
+
+  // --- Selected contact ---
+  const selectedContact = useMemo(() => {
+    if (!selectedContactId) return null;
+    return contacts.find(c => c.id === selectedContactId) ?? null;
+  }, [selectedContactId, contacts]);
+
+  // --- Messages for selected contact ---
+  const messages: ChatMessage[] = useMemo(() => {
+    if (!selectedContactId) return [];
+
+    // Matrix contact
+    if (!selectedContactId.startsWith('mumble:session:')) {
+      return matrixDmMessages?.get(selectedContactId) ?? [];
+    }
+
+    // Mumble fallback
+    return mumbleDmMessages.get(selectedContactId) ?? [];
+  }, [selectedContactId, matrixDmMessages, mumbleDmMessages]);
+
+  // --- Actions ---
+
+  const selectContact = useCallback((id: string) => {
+    setSelectedContactId(id);
+    setAppMode('dm');
+
+    // Fetch Matrix DM history if this is a Matrix contact
+    if (!id.startsWith('mumble:session:') && fetchDMHistory) {
+      fetchDMHistory(id).catch(console.error);
+    }
+  }, [fetchDMHistory]);
+
+  const startDM = useCallback((matrixUserId: string, displayName: string) => {
+    setSelectedContactId(matrixUserId);
+    setAppMode('dm');
+
+    if (fetchDMHistory) {
+      fetchDMHistory(matrixUserId).catch(console.error);
+    }
+  }, [fetchDMHistory]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedContactId(null);
+    setAppMode('channels');
+  }, []);
+
+  const toggleMode = useCallback(() => {
+    setAppMode(prev => prev === 'channels' ? 'dm' : 'channels');
+  }, []);
+
+  const sendMessage = useCallback((content: string) => {
+    if (!selectedContactId || !content || !username) return;
+
+    if (!selectedContactId.startsWith('mumble:session:')) {
+      // Matrix path
+      if (sendMatrixDM) {
+        sendMatrixDM(selectedContactId, content).catch(console.error);
+      }
+    } else {
+      // Mumble fallback path
+      const sessionId = parseInt(selectedContactId.replace('mumble:session:', ''), 10);
+      if (!isNaN(sessionId)) {
+        // Add local message
+        const msg: ChatMessage = {
+          id: `local-${Date.now()}-${Math.random()}`,
+          channelId: selectedContactId,
+          sender: username,
+          content,
+          timestamp: new Date(),
+        };
+        setMumbleDmMessages(prev => {
+          const next = new Map(prev);
+          const existing = next.get(selectedContactId!) ?? [];
+          next.set(selectedContactId!, [...existing, msg]);
+          return next;
+        });
+
+        // Send via Mumble bridge
+        bridgeSend('voice.sendPrivateMessage', {
+          message: content,
+          targetSession: sessionId,
+        });
+
+        // Update Mumble contact lastMessage
+        setMumbleContacts(prev => prev.map(c =>
+          c.id === selectedContactId
+            ? { ...c, lastMessage: content, lastMessageTime: Date.now() }
+            : c
+        ));
+      }
+    }
+  }, [selectedContactId, username, sendMatrixDM, bridgeSend]);
+
+  const receiveMumbleDM = useCallback((senderSession: number, senderName: string, text: string, media?: ChatMessage['media']) => {
+    // Check if this sender has a Matrix ID -- if so, skip (Matrix handles it)
+    const senderUser = users.find(u => u.session === senderSession);
+    if (senderUser?.matrixUserId) return;
+
+    const contactId = `mumble:session:${senderSession}`;
+    const msg: ChatMessage = {
+      id: `mumble-${Date.now()}-${Math.random()}`,
+      channelId: contactId,
+      sender: senderName,
+      content: text,
+      timestamp: new Date(),
+      media,
+    };
+
+    // Add message
+    setMumbleDmMessages(prev => {
+      const next = new Map(prev);
+      const existing = next.get(contactId) ?? [];
+      next.set(contactId, [...existing, msg]);
+      return next;
+    });
+
+    // Upsert Mumble contact
+    const isViewing = appModeRef.current === 'dm' && selectedContactIdRef.current === contactId;
+    setMumbleContacts(prev => {
+      const existing = prev.find(c => c.id === contactId);
+      if (existing) {
+        return prev.map(c => c.id === contactId ? {
+          ...c,
+          displayName: senderName,
+          lastMessage: text,
+          lastMessageTime: Date.now(),
+          unreadCount: isViewing ? 0 : c.unreadCount + 1,
+        } : c);
+      }
+      return [...prev, {
+        id: contactId,
+        displayName: senderName,
+        lastMessage: text,
+        lastMessageTime: Date.now(),
+        unreadCount: isViewing ? 0 : 1,
+        isEphemeral: true,
+        sessionId: senderSession,
+      }];
+    });
+  }, [users]);
+
+  const closeDM = useCallback((id: string) => {
+    if (id.startsWith('mumble:session:')) {
+      setMumbleContacts(prev => prev.filter(c => c.id !== id));
+      setMumbleDmMessages(prev => {
+        const next = new Map(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+    // For Matrix contacts, we don't remove from m.direct -- just deselect if active
+    if (selectedContactId === id) {
+      setSelectedContactId(null);
+    }
+  }, [selectedContactId]);
+
+  // --- Unread count ---
+  const mumbleUnreadCount = useMemo(() =>
+    mumbleContacts.reduce((sum, c) => sum + c.unreadCount, 0),
+  [mumbleContacts]);
+
+  const totalUnreadCount = matrixDmUnreadCount + mumbleUnreadCount;
+
+  // --- Reset on disconnect (users array becomes empty) ---
+  useEffect(() => {
+    if (users.length === 0) {
+      setAppMode('channels');
+      setSelectedContactId(null);
+      setMumbleDmMessages(new Map());
+      setMumbleContacts([]);
+    }
+  }, [users.length]);
+
+  return {
+    contacts,
+    selectedContact,
+    messages,
+    appMode,
+    selectContact,
+    sendMessage,
+    startDM,
+    clearSelection,
+    toggleMode,
+    closeDM,
+    receiveMumbleDM,
+    totalUnreadCount,
+    appModeRef,
+    selectedContactIdRef,
+  };
+}
+```
+
+**Step 2: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No new errors (the hook is not used yet)
+
+**Step 3: Commit**
+
+```
+feat: create useDMStore hook for centralized DM state management
+
+New hook that derives contacts from Matrix m.direct data, handles
+Mumble fallback DMs in-memory, and exposes a clean API for all DM
+operations. This replaces the ~150 lines of DM state scattered in App.tsx.
+```
+
+---
+
+### Task 4: Wire useDMStore into App.tsx and remove old DM state
+
+This is the largest task. We replace all DM state/handlers in App.tsx with the new hook.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+
+**Step 1: Add useDMStore import and instantiation**
+
+At the top of App.tsx, add the import:
+```typescript
+import { useDMStore } from './hooks/useDMStore';
+```
+
+Inside the component, after the existing `useMatrixClient` and `useUnreadTracker` calls, instantiate the hook. You need to wire up the `bridgeSend` function -- look for how the bridge is accessed (it's `bridge.send` where `bridge` is from the WebView2 bridge). The `matrixDmUnreadCount` comes from `useUnreadTracker`'s `totalDmUnreadCount`.
+
+```typescript
+const dmStore = useDMStore({
+  matrixDmMessages: matrixClient.dmMessages,
+  matrixDmRoomMap: matrixClient.dmRoomMap,
+  sendMatrixDM: matrixClient.sendDMMessage,
+  fetchDMHistory: matrixClient.fetchDMHistory,
+  users,
+  username,
+  bridgeSend: (event, data) => bridge.send(event, data),
+  matrixDmUnreadCount: unreadTracker.totalDmUnreadCount,
+});
+```
+
+**Step 2: Remove old DM state declarations**
+
+Remove these lines from App.tsx (approximate line numbers from the investigation):
+
+- Line 182: `const [dmContacts, setDmContacts] = ...`
+- Line 183: `const [appMode, setAppMode] = ...` (now owned by dmStore)
+- Line 184: `const [selectedDMUserId, setSelectedDMUserIdRaw] = ...`
+- Line 185: `const [selectedDMUserName, setSelectedDMUserName] = ...`
+- Lines 189-192: `setSelectedDMUserId` wrapper
+- Line 161: `const [dmDividerTs, setDmDividerTs] = ...` (keep this -- it's for the unread divider, handled separately)
+- Line 346: `const dmKey = ...`
+- Line 347: `const { messages: dmMessages, addMessage: addDMMessage } = useChatStore(dmKey);`
+- Lines 368-375: `selectedDMUserIdRef`, `appModeRef`, `setAppModeRef`, `addDMMessageRef` refs
+- Lines 397-403: `loadDMContacts` useEffect
+
+**Step 3: Remove old DM handler functions**
+
+Remove:
+- Lines 1275-1296: `handleSendDMMessage` function (replaced by `dmStore.sendMessage`)
+- Lines 1431-1447: `handleSelectDMUser` function (replaced by `dmStore.selectContact` / `dmStore.startDM`)
+- Lines 1449-1457: `handleCloseDMConversation` (replaced by `dmStore.closeDM`)
+- Lines 1387-1390: `toggleDMMode` (replaced by `dmStore.toggleMode`)
+- Lines 1392-1399: `localTotalDmUnreadCount` / `totalDmUnreadCount` (replaced by `dmStore.totalUnreadCount`)
+- Lines 1416-1429: `dmContactsWithComments` (contacts are already enriched in useDMStore)
+- Lines 1475-1479: `activeDmMessages` selection (replaced by `dmStore.messages`)
+
+**Step 4: Remove DM contact update effect**
+
+Remove lines 1142-1159 (the effect that updates dmContacts from matrixDmMessages). The new hook handles this internally.
+
+**Step 5: Update onVoiceMessage handler to use dmStore**
+
+In the `onVoiceMessage` handler (lines 656-709), replace the DM routing section (lines 694-708) with:
+
+```typescript
+// DM routing
+const senderSession = d.senderSession as number;
+const senderName = d.sender as string;
+const text = d.message as string;
+dmStore.receiveMumbleDM(senderSession, senderName, text, media);
+```
+
+Remove the old code that calls `addDMMessage`, `addMessageToStore`, and `upsertDMContact` for DMs.
+
+**Step 6: Update onServerCredentials to NOT clear DM data**
+
+In `onServerCredentials` (line 634), `clearChatStorage()` still runs but it no longer needs to clear DM contacts (since they come from Matrix). Verify that `clearChatStorage()` in `useChatStore.ts` no longer deletes DM-related keys -- we'll fix that in Task 5.
+
+**Step 7: Update disconnect handler**
+
+In `onVoiceDisconnected` (around line 621), remove `setAppMode('channels')` -- the useDMStore handles this via its `users.length === 0` effect.
+
+**Step 8: Update all references to old DM state**
+
+Replace throughout App.tsx:
+- `appMode` -> `dmStore.appMode`
+- `setAppMode(...)` -> (use dmStore actions instead, e.g. `dmStore.clearSelection()` or `dmStore.toggleMode()`)
+- `selectedDMUserId` -> `dmStore.selectedContact?.id ?? null`
+- `selectedDMUserName` -> `dmStore.selectedContact?.displayName ?? ''`
+- `totalDmUnreadCount` -> `dmStore.totalUnreadCount`
+- `dmContactsWithComments` -> `dmStore.contacts`
+- `activeDmMessages` -> `dmStore.messages`
+- `handleSendDMMessage` -> `dmStore.sendMessage`
+- `handleSelectDMUser` -> update: the old function took `(userId, userName)` where userId was a session ID. The new `dmStore.selectContact` takes a contact `id` (matrixUserId or `mumble:session:X`). Update call sites.
+- `handleCloseDMConversation` -> `dmStore.closeDM`
+- `toggleDMMode` -> `dmStore.toggleMode`
+- `appModeRef` -> `dmStore.appModeRef`
+- `selectedDMUserIdRef` -> `dmStore.selectedContactIdRef`
+
+**Step 9: Update DMContactList rendering**
+
+The `DMContactList` component props need updating. Currently it receives:
+```tsx
+<DMContactList
+  contacts={dmContactsWithComments}
+  selectedUserId={selectedDMUserId}
+  onSelectContact={handleSelectDMUser}
+  onCloseConversation={handleCloseDMConversation}
+  onlineUserIds={users.filter(u => !u.self).map(u => String(u.session))}
+  visible={appMode === 'dm'}
+/>
+```
+
+Replace with:
+```tsx
+<DMContactList
+  contacts={dmStore.contacts}
+  selectedUserId={dmStore.selectedContact?.id ?? null}
+  onSelectContact={(id, _name) => dmStore.selectContact(id)}
+  onCloseConversation={dmStore.closeDM}
+  onlineUserIds={users.filter(u => !u.self).map(u => u.matrixUserId ?? `mumble:session:${u.session}`)}
+  visible={dmStore.appMode === 'dm'}
+/>
+```
+
+Note: The `DMContactList` component's props interface will need updating in Task 6 to match the new `DMContact` shape from useDMStore.
+
+**Step 10: Update DM ChatPanel rendering**
+
+Replace the DM ChatPanel props:
+```tsx
+<ChatPanel
+  channelId={dmStore.selectedContact ? `dm-${dmStore.selectedContact.id}` : undefined}
+  channelName={dmStore.selectedContact?.displayName ?? ''}
+  messages={dmStore.messages}
+  currentUsername={username}
+  onSendMessage={dmStore.sendMessage}
+  isDM={true}
+  matrixClient={matrixClient.client}
+  matrixRoomId={dmStore.selectedContact && matrixClient.dmRoomMap ? matrixClient.dmRoomMap.get(dmStore.selectedContact.id) ?? null : null}
+  readMarkerTs={dmDividerTs}
+  users={users}
+/>
+```
+
+**Step 11: Update context menu "Start DM" handlers**
+
+In `Sidebar.tsx` and `ChannelTree.tsx`, the "Send Direct Message" context menu items call a handler that passes `(sessionId, userName)`. These need to be updated to pass `matrixUserId` instead. Find the handler wiring in App.tsx and update:
+
+Where `handleSelectDMUser` was passed as a prop (search for `onStartDM` or similar), replace with a wrapper:
+```typescript
+const handleStartDMFromContextMenu = (sessionIdStr: string, userName: string) => {
+  const user = users.find(u => String(u.session) === sessionIdStr);
+  if (user?.matrixUserId) {
+    dmStore.startDM(user.matrixUserId, userName);
+  } else {
+    // Mumble fallback
+    dmStore.selectContact(`mumble:session:${sessionIdStr}`);
+  }
+};
+```
+
+Pass this as the callback to sidebar/channel tree context menus.
+
+**Step 12: Remove old DM imports**
+
+Remove from the import at line 26:
+- `loadDMContacts`
+- `upsertDMContact`
+- `markDMContactRead`
+- `removeDMContact`
+
+Remove the `StoredDMContact` type import (line 28).
+
+**Step 13: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Fix any remaining type errors.
+
+**Step 14: Commit**
+
+```
+refactor: wire useDMStore into App.tsx, remove old DM state
+
+Replaces ~150 lines of scattered DM state management in App.tsx with
+the centralized useDMStore hook. DM contacts are now derived from
+Matrix m.direct data instead of localStorage. All DM actions route
+through the hook.
+```
+
+---
+
+### Task 5: Clean up useChatStore (remove DM localStorage)
+
+Fixes Bug 4: `clearChatStorage()` wiping all DM contacts.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useChatStore.ts`
+
+**Step 1: Remove DM contact functions and types**
+
+Remove the following from `useChatStore.ts`:
+- Line 110: `DM_CONTACTS_KEY_PREFIX` constant
+- Lines 114-116: `dmContactsKey` helper
+- Lines 118-124: `StoredDMContact` interface
+- Lines 126-134: `loadDMContacts` function
+- Lines 136-138: `saveDMContacts` function
+- Lines 140-169: `upsertDMContact` function
+- Lines 171-179: `markDMContactRead` function
+- Lines 181-185: `removeDMContact` function
+
+**Step 2: Update clearChatStorage**
+
+Replace the `clearChatStorage` function (lines 88-93) to only clear channel data:
+```typescript
+export function clearChatStorage() {
+  const serverRootKey = `${STORAGE_KEY_PREFIX}server-root`;
+  Object.keys(localStorage)
+    .filter(k => k.startsWith(STORAGE_KEY_PREFIX) && k !== serverRootKey)
+    .forEach(k => localStorage.removeItem(k));
+}
+```
+
+The key change: removed the `|| k.startsWith(DM_CONTACTS_KEY_PREFIX)` clause.
+
+**Step 3: Update exports**
+
+Remove the DM-related functions from the module's exports. The functions were individually exported, so removing them is sufficient.
+
+**Step 4: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Expected: No new errors (old callers were removed in Task 4)
+
+**Step 5: Commit**
+
+```
+fix: remove DM data from localStorage, stop clearChatStorage wiping contacts
+
+DM contacts are now derived from Matrix m.direct account data.
+clearChatStorage() no longer deletes DM-related localStorage keys,
+fixing the bug where reconnecting wiped all DM contacts across all servers.
+```
+
+---
+
+### Task 6: Update DMContactList component for new contact shape
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/DMContactList/DMContactList.tsx`
+
+**Step 1: Update DMContact interface to match useDMStore**
+
+Replace the internal `DMContact` interface (lines 8-17) with an import from useDMStore:
+```typescript
+import type { DMContact } from '../../hooks/useDMStore';
+```
+
+**Step 2: Update DMContactListProps**
+
+Update the props to use the new contact shape:
+```typescript
+interface DMContactListProps {
+  contacts: DMContact[];
+  selectedUserId: string | null;
+  onSelectContact: (id: string, displayName: string) => void;
+  onCloseConversation: (id: string) => void;
+  onlineUserIds: string[];
+  visible: boolean;
+}
+```
+
+**Step 3: Update rendering to use new field names**
+
+Throughout the component, update field access:
+- `contact.userId` -> `contact.id`
+- `contact.userName` -> `contact.displayName`
+- `contact.unread` -> `contact.unreadCount`
+- `contact.lastMessageTime` is now `number | undefined` (epoch ms) instead of `Date`. Update the time formatting to handle this:
+  ```typescript
+  const time = contact.lastMessageTime ? new Date(contact.lastMessageTime) : undefined;
+  ```
+
+**Step 4: Add ephemeral badge for Mumble-only contacts**
+
+For contacts where `contact.isEphemeral === true`, add a small warning indicator next to their name. This can be a simple title/tooltip:
+```tsx
+{contact.isEphemeral && (
+  <span className="dm-ephemeral-badge" title="Messages with this user won't be saved">!</span>
+)}
+```
+
+Add minimal CSS in `DMContactList.css`:
+```css
+.dm-ephemeral-badge {
+  color: var(--text-muted);
+  font-size: 0.7em;
+  margin-left: 4px;
+  opacity: 0.7;
+}
+```
+
+**Step 5: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+
+**Step 6: Commit**
+
+```
+refactor: update DMContactList for new DMContact shape from useDMStore
+
+Contacts are now keyed by Matrix user ID instead of session ID.
+Adds ephemeral badge indicator for Mumble-only contacts whose
+messages won't persist.
+```
+
+---
+
+### Task 7: Update Sidebar and ChannelTree DM context menus
+
+The context menus that initiate DMs currently pass session IDs. They need to work with the new identity model.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Sidebar/Sidebar.tsx`
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`
+
+**Step 1: Investigate how DM is initiated from context menus**
+
+Read the relevant sections of `Sidebar.tsx` and `ChannelTree.tsx` to find:
+- The "Send Direct Message" / "Start DM" menu items
+- What callback they invoke and what arguments they pass
+- How the callback prop is typed
+
+**Step 2: Update callbacks**
+
+The context menu callbacks should pass `matrixUserId` when available, falling back to session-based ID. The `handleStartDMFromContextMenu` wrapper added in Task 4 Step 11 handles the conversion, so the context menu just needs to pass what it has.
+
+If the callback currently takes `(sessionId: string, userName: string)`, update it to pass `(user.matrixUserId ?? \`mumble:session:${user.session}\`, user.name)` where `user` is the right-clicked user object.
+
+The exact changes depend on how the components are structured -- read the files first.
+
+**Step 3: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+
+**Step 4: Commit**
+
+```
+refactor: update sidebar DM context menus for Matrix user ID identity
+
+Context menus now pass Matrix user IDs when available for DM initiation,
+falling back to mumble:session: prefix for OG Mumble users.
+```
+
+---
+
+### Task 8: Fix initial sync timing for DM messages (Bug 6)
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.ts`
+
+**Step 1: Add buffering for pre-PREPARED DM timeline events**
+
+In the `useEffect` that creates the Matrix client, add a flag and buffer:
+
+```typescript
+let isPrepared = false;
+const bufferedDmEvents: Array<{ room: any; event: any }> = [];
+```
+
+**Step 2: Update the timeline handler**
+
+In the `onTimeline` handler (lines 80-197), in the DM message section (after line 140), add:
+
+```typescript
+const dmUserId = roomIdToDMUserIdRef.current.get(room?.roomId ?? '');
+if (!dmUserId) {
+  // Room not yet mapped -- might be a DM room discovered during initial sync
+  // Buffer if we haven't completed initial sync yet
+  if (!isPrepared && room?.roomId) {
+    bufferedDmEvents.push({ room, event });
+  }
+  return;
+}
+```
+
+**Step 3: Replay buffered events after PREPARED**
+
+In the `onSync` handler, after `refreshDMRoomMaps` is called on `PREPARED`:
+
+```typescript
+if (state === 'PREPARED') {
+  isPrepared = true;
+  const directEvent = client.getAccountData(EventType.Direct);
+  if (directEvent) {
+    refreshDMRoomMaps(directEvent.getContent() as Record<string, string[]>);
+  }
+  // Replay any DM timeline events that arrived before room maps were ready
+  for (const { room, event } of bufferedDmEvents) {
+    onTimeline(event, room, undefined, false, { liveEvent: false });
+  }
+  bufferedDmEvents.length = 0;
+}
+```
+
+**Step 4: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+
+**Step 5: Commit**
+
+```
+fix: buffer DM timeline events until initial sync completes
+
+DM room maps from m.direct may not be populated when early timeline
+events arrive during initial sync. Events for unmapped rooms are now
+buffered and replayed after PREPARED state fires.
+```
+
+---
+
+### Task 9: Add local echo for Matrix DMs (Bug 5)
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useDMStore.ts`
+- Modify: `src/Brmble.Web/src/types/index.ts`
+
+**Step 1: Add `pending` field to ChatMessage type**
+
+In `types/index.ts`, add an optional `pending` field to `ChatMessage`:
+```typescript
+export interface ChatMessage {
+  id: string;
+  channelId: string;
+  sender: string;
+  senderMatrixUserId?: string;
+  content: string;
+  timestamp: Date;
+  type?: 'system';
+  html?: boolean;
+  media?: MediaAttachment[];
+  pending?: boolean;  // <-- add this
+}
+```
+
+**Step 2: Add optimistic message state to useDMStore**
+
+In `useDMStore.ts`, add state for pending messages:
+```typescript
+const [pendingMessages, setPendingMessages] = useState<Map<string, ChatMessage[]>>(new Map());
+```
+
+**Step 3: Update sendMessage to insert optimistic message**
+
+In the Matrix path of `sendMessage`:
+```typescript
+if (!selectedContactId.startsWith('mumble:session:')) {
+  // Insert optimistic local echo
+  const optimisticMsg: ChatMessage = {
+    id: `pending-${Date.now()}-${Math.random()}`,
+    channelId: selectedContactId,
+    sender: username,
+    content,
+    timestamp: new Date(),
+    pending: true,
+  };
+  setPendingMessages(prev => {
+    const next = new Map(prev);
+    const existing = next.get(selectedContactId!) ?? [];
+    next.set(selectedContactId!, [...existing, optimisticMsg]);
+    return next;
+  });
+
+  if (sendMatrixDM) {
+    sendMatrixDM(selectedContactId, content)
+      .then(() => {
+        // Remove optimistic message -- the real one arrives via sync
+        setPendingMessages(prev => {
+          const next = new Map(prev);
+          const existing = next.get(selectedContactId!) ?? [];
+          next.set(selectedContactId!, existing.filter(m => m.id !== optimisticMsg.id));
+          return next;
+        });
+      })
+      .catch(console.error);
+  }
+}
+```
+
+**Step 4: Merge pending messages into the messages output**
+
+Update the `messages` useMemo to include pending messages:
+```typescript
+const messages: ChatMessage[] = useMemo(() => {
+  if (!selectedContactId) return [];
+
+  if (!selectedContactId.startsWith('mumble:session:')) {
+    const matrixMsgs = matrixDmMessages?.get(selectedContactId) ?? [];
+    const pending = pendingMessages.get(selectedContactId) ?? [];
+    return [...matrixMsgs, ...pending];
+  }
+
+  return mumbleDmMessages.get(selectedContactId) ?? [];
+}, [selectedContactId, matrixDmMessages, mumbleDmMessages, pendingMessages]);
+```
+
+**Step 5: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+
+**Step 6: Commit**
+
+```
+feat: add local echo for Matrix DMs
+
+Sent DM messages now appear immediately in the chat as pending messages,
+then are replaced when the confirmed event arrives via Matrix sync.
+Eliminates the visible delay between sending and seeing your own message.
+```
+
+---
+
+### Task 10: Update DM unread divider integration
+
+The unread divider (`dmDividerTs`) logic in App.tsx needs to work with the new useDMStore.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx` (lines 1644-1694 area)
+
+**Step 1: Update the DM divider snapshot effect**
+
+The existing effect (around lines 1644-1694) watches `selectedDMUserId` and `appMode` to snapshot the unread divider timestamp and mark the room as read. Update it to use `dmStore.selectedContact` and `dmStore.appMode`:
+
+```typescript
+useEffect(() => {
+  if (dmStore.appMode !== 'dm' || !dmStore.selectedContact) {
+    return;
+  }
+  const contact = dmStore.selectedContact;
+  if (contact.isEphemeral) return; // No unread tracking for Mumble DMs
+
+  const roomId = matrixClient.dmRoomMap?.get(contact.id);
+  if (!roomId) return;
+
+  // Snapshot the divider timestamp
+  const ts = unreadTracker.getMarkerTimestamp(roomId);
+  setDmDividerTs(ts);
+
+  // Mark as read
+  const room = matrixClient.client?.getRoom(roomId);
+  if (room) {
+    const lastEvent = room.getLastLiveEvent();
+    if (lastEvent?.getId()) {
+      unreadTracker.markRoomRead(roomId, lastEvent.getId()!).catch(console.error);
+    }
+  }
+}, [dmStore.appMode, dmStore.selectedContact, matrixClient.dmRoomMap, matrixClient.client, unreadTracker]);
+```
+
+**Step 2: Verify the build compiles**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+
+**Step 3: Commit**
+
+```
+fix: update DM unread divider to work with new useDMStore
+```
+
+---
+
+### Task 11: Final cleanup and build verification
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx` (remove any dead code)
+- Modify: `src/Brmble.Web/src/hooks/useChatStore.ts` (verify clean)
+
+**Step 1: Search for any remaining references to old DM patterns**
+
+Search for:
+- `dmContacts` (should not exist in App.tsx)
+- `selectedDMUserId` (should not exist in App.tsx)
+- `selectedDMUserName` (should not exist in App.tsx)
+- `handleSendDMMessage` (should not exist)
+- `handleSelectDMUser` (should not exist)
+- `handleCloseDMConversation` (should not exist)
+- `upsertDMContact` (should not exist anywhere)
+- `loadDMContacts` (should not exist)
+- `markDMContactRead` (should not exist)
+- `removeDMContact` (should not exist)
+- `DM_CONTACTS_KEY_PREFIX` (should not exist)
+- `StoredDMContact` (should not exist)
+
+**Step 2: Remove the `DMConversation` type if unused**
+
+In `types/index.ts`, the `DMConversation` type (lines 52-58) may now be unused. Check for references and remove if no longer needed.
+
+**Step 3: Remove `mapStoredContacts` utility**
+
+In App.tsx, the `mapStoredContacts` function (lines 128-135) is no longer needed. Remove it.
+
+**Step 4: Full build check**
+
+Run: `cd src/Brmble.Web && npx tsc --noEmit`
+Run: `cd src/Brmble.Web && npm run build`
+
+Both must succeed with no errors.
+
+**Step 5: Commit**
+
+```
+refactor: remove dead DM code and verify clean build
+```
+
+---
+
+## Summary of Tasks
+
+| Task | Description | Fixes |
+|------|-------------|-------|
+| 1 | Auto-join DM room invites | Bug 1 (Critical) |
+| 2 | Room creation mutex | Bug 2 (High) |
+| 3 | Create useDMStore hook | Core rebuild |
+| 4 | Wire useDMStore into App.tsx | Bug 3 (High) + core rebuild |
+| 5 | Clean up useChatStore | Bug 4 (High) |
+| 6 | Update DMContactList component | UI update |
+| 7 | Update context menu DM initiation | Identity model |
+| 8 | Fix initial sync timing | Bug 6 (Medium) |
+| 9 | Add local echo for Matrix DMs | Bug 5 (Medium) |
+| 10 | Update unread divider integration | Reconnect fix |
+| 11 | Final cleanup and build verification | Cleanup |

--- a/docs/plans/2026-03-23-mumble-dm-design.md
+++ b/docs/plans/2026-03-23-mumble-dm-design.md
@@ -1,0 +1,165 @@
+# Mumble DM Design
+
+**Date:** 2026-03-23
+**Status:** Approved
+
+## Problem
+
+After the DM subsystem rebuild, Brmble-to-Brmble DMs work via Matrix. But when a Brmble user tries to DM a pure Mumble user (someone with no Brmble account), nothing happens — the context menu checks for `matrixUserId` and bails if absent. Mumble private message handling was stripped out of the frontend entirely.
+
+Pure Mumble users are a first-class citizen of the voice server. They should be reachable via DM from Brmble users.
+
+## Scope
+
+- **In scope:** Brmble user sending/receiving DMs with pure Mumble users via Mumble's native private message system.
+- **Out of scope:** Pure Mumble-to-Mumble DMs (handled natively by Mumble, not our concern). Server-side DM bridging. Matrix rooms for Mumble users.
+
+## Decisions
+
+1. **Transport:** Mumble native private messages. Ephemeral — only while both users are online (or until the Brmble user disconnects).
+2. **UI:** Unified DM contact list. Mumble DM contacts appear alongside Matrix DM contacts with a visual "online only" indicator.
+3. **Persistence:** Conversation kept in memory until the Brmble user disconnects from the server. If the Mumble user disconnects and reconnects (matched by cert hash), the conversation reattaches.
+4. **Transport selection:** If the target has a `matrixUserId` (from `SessionMappingService`), use Matrix. Only users with NO Matrix identity get Mumble PMs. This means a registered Brmble user on a Mumble client still gets Matrix DMs (they'll see them when they next open Brmble).
+5. **No manual dismiss:** Mumble DM conversations are cleared automatically on Brmble disconnect. No close/dismiss button needed.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│  UI Layer (ChatPanel, DMContactList)     │
+├─────────────────────────────────────────┤
+│  useDMStore hook (state + actions)       │
+│  ├── Matrix contacts (existing)          │
+│  └── Mumble contacts (NEW)              │
+│      ├── keyed by mumbleCertHash        │
+│      ├── in-memory messages only        │
+│      └── cleared on disconnect          │
+├─────────────────────────────────────────┤
+│  useMatrixClient (Matrix transport)      │  <-- unchanged
+│  MumbleAdapter.cs (Mumble transport)     │  <-- existing plumbing, now used
+└─────────────────────────────────────────┘
+```
+
+No server-side changes required. The Brmble client talks directly to the Mumble server for PMs (via MumbleSharp in `MumbleAdapter.cs`), and directly to Matrix for DMs. The server doesn't bridge anything for this scenario.
+
+## Contact Model
+
+```typescript
+interface DMContact {
+  // Common fields
+  displayName: string;
+  unreadCount: number;
+  lastMessage?: string;
+  lastMessageTime?: number;
+
+  // Matrix DM (existing)
+  matrixUserId?: string;     // e.g., "@2:noscope.it"
+  matrixRoomId?: string;
+
+  // Mumble DM (new)
+  mumbleCertHash?: string;   // stable identity across reconnects
+  mumbleSessionId?: number;  // current session (null if offline)
+  isEphemeral: boolean;      // true for Mumble DMs, false for Matrix
+}
+```
+
+A contact has either `matrixUserId` or `mumbleCertHash`, never both. If a user has a Matrix identity, they always go through Matrix regardless of what client they're using.
+
+## Transport Selection
+
+```
+User initiates DM from context menu
+  ├── target has matrixUserId? ──→ Matrix DM (existing flow)
+  └── target has no matrixUserId? ──→ Mumble PM (new flow)
+```
+
+The check happens on the frontend using user list data that `SessionMappingService` already broadcasts. The frontend already receives `matrixUserId` (or null) for each user in the channel tree.
+
+## Message Flow
+
+### Sending (Brmble → Mumble user)
+
+```
+User types message → useDMStore.sendMessage(content)
+  → Insert optimistic message (local echo)
+  → bridge.send('voice.sendPrivateMessage', { targetSession, text })
+  → MumbleAdapter.cs → MumbleSharp → Mumble server → target user
+```
+
+### Receiving (Mumble user → Brmble)
+
+```
+MumbleAdapter.cs receives TextMessage with sessions target
+  → bridge sends 'voice.message' { sender, sessionId, certHash, text, isPrivate: true }
+  → App.tsx routes to useDMStore
+  → Look up sender by certHash
+  → If contact exists → append message
+  → If no contact → auto-create ephemeral contact, append message
+  → Increment unread count
+```
+
+### Reconnection
+
+```
+Mumble user disconnects:
+  → User list update removes their session
+  → DM contact's mumbleSessionId set to null
+  → UI shows contact as offline
+  → Message input disabled (can't deliver)
+
+Mumble user reconnects:
+  → User list update adds new session with same certHash
+  → DM contact's mumbleSessionId updated to new value
+  → UI shows contact as online again
+  → Conversation history (in memory) preserved
+```
+
+### Cleanup
+
+All Mumble DM contacts and messages are cleared when the Brmble user disconnects from the server.
+
+## Frontend Changes
+
+### useDMStore.ts
+
+- Add Mumble contact state: `mumbleContacts` map keyed by `certHash`
+- Add Mumble message storage: in-memory `Map<certHash, ChatMessage[]>`
+- Extend `sendMessage()` to dispatch to Mumble bridge when `contact.isEphemeral`
+- Add `receiveMumbleDM(certHash, sessionId, displayName, text)` action
+- Add `updateMumbleSession(certHash, sessionId | null)` for connect/disconnect
+- Add `clearMumbleContacts()` for server disconnect cleanup
+- Merge Mumble contacts into the unified contact list (sorted by lastMessageTime alongside Matrix contacts)
+
+### App.tsx
+
+- Un-ignore `voice.message` with `isPrivate: true` — route to `useDMStore.receiveMumbleDM()`
+- Handle user list updates to detect Mumble user connect/disconnect — call `updateMumbleSession()`
+- Extend `handleStartDMFromContextMenu` with Mumble path for users without `matrixUserId`
+- On server disconnect: call `clearMumbleContacts()`
+
+### DMContactList.tsx
+
+- Show "online only" indicator for ephemeral contacts
+- Show offline state when `mumbleSessionId` is null
+- Disable message input when Mumble contact is offline
+
+### MumbleAdapter.cs
+
+- Verify `voice.message` includes `certHash` for the sender (the session mapping data should have this; may need a small addition to include cert hash in the message payload)
+
+## Server Changes
+
+Minimal. Verify that user list broadcast events include `certHash` for all users (not just Brmble users). If not, add cert hash to the user connected/user list events in `SessionMappingService`.
+
+## Testing
+
+### Manual Scenarios
+
+1. **Happy path:** Brmble user sends DM to pure Mumble user. Mumble user receives it. Mumble user replies. Brmble user sees reply.
+2. **Auto-create contact:** Mumble user sends first DM to Brmble user. Contact auto-created in DM list.
+3. **Reconnection:** Mumble user disconnects, shown as offline. Reconnects — conversation preserved, shown as online.
+4. **Session cleanup:** Brmble user disconnects from server. All Mumble DM contacts cleared.
+5. **Transport selection:** Right-click a user with Matrix ID → Matrix DM. Right-click a user without → Mumble DM.
+6. **Brmble user on Mumble client:** Right-click them → Matrix DM (they have a Matrix ID even though they're on a Mumble client).
+7. **Offline send blocked:** Mumble contact offline → message input disabled, cannot send.
+8. **Unread tracking:** Mumble DM arrives while viewing channels → unread badge appears.

--- a/docs/plans/2026-03-23-mumble-dm-implementation.md
+++ b/docs/plans/2026-03-23-mumble-dm-implementation.md
@@ -1,0 +1,689 @@
+# Mumble DM Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable Brmble users to send/receive DMs with pure Mumble users via Mumble's native private message system.
+
+**Architecture:** Frontend-only transport selection. If the target user has a `matrixUserId`, use Matrix DMs (existing). If not, use Mumble PMs via `voice.sendPrivateMessage` bridge. Mumble DM contacts and messages are ephemeral (in-memory only, cleared on disconnect). Mumble users are identified across reconnects by their certificate hash.
+
+**Tech Stack:** React + TypeScript (frontend), C# + MumbleSharp (client bridge)
+
+**Design doc:** `docs/plans/2026-03-23-mumble-dm-design.md`
+
+---
+
+### Task 1: Add certHash to voice.userJoined and voice.message bridge events
+
+The frontend needs certificate hashes for all Mumble users, but `MumbleAdapter.cs` currently doesn't include them in bridge events. MumbleSharp already parses `User.CertificateHash` from the protocol.
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:2119-2131` (voice.userJoined)
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:2256-2266` (voice.message / TextMessage override)
+
+**Step 1: Add `certHash` to the `voice.userJoined` payload**
+
+In `MumbleAdapter.cs` around line 2119, the `voice.userJoined` bridge message is sent. Add `certHash` from the MumbleSharp User object:
+
+```csharp
+_bridge?.Send("voice.userJoined", new
+{
+    session = userState.Session,
+    name = joinedUserName,
+    channelId = currentChannelId,
+    muted = ...,
+    deafened = ...,
+    self = isSelf,
+    comment = user?.Comment,
+    matrixUserId = _sessionMappings.TryGetValue(userState.Session, out var sm)
+        ? sm.MatrixUserId
+        : _userMappings.GetValueOrDefault(joinedUserName),
+    certHash = user?.CertificateHash,  // NEW
+});
+```
+
+Find the exact location by looking at the existing `voice.userJoined` send call near line 2119. The `user` variable is the MumbleSharp `User` object — add `certHash = user?.CertificateHash` to the anonymous object.
+
+**Step 2: Add `certHash` to the `voice.message` (TextMessage) payload**
+
+In `MumbleAdapter.cs` around line 2256, the `TextMessage` override sends `voice.message`. Add the sender's cert hash:
+
+```csharp
+public override void TextMessage(TextMessage textMessage)
+{
+    base.TextMessage(textMessage);
+    var senderUser = Users.FirstOrDefault(u => u.Id == textMessage.Actor);
+    _bridge?.Send("voice.message", new
+    {
+        message = textMessage.Message,
+        senderSession = textMessage.Actor,
+        channelIds = textMessage.ChannelIds ?? Array.Empty<uint>(),
+        sessions = textMessage.Sessions ?? Array.Empty<uint>(),
+        certHash = senderUser?.CertificateHash,  // NEW
+    });
+}
+```
+
+Note: `Users` is the MumbleSharp user collection on the protocol. The `textMessage.Actor` is the sender's session ID. Look up the sender by session to get their cert hash. Verify the correct property/method to find a user by session ID in MumbleSharp (may be `Users.FirstOrDefault(u => u.Id == textMessage.Actor)` or similar — check MumbleSharp's API).
+
+**Step 3: Commit**
+
+```
+git add src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+git commit -m "feat: include certHash in voice.userJoined and voice.message bridge events"
+```
+
+---
+
+### Task 2: Add certHash to frontend User type and wire through App.tsx
+
+The frontend `User` interface needs a `certHash` field, and the user-join handler needs to read it.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/types/index.ts:15-28` (User interface)
+- Modify: `src/Brmble.Web/src/App.tsx:689` (onVoiceUserJoined handler)
+
+**Step 1: Add `certHash` to the `User` interface**
+
+In `src/Brmble.Web/src/types/index.ts`, add `certHash` to the `User` interface:
+
+```typescript
+export interface User {
+  id?: string;
+  session: number;
+  name: string;
+  channelId?: number;
+  muted?: boolean;
+  deafened?: boolean;
+  self?: boolean;
+  matrixUserId?: string;
+  speaking?: boolean;
+  comment?: string;
+  prioritySpeaker?: boolean;
+  avatarUrl?: string;
+  certHash?: string;  // NEW: Mumble certificate hash, stable across reconnects
+}
+```
+
+**Step 2: Update `onVoiceUserJoined` cast in App.tsx**
+
+In `App.tsx` around line 689, the `onVoiceUserJoined` handler casts the data. Add `certHash` to the type assertion:
+
+```typescript
+const d = data as { session: number; name: string; channelId?: number; muted?: boolean; deafened?: boolean; self?: boolean; comment?: string; matrixUserId?: string; certHash?: string } | undefined;
+```
+
+No other changes needed — the spread `{...d}` into the users array will carry `certHash` through automatically.
+
+**Step 3: Commit**
+
+```
+git add src/Brmble.Web/src/types/index.ts src/Brmble.Web/src/App.tsx
+git commit -m "feat: add certHash to User type and wire from bridge"
+```
+
+---
+
+### Task 3: Extend useDMStore with Mumble contact support
+
+This is the core task. Extend `useDMStore.ts` to manage Mumble DM contacts alongside Matrix contacts.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useDMStore.ts`
+
+**Step 1: Extend DMContact interface**
+
+Replace the existing `DMContact` interface (lines 8-16) with:
+
+```typescript
+export interface DMContact {
+  /** Primary key: matrixUserId for Matrix contacts, mumbleCertHash for Mumble contacts */
+  id: string;
+  displayName: string;
+  avatarUrl?: string;
+  lastMessage?: string;
+  lastMessageTime?: number;
+  unreadCount: number;
+
+  // Mumble DM fields (only set for ephemeral Mumble contacts)
+  isEphemeral?: boolean;
+  mumbleCertHash?: string;
+  mumbleSessionId?: number | null;  // null = offline
+}
+```
+
+**Step 2: Add Mumble contact state and options**
+
+Add to `DMStoreOptions`:
+
+```typescript
+export interface DMStoreOptions {
+  // ... existing fields ...
+  sendMumbleDM?: (targetSession: number, text: string) => void;
+}
+```
+
+Add to `DMStore`:
+
+```typescript
+export interface DMStore {
+  // ... existing fields ...
+  receiveMumbleDM: (certHash: string, sessionId: number, displayName: string, text: string) => void;
+  updateMumbleSession: (certHash: string, sessionId: number | null, displayName?: string) => void;
+  clearMumbleContacts: () => void;
+  startMumbleDM: (certHash: string, sessionId: number, displayName: string) => void;
+}
+```
+
+**Step 3: Add Mumble state inside the hook**
+
+After the existing `pendingMessages` state (line 62), add:
+
+```typescript
+const [mumbleContacts, setMumbleContacts] = useState<Map<string, DMContact>>(new Map());
+const [mumbleMessages, setMumbleMessages] = useState<Map<string, ChatMessage[]>>(new Map());
+```
+
+**Step 4: Extend the `contacts` memo to merge Mumble contacts**
+
+Update the `contacts` useMemo (starting at line 91). After building the Matrix `result` array, merge Mumble contacts:
+
+```typescript
+const contacts: DMContact[] = useMemo(() => {
+  // ... existing Matrix contact derivation (unchanged) ...
+
+  // Merge Mumble contacts
+  for (const [, mc] of mumbleContacts) {
+    const msgs = mumbleMessages.get(mc.mumbleCertHash!);
+    const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
+    result.push({
+      ...mc,
+      lastMessage: lastMsg?.content,
+      lastMessageTime: lastMsg?.timestamp.getTime(),
+    });
+  }
+
+  result.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
+  return result;
+}, [matrixDmRoomMap, matrixDmMessages, matrixDmUserDisplayNames, users, mumbleContacts, mumbleMessages]);
+```
+
+**Step 5: Extend messages memo for Mumble contacts**
+
+Update the `messages` useMemo (line 128). After getting Matrix messages, also check Mumble messages:
+
+```typescript
+const messages: ChatMessage[] = useMemo(() => {
+  if (!selectedContactId) return [];
+  // Check if this is a Mumble contact
+  const mumbleMsgs = mumbleMessages.get(selectedContactId);
+  if (mumbleMsgs) return mumbleMsgs;
+  // Otherwise Matrix messages
+  const matrixMsgs = matrixDmMessages?.get(selectedContactId) ?? [];
+  const pending = pendingMessages.get(selectedContactId) ?? [];
+  return [...matrixMsgs, ...pending];
+}, [selectedContactId, matrixDmMessages, pendingMessages, mumbleMessages]);
+```
+
+**Step 6: Extend sendMessage for Mumble contacts**
+
+Update `sendMessage` (line 163). Before the Matrix send path, check if the selected contact is ephemeral:
+
+```typescript
+const sendMessage = useCallback((content: string) => {
+  if (!selectedContactId) return;
+
+  const contact = mumbleContacts.get(selectedContactId);
+  if (contact?.isEphemeral) {
+    // Mumble DM path
+    if (contact.mumbleSessionId == null) return; // offline, can't send
+    const msg: ChatMessage = {
+      id: `mumble-${Date.now()}-${Math.random()}`,
+      channelId: selectedContactId,
+      sender: username,
+      content,
+      timestamp: new Date(),
+    };
+    setMumbleMessages(prev => {
+      const next = new Map(prev);
+      const existing = next.get(selectedContactId!) ?? [];
+      next.set(selectedContactId!, [...existing, msg]);
+      return next;
+    });
+    options.sendMumbleDM?.(contact.mumbleSessionId, content);
+    return;
+  }
+
+  // ... existing Matrix send path (unchanged) ...
+}, [selectedContactId, username, sendMatrixDM, mumbleContacts, options.sendMumbleDM]);
+```
+
+Note: `options` needs to be accessible — destructure `sendMumbleDM` from `options` at the top alongside the other destructured fields.
+
+**Step 7: Add Mumble-specific actions**
+
+Add these callbacks after the existing actions:
+
+```typescript
+const receiveMumbleDM = useCallback((certHash: string, sessionId: number, displayName: string, text: string) => {
+  // Ensure contact exists
+  setMumbleContacts(prev => {
+    const next = new Map(prev);
+    if (!next.has(certHash)) {
+      next.set(certHash, {
+        id: certHash,
+        displayName,
+        unreadCount: 0,
+        isEphemeral: true,
+        mumbleCertHash: certHash,
+        mumbleSessionId: sessionId,
+      });
+    }
+    return next;
+  });
+  // Append message
+  const msg: ChatMessage = {
+    id: `mumble-${Date.now()}-${Math.random()}`,
+    channelId: certHash,
+    sender: displayName,
+    content: text,
+    timestamp: new Date(),
+  };
+  setMumbleMessages(prev => {
+    const next = new Map(prev);
+    const existing = next.get(certHash) ?? [];
+    next.set(certHash, [...existing, msg]);
+    return next;
+  });
+  // Increment unread if not currently viewing this contact
+  if (selectedContactIdRef.current !== certHash || appModeRef.current !== 'dm') {
+    setMumbleContacts(prev => {
+      const next = new Map(prev);
+      const contact = next.get(certHash);
+      if (contact) {
+        next.set(certHash, { ...contact, unreadCount: contact.unreadCount + 1 });
+      }
+      return next;
+    });
+  }
+}, []);
+
+const updateMumbleSession = useCallback((certHash: string, sessionId: number | null, displayName?: string) => {
+  setMumbleContacts(prev => {
+    const next = new Map(prev);
+    const contact = next.get(certHash);
+    if (contact) {
+      next.set(certHash, { ...contact, mumbleSessionId: sessionId ?? undefined, displayName: displayName ?? contact.displayName });
+    }
+    return next;
+  });
+}, []);
+
+const clearMumbleContacts = useCallback(() => {
+  setMumbleContacts(new Map());
+  setMumbleMessages(new Map());
+}, []);
+
+const startMumbleDM = useCallback((certHash: string, sessionId: number, displayName: string) => {
+  setMumbleContacts(prev => {
+    const next = new Map(prev);
+    if (!next.has(certHash)) {
+      next.set(certHash, {
+        id: certHash,
+        displayName,
+        unreadCount: 0,
+        isEphemeral: true,
+        mumbleCertHash: certHash,
+        mumbleSessionId: sessionId,
+      });
+    }
+    return next;
+  });
+  setSelectedContactId(certHash);
+  setAppMode('dm');
+}, []);
+```
+
+**Step 8: Extend the disconnect reset**
+
+In the `useEffect` that resets on disconnect (line 79), also clear Mumble state:
+
+```typescript
+useEffect(() => {
+  if (users.length === 0) {
+    setAppMode('channels');
+    setSelectedContactId(null);
+    setPendingMessages(new Map());
+    setMumbleContacts(new Map());   // NEW
+    setMumbleMessages(new Map());    // NEW
+    appModeRef.current = 'channels';
+    selectedContactIdRef.current = null;
+  }
+}, [users.length]);
+```
+
+**Step 9: Clear unread on select**
+
+When selecting a Mumble contact, clear its unread count. Extend `selectContact`:
+
+```typescript
+const selectContact = useCallback((id: string) => {
+  setSelectedContactId(id);
+  setAppMode('dm');
+
+  // Clear Mumble unread if applicable
+  setMumbleContacts(prev => {
+    const contact = prev.get(id);
+    if (contact && contact.unreadCount > 0) {
+      const next = new Map(prev);
+      next.set(id, { ...contact, unreadCount: 0 });
+      return next;
+    }
+    return prev;
+  });
+
+  if (fetchDMHistory) {
+    fetchDMHistory(id).catch(console.warn);
+  }
+}, [fetchDMHistory]);
+```
+
+**Step 10: Update return object**
+
+Add the new actions to the return:
+
+```typescript
+return {
+  // ... existing ...
+  receiveMumbleDM,
+  updateMumbleSession,
+  clearMumbleContacts,
+  startMumbleDM,
+};
+```
+
+**Step 11: Commit**
+
+```
+git add src/Brmble.Web/src/hooks/useDMStore.ts
+git commit -m "feat: extend useDMStore with Mumble DM contact and message support"
+```
+
+---
+
+### Task 4: Wire Mumble DM events in App.tsx
+
+Connect the bridge events to `useDMStore`'s new Mumble actions.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+
+**Step 1: Pass `sendMumbleDM` to useDMStore options**
+
+Where `useDMStore` is instantiated (find the call site), add:
+
+```typescript
+const dmStore = useDMStore({
+  // ... existing options ...
+  sendMumbleDM: (targetSession: number, text: string) => {
+    bridge.send('voice.sendPrivateMessage', { message: text, targetSession });
+  },
+});
+```
+
+**Step 2: Handle incoming private Mumble messages**
+
+In `onVoiceMessage` (around line 635), replace the comment at line 673 (`// Private Mumble messages are ignored — DMs are Matrix-only`) with actual handling:
+
+```typescript
+// Private Mumble message → route to DM store
+if (isPrivateMessage) {
+  const d2 = data as { certHash?: string };
+  const senderCertHash = d2?.certHash;
+  if (senderCertHash) {
+    dmStore.receiveMumbleDM(senderCertHash, d.senderSession!, senderName, d.message);
+  }
+  return;
+}
+```
+
+Note: `dmStore` needs to be accessible from within `onVoiceMessage`. Since `onVoiceMessage` is defined inside the same component, it should have access via closure. However, beware of stale closures — you may need a ref for `dmStore` or use `dmStoreRef.current.receiveMumbleDM(...)`. Check how other dmStore calls are made in the bridge callbacks.
+
+**Step 3: Extend `handleStartDMFromContextMenu`**
+
+Replace the existing handler (lines 1315-1321):
+
+```typescript
+const handleStartDMFromContextMenu = useCallback((sessionIdStr: string, userName: string) => {
+  const user = users.find(u => String(u.session) === sessionIdStr);
+  if (user?.matrixUserId) {
+    dmStore.startDM(user.matrixUserId, userName);
+  } else if (user?.certHash) {
+    dmStore.startMumbleDM(user.certHash, user.session, userName);
+  }
+  // Users with neither matrixUserId nor certHash can't receive DMs
+}, [users, dmStore]);
+```
+
+**Step 4: Handle Mumble user disconnect/reconnect**
+
+In `onVoiceUserLeft` (around line 753), after removing the user from the users list, update the Mumble DM contact's session:
+
+```typescript
+const onVoiceUserLeft = ((data: unknown) => {
+  const d = data as { session: number; name?: string; channelId?: number; certHash?: string } | undefined;
+  if (d?.session) {
+    // ... existing speak announcement logic ...
+    
+    // Update Mumble DM contact session to null (offline)
+    const leavingUser = usersRef.current.find(u => u.session === d.session);
+    const certHash = d.certHash || leavingUser?.certHash;
+    if (certHash) {
+      dmStore.updateMumbleSession(certHash, null);
+    }
+
+    setUsers(prev => prev.filter(u => u.session !== d.session));
+  }
+});
+```
+
+For reconnection, `onVoiceUserJoined` already adds the user with their `certHash`. Add session reattachment:
+
+```typescript
+// In onVoiceUserJoined, after the setUsers call:
+if (d.certHash && !d.self) {
+  dmStore.updateMumbleSession(d.certHash, d.session, d.name);
+}
+```
+
+**Step 5: Include Mumble DM unreads in totalDmUnreadCount**
+
+The `totalDmUnreadCount` memo (line 329) currently only uses Matrix unreads. Extend it to include Mumble DM unreads:
+
+```typescript
+const totalDmUnreadCount = useMemo(() => {
+  let total = unreadTracker.totalDmUnreadCount;
+  // Add Mumble DM unreads
+  for (const contact of dmStore.contacts) {
+    if (contact.isEphemeral) {
+      total += contact.unreadCount;
+    }
+  }
+  return total;
+}, [unreadTracker.totalDmUnreadCount, dmStore.contacts]);
+```
+
+**Step 6: Verify `voice.userLeft` includes certHash from bridge**
+
+Check if `MumbleAdapter.cs` includes `certHash` in the `voice.userLeft` event. If not, this needs to be added in a sub-step (similar to Task 1). The `onVoiceUserLeft` handler can fall back to looking up the cert hash from `usersRef.current` before the user is removed.
+
+**Step 7: Commit**
+
+```
+git add src/Brmble.Web/src/App.tsx
+git commit -m "feat: wire Mumble DM events to useDMStore in App.tsx"
+```
+
+---
+
+### Task 5: Update DMContactList for ephemeral contacts
+
+Add visual indicators for Mumble DM contacts and handle the offline state.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/DMContactList/DMContactList.tsx`
+- Modify: `src/Brmble.Web/src/components/DMContactList/DMContactList.css`
+
+**Step 1: Add ephemeral indicator to contact entries**
+
+In `DMContactList.tsx`, inside the contact entry `<button>` (around line 66-96), add an "online only" tag for ephemeral contacts and an offline indicator:
+
+After the contact name span (line 80-83), add:
+
+```tsx
+{contact.isEphemeral && (
+  <span className="dm-contact-ephemeral-tag">mumble</span>
+)}
+```
+
+Add an offline overlay or muted style when `contact.mumbleSessionId == null && contact.isEphemeral`:
+
+```tsx
+<button
+  key={contact.id}
+  className={`dm-contact-entry ${selectedUserId === contact.id ? 'active' : ''} ${contact.isEphemeral && contact.mumbleSessionId == null ? 'offline' : ''}`}
+  // ...
+>
+```
+
+**Step 2: Add CSS for ephemeral tag and offline state**
+
+In `DMContactList.css`, add:
+
+```css
+.dm-contact-ephemeral-tag {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  background: var(--bg-deep);
+  padding: 0 var(--space-2xs);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.dm-contact-entry.offline {
+  opacity: 0.5;
+}
+
+.dm-contact-entry.offline .dm-contact-name {
+  color: var(--text-muted);
+}
+```
+
+**Step 3: Update the Avatar component call for Mumble contacts**
+
+The Avatar currently passes `matrixUserId: contact.id`. For Mumble contacts, `contact.id` is a cert hash, not a Matrix user ID. Update:
+
+```tsx
+<Avatar
+  user={{
+    name: contact.displayName,
+    matrixUserId: contact.isEphemeral ? undefined : contact.id,
+    avatarUrl: contact.avatarUrl
+  }}
+  size={28}
+/>
+```
+
+**Step 4: Commit**
+
+```
+git add src/Brmble.Web/src/components/DMContactList/DMContactList.tsx src/Brmble.Web/src/components/DMContactList/DMContactList.css
+git commit -m "feat: add ephemeral indicator and offline state to DMContactList"
+```
+
+---
+
+### Task 6: Disable message input for offline Mumble contacts
+
+When a Mumble DM contact is offline (disconnected), the chat panel should disable message input and show a note.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx` (pass contact info to ChatPanel)
+- Possibly modify: `src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx`
+
+**Step 1: Determine how ChatPanel receives its disabled state**
+
+Read `ChatPanel.tsx` to understand its props. The message input likely has a disabled or placeholder prop. Pass whether the selected contact is an offline Mumble user.
+
+Wherever the DM chat input is rendered, add a conditional:
+
+```tsx
+const isContactOffline = dmStore.selectedContact?.isEphemeral && dmStore.selectedContact?.mumbleSessionId == null;
+```
+
+Pass this as a prop to the chat panel or input component. If the input area is directly in App.tsx, add the `disabled` attribute and a placeholder like "User is offline".
+
+**Step 2: Commit**
+
+```
+git add -A
+git commit -m "feat: disable message input for offline Mumble DM contacts"
+```
+
+---
+
+### Task 7: Add certHash to voice.userLeft bridge event
+
+The `voice.userLeft` event from `MumbleAdapter.cs` likely doesn't include `certHash`. Add it so the frontend can match disconnecting users to their DM contacts.
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` (voice.userLeft emission)
+
+**Step 1: Find the `voice.userLeft` emission**
+
+Search for `voice.userLeft` in MumbleAdapter.cs. Add `certHash` to the payload, looking up the user's cert hash before they're removed from the Users collection.
+
+```csharp
+_bridge?.Send("voice.userLeft", new
+{
+    session = userState.Session,
+    name = ...,
+    channelId = ...,
+    certHash = user?.CertificateHash,  // NEW
+});
+```
+
+**Step 2: Update the type assertion in App.tsx `onVoiceUserLeft`**
+
+Already handled in Task 4 step 4 (the cast includes `certHash`).
+
+**Step 3: Commit**
+
+```
+git add src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+git commit -m "feat: include certHash in voice.userLeft bridge event"
+```
+
+---
+
+### Task 8: Build verification and manual testing
+
+**Step 1: Run the frontend build**
+
+```bash
+cd src/Brmble.Web && npx tsc -b && npx vite build
+```
+
+Expected: Clean build, no type errors.
+
+**Step 2: Fix any build errors**
+
+Address type errors, missing imports, or interface mismatches.
+
+**Step 3: Commit any fixes**
+
+```
+git add -A
+git commit -m "fix: resolve build errors from Mumble DM implementation"
+```

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -2110,6 +2110,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 channelId = previousUserChannel,
                 previousChannelId = previousUserChannel,
                 currentChannelId = currentChannelId,
+                certHash = user?.CertificateHash,
                 moved = true
             });
             Debug.WriteLine($"[Mumble] User left our channel: {leftUserName} (session: {userState.Session})");
@@ -2125,6 +2126,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             deafened = user != null ? (user.Deaf || user.SelfDeaf) : (userState.Deaf || userState.SelfDeaf),
             self = isSelf,
             comment = user?.Comment,
+            certHash = user?.CertificateHash,
             matrixUserId = _sessionMappings.TryGetValue(userState.Session, out var sm)
                 ? sm.MatrixUserId
                 : _userMappings.GetValueOrDefault(joinedUserName)
@@ -2203,7 +2205,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         _audioManager?.RemoveUser(userRemove.Session);
         var channelId = user?.Channel?.Id;
-        _bridge?.Send("voice.userLeft", new { session = userRemove.Session, name = userName, channelId, moved = false });
+        var certHash = user?.CertificateHash;
+        _bridge?.Send("voice.userLeft", new { session = userRemove.Session, name = userName, channelId, certHash, moved = false });
 
         // Emit system message
         if (isSelf)
@@ -2256,12 +2259,14 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     public override void TextMessage(TextMessage textMessage)
     {
         base.TextMessage(textMessage);
+        UserDictionary.TryGetValue(textMessage.Actor, out var senderUser);
         _bridge?.Send("voice.message", new
         {
             message = textMessage.Message,
             senderSession = textMessage.Actor,
             channelIds = textMessage.ChannelIds ?? Array.Empty<uint>(),
             sessions = textMessage.Sessions ?? Array.Empty<uint>(),
+            certHash = senderUser?.CertificateHash,
         });
     }
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -62,7 +62,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     })
     { Timeout = TimeSpan.FromSeconds(5) };
 
-    private record SessionMappingEntry(string MatrixUserId, string MumbleName);
+    private record SessionMappingEntry(string MatrixUserId, string MumbleName, bool IsBrmbleClient = false);
 
     public string ServiceName => "mumble";
 
@@ -1362,12 +1362,15 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                                 var matrixId = prop.Value.TryGetProperty("matrixUserId", out var m) ? m.GetString() : null;
                                 var name = prop.Value.TryGetProperty("mumbleName", out var n) ? n.GetString() : null;
                                 if (matrixId is not null && name is not null)
-                                    _sessionMappings[sid] = new SessionMappingEntry(matrixId, name);
+                                {
+                                    var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b) && b.GetBoolean();
+                                    _sessionMappings[sid] = new SessionMappingEntry(matrixId, name, isBrmble);
+                                }
                             }
                         }
                     }
                     _bridge?.Send("voice.sessionMappingSnapshot",
-                        new { mappings = _sessionMappings.ToDictionary(k => k.Key, k => new { k.Value.MatrixUserId, k.Value.MumbleName }) });
+                        new { mappings = _sessionMappings.ToDictionary(k => k.Key, k => new { k.Value.MatrixUserId, k.Value.MumbleName, k.Value.IsBrmbleClient }) });
                     _bridge?.NotifyUiThread();
                     break;
 
@@ -1375,10 +1378,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                     var addSid = root.TryGetProperty("sessionId", out var sidProp) ? sidProp.GetUInt32() : 0u;
                     var addMatrixId = root.TryGetProperty("matrixUserId", out var matrixProp) ? matrixProp.GetString() : null;
                     var addName = root.TryGetProperty("mumbleName", out var nameProp) ? nameProp.GetString() : null;
+                    var addIsBrmble = root.TryGetProperty("isBrmbleClient", out var brmbleProp) && brmbleProp.GetBoolean();
                     if (addSid > 0 && addMatrixId is not null && addName is not null)
                     {
-                        _sessionMappings[addSid] = new SessionMappingEntry(addMatrixId, addName);
-                        _bridge?.Send("voice.userMappingUpdated", new { sessionId = addSid, matrixUserId = addMatrixId, mumbleName = addName, action = "added" });
+                        _sessionMappings[addSid] = new SessionMappingEntry(addMatrixId, addName, addIsBrmble);
+                        _bridge?.Send("voice.userMappingUpdated", new { sessionId = addSid, matrixUserId = addMatrixId, mumbleName = addName, isBrmbleClient = addIsBrmble, action = "added" });
                         _bridge?.NotifyUiThread();
                     }
                     break;
@@ -1391,6 +1395,26 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                         _bridge?.Send("voice.userMappingUpdated", new { sessionId = rmSid, action = "removed" });
                         _bridge?.NotifyUiThread();
                     }
+                    break;
+
+                case "brmbleClientActivated":
+                    var actSid = root.TryGetProperty("sessionId", out var actSidProp) ? actSidProp.GetUInt32() : 0u;
+                    if (actSid > 0 && _sessionMappings.TryGetValue(actSid, out var actEntry))
+                    {
+                        _sessionMappings[actSid] = actEntry with { IsBrmbleClient = true };
+                    }
+                    _bridge?.Send("voice.brmbleClientActivated", new { sessionId = actSid });
+                    _bridge?.NotifyUiThread();
+                    break;
+
+                case "brmbleClientDeactivated":
+                    var deactSid = root.TryGetProperty("sessionId", out var deactSidProp) ? deactSidProp.GetUInt32() : 0u;
+                    if (deactSid > 0 && _sessionMappings.TryGetValue(deactSid, out var deactEntry))
+                    {
+                        _sessionMappings[deactSid] = deactEntry with { IsBrmbleClient = false };
+                    }
+                    _bridge?.Send("voice.brmbleClientDeactivated", new { sessionId = deactSid });
+                    _bridge?.NotifyUiThread();
                     break;
 
                 case "screenShare.started":
@@ -2010,19 +2034,22 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     {
         var channelId = overrideChannelId ?? (uint)(LocalUser?.Channel?.Id ?? 0);
         var channels = Channels.Select(c => new { id = c.Id, name = c.Name, parent = c.Parent }).ToList();
-        var users = Users.Select(u => new
+        var users = Users.Select(u =>
         {
-            session = u.Id,
-            name = u.Name,
-            channelId = u.Channel?.Id ?? 0,
-            muted = u.Muted || u.SelfMuted || u.Deaf || u.SelfDeaf,
-            deafened = u.Deaf || u.SelfDeaf,
-            self = u == LocalUser,
-            comment = u.Comment,
-            certHash = u.CertificateHash,
-            matrixUserId = _sessionMappings.TryGetValue(u.Id, out var sm)
-                ? sm.MatrixUserId
-                : _userMappings.GetValueOrDefault(u.Name)
+            var hasMap = _sessionMappings.TryGetValue(u.Id, out var sm);
+            return new
+            {
+                session = u.Id,
+                name = u.Name,
+                channelId = u.Channel?.Id ?? 0,
+                muted = u.Muted || u.SelfMuted || u.Deaf || u.SelfDeaf,
+                deafened = u.Deaf || u.SelfDeaf,
+                self = u == LocalUser,
+                comment = u.Comment,
+                certHash = u.CertificateHash,
+                matrixUserId = hasMap ? sm.MatrixUserId : _userMappings.GetValueOrDefault(u.Name),
+                isBrmbleClient = hasMap && sm.IsBrmbleClient
+            };
         }).ToList();
 
         _bridge?.Send("voice.connected", new
@@ -2116,6 +2143,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         }
 
         var joinedUserName = user?.Name ?? userState.Name;
+        var hasJoinMapping = _sessionMappings.TryGetValue(userState.Session, out var joinMapping);
         _bridge?.Send("voice.userJoined", new
         {
             session = userState.Session,
@@ -2126,9 +2154,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             self = isSelf,
             comment = user?.Comment,
             certHash = user?.CertificateHash,
-            matrixUserId = _sessionMappings.TryGetValue(userState.Session, out var sm)
-                ? sm.MatrixUserId
-                : _userMappings.GetValueOrDefault(joinedUserName)
+            matrixUserId = hasJoinMapping ? joinMapping.MatrixUserId : _userMappings.GetValueOrDefault(joinedUserName),
+            isBrmbleClient = hasJoinMapping && joinMapping.IsBrmbleClient
         });
 
         // Emit system message for genuinely new users (not initial sync, not self)

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -2019,6 +2019,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             deafened = u.Deaf || u.SelfDeaf,
             self = u == LocalUser,
             comment = u.Comment,
+            certHash = u.CertificateHash,
             matrixUserId = _sessionMappings.TryGetValue(u.Id, out var sm)
                 ? sm.MatrixUserId
                 : _userMappings.GetValueOrDefault(u.Name)
@@ -2081,8 +2082,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         {
             SendRequestBlob(new RequestBlob { SessionComments = new[] { userState.Session } });
         }
-
-        Debug.WriteLine($"[Mumble] UserState: {user?.Name ?? userState.Name} (session: {userState.Session}), isNew: {isNewUser}, prevChannel: {previousUserChannel}");
 
         var isSelf = LocalUser != null && userState.Session == LocalUser.Id;
         var currentChannelId = user?.Channel?.Id ?? userState.ChannelId;

--- a/src/Brmble.Server/Auth/AuthService.cs
+++ b/src/Brmble.Server/Auth/AuthService.cs
@@ -37,6 +37,7 @@ public class AuthService : IActiveBrmbleSessions
     private readonly ILogger<AuthService> _logger;
     private readonly IMumbleRegistrationService _mumbleRegistration;
     private readonly ISessionMappingService _sessionMapping;
+    private readonly IBrmbleEventBus _eventBus;
     private readonly HashSet<string> _activeSessions = [];
     private readonly HashSet<string> _activeNames = [];
     private readonly Dictionary<string, string> _certToName = [];
@@ -50,13 +51,15 @@ public class AuthService : IActiveBrmbleSessions
         IMatrixAppService matrixAppService,
         ILogger<AuthService> logger,
         IMumbleRegistrationService mumbleRegistration,
-        ISessionMappingService sessionMapping)
+        ISessionMappingService sessionMapping,
+        IBrmbleEventBus eventBus)
     {
         _userRepository = userRepository;
         _matrixAppService = matrixAppService;
         _logger = logger;
         _mumbleRegistration = mumbleRegistration;
         _sessionMapping = sessionMapping;
+        _eventBus = eventBus;
     }
 
     public bool IsBrmbleClient(string certHash)
@@ -247,7 +250,18 @@ public class AuthService : IActiveBrmbleSessions
             _activeSessions.Add(certHash);
         }
 
-        return new AuthResult(user!.Id, user.MatrixUserId, user.MatrixAccessToken!, user.DisplayName, isRegistered);
+        // Broadcast Brmble client activation
+        if (_sessionMapping.TryGetSessionByUserId(user!.Id, out var activatedSessionId))
+        {
+            _sessionMapping.TryUpdateBrmbleStatus(activatedSessionId, true);
+            _ = _eventBus.BroadcastAsync(new
+            {
+                type = "brmbleClientActivated",
+                sessionId = activatedSessionId
+            });
+        }
+
+        return new AuthResult(user.Id, user.MatrixUserId, user.MatrixAccessToken!, user.DisplayName, isRegistered);
     }
 
     public void Deactivate(string certHash)
@@ -256,7 +270,19 @@ public class AuthService : IActiveBrmbleSessions
         {
             _activeSessions.Remove(certHash);
             if (_certToName.Remove(certHash, out var name))
+            {
                 _activeNames.Remove(name);
+                // Broadcast Brmble client deactivation
+                if (_sessionMapping.TryGetSessionId(name, out var deactivatedSessionId))
+                {
+                    _sessionMapping.TryUpdateBrmbleStatus(deactivatedSessionId, false);
+                    _ = _eventBus.BroadcastAsync(new
+                    {
+                        type = "brmbleClientDeactivated",
+                        sessionId = deactivatedSessionId
+                    });
+                }
+            }
         }
     }
 

--- a/src/Brmble.Server/Events/ISessionMappingService.cs
+++ b/src/Brmble.Server/Events/ISessionMappingService.cs
@@ -1,6 +1,6 @@
 namespace Brmble.Server.Events;
 
-public record SessionMapping(string MatrixUserId, string MumbleName, long UserId);
+public record SessionMapping(string MatrixUserId, string MumbleName, long UserId, bool IsBrmbleClient = false);
 
 public interface ISessionMappingService
 {

--- a/src/Brmble.Server/Events/ISessionMappingService.cs
+++ b/src/Brmble.Server/Events/ISessionMappingService.cs
@@ -10,5 +10,6 @@ public interface ISessionMappingService
     bool TryGetMatrixUserId(int sessionId, out string? matrixUserId);
     bool TryGetSessionId(string mumbleName, out int sessionId);
     bool TryGetSessionByUserId(long userId, out int sessionId);
+    bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient);
     IReadOnlyDictionary<int, SessionMapping> GetSnapshot();
 }

--- a/src/Brmble.Server/Events/SessionMappingHandler.cs
+++ b/src/Brmble.Server/Events/SessionMappingHandler.cs
@@ -8,17 +8,20 @@ public class SessionMappingHandler : IMumbleEventHandler
     private readonly ISessionMappingService _sessionMapping;
     private readonly IBrmbleEventBus _eventBus;
     private readonly UserRepository _userRepository;
+    private readonly IActiveBrmbleSessions _activeSessions;
     private readonly ILogger<SessionMappingHandler> _logger;
 
     public SessionMappingHandler(
         ISessionMappingService sessionMapping,
         IBrmbleEventBus eventBus,
         UserRepository userRepository,
+        IActiveBrmbleSessions activeSessions,
         ILogger<SessionMappingHandler> logger)
     {
         _sessionMapping = sessionMapping;
         _eventBus = eventBus;
         _userRepository = userRepository;
+        _activeSessions = activeSessions;
         _logger = logger;
     }
 
@@ -29,17 +32,20 @@ public class SessionMappingHandler : IMumbleEventHandler
         var dbUser = await _userRepository.GetByCertHash(user.CertHash);
         if (dbUser is null) return;
 
+        var isBrmbleClient = _activeSessions.IsBrmbleClient(user.CertHash);
+
         if (_sessionMapping.TryAddMatrixUser(user.SessionId, dbUser.MatrixUserId, user.Name, dbUser.Id))
         {
             _logger.LogInformation(
-                "Mapped session {Session} ({Name}) to {MatrixUserId} via cert",
-                user.SessionId, user.Name, dbUser.MatrixUserId);
+                "Mapped session {Session} ({Name}) to {MatrixUserId} via cert (brmbleClient={IsBrmble})",
+                user.SessionId, user.Name, dbUser.MatrixUserId, isBrmbleClient);
             await _eventBus.BroadcastAsync(new
             {
                 type = "userMappingAdded",
                 sessionId = user.SessionId,
                 matrixUserId = dbUser.MatrixUserId,
-                mumbleName = user.Name
+                mumbleName = user.Name,
+                isBrmbleClient
             });
         }
     }

--- a/src/Brmble.Server/Events/SessionMappingService.cs
+++ b/src/Brmble.Server/Events/SessionMappingService.cs
@@ -63,6 +63,16 @@ public class SessionMappingService : ISessionMappingService
         return _userIdToSession.TryGetValue(userId, out sessionId);
     }
 
+    public bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient)
+    {
+        if (_sessionToMapping.TryGetValue(sessionId, out var existing))
+        {
+            _sessionToMapping[sessionId] = existing with { IsBrmbleClient = isBrmbleClient };
+            return true;
+        }
+        return false;
+    }
+
     public IReadOnlyDictionary<int, SessionMapping> GetSnapshot()
     {
         return new Dictionary<int, SessionMapping>(_sessionToMapping);

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -46,7 +46,7 @@ public static class BrmbleWebSocketHandler
             var snapshot = sessionMapping.GetSnapshot()
                 .ToDictionary(
                     kvp => kvp.Key.ToString(),
-                    kvp => new { matrixUserId = kvp.Value.MatrixUserId, mumbleName = kvp.Value.MumbleName });
+                    kvp => new { matrixUserId = kvp.Value.MatrixUserId, mumbleName = kvp.Value.MumbleName, isBrmbleClient = kvp.Value.IsBrmbleClient });
             var snapshotJson = JsonSerializer.Serialize(new { type = "sessionMappingSnapshot", mappings = snapshot }, JsonOptions);
             var snapshotBytes = Encoding.UTF8.GetBytes(snapshotJson);
             await ws.SendAsync(snapshotBytes, WebSocketMessageType.Text, true, context.RequestAborted);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -278,7 +278,28 @@ function App() {
     return set;
   }, [matrixClient?.dmRoomMap]);
 
-  // Determine active Matrix room ID
+  // Per-panel Matrix room IDs for scoping mention suggestions
+  const channelMatrixRoomId = useMemo(() => {
+    if (currentChannelId && currentChannelId !== 'server-root' && matrixCredentials?.roomMap?.[currentChannelId]) {
+      return matrixCredentials.roomMap[currentChannelId];
+    }
+    return null;
+  }, [currentChannelId, matrixCredentials?.roomMap]);
+
+  const channelKey = currentChannelId === 'server-root' ? 'server-root' : currentChannelId ? `channel-${currentChannelId}` : 'no-channel';
+  const { messages, addMessage } = useChatStore(channelKey);
+
+  const dmStore = useDMStore({
+    matrixDmMessages: matrixClient.dmMessages,
+    matrixDmRoomMap: matrixClient.dmRoomMap,
+    sendMatrixDM: matrixClient.sendDMMessage,
+    fetchDMHistory: matrixClient.fetchDMHistory,
+    users,
+    username,
+    bridgeSend: bridge.send,
+  });
+
+  // Determine active Matrix room ID (depends on dmStore.selectedContact)
   const activeMatrixRoomId = useMemo(() => {
     if (dmStore.selectedContact && matrixClient?.dmRoomMap) {
       const roomId = matrixClient.dmRoomMap.get(dmStore.selectedContact.id);
@@ -289,14 +310,6 @@ function App() {
     }
     return null;
   }, [dmStore.selectedContact, currentChannelId, matrixClient?.dmRoomMap, matrixCredentials?.roomMap]);
-
-  // Per-panel Matrix room IDs for scoping mention suggestions
-  const channelMatrixRoomId = useMemo(() => {
-    if (currentChannelId && currentChannelId !== 'server-root' && matrixCredentials?.roomMap?.[currentChannelId]) {
-      return matrixCredentials.roomMap[currentChannelId];
-    }
-    return null;
-  }, [currentChannelId, matrixCredentials?.roomMap]);
 
   const dmMatrixRoomId = useMemo(() => {
     if (dmStore.selectedContact && !dmStore.selectedContact.isEphemeral && matrixClient?.dmRoomMap) {
@@ -313,19 +326,10 @@ function App() {
     certFingerprint,
   );
 
-  const channelKey = currentChannelId === 'server-root' ? 'server-root' : currentChannelId ? `channel-${currentChannelId}` : 'no-channel';
-  const { messages, addMessage } = useChatStore(channelKey);
-
-  const dmStore = useDMStore({
-    matrixDmMessages: matrixClient.dmMessages,
-    matrixDmRoomMap: matrixClient.dmRoomMap,
-    sendMatrixDM: matrixClient.sendDMMessage,
-    fetchDMHistory: matrixClient.fetchDMHistory,
-    users,
-    username,
-    bridgeSend: (event: string, data: unknown) => bridge.send(event, data),
-    matrixDmUnreadCount: unreadTracker.totalDmUnreadCount,
-  });
+  // Combine Matrix + Mumble DM unread counts (computed outside dmStore to avoid circular deps)
+  const totalDmUnreadCount = useMemo(() => {
+    return unreadTracker.totalDmUnreadCount + dmStore.mumbleUnreadCount;
+  }, [unreadTracker.totalDmUnreadCount, dmStore.mumbleUnreadCount]);
 
   const updateBadge = useCallback((unread: number, invite: boolean) => {
     const effectiveUnreadDMs = unread > 0;
@@ -1299,8 +1303,8 @@ const handleConnect = (serverData: SavedServer) => {
 
   // Push DM badge state to native side whenever unread count changes
   useEffect(() => {
-    updateBadge(dmStore.totalUnreadCount, hasPendingInvite);
-  }, [dmStore.totalUnreadCount, hasPendingInvite, updateBadge]);
+    updateBadge(totalDmUnreadCount, hasPendingInvite);
+  }, [totalDmUnreadCount, hasPendingInvite, updateBadge]);
 
   const handleStartDMFromContextMenu = useCallback((sessionIdStr: string, userName: string) => {
     const user = users.find(u => String(u.session) === sessionIdStr);
@@ -1543,7 +1547,7 @@ const handleConnect = (serverData: SavedServer) => {
         username={username}
         onToggleDM={connected ? toggleDMMode : undefined}
         dmActive={dmStore.appMode === 'dm'}
-        unreadDMCount={dmStore.totalUnreadCount}
+        unreadDMCount={totalDmUnreadCount}
         onOpenSettings={() => setShowSettings(true)}
         onAvatarClick={connected ? () => setShowAvatarEditor(true) : undefined}
         avatarUrl={currentUserAvatarUrl}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -297,7 +297,6 @@ function App() {
     fetchDMHistory: matrixClient.fetchDMHistory,
     users,
     username,
-    bridgeSend: bridge.send,
   });
 
   // Determine active Matrix room ID (depends on dmStore.selectedContact)
@@ -313,7 +312,7 @@ function App() {
   }, [dmStore.selectedContact, currentChannelId, matrixClient?.dmRoomMap, matrixCredentials?.roomMap]);
 
   const dmMatrixRoomId = useMemo(() => {
-    if (dmStore.selectedContact && !dmStore.selectedContact.isEphemeral && matrixClient?.dmRoomMap) {
+    if (dmStore.selectedContact && matrixClient?.dmRoomMap) {
       return matrixClient.dmRoomMap.get(dmStore.selectedContact.id) ?? null;
     }
     return null;
@@ -327,10 +326,10 @@ function App() {
     certFingerprint,
   );
 
-  // Combine Matrix + Mumble DM unread counts (computed outside dmStore to avoid circular deps)
+  // DM unread count from Matrix (computed outside dmStore to avoid circular deps)
   const totalDmUnreadCount = useMemo(() => {
-    return unreadTracker.totalDmUnreadCount + dmStore.mumbleUnreadCount;
-  }, [unreadTracker.totalDmUnreadCount, dmStore.mumbleUnreadCount]);
+    return unreadTracker.totalDmUnreadCount;
+  }, [unreadTracker.totalDmUnreadCount]);
 
   const updateBadge = useCallback((unread: number, invite: boolean) => {
     const effectiveUnreadDMs = unread > 0;
@@ -659,13 +658,7 @@ function App() {
         return;
       }
 
-      const { text: dmText, media: dmMedia } = parseMessageMedia(d.message);
-      dmStoreRef.current.receiveMumbleDM(
-        d.senderSession as number,
-        senderName,
-        dmText,
-        dmMedia.length > 0 ? dmMedia : undefined
-      );
+      // Private Mumble messages are ignored — DMs are Matrix-only
     });
 
     const onVoiceSystem = ((data: unknown) => {
@@ -1311,9 +1304,8 @@ const handleConnect = (serverData: SavedServer) => {
     const user = users.find(u => String(u.session) === sessionIdStr);
     if (user?.matrixUserId) {
       dmStore.startDM(user.matrixUserId, userName);
-    } else {
-      dmStore.selectContact(`mumble:session:${sessionIdStr}`);
     }
+    // Non-Brmble (Mumble-only) users can't receive DMs — do nothing
   }, [users, dmStore]);
 
   const activeChannelId = currentChannelId && currentChannelId !== 'server-root'
@@ -1499,7 +1491,7 @@ const handleConnect = (serverData: SavedServer) => {
       return;
     }
     // Only Matrix contacts have room IDs for unread tracking
-    if (dmStore.selectedContact.isEphemeral || !matrixClient?.dmRoomMap || !matrixClient?.client) {
+    if (!matrixClient?.dmRoomMap || !matrixClient?.client) {
       if (dmChanged) setDmDividerTs(null);
       return;
     }
@@ -1670,7 +1662,7 @@ const handleConnect = (serverData: SavedServer) => {
           selectedUserId={dmStore.selectedContact?.id ?? null}
           onSelectContact={(id: string, _name: string) => dmStore.selectContact(id)}
           onCloseConversation={dmStore.closeDM}
-          onlineUserIds={users.filter(u => !u.self).map(u => u.matrixUserId ?? `mumble:session:${u.session}`)}
+           onlineUserIds={users.filter(u => !u.self && u.matrixUserId).map(u => u.matrixUserId!)}
           visible={dmStore.appMode === 'dm'}
         />
       </div>

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -686,7 +686,7 @@ function App() {
     });
 
     const onVoiceUserJoined = ((data: unknown) => {
-      const d = data as { session: number; name: string; channelId?: number; muted?: boolean; deafened?: boolean; self?: boolean; comment?: string; matrixUserId?: string } | undefined;
+      const d = data as { session: number; name: string; channelId?: number; muted?: boolean; deafened?: boolean; self?: boolean; comment?: string; matrixUserId?: string; certHash?: string } | undefined;
       if (d?.session && d.channelId !== undefined) {
         const previousChannelId = previousChannelIdRef.current.get(d.session);
         
@@ -751,7 +751,7 @@ function App() {
     });
 
     const onVoiceUserLeft = ((data: unknown) => {
-      const d = data as { session: number; name?: string; channelId?: number } | undefined;
+      const d = data as { session: number; name?: string; channelId?: number; certHash?: string } | undefined;
       if (d?.session) {
         const selfUser = usersRef.current.find(u => u.self);
         const userName = d.name;

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -687,7 +687,10 @@ function App() {
 
       // Private Mumble message → route to DM store
       if (d.certHash) {
-        dmStoreRef.current.receiveMumbleDM(d.certHash, d.senderSession!, senderName, d.message);
+        // Mumble clients send HTML — strip tags and decode entities for plain-text display
+        const { text, media } = parseMessageMedia(d.message);
+        const plainText = text.replace(/<[^>]*>/g, '').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'").trim();
+        dmStoreRef.current.receiveMumbleDM(d.certHash, d.senderSession!, senderName, plainText || d.message);
       }
     });
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1370,22 +1370,22 @@ const handleConnect = (serverData: SavedServer) => {
 
   const handleStartDMFromContextMenu = useCallback((sessionIdStr: string, userName: string) => {
     const user = users.find(u => String(u.session) === sessionIdStr);
-    // If the user has a certHash and an existing Mumble DM contact, prefer that
-    // (handles Brmble-registered users connected via plain Mumble client who already sent a DM)
-    if (user?.certHash) {
+
+    // Route based on whether the user is on a Brmble client
+    if (user?.isBrmbleClient && user.matrixUserId) {
+      // Brmble client → Matrix DM (persistent)
+      dmStore.startDM(user.matrixUserId, userName);
+    } else if (user?.certHash) {
+      // Mumble client (even if Brmble-registered) → Mumble DM (ephemeral)
+      // Check for existing ephemeral contact first
       const existingMumbleContact = dmStore.contacts.find(c => c.isEphemeral && c.mumbleCertHash === user.certHash);
       if (existingMumbleContact) {
         dmStore.selectContact(existingMumbleContact.id);
-        return;
+      } else {
+        dmStore.startMumbleDM(user.certHash, user.session, userName);
       }
-    }
-
-    if (user?.matrixUserId) {
-      dmStore.startDM(user.matrixUserId, userName);
-    } else if (user?.certHash) {
-      dmStore.startMumbleDM(user.certHash, user.session, userName);
     } else {
-      console.warn('[DM] Cannot start DM: user has no matrixUserId or certHash');
+      console.warn('[DM] Cannot start DM: user has no certHash');
     }
   }, [users, dmStore]);
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -122,6 +122,7 @@ interface User {
   comment?: string;
   matrixUserId?: string;
   avatarUrl?: string;
+  certHash?: string;
 }
 
 
@@ -297,6 +298,9 @@ function App() {
     fetchDMHistory: matrixClient.fetchDMHistory,
     users,
     username,
+    sendMumbleDM: (targetSession: number, text: string) => {
+      bridge.send('voice.sendPrivateMessage', { message: text, targetSession });
+    },
   });
 
   // Determine active Matrix room ID (depends on dmStore.selectedContact)
@@ -326,15 +330,23 @@ function App() {
     certFingerprint,
   );
 
-  // DM unread count from Matrix (computed outside dmStore to avoid circular deps)
+  // DM unread count from Matrix + Mumble ephemeral contacts
   const totalDmUnreadCount = useMemo(() => {
-    return unreadTracker.totalDmUnreadCount;
-  }, [unreadTracker.totalDmUnreadCount]);
+    let total = unreadTracker.totalDmUnreadCount;
+    // Add Mumble DM unreads
+    for (const contact of dmStore.contacts) {
+      if (contact.isEphemeral) {
+        total += contact.unreadCount;
+      }
+    }
+    return total;
+  }, [unreadTracker.totalDmUnreadCount, dmStore.contacts]);
 
   // Enrich DM contacts with per-contact unread counts from the unread tracker
   const dmContactsWithUnreads = useMemo(() => {
     if (!matrixClient?.dmRoomMap) return dmStore.contacts;
     return dmStore.contacts.map(contact => {
+      if (contact.isEphemeral) return contact; // Mumble contacts track their own unreads
       const roomId = matrixClient.dmRoomMap?.get(contact.id);
       if (!roomId) return contact;
       const unread = unreadTracker.getRoomUnread(roomId);
@@ -638,6 +650,7 @@ function App() {
         senderSession?: number;
         channelIds?: number[];
         sessions?: number[];
+        certHash?: string;
       } | undefined;
       if (!d?.message) return;
 
@@ -670,7 +683,10 @@ function App() {
         return;
       }
 
-      // Private Mumble messages are ignored — DMs are Matrix-only
+      // Private Mumble message → route to DM store
+      if (d.certHash) {
+        dmStoreRef.current.receiveMumbleDM(d.certHash, d.senderSession!, senderName, d.message);
+      }
     });
 
     const onVoiceSystem = ((data: unknown) => {
@@ -708,6 +724,11 @@ function App() {
         }
         
         previousChannelIdRef.current.set(d.session, d.channelId);
+
+        // Update Mumble DM contact session on reconnect
+        if (d.certHash && !d.self) {
+          dmStoreRef.current.updateMumbleSession(d.certHash, d.session, d.name);
+        }
       }
     });
 
@@ -764,6 +785,14 @@ function App() {
         ) {
           speakText(`${userName} left`);
         }
+
+        // Update Mumble DM contact session to null (offline)
+        const leavingUser = usersRef.current.find(u => u.session === d.session);
+        const certHash = d.certHash || leavingUser?.certHash;
+        if (certHash) {
+          dmStoreRef.current.updateMumbleSession(certHash, null);
+        }
+
         setUsers(prev => prev.filter(u => u.session !== d.session));
       }
     });
@@ -1316,8 +1345,10 @@ const handleConnect = (serverData: SavedServer) => {
     const user = users.find(u => String(u.session) === sessionIdStr);
     if (user?.matrixUserId) {
       dmStore.startDM(user.matrixUserId, userName);
+    } else if (user?.certHash) {
+      dmStore.startMumbleDM(user.certHash, user.session, userName);
     }
-    // Non-Brmble (Mumble-only) users can't receive DMs — do nothing
+    // Users with neither matrixUserId nor certHash can't receive DMs
   }, [users, dmStore]);
 
   const activeChannelId = currentChannelId && currentChannelId !== 'server-root'

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -292,6 +292,7 @@ function App() {
   const dmStore = useDMStore({
     matrixDmMessages: matrixClient.dmMessages,
     matrixDmRoomMap: matrixClient.dmRoomMap,
+    matrixDmUserDisplayNames: matrixClient.dmUserDisplayNames,
     sendMatrixDM: matrixClient.sendDMMessage,
     fetchDMHistory: matrixClient.fetchDMHistory,
     users,

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -23,9 +23,9 @@ import { CloseDialog } from './components/CloseDialog/CloseDialog';
 import { CertWizard } from './components/CertWizard/CertWizard';
 import { Version } from './components/Version/Version';
 import { ZoomIndicator } from './components/ZoomIndicator/ZoomIndicator';
-import { useChatStore, addMessageToStore, clearChatStorage, loadDMContacts, upsertDMContact, markDMContactRead, removeDMContact } from './hooks/useChatStore';
+import { useChatStore, addMessageToStore, clearChatStorage } from './hooks/useChatStore';
 import { parseMessageMedia } from './utils/parseMessageMedia';
-import type { StoredDMContact } from './hooks/useChatStore';
+import { useDMStore } from './hooks/useDMStore';
 import { DMContactList } from './components/DMContactList/DMContactList';
 import { usePrompt, confirm } from './hooks/usePrompt';
 import { Toast } from './components/Toast/Toast';
@@ -125,15 +125,6 @@ interface User {
 }
 
 
-const mapStoredContacts = (contacts: StoredDMContact[]) =>
-  contacts.map(c => ({
-    userId: c.userId,
-    userName: c.userName,
-    lastMessage: c.lastMessage,
-    lastMessageTime: c.lastMessageTime ? new Date(c.lastMessageTime) : undefined,
-    unread: c.unread,
-  }));
-
 function App() {
   // null = status not yet received, false = no cert, true = cert exists
   const [certExists, setCertExists] = useState<boolean | null>(null);
@@ -179,17 +170,6 @@ function App() {
   const pendingChannelActionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [showConnectModal, setShowConnectModal] = useState(false);
-  const [dmContacts, setDmContacts] = useState<ReturnType<typeof mapStoredContacts>>([]);
-  const [appMode, setAppMode] = useState<'channels' | 'dm'>('channels');
-  const [selectedDMUserId, setSelectedDMUserIdRaw] = useState<string | null>(null);
-  const [selectedDMUserName, setSelectedDMUserName] = useState<string>('');
-
-  // Same pattern as setCurrentChannelId: clear the DM divider snapshot synchronously
-  // to prevent stale divider scroll on DM switch.
-  const setSelectedDMUserId = useCallback((id: string | null) => {
-    setSelectedDMUserIdRaw(id);
-    setDmDividerTs(null);
-  }, []);
   const [showSettings, setShowSettings] = useState(false);
   const [showGame, setShowGame] = useState(false);
   const [showAvatarEditor, setShowAvatarEditor] = useState(false);
@@ -204,7 +184,6 @@ function App() {
 
   const [matrixCredentials, setMatrixCredentials] = useState<MatrixCredentials | null>(null);
   const matrixClient = useMatrixClient(matrixCredentials);
-  const { dmMessages: matrixDmMessages, sendDMMessage: sendMatrixDM, fetchDMHistory } = matrixClient;
   useServerHealth();
 
   // Avatar state and management
@@ -301,18 +280,15 @@ function App() {
 
   // Determine active Matrix room ID
   const activeMatrixRoomId = useMemo(() => {
-    if (selectedDMUserId && matrixClient?.dmRoomMap) {
-      const targetUser = users.find(u => String(u.session) === selectedDMUserId);
-      if (targetUser?.matrixUserId) {
-        const roomId = matrixClient.dmRoomMap.get(targetUser.matrixUserId);
-        if (roomId) return roomId;
-      }
+    if (dmStore.selectedContact && matrixClient?.dmRoomMap) {
+      const roomId = matrixClient.dmRoomMap.get(dmStore.selectedContact.id);
+      if (roomId) return roomId;
     }
     if (currentChannelId && currentChannelId !== 'server-root' && matrixCredentials?.roomMap?.[currentChannelId]) {
       return matrixCredentials.roomMap[currentChannelId];
     }
     return null;
-  }, [selectedDMUserId, currentChannelId, matrixClient?.dmRoomMap, matrixCredentials?.roomMap, users]);
+  }, [dmStore.selectedContact, currentChannelId, matrixClient?.dmRoomMap, matrixCredentials?.roomMap]);
 
   // Per-panel Matrix room IDs for scoping mention suggestions
   const channelMatrixRoomId = useMemo(() => {
@@ -323,14 +299,11 @@ function App() {
   }, [currentChannelId, matrixCredentials?.roomMap]);
 
   const dmMatrixRoomId = useMemo(() => {
-    if (selectedDMUserId && matrixClient?.dmRoomMap) {
-      const targetUser = users.find(u => String(u.session) === selectedDMUserId);
-      if (targetUser?.matrixUserId) {
-        return matrixClient.dmRoomMap.get(targetUser.matrixUserId) ?? null;
-      }
+    if (dmStore.selectedContact && !dmStore.selectedContact.isEphemeral && matrixClient?.dmRoomMap) {
+      return matrixClient.dmRoomMap.get(dmStore.selectedContact.id) ?? null;
     }
     return null;
-  }, [selectedDMUserId, matrixClient?.dmRoomMap, users]);
+  }, [dmStore.selectedContact, matrixClient?.dmRoomMap]);
 
   const unreadTracker = useUnreadTracker(
     matrixClient?.client ?? null,
@@ -343,8 +316,16 @@ function App() {
   const channelKey = currentChannelId === 'server-root' ? 'server-root' : currentChannelId ? `channel-${currentChannelId}` : 'no-channel';
   const { messages, addMessage } = useChatStore(channelKey);
 
-  const dmKey = selectedDMUserId ? `dm-${selectedDMUserId}` : 'no-dm';
-  const { messages: dmMessages, addMessage: addDMMessage } = useChatStore(dmKey);
+  const dmStore = useDMStore({
+    matrixDmMessages: matrixClient.dmMessages,
+    matrixDmRoomMap: matrixClient.dmRoomMap,
+    sendMatrixDM: matrixClient.sendDMMessage,
+    fetchDMHistory: matrixClient.fetchDMHistory,
+    users,
+    username,
+    bridgeSend: (event: string, data: unknown) => bridge.send(event, data),
+    matrixDmUnreadCount: unreadTracker.totalDmUnreadCount,
+  });
 
   const updateBadge = useCallback((unread: number, invite: boolean) => {
     const effectiveUnreadDMs = unread > 0;
@@ -365,18 +346,12 @@ function App() {
   unreadCountRef.current = unreadCount;
   const hasPendingInviteRef = useRef(hasPendingInvite);
   hasPendingInviteRef.current = hasPendingInvite;
-  const selectedDMUserIdRef = useRef(selectedDMUserId);
-  selectedDMUserIdRef.current = selectedDMUserId;
-  const appModeRef = useRef(appMode);
-  appModeRef.current = appMode;
-  const setAppModeRef = useRef(setAppMode);
-  setAppModeRef.current = setAppMode;
-  const addDMMessageRef = useRef(addDMMessage);
-  addDMMessageRef.current = addDMMessage;
   const matrixCredentialsRef = useRef(matrixCredentials);
   matrixCredentialsRef.current = matrixCredentials;
   const serverAddressRef = useRef(serverAddress);
   serverAddressRef.current = serverAddress;
+  const dmStoreRef = useRef(dmStore);
+  dmStoreRef.current = dmStore;
   const connectionStatusRef = useRef(connectionStatus);
   connectionStatusRef.current = connectionStatus;
   const handleToggleScreenShareRef = useRef<(() => void) | null>(null);
@@ -392,15 +367,6 @@ function App() {
       userSawConnectedRef.current = true;
     }
   }, [connectionStatus]);
-
-  // Load DM contacts scoped to the current server
-  useEffect(() => {
-    if (serverAddress) {
-      setDmContacts(mapStoredContacts(loadDMContacts(serverAddress)));
-    } else {
-      setDmContacts([]);
-    }
-  }, [serverAddress]);
 
   const clearPendingAction = useCallback(() => {
     if (pendingChannelActionTimeoutRef.current) {
@@ -618,9 +584,6 @@ function App() {
       disconnectViewerRef.current?.();
       setSharingChannelId(undefined);
       setScreenShareToast(null);
-      setAppModeRef.current('channels');
-      setSelectedDMUserIdRaw(null);
-      setSelectedDMUserName('');
       updateStatus('livekit', { state: 'idle', error: undefined });
       updateStatus('server', { state: 'idle', error: undefined });
     };
@@ -691,21 +654,13 @@ function App() {
         return;
       }
 
-      const senderSession = String(d.senderSession);
-      const dmStoreKey = `dm-${senderSession}`;
-
-      const isViewingThisDM = appModeRef.current === 'dm' &&
-        selectedDMUserIdRef.current === senderSession;
-
       const { text: dmText, media: dmMedia } = parseMessageMedia(d.message);
-      if (isViewingThisDM) {
-        addDMMessageRef.current(senderName, dmText, undefined, undefined, dmMedia.length > 0 ? dmMedia : undefined);
-      } else {
-        addMessageToStore(dmStoreKey, senderName, dmText, undefined, undefined, dmMedia.length > 0 ? dmMedia : undefined);
-      }
-
-      const updated = upsertDMContact(senderSession, senderName, d.message, !isViewingThisDM, serverAddressRef.current);
-      setDmContacts(mapStoredContacts(updated));
+      dmStoreRef.current.receiveMumbleDM(
+        d.senderSession as number,
+        senderName,
+        dmText,
+        dmMedia.length > 0 ? dmMedia : undefined
+      );
     });
 
     const onVoiceSystem = ((data: unknown) => {
@@ -896,10 +851,10 @@ function App() {
 
     const onToggleDmScreen = () => {
       if (connectionStatusRef.current !== 'connected') {
-        setAppModeRef.current('channels');
+        dmStoreRef.current.clearSelection();
         return;
       }
-      setAppModeRef.current(prev => prev === 'channels' ? 'dm' : 'channels');
+      dmStoreRef.current.toggleMode();
     };
 
     const onToggleScreenShare = () => {
@@ -1138,26 +1093,6 @@ function App() {
     }
   }, [currentChannelId, matrixCredentials]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Update DM contacts when Matrix DM messages arrive
-  useEffect(() => {
-    if (!matrixDmMessages || matrixDmMessages.size === 0 || !serverAddress) return;
-
-    let updated = false;
-    for (const [matrixUserId, msgs] of matrixDmMessages.entries()) {
-      if (msgs.length === 0) continue;
-      const lastMsg = msgs[msgs.length - 1];
-
-      const matchedUser = users.find(u => u.matrixUserId === matrixUserId);
-      if (!matchedUser) continue;
-
-      const sessionKey = String(matchedUser.session);
-      const isViewing = appMode === 'dm' && selectedDMUserId === sessionKey;
-      upsertDMContact(sessionKey, matchedUser.name, lastMsg.content, !isViewing, serverAddress);
-      updated = true;
-    }
-    if (updated) setDmContacts(mapStoredContacts(loadDMContacts(serverAddress)));
-  }, [matrixDmMessages, users, appMode, selectedDMUserId, serverAddress]);
-
   useEffect(() => {
     return () => {
       if (pendingChannelActionTimeoutRef.current) {
@@ -1234,10 +1169,9 @@ const handleConnect = (serverData: SavedServer) => {
       updateBadge(0, hasPendingInvite);
       setShowGame(false);
 
-      if (appMode === 'dm') {
-        setAppMode('channels');
-        setSelectedDMUserId(null);
-        setSelectedDMUserName('');
+      if (dmStore.appMode === 'dm') {
+        dmStore.toggleMode();
+        dmStore.clearSelection();
       }
     }
   };
@@ -1270,29 +1204,6 @@ const handleConnect = (serverData: SavedServer) => {
 
     setUnreadCount(0);
     updateBadge(0, hasPendingInvite);
-  };
-
-  const handleSendDMMessage = (content: string) => {
-    if (!username || !content || !selectedDMUserId) return;
-
-    // Find the selected user to check for matrixUserId
-    const targetUser = users.find(u => String(u.session) === selectedDMUserId);
-    const targetMatrixId = targetUser?.matrixUserId;
-
-    if (targetMatrixId) {
-      // Matrix path: send via Matrix DM room
-      sendMatrixDM(targetMatrixId, content).catch(console.error);
-    } else {
-      // Mumble fallback: send via bridge + localStorage
-      addDMMessage(username, content);
-      bridge.send('voice.sendPrivateMessage', {
-        message: content,
-        targetSession: Number(selectedDMUserId),
-      });
-    }
-
-    const updated = upsertDMContact(selectedDMUserId, selectedDMUserName, content, false, serverAddress);
-    setDmContacts(mapStoredContacts(updated));
   };
 
   const handleDisconnect = () => {
@@ -1338,9 +1249,6 @@ const handleConnect = (serverData: SavedServer) => {
     setSpeakingUsers(new Map());
     setMatrixCredentials(null);
     setSharingChannelId(undefined);
-    setAppMode('channels');
-    setSelectedDMUserId(null);
-    setSelectedDMUserName('');
   };
 
   const handleToggleMute = () => {
@@ -1386,82 +1294,22 @@ const handleConnect = (serverData: SavedServer) => {
 
   const toggleDMMode = () => {
     setShowGame(false);
-    setAppMode(prev => prev === 'channels' ? 'dm' : 'channels');
+    dmStore.toggleMode();
   };
-
-  // Local fallback: total unread DM messages across all contacts
-  const localTotalDmUnreadCount = dmContacts.reduce(
-    (sum, c) => sum + (c.unread || 0),
-    0,
-  );
-
-  // Combine Matrix DM unread count with local Mumble DM unread count
-  const totalDmUnreadCount = (matrixClient?.client ? unreadTracker.totalDmUnreadCount : 0) + localTotalDmUnreadCount;
 
   // Push DM badge state to native side whenever unread count changes
   useEffect(() => {
-    updateBadge(totalDmUnreadCount, hasPendingInvite);
-  }, [totalDmUnreadCount, hasPendingInvite, updateBadge]);
+    updateBadge(dmStore.totalUnreadCount, hasPendingInvite);
+  }, [dmStore.totalUnreadCount, hasPendingInvite, updateBadge]);
 
-  const userCommentsBySession = useMemo(
-    () =>
-      new Map(
-        users
-          .filter(u => u.comment)
-          .map(u => [String(u.session), u.comment as string]),
-      ),
-    [users],
-  );
-
-  const dmContactsWithComments = useMemo(
-    () =>
-      dmContacts.map(c => {
-        const comment = userCommentsBySession.get(c.userId);
-        const user = users.find(u => String(u.session) === c.userId);
-        return {
-          ...c,
-          ...(comment ? { comment } : {}),
-          ...(user?.matrixUserId ? { matrixUserId: user.matrixUserId } : {}),
-          ...(user?.avatarUrl ? { avatarUrl: user.avatarUrl } : {}),
-        };
-      }),
-    [dmContacts, userCommentsBySession, users],
-  );
-
-  const handleSelectDMUser = (userId: string, userName: string) => {
-    setSelectedDMUserId(userId);
-    setSelectedDMUserName(userName);
-    setAppMode('dm');
-    // Mark this contact as read, then upsert to ensure contact exists
-    markDMContactRead(userId, serverAddress);
-    const updated = upsertDMContact(userId, userName, undefined, false, serverAddress);
-    setDmContacts(mapStoredContacts(updated));
-
-    // Mark Matrix DM room as read
-    const targetUser = users.find(u => String(u.session) === userId);
-
-    // Fetch Matrix DM history if available
-    if (targetUser?.matrixUserId && fetchDMHistory) {
-      fetchDMHistory(targetUser.matrixUserId).catch(console.error);
+  const handleStartDMFromContextMenu = useCallback((sessionIdStr: string, userName: string) => {
+    const user = users.find(u => String(u.session) === sessionIdStr);
+    if (user?.matrixUserId) {
+      dmStore.startDM(user.matrixUserId, userName);
+    } else {
+      dmStore.selectContact(`mumble:session:${sessionIdStr}`);
     }
-  };
-
-  const handleCloseDMConversation = (userId: string) => {
-    const updated = removeDMContact(userId, serverAddress);
-    setDmContacts(mapStoredContacts(updated));
-    if (selectedDMUserId === userId) {
-      setSelectedDMUserId(null);
-      setSelectedDMUserName('');
-      setAppMode('channels');
-    }
-  };
-
-  const availableUsers = users
-    .filter(u => !u.self)
-    .map(u => ({ id: String(u.session), name: u.name }));
-
-  // Suppress unused warnings — these are wired up in subsequent DM tasks
-  void availableUsers;
+  }, [users, dmStore]);
 
   const activeChannelId = currentChannelId && currentChannelId !== 'server-root'
     ? currentChannelId
@@ -1470,13 +1318,6 @@ const handleConnect = (serverData: SavedServer) => {
   const matrixMessages = activeChannelId
     ? matrixClient.messages.get(activeChannelId)
     : undefined;
-
-  // Determine which DM messages to display: Matrix or localStorage
-  const selectedUser = selectedDMUserId ? users.find(u => String(u.session) === selectedDMUserId) : undefined;
-  const selectedMatrixId = selectedUser?.matrixUserId;
-  const activeDmMessages = selectedMatrixId
-    ? (matrixDmMessages?.get(selectedMatrixId) ?? [])
-    : dmMessages;
 
   const { Prompt } = usePrompt();
 
@@ -1642,21 +1483,22 @@ const handleConnect = (serverData: SavedServer) => {
 
   // Same pattern for DM switches
   useEffect(() => {
-    const dmChanged = selectedDMUserId !== prevDMUserIdRef.current;
+    const selectedId = dmStore.selectedContact?.id ?? null;
+    const dmChanged = selectedId !== prevDMUserIdRef.current;
     if (dmChanged) {
-      prevDMUserIdRef.current = selectedDMUserId;
+      prevDMUserIdRef.current = selectedId;
     }
 
-    if (!selectedDMUserId) {
+    if (!selectedId || !dmStore.selectedContact) {
       if (dmChanged) setDmDividerTs(null);
       return;
     }
-    const targetUser = users.find(u => String(u.session) === selectedDMUserId);
-    if (!targetUser?.matrixUserId || !matrixClient?.dmRoomMap || !matrixClient?.client) {
+    // Only Matrix contacts have room IDs for unread tracking
+    if (dmStore.selectedContact.isEphemeral || !matrixClient?.dmRoomMap || !matrixClient?.client) {
       if (dmChanged) setDmDividerTs(null);
       return;
     }
-    const roomId = matrixClient.dmRoomMap.get(targetUser.matrixUserId);
+    const roomId = matrixClient.dmRoomMap.get(selectedId);
     if (!roomId) {
       if (dmChanged) setDmDividerTs(null);
       return;
@@ -1691,7 +1533,7 @@ const handleConnect = (serverData: SavedServer) => {
         return markerTs;
       });
     }
-  }, [selectedDMUserId, unreadTracker.roomUnreads, matrixClient.client, unreadTracker, users]);
+  }, [dmStore.selectedContact, unreadTracker.roomUnreads, matrixClient.client, unreadTracker, matrixClient?.dmRoomMap]);
 
   return (
     <div className="app">
@@ -1700,8 +1542,8 @@ const handleConnect = (serverData: SavedServer) => {
       <Header
         username={username}
         onToggleDM={connected ? toggleDMMode : undefined}
-        dmActive={appMode === 'dm'}
-        unreadDMCount={totalDmUnreadCount}
+        dmActive={dmStore.appMode === 'dm'}
+        unreadDMCount={dmStore.totalUnreadCount}
         onOpenSettings={() => setShowSettings(true)}
         onAvatarClick={connected ? () => setShowAvatarEditor(true) : undefined}
         avatarUrl={currentUserAvatarUrl}
@@ -1738,7 +1580,7 @@ const handleConnect = (serverData: SavedServer) => {
           serverAddress={serverAddress}
           username={username}
           onDisconnect={handleDisconnect}
-          onStartDM={handleSelectDMUser}
+          onStartDM={handleStartDMFromContextMenu}
           speakingUsers={speakingUsers}
           connectionStatus={connectionStatus}
           onCancelReconnect={handleCancelReconnect}
@@ -1769,7 +1611,7 @@ const handleConnect = (serverData: SavedServer) => {
             showGame ? (
               <GameUI onClose={() => setShowGame(false)} />
             ) : (
-              <div className={`content-slider ${appMode === 'dm' ? 'dm-active' : ''}`}>
+              <div className={`content-slider ${dmStore.appMode === 'dm' ? 'dm-active' : ''}`}>
                 <div className="content-slide">
                   <ErrorBoundary label="ChatPanel:Channel">
                    <ChatPanel
@@ -1791,11 +1633,11 @@ const handleConnect = (serverData: SavedServer) => {
                 <div className="content-slide">
                   <ErrorBoundary label="ChatPanel:DM">
                    <ChatPanel
-                    channelId={selectedDMUserId ? `dm-${selectedDMUserId}` : undefined}
-                    channelName={selectedDMUserName}
-                    messages={activeDmMessages}
+                    channelId={dmStore.selectedContact ? `dm-${dmStore.selectedContact.id}` : undefined}
+                    channelName={dmStore.selectedContact?.displayName ?? ''}
+                    messages={dmStore.messages}
                     currentUsername={username}
-                    onSendMessage={handleSendDMMessage}
+                    onSendMessage={dmStore.sendMessage}
                     isDM={true}
                     matrixClient={matrixClient.client}
                     matrixRoomId={dmMatrixRoomId}
@@ -1819,12 +1661,12 @@ const handleConnect = (serverData: SavedServer) => {
         </main>
 
         <DMContactList
-          contacts={dmContactsWithComments}
-          selectedUserId={selectedDMUserId}
-          onSelectContact={handleSelectDMUser}
-          onCloseConversation={handleCloseDMConversation}
-          onlineUserIds={users.filter(u => !u.self).map(u => String(u.session))}
-          visible={appMode === 'dm'}
+          contacts={dmStore.contacts}
+          selectedUserId={dmStore.selectedContact?.id ?? null}
+          onSelectContact={(id: string, _name: string) => dmStore.selectContact(id)}
+          onCloseConversation={dmStore.closeDM}
+          onlineUserIds={users.filter(u => !u.self).map(u => u.matrixUserId ?? `mumble:session:${u.session}`)}
+          visible={dmStore.appMode === 'dm'}
         />
       </div>
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -331,6 +331,18 @@ function App() {
     return unreadTracker.totalDmUnreadCount;
   }, [unreadTracker.totalDmUnreadCount]);
 
+  // Enrich DM contacts with per-contact unread counts from the unread tracker
+  const dmContactsWithUnreads = useMemo(() => {
+    if (!matrixClient?.dmRoomMap) return dmStore.contacts;
+    return dmStore.contacts.map(contact => {
+      const roomId = matrixClient.dmRoomMap?.get(contact.id);
+      if (!roomId) return contact;
+      const unread = unreadTracker.getRoomUnread(roomId);
+      if (unread.notificationCount === contact.unreadCount) return contact;
+      return { ...contact, unreadCount: unread.notificationCount };
+    });
+  }, [dmStore.contacts, matrixClient?.dmRoomMap, unreadTracker]);
+
   const updateBadge = useCallback((unread: number, invite: boolean) => {
     const effectiveUnreadDMs = unread > 0;
     bridge.send('notification.badge', { unreadDMs: effectiveUnreadDMs, pendingInvite: invite });
@@ -1658,7 +1670,7 @@ const handleConnect = (serverData: SavedServer) => {
         </main>
 
         <DMContactList
-          contacts={dmStore.contacts}
+          contacts={dmContactsWithUnreads}
           selectedUserId={dmStore.selectedContact?.id ?? null}
           onSelectContact={(id: string, _name: string) => dmStore.selectContact(id)}
           onCloseConversation={dmStore.closeDM}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -686,7 +686,12 @@ function App() {
 
       // Private Mumble message → route to DM store
       if (d.certHash) {
-        dmStoreRef.current.receiveMumbleDM(d.certHash, d.senderSession!, senderName, d.message);
+        // If sender has a Matrix identity (hybrid user), route to Matrix DM contact
+        if (senderUser?.matrixUserId) {
+          dmStoreRef.current.addIncomingDMMessage(senderUser.matrixUserId, senderName, d.message);
+        } else {
+          dmStoreRef.current.receiveMumbleDM(d.certHash, d.senderSession!, senderName, d.message);
+        }
       }
     });
 
@@ -729,8 +734,9 @@ function App() {
         
         previousChannelIdRef.current.set(d.session, d.channelId);
 
-        // Update Mumble DM contact session on reconnect
-        if (d.certHash && !d.self) {
+        // Update Mumble DM contact session on reconnect (skip hybrid users — they use Matrix)
+        const hasMatrixId = d.matrixUserId || usersRef.current.find(u => u.session === d.session)?.matrixUserId;
+        if (d.certHash && !d.self && !hasMatrixId) {
           dmStoreRef.current.updateMumbleSession(d.certHash, d.session, d.name);
         }
       }
@@ -790,10 +796,10 @@ function App() {
           speakText(`${userName} left`);
         }
 
-        // Update Mumble DM contact session to null (offline)
+        // Update Mumble DM contact session to null (offline) — skip hybrid users (they use Matrix)
         const leavingUser = usersRef.current.find(u => u.session === d.session);
         const certHash = d.certHash || leavingUser?.certHash;
-        if (certHash) {
+        if (certHash && !leavingUser?.matrixUserId) {
           dmStoreRef.current.updateMumbleSession(certHash, null);
         }
 
@@ -1347,16 +1353,7 @@ const handleConnect = (serverData: SavedServer) => {
 
   const handleStartDMFromContextMenu = useCallback((sessionIdStr: string, userName: string) => {
     const user = users.find(u => String(u.session) === sessionIdStr);
-    // If the user has a certHash and an existing Mumble DM contact, prefer that
-    // (handles Brmble-registered users connected via plain Mumble client who already sent a DM)
-    if (user?.certHash) {
-      const existingMumbleContact = dmStore.contacts.find(c => c.isEphemeral && c.mumbleCertHash === user.certHash);
-      if (existingMumbleContact) {
-        dmStore.selectContact(existingMumbleContact.id);
-        return;
-      }
-    }
-
+    // Always prefer Matrix if the user has a Matrix identity (even if they're on a Mumble client)
     if (user?.matrixUserId) {
       dmStore.startDM(user.matrixUserId, userName);
     } else if (user?.certHash) {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -686,12 +686,7 @@ function App() {
 
       // Private Mumble message → route to DM store
       if (d.certHash) {
-        // If sender has a Matrix identity (hybrid user), route to Matrix DM contact
-        if (senderUser?.matrixUserId) {
-          dmStoreRef.current.addIncomingDMMessage(senderUser.matrixUserId, senderName, d.message);
-        } else {
-          dmStoreRef.current.receiveMumbleDM(d.certHash, d.senderSession!, senderName, d.message);
-        }
+        dmStoreRef.current.receiveMumbleDM(d.certHash, d.senderSession!, senderName, d.message);
       }
     });
 
@@ -734,9 +729,8 @@ function App() {
         
         previousChannelIdRef.current.set(d.session, d.channelId);
 
-        // Update Mumble DM contact session on reconnect (skip hybrid users — they use Matrix)
-        const hasMatrixId = d.matrixUserId || usersRef.current.find(u => u.session === d.session)?.matrixUserId;
-        if (d.certHash && !d.self && !hasMatrixId) {
+        // Update Mumble DM contact session on reconnect
+        if (d.certHash && !d.self) {
           dmStoreRef.current.updateMumbleSession(d.certHash, d.session, d.name);
         }
       }
@@ -796,10 +790,10 @@ function App() {
           speakText(`${userName} left`);
         }
 
-        // Update Mumble DM contact session to null (offline) — skip hybrid users (they use Matrix)
+        // Update Mumble DM contact session to null (offline)
         const leavingUser = usersRef.current.find(u => u.session === d.session);
         const certHash = d.certHash || leavingUser?.certHash;
-        if (certHash && !leavingUser?.matrixUserId) {
+        if (certHash) {
           dmStoreRef.current.updateMumbleSession(certHash, null);
         }
 
@@ -1353,7 +1347,16 @@ const handleConnect = (serverData: SavedServer) => {
 
   const handleStartDMFromContextMenu = useCallback((sessionIdStr: string, userName: string) => {
     const user = users.find(u => String(u.session) === sessionIdStr);
-    // Always prefer Matrix if the user has a Matrix identity (even if they're on a Mumble client)
+    // If the user has a certHash and an existing Mumble DM contact, prefer that
+    // (handles Brmble-registered users connected via plain Mumble client who already sent a DM)
+    if (user?.certHash) {
+      const existingMumbleContact = dmStore.contacts.find(c => c.isEphemeral && c.mumbleCertHash === user.certHash);
+      if (existingMumbleContact) {
+        dmStore.selectContact(existingMumbleContact.id);
+        return;
+      }
+    }
+
     if (user?.matrixUserId) {
       dmStore.startDM(user.matrixUserId, userName);
     } else if (user?.certHash) {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1683,6 +1683,7 @@ const handleConnect = (serverData: SavedServer) => {
                     matrixRoomId={dmMatrixRoomId}
                     readMarkerTs={dmDividerTs}
                     users={users}
+                    disabled={dmStore.selectedContact?.isEphemeral === true && dmStore.selectedContact?.mumbleSessionId == null}
                   />
                   </ErrorBoundary>
                 </div>

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -294,6 +294,7 @@ function App() {
     matrixDmMessages: matrixClient.dmMessages,
     matrixDmRoomMap: matrixClient.dmRoomMap,
     matrixDmUserDisplayNames: matrixClient.dmUserDisplayNames,
+    matrixDmUserAvatarUrls: matrixClient.dmUserAvatarUrls,
     sendMatrixDM: matrixClient.sendDMMessage,
     fetchDMHistory: matrixClient.fetchDMHistory,
     users,
@@ -710,7 +711,10 @@ function App() {
           const existing = prev.find(u => u.session === d.session);
           if (existing) {
             const updatedChannelId = d.channelId !== undefined ? d.channelId : existing.channelId;
-            return prev.map(u => u.session === d.session ? { ...u, ...d, channelId: updatedChannelId } : u);
+            // Preserve certHash and matrixUserId — don't let falsy updates overwrite valid values
+            const certHash = d.certHash || existing.certHash;
+            const matrixUserId = d.matrixUserId || existing.matrixUserId;
+            return prev.map(u => u.session === d.session ? { ...u, ...d, channelId: updatedChannelId, certHash, matrixUserId } : u);
           }
           return [...prev, d];
         });
@@ -1343,12 +1347,23 @@ const handleConnect = (serverData: SavedServer) => {
 
   const handleStartDMFromContextMenu = useCallback((sessionIdStr: string, userName: string) => {
     const user = users.find(u => String(u.session) === sessionIdStr);
+    // If the user has a certHash and an existing Mumble DM contact, prefer that
+    // (handles Brmble-registered users connected via plain Mumble client who already sent a DM)
+    if (user?.certHash) {
+      const existingMumbleContact = dmStore.contacts.find(c => c.isEphemeral && c.mumbleCertHash === user.certHash);
+      if (existingMumbleContact) {
+        dmStore.selectContact(existingMumbleContact.id);
+        return;
+      }
+    }
+
     if (user?.matrixUserId) {
       dmStore.startDM(user.matrixUserId, userName);
     } else if (user?.certHash) {
       dmStore.startMumbleDM(user.certHash, user.session, userName);
+    } else {
+      console.warn('[DM] Cannot start DM: user has no matrixUserId or certHash');
     }
-    // Users with neither matrixUserId nor certHash can't receive DMs
   }, [users, dmStore]);
 
   const activeChannelId = currentChannelId && currentChannelId !== 'server-root'
@@ -1684,6 +1699,7 @@ const handleConnect = (serverData: SavedServer) => {
                     readMarkerTs={dmDividerTs}
                     users={users}
                     disabled={dmStore.selectedContact?.isEphemeral === true && dmStore.selectedContact?.mumbleSessionId == null}
+                    topNotice={dmStore.selectedContact?.isEphemeral ? 'This is a Mumble direct message. Chat history will be lost when you disconnect.' : undefined}
                   />
                   </ErrorBoundary>
                 </div>

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -123,6 +123,7 @@ interface User {
   matrixUserId?: string;
   avatarUrl?: string;
   certHash?: string;
+  isBrmbleClient?: boolean;
 }
 
 
@@ -703,7 +704,7 @@ function App() {
     });
 
     const onVoiceUserJoined = ((data: unknown) => {
-      const d = data as { session: number; name: string; channelId?: number; muted?: boolean; deafened?: boolean; self?: boolean; comment?: string; matrixUserId?: string; certHash?: string } | undefined;
+      const d = data as { session: number; name: string; channelId?: number; muted?: boolean; deafened?: boolean; self?: boolean; comment?: string; matrixUserId?: string; certHash?: string; isBrmbleClient?: boolean } | undefined;
       if (d?.session && d.channelId !== undefined) {
         const previousChannelId = previousChannelIdRef.current.get(d.session);
         
@@ -714,7 +715,8 @@ function App() {
             // Preserve certHash and matrixUserId — don't let falsy updates overwrite valid values
             const certHash = d.certHash || existing.certHash;
             const matrixUserId = d.matrixUserId || existing.matrixUserId;
-            return prev.map(u => u.session === d.session ? { ...u, ...d, channelId: updatedChannelId, certHash, matrixUserId } : u);
+            const isBrmbleClient = d.isBrmbleClient !== undefined ? d.isBrmbleClient : existing.isBrmbleClient;
+            return prev.map(u => u.session === d.session ? { ...u, ...d, channelId: updatedChannelId, certHash, matrixUserId, isBrmbleClient } : u);
           }
           return [...prev, d];
         });
@@ -1004,30 +1006,47 @@ function App() {
     };
 
     const onUserMappingUpdated = (data: unknown) => {
-      const d = data as { sessionId: number; matrixUserId?: string; action: string } | undefined;
+      const d = data as { sessionId: number; matrixUserId?: string; isBrmbleClient?: boolean; action: string } | undefined;
       if (d?.sessionId !== undefined) {
         setUsers(prev => prev.map(u =>
           u.session === d.sessionId
-            ? { ...u, matrixUserId: d.action === 'added' ? d.matrixUserId : undefined }
+            ? { ...u, matrixUserId: d.action === 'added' ? d.matrixUserId : undefined, isBrmbleClient: d.action === 'added' ? d.isBrmbleClient : undefined }
             : u
         ));
       }
     };
 
     const onSessionMappingSnapshot = (data: unknown) => {
-      const d = data as { mappings: Record<string, { matrixUserId: string; mumbleName: string }> } | undefined;
+      const d = data as { mappings: Record<string, { matrixUserId: string; mumbleName: string; isBrmbleClient?: boolean }> } | undefined;
       if (d?.mappings && typeof d.mappings === 'object') {
         setUsers(prev => {
-          const mappingMap = new Map<number, string>();
+          const mappingMap = new Map<number, { matrixUserId: string; isBrmbleClient?: boolean }>();
           for (const [sid, entry] of Object.entries(d.mappings)) {
-            mappingMap.set(Number(sid), entry.matrixUserId);
+            mappingMap.set(Number(sid), { matrixUserId: entry.matrixUserId, isBrmbleClient: entry.isBrmbleClient });
           }
-          return prev.map(u =>
-            mappingMap.has(u.session)
-              ? { ...u, matrixUserId: mappingMap.get(u.session) }
-              : u
-          );
+          return prev.map(u => {
+            const m = mappingMap.get(u.session);
+            return m ? { ...u, matrixUserId: m.matrixUserId, isBrmbleClient: m.isBrmbleClient } : u;
+          });
         });
+      }
+    };
+
+    const onBrmbleClientActivated = (data: unknown) => {
+      const d = data as { sessionId: number } | undefined;
+      if (d?.sessionId !== undefined) {
+        setUsers(prev => prev.map(u =>
+          u.session === d.sessionId ? { ...u, isBrmbleClient: true } : u
+        ));
+      }
+    };
+
+    const onBrmbleClientDeactivated = (data: unknown) => {
+      const d = data as { sessionId: number } | undefined;
+      if (d?.sessionId !== undefined) {
+        setUsers(prev => prev.map(u =>
+          u.session === d.sessionId ? { ...u, isBrmbleClient: false } : u
+        ));
       }
     };
 
@@ -1082,6 +1101,8 @@ function App() {
     bridge.on('voice.authError', onVoiceAuthError);
     bridge.on('voice.userMappingUpdated', onUserMappingUpdated);
     bridge.on('voice.sessionMappingSnapshot', onSessionMappingSnapshot);
+    bridge.on('voice.brmbleClientActivated', onBrmbleClientActivated);
+    bridge.on('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
     bridge.on('voice.registrationStatus', onRegistrationStatus);
 
     return () => {
@@ -1120,6 +1141,8 @@ function App() {
       bridge.off('voice.authError', onVoiceAuthError);
       bridge.off('voice.userMappingUpdated', onUserMappingUpdated);
       bridge.off('voice.sessionMappingSnapshot', onSessionMappingSnapshot);
+      bridge.off('voice.brmbleClientActivated', onBrmbleClientActivated);
+      bridge.off('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
       bridge.off('voice.registrationStatus', onRegistrationStatus);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.css
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.css
@@ -268,6 +268,24 @@
   font-style: italic;
 }
 
+/* Ephemeral / informational notice at top of message area */
+.chat-top-notice {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  margin: var(--space-sm) var(--space-md) 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  border-radius: var(--radius-md);
+  background: var(--bg-glass);
+}
+
+.chat-top-notice svg {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
 /* Date separator */
 .chat-date-sentinel {
   height: 1px;

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -26,13 +26,14 @@ interface ChatPanelProps {
   onCloseScreenShare?: () => void;
   /** Connected users for avatar lookup by sender name */
   users?: { name: string; matrixUserId?: string; avatarUrl?: string }[];
+  disabled?: boolean;
 }
 
 const SCROLL_THRESHOLD = 150;
 const SPLIT_STORAGE_KEY = 'brmble-screenshare-split';
 const DEFAULT_SPLIT = 50;
 
-export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, screenShareVideoEl, screenSharerName, onCloseScreenShare, users }: ChatPanelProps) {
+export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, screenShareVideoEl, screenSharerName, onCloseScreenShare, users, disabled }: ChatPanelProps) {
   // Build lookup maps from sender name and matrixUserId → avatar data for MessageBubble.
   // Name-based lookup works when Mumble name matches message sender.
   // MatrixUserId-based lookup handles cases where the user connected with a different
@@ -710,7 +711,7 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
           </button>
           </Tooltip>
         )}
-        <MessageInput onSend={onSendMessage} placeholder={isDM ? `Message @${channelName}` : `Message #${channelName}`} mentionableUsers={mentionableUsers} />
+        <MessageInput onSend={onSendMessage} placeholder={isDM ? `Message @${channelName}` : `Message #${channelName}`} mentionableUsers={mentionableUsers} disabled={disabled} />
       </div>
     </div>
   );

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -27,20 +27,41 @@ interface ChatPanelProps {
   /** Connected users for avatar lookup by sender name */
   users?: { name: string; matrixUserId?: string; avatarUrl?: string }[];
   disabled?: boolean;
+  /** Optional notice shown at the top of the message area (e.g. ephemeral chat warning). */
+  topNotice?: string;
 }
 
 const SCROLL_THRESHOLD = 150;
 const SPLIT_STORAGE_KEY = 'brmble-screenshare-split';
 const DEFAULT_SPLIT = 50;
 
-export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, screenShareVideoEl, screenSharerName, onCloseScreenShare, users, disabled }: ChatPanelProps) {
+export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, screenShareVideoEl, screenSharerName, onCloseScreenShare, users, disabled, topNotice }: ChatPanelProps) {
   // Build lookup maps from sender name and matrixUserId → avatar data for MessageBubble.
   // Name-based lookup works when Mumble name matches message sender.
   // MatrixUserId-based lookup handles cases where the user connected with a different
   // Mumble name than the Matrix display name used in messages.
+  // Falls back to Matrix room membership for offline users.
   const senderAvatarMap = useMemo(() => {
     const byName = new Map<string, { avatarUrl?: string; matrixUserId?: string }>();
     const byMatrixId = new Map<string, { avatarUrl?: string; matrixUserId?: string }>();
+
+    // First, populate from Matrix room members (lower priority — offline fallback)
+    if (matrixClient && matrixRoomId) {
+      const room = matrixClient.getRoom(matrixRoomId);
+      if (room) {
+        for (const member of room.getJoinedMembers()) {
+          const avatarUrl = member.getAvatarUrl(matrixClient.baseUrl, 128, 128, 'crop', false, false) ?? undefined;
+          const displayName = member.rawDisplayName || member.name;
+          const entry = { avatarUrl, matrixUserId: member.userId };
+          if (displayName && displayName !== member.userId) {
+            byName.set(displayName, entry);
+          }
+          byMatrixId.set(member.userId, entry);
+        }
+      }
+    }
+
+    // Then, overwrite with live Mumble users (higher priority — online with fresh data)
     if (users) {
       for (const u of users) {
         const entry = { avatarUrl: u.avatarUrl, matrixUserId: u.matrixUserId };
@@ -51,7 +72,7 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
       }
     }
     return { byName, byMatrixId };
-  }, [users]);
+  }, [users, matrixClient, matrixRoomId]);
 
   /** Look up avatar data by sender name first, then fall back to matrixUserId. */
   const lookupAvatar = useCallback((senderName: string, senderMatrixId?: string) => {
@@ -625,6 +646,16 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
       )}
 
       <div className="chat-messages" ref={messagesContainerRef} onScroll={handleScroll}>
+        {topNotice && (
+          <div className="chat-top-notice">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="16" x2="12" y2="12" />
+              <line x1="12" y1="8" x2="12.01" y2="8" />
+            </svg>
+            <span>{topNotice}</span>
+          </div>
+        )}
         {grouped.length === 0 ? (
           <div className="chat-no-messages">
             <p>No messages yet. Start the conversation!</p>

--- a/src/Brmble.Web/src/components/ChatPanel/MessageInput.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageInput.tsx
@@ -8,9 +8,10 @@ interface MessageInputProps {
   onSend: (content: string) => void;
   placeholder?: string;
   mentionableUsers?: MentionableUser[];
+  disabled?: boolean;
 }
 
-export function MessageInput({ onSend, placeholder = 'Type a message...', mentionableUsers = [] }: MessageInputProps) {
+export function MessageInput({ onSend, placeholder = 'Type a message...', mentionableUsers = [], disabled }: MessageInputProps) {
   const [message, setMessage] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -207,7 +208,8 @@ export function MessageInput({ onSend, placeholder = 'Type a message...', mentio
           onChange={handleChange}
           onKeyDown={handleKeyDown}
           onSelect={handleSelect}
-          placeholder={placeholder}
+          placeholder={disabled ? 'User is offline' : placeholder}
+          disabled={disabled}
           rows={1}
           role="combobox"
           aria-expanded={mentionActive && filteredUsers.length > 0}
@@ -220,7 +222,7 @@ export function MessageInput({ onSend, placeholder = 'Type a message...', mentio
         <button
           className="btn btn-primary btn-icon send-button"
           onClick={handleSend}
-          disabled={!message.trim()}
+          disabled={disabled || !message.trim()}
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <line x1="22" y1="2" x2="11" y2="13"></line>

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.css
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.css
@@ -138,3 +138,22 @@
   justify-content: center;
   flex-shrink: 0;
 }
+
+.dm-contact-ephemeral-tag {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  background: var(--bg-deep);
+  padding: 0 var(--space-2xs);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.dm-contact-entry.offline {
+  opacity: 0.5;
+}
+
+.dm-contact-entry.offline .dm-contact-name {
+  color: var(--text-muted);
+}

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.css
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.css
@@ -138,10 +138,3 @@
   justify-content: center;
   flex-shrink: 0;
 }
-
-.dm-ephemeral-badge {
-  color: var(--text-muted);
-  font-size: 0.7em;
-  margin-left: 4px;
-  opacity: 0.7;
-}

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.css
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.css
@@ -138,3 +138,10 @@
   justify-content: center;
   flex-shrink: 0;
 }
+
+.dm-ephemeral-badge {
+  color: var(--text-muted);
+  font-size: 0.7em;
+  margin-left: 4px;
+  opacity: 0.7;
+}

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
@@ -3,43 +3,31 @@ import { ContextMenu } from '../ContextMenu/ContextMenu';
 import { UserInfoDialog } from '../UserInfoDialog/UserInfoDialog';
 import { Tooltip } from '../Tooltip/Tooltip';
 import Avatar from '../Avatar/Avatar';
+import type { DMContact } from '../../hooks/useDMStore';
 import './DMContactList.css';
-
-interface DMContact {
-  userId: string;
-  userName: string;
-  lastMessage?: string;
-  lastMessageTime?: Date;
-  unread: number;
-  comment?: string;
-  matrixUserId?: string;
-  avatarUrl?: string;
-}
 
 interface DMContactListProps {
   contacts: DMContact[];
   selectedUserId: string | null;
-  onSelectContact: (userId: string, userName: string) => void;
-  onCloseConversation: (userId: string) => void;
+  onSelectContact: (id: string, displayName: string) => void;
+  onCloseConversation: (id: string) => void;
   onlineUserIds: string[];
   visible: boolean;
 }
 
-export type { DMContact };
-
 export function DMContactList({ contacts, selectedUserId, onSelectContact, onCloseConversation, onlineUserIds, visible }: DMContactListProps) {
   const [searchQuery, setSearchQuery] = useState('');
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; userId: string; userName: string } | null>(null);
-  const [infoDialogUser, setInfoDialogUser] = useState<{ userId: string; userName: string } | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; id: string; displayName: string } | null>(null);
+  const [infoDialogUser, setInfoDialogUser] = useState<{ id: string; displayName: string } | null>(null);
 
   const filtered = contacts.filter(c =>
-    c.userName.toLowerCase().includes(searchQuery.toLowerCase())
+    c.displayName.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-  const formatTime = (date?: Date) => {
-    if (!date) return '';
-    const now = new Date();
-    const diff = now.getTime() - new Date(date).getTime();
+  const formatTime = (ts?: number) => {
+    if (!ts) return '';
+    const now = Date.now();
+    const diff = now - ts;
     const minutes = Math.floor(diff / 60000);
     if (minutes < 1) return 'now';
     if (minutes < 60) return `${minutes}m`;
@@ -77,19 +65,24 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
         )}
         {filtered.map(contact => (
           <button
-            key={contact.userId}
-            className={`dm-contact-entry ${selectedUserId === contact.userId ? 'active' : ''}`}
-            onClick={() => onSelectContact(contact.userId, contact.userName)}
+            key={contact.id}
+            className={`dm-contact-entry ${selectedUserId === contact.id ? 'active' : ''}`}
+            onClick={() => onSelectContact(contact.id, contact.displayName)}
             onContextMenu={(e) => {
               e.preventDefault();
-              setContextMenu({ x: e.clientX, y: e.clientY, userId: contact.userId, userName: contact.userName });
+              setContextMenu({ x: e.clientX, y: e.clientY, id: contact.id, displayName: contact.displayName });
             }}
           >
-            <Avatar user={{ name: contact.userName, matrixUserId: contact.matrixUserId, avatarUrl: contact.avatarUrl }} size={28} isMumbleOnly={!contact.matrixUserId} />
+            <Avatar user={{ name: contact.displayName, matrixUserId: contact.isEphemeral ? undefined : contact.id, avatarUrl: contact.avatarUrl }} size={28} isMumbleOnly={contact.isEphemeral} />
             <div className="dm-contact-info">
               <div className="dm-contact-name-row">
-                <Tooltip content={contact.comment || ''}>
-                <span className="dm-contact-name">{contact.userName}</span>
+                <Tooltip content="">
+                <span className="dm-contact-name">
+                  {contact.displayName}
+                  {contact.isEphemeral && (
+                    <span className="dm-ephemeral-badge" title="Messages with this user won't be saved">!</span>
+                  )}
+                </span>
                 </Tooltip>
                 {contact.lastMessageTime && (
                   <span className="dm-contact-time">{formatTime(contact.lastMessageTime)}</span>
@@ -99,8 +92,8 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
                 <span className="dm-contact-preview">{contact.lastMessage}</span>
               )}
             </div>
-            {contact.unread > 0 && (
-              <span className="dm-contact-unread">{contact.unread}</span>
+            {contact.unreadCount > 0 && (
+              <span className="dm-contact-unread">{contact.unreadCount}</span>
             )}
           </button>
         ))}
@@ -118,7 +111,7 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
                   <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
                 </svg>
               ),
-              onClick: () => { onSelectContact(contextMenu.userId, contextMenu.userName); setContextMenu(null); },
+              onClick: () => { onSelectContact(contextMenu.id, contextMenu.displayName); setContextMenu(null); },
             },
             {
               label: 'User Information',
@@ -129,8 +122,8 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
                   <line x1="12" y1="12" x2="12" y2="16" />
                 </svg>
               ),
-              disabled: !onlineUserIds.includes(contextMenu.userId),
-              onClick: () => { setInfoDialogUser({ userId: contextMenu.userId, userName: contextMenu.userName }); setContextMenu(null); },
+              disabled: !onlineUserIds.includes(contextMenu.id),
+              onClick: () => { setInfoDialogUser({ id: contextMenu.id, displayName: contextMenu.displayName }); setContextMenu(null); },
             },
             {
               label: 'Close Conversation',
@@ -140,7 +133,7 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
                   <line x1="6" y1="6" x2="18" y2="18" />
                 </svg>
               ),
-              onClick: () => { onCloseConversation(contextMenu.userId); setContextMenu(null); },
+              onClick: () => { onCloseConversation(contextMenu.id); setContextMenu(null); },
             },
           ]}
           onClose={() => setContextMenu(null)}
@@ -148,16 +141,20 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
       )}
 
       {infoDialogUser && (() => {
-        const contact = contacts.find(c => c.userId === infoDialogUser.userId);
+        const contact = contacts.find(c => c.id === infoDialogUser.id);
+        const isMumbleContact = infoDialogUser.id.startsWith('mumble:session:');
+        const sessionId = isMumbleContact
+          ? parseInt(infoDialogUser.id.replace('mumble:session:', ''))
+          : 0;
         return (
         <UserInfoDialog
           isOpen={true}
           onClose={() => setInfoDialogUser(null)}
-          userName={infoDialogUser.userName}
-          session={parseInt(infoDialogUser.userId)}
+          userName={infoDialogUser.displayName}
+          session={sessionId}
           isSelf={false}
-          comment={contact?.comment}
-          matrixUserId={contact?.matrixUserId}
+          comment={undefined}
+          matrixUserId={!isMumbleContact ? contact?.id : undefined}
           avatarUrl={contact?.avatarUrl}
           onStartDM={(userId, userName) => onSelectContact(userId, userName)}
         />

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
@@ -73,7 +73,7 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
               setContextMenu({ x: e.clientX, y: e.clientY, id: contact.id, displayName: contact.displayName });
             }}
           >
-            <Avatar user={{ name: contact.displayName, matrixUserId: contact.isEphemeral ? undefined : contact.id, avatarUrl: contact.avatarUrl }} size={28} />
+            <Avatar user={{ name: contact.displayName, matrixUserId: contact.isEphemeral ? undefined : contact.id, avatarUrl: contact.avatarUrl }} size={28} isMumbleOnly={contact.isEphemeral} />
             <div className="dm-contact-info">
               <div className="dm-contact-name-row">
                 <Tooltip content="">

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
@@ -66,14 +66,14 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
         {filtered.map(contact => (
           <button
             key={contact.id}
-            className={`dm-contact-entry ${selectedUserId === contact.id ? 'active' : ''}`}
+            className={`dm-contact-entry ${selectedUserId === contact.id ? 'active' : ''} ${contact.isEphemeral && contact.mumbleSessionId == null ? 'offline' : ''}`}
             onClick={() => onSelectContact(contact.id, contact.displayName)}
             onContextMenu={(e) => {
               e.preventDefault();
               setContextMenu({ x: e.clientX, y: e.clientY, id: contact.id, displayName: contact.displayName });
             }}
           >
-            <Avatar user={{ name: contact.displayName, matrixUserId: contact.id, avatarUrl: contact.avatarUrl }} size={28} />
+            <Avatar user={{ name: contact.displayName, matrixUserId: contact.isEphemeral ? undefined : contact.id, avatarUrl: contact.avatarUrl }} size={28} />
             <div className="dm-contact-info">
               <div className="dm-contact-name-row">
                 <Tooltip content="">
@@ -81,6 +81,9 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
                   {contact.displayName}
                 </span>
                 </Tooltip>
+                {contact.isEphemeral && (
+                  <span className="dm-contact-ephemeral-tag">mumble</span>
+                )}
                 {contact.lastMessageTime && (
                   <span className="dm-contact-time">{formatTime(contact.lastMessageTime)}</span>
                 )}

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
@@ -73,15 +73,12 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
               setContextMenu({ x: e.clientX, y: e.clientY, id: contact.id, displayName: contact.displayName });
             }}
           >
-            <Avatar user={{ name: contact.displayName, matrixUserId: contact.isEphemeral ? undefined : contact.id, avatarUrl: contact.avatarUrl }} size={28} isMumbleOnly={contact.isEphemeral} />
+            <Avatar user={{ name: contact.displayName, matrixUserId: contact.id, avatarUrl: contact.avatarUrl }} size={28} />
             <div className="dm-contact-info">
               <div className="dm-contact-name-row">
                 <Tooltip content="">
                 <span className="dm-contact-name">
                   {contact.displayName}
-                  {contact.isEphemeral && (
-                    <span className="dm-ephemeral-badge" title="Messages with this user won't be saved">!</span>
-                  )}
                 </span>
                 </Tooltip>
                 {contact.lastMessageTime && (
@@ -142,19 +139,15 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
 
       {infoDialogUser && (() => {
         const contact = contacts.find(c => c.id === infoDialogUser.id);
-        const isMumbleContact = infoDialogUser.id.startsWith('mumble:session:');
-        const sessionId = isMumbleContact
-          ? parseInt(infoDialogUser.id.replace('mumble:session:', ''))
-          : 0;
         return (
         <UserInfoDialog
           isOpen={true}
           onClose={() => setInfoDialogUser(null)}
           userName={infoDialogUser.displayName}
-          session={sessionId}
+          session={0}
           isSelf={false}
           comment={undefined}
-          matrixUserId={!isMumbleContact ? contact?.id : undefined}
+          matrixUserId={contact?.id}
           avatarUrl={contact?.avatarUrl}
           onStartDM={(userId, userName) => onSelectContact(userId, userName)}
         />

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -19,6 +19,7 @@ interface User {
   comment?: string;
   matrixUserId?: string;
   avatarUrl?: string;
+  isBrmbleClient?: boolean;
 }
 
 interface Channel {
@@ -282,10 +283,10 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
                     </>
                   )}
                 </span>
-                <Avatar user={{ name: user.name, matrixUserId: user.matrixUserId, avatarUrl: user.avatarUrl }} size={20} isMumbleOnly={!user.self && !user.matrixUserId} />
+                <Avatar user={{ name: user.name, matrixUserId: user.matrixUserId, avatarUrl: user.avatarUrl }} size={20} isMumbleOnly={!user.self && !user.isBrmbleClient} />
                 <span className="user-name">{user.name}</span>
                 {user.self && <span className="self-badge">(you)</span>}
-                {user.matrixUserId && <Tooltip content="Brmble user"><span className="brmble-badge" /></Tooltip>}
+                {user.isBrmbleClient && <Tooltip content="Brmble user"><span className="brmble-badge" /></Tooltip>}
                 {user.session === sharingUserSession && (
                   <span className="sharing-badge">Sharing</span>
                 )}

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -280,7 +280,7 @@ export function Sidebar({
                     </>
                   )}
                 </span>
-                <Avatar user={{ name: user.name, matrixUserId: user.matrixUserId, avatarUrl: user.avatarUrl }} size={20} isMumbleOnly={!user.self && !user.matrixUserId} />
+                <Avatar user={{ name: user.name, matrixUserId: user.matrixUserId, avatarUrl: user.avatarUrl }} size={20} isMumbleOnly={!user.self && !user.isBrmbleClient} />
                 <span className="root-user-name">{user.name}</span>
                 {user.self && <span className="root-self-badge">you</span>}
                 {user.session === sharingUserSession && (

--- a/src/Brmble.Web/src/hooks/useChatStore.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.ts
@@ -83,12 +83,12 @@ export function addMessageToStore(storeKey: string, sender: string, content: str
   localStorage.setItem(fullKey, JSON.stringify(messages));
 }
 
-/** Clear all chat messages and DM contacts from localStorage.
+/** Clear all chat messages from localStorage.
  *  Preserves server-root messages since those are current-session system messages. */
 export function clearChatStorage() {
   const serverRootKey = `${STORAGE_KEY_PREFIX}server-root`;
   Object.keys(localStorage)
-    .filter(k => (k.startsWith(STORAGE_KEY_PREFIX) && k !== serverRootKey) || k.startsWith(DM_CONTACTS_KEY_PREFIX))
+    .filter(k => k.startsWith(STORAGE_KEY_PREFIX) && k !== serverRootKey)
     .forEach(k => localStorage.removeItem(k));
 }
 
@@ -105,81 +105,4 @@ export function useAllChats() {
   }, [getAllChannelIds]);
 
   return { getAllChannelIds, clearAllChats };
-}
-
-const DM_CONTACTS_KEY_PREFIX = 'brmble_dm_contacts';
-
-/** Build a server-scoped DM contacts key. When no server is provided, falls back to
- *  the legacy global key so that callers without a server context still work. */
-function dmContactsKey(serverAddress?: string): string {
-  return serverAddress ? `${DM_CONTACTS_KEY_PREFIX}_${serverAddress}` : DM_CONTACTS_KEY_PREFIX;
-}
-
-export interface StoredDMContact {
-  userId: string;
-  userName: string;
-  lastMessage?: string;
-  lastMessageTime?: string;
-  unread: number;
-}
-
-export function loadDMContacts(serverAddress?: string): StoredDMContact[] {
-  const stored = localStorage.getItem(dmContactsKey(serverAddress));
-  if (!stored) return [];
-  try {
-    return JSON.parse(stored);
-  } catch {
-    return [];
-  }
-}
-
-export function saveDMContacts(contacts: StoredDMContact[], serverAddress?: string) {
-  localStorage.setItem(dmContactsKey(serverAddress), JSON.stringify(contacts));
-}
-
-export function upsertDMContact(userId: string, userName: string, lastMessage?: string, incrementUnread?: boolean, serverAddress?: string) {
-  const contacts = loadDMContacts(serverAddress);
-  const existing = contacts.find(c => c.userId === userId);
-  if (existing) {
-    existing.userName = userName;
-    if (lastMessage) {
-      existing.lastMessage = lastMessage;
-      existing.lastMessageTime = new Date().toISOString();
-    }
-    if (incrementUnread) {
-      existing.unread = (existing.unread || 0) + 1;
-    }
-  } else {
-    contacts.unshift({
-      userId,
-      userName,
-      lastMessage,
-      lastMessageTime: lastMessage ? new Date().toISOString() : undefined,
-      unread: incrementUnread ? 1 : 0,
-    });
-  }
-  // Sort by most recent message
-  contacts.sort((a, b) => {
-    if (!a.lastMessageTime) return 1;
-    if (!b.lastMessageTime) return -1;
-    return new Date(b.lastMessageTime).getTime() - new Date(a.lastMessageTime).getTime();
-  });
-  saveDMContacts(contacts, serverAddress);
-  return contacts;
-}
-
-export function markDMContactRead(userId: string, serverAddress?: string): StoredDMContact[] {
-  const contacts = loadDMContacts(serverAddress);
-  const contact = contacts.find(c => c.userId === userId);
-  if (contact) {
-    contact.unread = 0;
-    saveDMContacts(contacts, serverAddress);
-  }
-  return contacts;
-}
-
-export function removeDMContact(userId: string, serverAddress?: string): StoredDMContact[] {
-  const contacts = loadDMContacts(serverAddress).filter(c => c.userId !== userId);
-  saveDMContacts(contacts, serverAddress);
-  return contacts;
 }

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -27,7 +27,6 @@ export interface DMStoreOptions {
   users: User[];
   username: string;
   bridgeSend: (event: string, data: unknown) => void;
-  matrixDmUnreadCount: number;
 }
 
 export interface DMStore {
@@ -42,7 +41,7 @@ export interface DMStore {
   toggleMode: () => void;
   closeDM: (id: string) => void;
   receiveMumbleDM: (senderSession: number, senderName: string, text: string, media?: ChatMessage['media']) => void;
-  totalUnreadCount: number;
+  mumbleUnreadCount: number;
   appModeRef: React.RefObject<'channels' | 'dm'>;
   selectedContactIdRef: React.RefObject<string | null>;
 }
@@ -68,7 +67,6 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     users,
     username,
     bridgeSend,
-    matrixDmUnreadCount,
   } = options;
 
   // ---- Core state ----------------------------------------------------------
@@ -119,7 +117,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
       contacts.push({
         id: matrixUserId,
-        displayName: user?.name ?? matrixUserId,
+        displayName: user?.name ?? matrixUserId.split(':')[0].replace('@', ''),
         avatarUrl: user?.avatarUrl,
         lastMessage: lastMsg?.content,
         lastMessageTime: lastMsg?.timestamp.getTime(),
@@ -233,7 +231,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       const contact = contacts.find(c => c.id === selectedContactId);
       if (contact?.sessionId != null) {
         bridgeSend('voice.sendPrivateMessage', {
-          sessionId: contact.sessionId,
+          targetSession: contact.sessionId,
           message: content,
         });
       }
@@ -310,7 +308,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
                 ...c,
                 lastMessage: text,
                 lastMessageTime: now.getTime(),
-                unreadCount: selectedContactIdRef.current === contactId ? c.unreadCount : c.unreadCount + 1,
+                unreadCount: (appModeRef.current === 'dm' && selectedContactIdRef.current === contactId) ? c.unreadCount : c.unreadCount + 1,
               }
             : c
         );
@@ -323,7 +321,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
           displayName: senderName,
           lastMessage: text,
           lastMessageTime: now.getTime(),
-          unreadCount: selectedContactIdRef.current === contactId ? 0 : 1,
+          unreadCount: (appModeRef.current === 'dm' && selectedContactIdRef.current === contactId) ? 0 : 1,
           isEphemeral: true,
           sessionId: senderSession,
         },
@@ -352,12 +350,11 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     }
   }, [selectedContactId]);
 
-  // ---- Total unread count --------------------------------------------------
+  // ---- Mumble unread count -------------------------------------------------
 
-  const totalUnreadCount = useMemo(() => {
-    const mumbleUnread = mumbleContacts.reduce((sum, c) => sum + c.unreadCount, 0);
-    return matrixDmUnreadCount + mumbleUnread;
-  }, [matrixDmUnreadCount, mumbleContacts]);
+  const mumbleUnreadCount = useMemo(() => {
+    return mumbleContacts.reduce((sum, c) => sum + c.unreadCount, 0);
+  }, [mumbleContacts]);
 
   // ---- Return --------------------------------------------------------------
 
@@ -373,7 +370,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     toggleMode,
     closeDM,
     receiveMumbleDM,
-    totalUnreadCount,
+    mumbleUnreadCount,
     appModeRef,
     selectedContactIdRef,
   };

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -22,6 +22,7 @@ export interface DMContact {
 export interface DMStoreOptions {
   matrixDmMessages: Map<string, ChatMessage[]> | undefined;
   matrixDmRoomMap: Map<string, string> | undefined;
+  matrixDmUserDisplayNames: Map<string, string> | undefined;
   sendMatrixDM: ((targetMatrixUserId: string, text: string) => Promise<void>) | undefined;
   fetchDMHistory: ((targetMatrixUserId: string) => Promise<void>) | undefined;
   users: User[];
@@ -62,6 +63,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   const {
     matrixDmMessages,
     matrixDmRoomMap,
+    matrixDmUserDisplayNames,
     sendMatrixDM,
     fetchDMHistory,
     users,
@@ -115,9 +117,14 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       const msgs = matrixDmMessages?.get(matrixUserId);
       const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
 
+      // Resolve display name: Matrix room membership > Mumble user list > parse Matrix ID
+      const displayName = matrixDmUserDisplayNames?.get(matrixUserId)
+        ?? user?.name
+        ?? matrixUserId.split(':')[0].replace('@', '');
+
       contacts.push({
         id: matrixUserId,
-        displayName: user?.name ?? matrixUserId.split(':')[0].replace('@', ''),
+        displayName,
         avatarUrl: user?.avatarUrl,
         lastMessage: lastMsg?.content,
         lastMessageTime: lastMsg?.timestamp.getTime(),
@@ -127,7 +134,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     }
 
     return contacts;
-  }, [matrixDmRoomMap, matrixDmMessages, users]);
+  }, [matrixDmRoomMap, matrixDmMessages, matrixDmUserDisplayNames, users]);
 
   // ---- Combined contacts ---------------------------------------------------
 

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -45,8 +45,6 @@ export interface DMStore {
   appModeRef: React.RefObject<'channels' | 'dm'>;
   selectedContactIdRef: React.RefObject<string | null>;
   receiveMumbleDM: (certHash: string, sessionId: number, displayName: string, text: string) => void;
-  /** Inject a received message into a Matrix DM contact's message list (e.g. Mumble PM from a hybrid user). */
-  addIncomingDMMessage: (matrixUserId: string, senderName: string, text: string) => void;
   updateMumbleSession: (certHash: string, sessionId: number | null, displayName?: string) => void;
   clearMumbleContacts: () => void;
   startMumbleDM: (certHash: string, sessionId: number, displayName: string) => void;
@@ -222,48 +220,6 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     }
   }, [fetchDMHistory, matrixDmRoomMap]);
 
-  const addIncomingDMMessage = useCallback((matrixUserId: string, senderName: string, text: string) => {
-    // Ensure contact exists (first-time DM from hybrid user via Mumble PM)
-    if (!matrixDmRoomMap?.has(matrixUserId)) {
-      setPendingMatrixContacts(prev => {
-        if (prev.has(matrixUserId)) return prev;
-        const next = new Map(prev);
-        next.set(matrixUserId, {
-          id: matrixUserId,
-          displayName: senderName,
-          unreadCount: 0,
-        });
-        return next;
-      });
-    }
-
-    const msg: ChatMessage = {
-      id: `mumble-routed-${Date.now()}-${Math.random()}`,
-      channelId: matrixUserId,
-      sender: senderName,
-      content: text,
-      timestamp: new Date(),
-    };
-    setPendingMessages(prev => {
-      const next = new Map(prev);
-      const existing = next.get(matrixUserId) ?? [];
-      next.set(matrixUserId, [...existing, msg]);
-      return next;
-    });
-
-    // Increment unread if not currently viewing this contact
-    if (selectedContactIdRef.current !== matrixUserId || appModeRef.current !== 'dm') {
-      setPendingMatrixContacts(prev => {
-        const next = new Map(prev);
-        const contact = next.get(matrixUserId);
-        if (contact) {
-          next.set(matrixUserId, { ...contact, unreadCount: contact.unreadCount + 1 });
-        }
-        return next;
-      });
-    }
-  }, [matrixDmRoomMap]);
-
   const clearSelection = useCallback(() => {
     setSelectedContactId(null);
   }, []);
@@ -433,7 +389,6 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     appModeRef,
     selectedContactIdRef,
     receiveMumbleDM,
-    addIncomingDMMessage,
     updateMumbleSession,
     clearMumbleContacts,
     startMumbleDM,

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -1,0 +1,348 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import type { ChatMessage, User } from '../types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DMContact {
+  /** Primary key: Matrix user ID for Brmble users, "mumble:session:{id}" for Mumble-only */
+  id: string;
+  displayName: string;
+  avatarUrl?: string;
+  lastMessage?: string;
+  lastMessageTime?: number;
+  unreadCount: number;
+  /** true for Mumble-only contacts (no Matrix ID, ephemeral session) */
+  isEphemeral: boolean;
+  /** Mumble session ID, used for Mumble fallback sends */
+  sessionId?: number;
+}
+
+export interface DMStoreOptions {
+  matrixDmMessages: Map<string, ChatMessage[]> | undefined;
+  matrixDmRoomMap: Map<string, string> | undefined;
+  sendMatrixDM: ((targetMatrixUserId: string, text: string) => Promise<void>) | undefined;
+  fetchDMHistory: ((targetMatrixUserId: string) => Promise<void>) | undefined;
+  users: User[];
+  username: string;
+  bridgeSend: (event: string, data: unknown) => void;
+  matrixDmUnreadCount: number;
+}
+
+export interface DMStore {
+  contacts: DMContact[];
+  selectedContact: DMContact | null;
+  messages: ChatMessage[];
+  appMode: 'channels' | 'dm';
+  selectContact: (id: string) => void;
+  sendMessage: (content: string) => void;
+  startDM: (matrixUserId: string, displayName: string) => void;
+  clearSelection: () => void;
+  toggleMode: () => void;
+  closeDM: (id: string) => void;
+  receiveMumbleDM: (senderSession: number, senderName: string, text: string, media?: ChatMessage['media']) => void;
+  totalUnreadCount: number;
+  appModeRef: React.RefObject<'channels' | 'dm'>;
+  selectedContactIdRef: React.RefObject<string | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mumbleContactId(sessionId: number): string {
+  return `mumble:session:${sessionId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useDMStore(options: DMStoreOptions): DMStore {
+  const {
+    matrixDmMessages,
+    matrixDmRoomMap,
+    sendMatrixDM,
+    fetchDMHistory,
+    users,
+    username,
+    bridgeSend,
+    matrixDmUnreadCount,
+  } = options;
+
+  // ---- Core state ----------------------------------------------------------
+
+  const [appMode, setAppMode] = useState<'channels' | 'dm'>('channels');
+  const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
+  const [mumbleDmMessages, setMumbleDmMessages] = useState<Map<string, ChatMessage[]>>(new Map());
+  const [mumbleContacts, setMumbleContacts] = useState<DMContact[]>([]);
+
+  // ---- Refs for bridge callbacks -------------------------------------------
+
+  const appModeRef = useRef<'channels' | 'dm'>('channels');
+  const selectedContactIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    appModeRef.current = appMode;
+  }, [appMode]);
+
+  useEffect(() => {
+    selectedContactIdRef.current = selectedContactId;
+  }, [selectedContactId]);
+
+  // ---- Reset on disconnect -------------------------------------------------
+
+  useEffect(() => {
+    if (users.length === 0) {
+      setAppMode('channels');
+      setSelectedContactId(null);
+      setMumbleDmMessages(new Map());
+      setMumbleContacts([]);
+      appModeRef.current = 'channels';
+      selectedContactIdRef.current = null;
+    }
+  }, [users.length]);
+
+  // ---- Matrix contacts derived from matrixDmRoomMap ------------------------
+
+  const matrixContacts: DMContact[] = useMemo(() => {
+    if (!matrixDmRoomMap) return [];
+
+    const contacts: DMContact[] = [];
+    for (const [matrixUserId] of matrixDmRoomMap) {
+      const user = users.find(u => u.matrixUserId === matrixUserId);
+      const msgs = matrixDmMessages?.get(matrixUserId);
+      const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
+
+      contacts.push({
+        id: matrixUserId,
+        displayName: user?.name ?? matrixUserId,
+        avatarUrl: user?.avatarUrl,
+        lastMessage: lastMsg?.content,
+        lastMessageTime: lastMsg?.timestamp.getTime(),
+        unreadCount: 0, // Matrix unread is tracked globally via matrixDmUnreadCount
+        isEphemeral: false,
+      });
+    }
+
+    return contacts;
+  }, [matrixDmRoomMap, matrixDmMessages, users]);
+
+  // ---- Combined contacts ---------------------------------------------------
+
+  const contacts: DMContact[] = useMemo(() => {
+    const merged = [...matrixContacts, ...mumbleContacts];
+    merged.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
+    return merged;
+  }, [matrixContacts, mumbleContacts]);
+
+  // ---- Selected contact ----------------------------------------------------
+
+  const selectedContact: DMContact | null = useMemo(() => {
+    if (!selectedContactId) return null;
+    return contacts.find(c => c.id === selectedContactId) ?? null;
+  }, [contacts, selectedContactId]);
+
+  // ---- Messages for selected contact ---------------------------------------
+
+  const messages: ChatMessage[] = useMemo(() => {
+    if (!selectedContact) return [];
+
+    if (selectedContact.isEphemeral) {
+      return mumbleDmMessages.get(selectedContact.id) ?? [];
+    }
+
+    return matrixDmMessages?.get(selectedContact.id) ?? [];
+  }, [selectedContact, matrixDmMessages, mumbleDmMessages]);
+
+  // ---- Actions -------------------------------------------------------------
+
+  const selectContact = useCallback((id: string) => {
+    setSelectedContactId(id);
+    setAppMode('dm');
+
+    // Fetch Matrix DM history if it's a Matrix contact
+    const isMumble = id.startsWith('mumble:session:');
+    if (!isMumble && fetchDMHistory) {
+      fetchDMHistory(id).catch(console.warn);
+    }
+
+    // Clear unread for mumble contacts
+    if (isMumble) {
+      setMumbleContacts(prev =>
+        prev.map(c => c.id === id ? { ...c, unreadCount: 0 } : c)
+      );
+    }
+  }, [fetchDMHistory]);
+
+  const startDM = useCallback((matrixUserId: string, _displayName: string) => {
+    setSelectedContactId(matrixUserId);
+    setAppMode('dm');
+
+    if (fetchDMHistory) {
+      fetchDMHistory(matrixUserId).catch(console.warn);
+    }
+  }, [fetchDMHistory]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedContactId(null);
+  }, []);
+
+  const toggleMode = useCallback(() => {
+    setAppMode(prev => {
+      const next = prev === 'channels' ? 'dm' : 'channels';
+      return next;
+    });
+  }, []);
+
+  const sendMessage = useCallback((content: string) => {
+    if (!selectedContact) return;
+
+    if (selectedContact.isEphemeral) {
+      // Mumble fallback path
+      const now = new Date();
+      const msg: ChatMessage = {
+        id: crypto.randomUUID(),
+        channelId: selectedContact.id,
+        sender: username,
+        content,
+        timestamp: now,
+      };
+
+      setMumbleDmMessages(prev => {
+        const existing = prev.get(selectedContact.id) ?? [];
+        const updated = new Map(prev);
+        updated.set(selectedContact.id, [...existing, msg]);
+        return updated;
+      });
+
+      // Update last message on contact
+      setMumbleContacts(prev =>
+        prev.map(c =>
+          c.id === selectedContact.id
+            ? { ...c, lastMessage: content, lastMessageTime: now.getTime() }
+            : c
+        )
+      );
+
+      bridgeSend('voice.sendPrivateMessage', {
+        sessionId: selectedContact.sessionId,
+        message: content,
+      });
+    } else {
+      // Matrix path
+      if (sendMatrixDM) {
+        sendMatrixDM(selectedContact.id, content).catch(console.warn);
+      }
+    }
+  }, [selectedContact, username, bridgeSend, sendMatrixDM]);
+
+  const receiveMumbleDM = useCallback((
+    senderSession: number,
+    senderName: string,
+    text: string,
+    media?: ChatMessage['media'],
+  ) => {
+    // Skip if sender has a Matrix user ID (Matrix handles it)
+    const senderUser = users.find(u => u.session === senderSession);
+    if (senderUser?.matrixUserId) return;
+
+    const contactId = mumbleContactId(senderSession);
+    const now = new Date();
+
+    const msg: ChatMessage = {
+      id: crypto.randomUUID(),
+      channelId: contactId,
+      sender: senderName,
+      content: text,
+      timestamp: now,
+      ...(media && { media }),
+    };
+
+    // Add message
+    setMumbleDmMessages(prev => {
+      const existing = prev.get(contactId) ?? [];
+      const updated = new Map(prev);
+      updated.set(contactId, [...existing, msg]);
+      return updated;
+    });
+
+    // Create or update contact
+    setMumbleContacts(prev => {
+      const existing = prev.find(c => c.id === contactId);
+      if (existing) {
+        return prev.map(c =>
+          c.id === contactId
+            ? {
+                ...c,
+                lastMessage: text,
+                lastMessageTime: now.getTime(),
+                unreadCount: selectedContactIdRef.current === contactId ? c.unreadCount : c.unreadCount + 1,
+              }
+            : c
+        );
+      }
+
+      return [
+        ...prev,
+        {
+          id: contactId,
+          displayName: senderName,
+          lastMessage: text,
+          lastMessageTime: now.getTime(),
+          unreadCount: selectedContactIdRef.current === contactId ? 0 : 1,
+          isEphemeral: true,
+          sessionId: senderSession,
+        },
+      ];
+    });
+  }, [users]);
+
+  const closeDM = useCallback((id: string) => {
+    if (id.startsWith('mumble:session:')) {
+      // Remove mumble contact and messages
+      setMumbleContacts(prev => prev.filter(c => c.id !== id));
+      setMumbleDmMessages(prev => {
+        const updated = new Map(prev);
+        updated.delete(id);
+        return updated;
+      });
+
+      if (selectedContactId === id) {
+        setSelectedContactId(null);
+      }
+    } else {
+      // Matrix contacts can't be "closed" — just deselect if active
+      if (selectedContactId === id) {
+        setSelectedContactId(null);
+      }
+    }
+  }, [selectedContactId]);
+
+  // ---- Total unread count --------------------------------------------------
+
+  const totalUnreadCount = useMemo(() => {
+    const mumbleUnread = mumbleContacts.reduce((sum, c) => sum + c.unreadCount, 0);
+    return matrixDmUnreadCount + mumbleUnread;
+  }, [matrixDmUnreadCount, mumbleContacts]);
+
+  // ---- Return --------------------------------------------------------------
+
+  return {
+    contacts,
+    selectedContact,
+    messages,
+    appMode,
+    selectContact,
+    sendMessage,
+    startDM,
+    clearSelection,
+    toggleMode,
+    closeDM,
+    receiveMumbleDM,
+    totalUnreadCount,
+    appModeRef,
+    selectedContactIdRef,
+  };
+}

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -6,13 +6,17 @@ import type { ChatMessage, User } from '../types';
 // ---------------------------------------------------------------------------
 
 export interface DMContact {
-  /** Primary key: Matrix user ID (e.g. "@5:noscope.it") */
+  /** Primary key: matrixUserId for Matrix contacts, mumbleCertHash for Mumble contacts */
   id: string;
   displayName: string;
   avatarUrl?: string;
   lastMessage?: string;
   lastMessageTime?: number;
   unreadCount: number;
+  // Mumble DM fields (only set for ephemeral Mumble contacts)
+  isEphemeral?: boolean;
+  mumbleCertHash?: string;
+  mumbleSessionId?: number | null;  // null = offline
 }
 
 export interface DMStoreOptions {
@@ -21,6 +25,7 @@ export interface DMStoreOptions {
   matrixDmUserDisplayNames: Map<string, string> | undefined;
   sendMatrixDM: ((targetMatrixUserId: string, text: string) => Promise<void>) | undefined;
   fetchDMHistory: ((targetMatrixUserId: string) => Promise<void>) | undefined;
+  sendMumbleDM?: (targetSession: number, text: string) => void;
   users: User[];
   username: string;
 }
@@ -38,6 +43,10 @@ export interface DMStore {
   closeDM: (id: string) => void;
   appModeRef: React.RefObject<'channels' | 'dm'>;
   selectedContactIdRef: React.RefObject<string | null>;
+  receiveMumbleDM: (certHash: string, sessionId: number, displayName: string, text: string) => void;
+  updateMumbleSession: (certHash: string, sessionId: number | null, displayName?: string) => void;
+  clearMumbleContacts: () => void;
+  startMumbleDM: (certHash: string, sessionId: number, displayName: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -51,6 +60,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     matrixDmUserDisplayNames,
     sendMatrixDM,
     fetchDMHistory,
+    sendMumbleDM,
     users,
     username,
   } = options;
@@ -60,6 +70,8 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   const [appMode, setAppMode] = useState<'channels' | 'dm'>('channels');
   const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
   const [pendingMessages, setPendingMessages] = useState<Map<string, ChatMessage[]>>(new Map());
+  const [mumbleContacts, setMumbleContacts] = useState<Map<string, DMContact>>(new Map());
+  const [mumbleMessages, setMumbleMessages] = useState<Map<string, ChatMessage[]>>(new Map());
 
   // ---- Refs for bridge callbacks -------------------------------------------
 
@@ -81,6 +93,8 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       setAppMode('channels');
       setSelectedContactId(null);
       setPendingMessages(new Map());
+      setMumbleContacts(new Map());
+      setMumbleMessages(new Map());
       appModeRef.current = 'channels';
       selectedContactIdRef.current = null;
     }
@@ -89,32 +103,44 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   // ---- Matrix contacts derived from matrixDmRoomMap ------------------------
 
   const contacts: DMContact[] = useMemo(() => {
-    if (!matrixDmRoomMap) return [];
-
     const result: DMContact[] = [];
-    for (const [matrixUserId] of matrixDmRoomMap) {
-      const user = users.find(u => u.matrixUserId === matrixUserId);
-      const msgs = matrixDmMessages?.get(matrixUserId);
+
+    if (matrixDmRoomMap) {
+      for (const [matrixUserId] of matrixDmRoomMap) {
+        const user = users.find(u => u.matrixUserId === matrixUserId);
+        const msgs = matrixDmMessages?.get(matrixUserId);
+        const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
+
+        // Resolve display name: Matrix room membership > Mumble user list > parse Matrix ID
+        const displayName = matrixDmUserDisplayNames?.get(matrixUserId)
+          ?? user?.name
+          ?? matrixUserId.split(':')[0].replace('@', '');
+
+        result.push({
+          id: matrixUserId,
+          displayName,
+          avatarUrl: user?.avatarUrl,
+          lastMessage: lastMsg?.content,
+          lastMessageTime: lastMsg?.timestamp.getTime(),
+          unreadCount: 0, // Matrix unread is tracked globally via matrixDmUnreadCount
+        });
+      }
+    }
+
+    // Merge Mumble contacts
+    for (const [, mc] of mumbleContacts) {
+      const msgs = mumbleMessages.get(mc.mumbleCertHash!);
       const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
-
-      // Resolve display name: Matrix room membership > Mumble user list > parse Matrix ID
-      const displayName = matrixDmUserDisplayNames?.get(matrixUserId)
-        ?? user?.name
-        ?? matrixUserId.split(':')[0].replace('@', '');
-
       result.push({
-        id: matrixUserId,
-        displayName,
-        avatarUrl: user?.avatarUrl,
+        ...mc,
         lastMessage: lastMsg?.content,
         lastMessageTime: lastMsg?.timestamp.getTime(),
-        unreadCount: 0, // Matrix unread is tracked globally via matrixDmUnreadCount
       });
     }
 
     result.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
     return result;
-  }, [matrixDmRoomMap, matrixDmMessages, matrixDmUserDisplayNames, users]);
+  }, [matrixDmRoomMap, matrixDmMessages, matrixDmUserDisplayNames, users, mumbleContacts, mumbleMessages]);
 
   // ---- Selected contact ----------------------------------------------------
 
@@ -127,16 +153,31 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
   const messages: ChatMessage[] = useMemo(() => {
     if (!selectedContactId) return [];
+    // Check if this is a Mumble contact
+    const mumbleMsgs = mumbleMessages.get(selectedContactId);
+    if (mumbleMsgs) return mumbleMsgs;
+    // Otherwise Matrix messages
     const matrixMsgs = matrixDmMessages?.get(selectedContactId) ?? [];
     const pending = pendingMessages.get(selectedContactId) ?? [];
     return [...matrixMsgs, ...pending];
-  }, [selectedContactId, matrixDmMessages, pendingMessages]);
+  }, [selectedContactId, matrixDmMessages, pendingMessages, mumbleMessages]);
 
   // ---- Actions -------------------------------------------------------------
 
   const selectContact = useCallback((id: string) => {
     setSelectedContactId(id);
     setAppMode('dm');
+
+    // Clear Mumble unread if applicable
+    setMumbleContacts(prev => {
+      const contact = prev.get(id);
+      if (contact && contact.unreadCount > 0) {
+        const next = new Map(prev);
+        next.set(id, { ...contact, unreadCount: 0 });
+        return next;
+      }
+      return prev;
+    });
 
     if (fetchDMHistory) {
       fetchDMHistory(id).catch(console.warn);
@@ -162,6 +203,27 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
   const sendMessage = useCallback((content: string) => {
     if (!selectedContactId) return;
+
+    const contact = mumbleContacts.get(selectedContactId);
+    if (contact?.isEphemeral) {
+      // Mumble DM path
+      if (contact.mumbleSessionId == null) return; // offline, can't send
+      const msg: ChatMessage = {
+        id: `mumble-${Date.now()}-${Math.random()}`,
+        channelId: selectedContactId,
+        sender: username,
+        content,
+        timestamp: new Date(),
+      };
+      setMumbleMessages(prev => {
+        const next = new Map(prev);
+        const existing = next.get(selectedContactId!) ?? [];
+        next.set(selectedContactId!, [...existing, msg]);
+        return next;
+      });
+      sendMumbleDM?.(contact.mumbleSessionId, content);
+      return;
+    }
 
     // Insert optimistic local echo
     const optimisticMsg: ChatMessage = {
@@ -192,7 +254,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
         })
         .catch(console.error);
     }
-  }, [selectedContactId, username, sendMatrixDM]);
+  }, [selectedContactId, username, sendMatrixDM, mumbleContacts, sendMumbleDM]);
 
   const closeDM = useCallback((id: string) => {
     // Matrix contacts can't truly be "closed" — just deselect if active
@@ -200,6 +262,89 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       setSelectedContactId(null);
     }
   }, [selectedContactId]);
+
+  // ---- Mumble-specific actions ---------------------------------------------
+
+  const receiveMumbleDM = useCallback((certHash: string, sessionId: number, displayName: string, text: string) => {
+    // Ensure contact exists
+    setMumbleContacts(prev => {
+      const next = new Map(prev);
+      if (!next.has(certHash)) {
+        next.set(certHash, {
+          id: certHash,
+          displayName,
+          unreadCount: 0,
+          isEphemeral: true,
+          mumbleCertHash: certHash,
+          mumbleSessionId: sessionId,
+        });
+      }
+      return next;
+    });
+    // Append message
+    const msg: ChatMessage = {
+      id: `mumble-${Date.now()}-${Math.random()}`,
+      channelId: certHash,
+      sender: displayName,
+      content: text,
+      timestamp: new Date(),
+    };
+    setMumbleMessages(prev => {
+      const next = new Map(prev);
+      const existing = next.get(certHash) ?? [];
+      next.set(certHash, [...existing, msg]);
+      return next;
+    });
+    // Increment unread if not currently viewing this contact
+    if (selectedContactIdRef.current !== certHash || appModeRef.current !== 'dm') {
+      setMumbleContacts(prev => {
+        const next = new Map(prev);
+        const contact = next.get(certHash);
+        if (contact) {
+          next.set(certHash, { ...contact, unreadCount: contact.unreadCount + 1 });
+        }
+        return next;
+      });
+    }
+  }, []);
+
+  const updateMumbleSession = useCallback((certHash: string, sessionId: number | null, displayName?: string) => {
+    setMumbleContacts(prev => {
+      const contact = prev.get(certHash);
+      if (!contact) return prev;
+      const next = new Map(prev);
+      next.set(certHash, {
+        ...contact,
+        mumbleSessionId: sessionId,
+        displayName: displayName ?? contact.displayName,
+      });
+      return next;
+    });
+  }, []);
+
+  const clearMumbleContacts = useCallback(() => {
+    setMumbleContacts(new Map());
+    setMumbleMessages(new Map());
+  }, []);
+
+  const startMumbleDM = useCallback((certHash: string, sessionId: number, displayName: string) => {
+    setMumbleContacts(prev => {
+      const next = new Map(prev);
+      if (!next.has(certHash)) {
+        next.set(certHash, {
+          id: certHash,
+          displayName,
+          unreadCount: 0,
+          isEphemeral: true,
+          mumbleCertHash: certHash,
+          mumbleSessionId: sessionId,
+        });
+      }
+      return next;
+    });
+    setSelectedContactId(certHash);
+    setAppMode('dm');
+  }, []);
 
   // ---- Return --------------------------------------------------------------
 
@@ -216,5 +361,9 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     closeDM,
     appModeRef,
     selectedContactIdRef,
+    receiveMumbleDM,
+    updateMumbleSession,
+    clearMumbleContacts,
+    startMumbleDM,
   };
 }

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -23,6 +23,7 @@ export interface DMStoreOptions {
   matrixDmMessages: Map<string, ChatMessage[]> | undefined;
   matrixDmRoomMap: Map<string, string> | undefined;
   matrixDmUserDisplayNames: Map<string, string> | undefined;
+  matrixDmUserAvatarUrls: Map<string, string> | undefined;
   sendMatrixDM: ((targetMatrixUserId: string, text: string) => Promise<void>) | undefined;
   fetchDMHistory: ((targetMatrixUserId: string) => Promise<void>) | undefined;
   sendMumbleDM?: (targetSession: number, text: string) => void;
@@ -58,6 +59,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     matrixDmMessages,
     matrixDmRoomMap,
     matrixDmUserDisplayNames,
+    matrixDmUserAvatarUrls,
     sendMatrixDM,
     fetchDMHistory,
     sendMumbleDM,
@@ -70,6 +72,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   const [appMode, setAppMode] = useState<'channels' | 'dm'>('channels');
   const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
   const [pendingMessages, setPendingMessages] = useState<Map<string, ChatMessage[]>>(new Map());
+  const [pendingMatrixContacts, setPendingMatrixContacts] = useState<Map<string, DMContact>>(new Map());
   const [mumbleContacts, setMumbleContacts] = useState<Map<string, DMContact>>(new Map());
   const [mumbleMessages, setMumbleMessages] = useState<Map<string, ChatMessage[]>>(new Map());
 
@@ -93,6 +96,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       setAppMode('channels');
       setSelectedContactId(null);
       setPendingMessages(new Map());
+      setPendingMatrixContacts(new Map());
       setMumbleContacts(new Map());
       setMumbleMessages(new Map());
       appModeRef.current = 'channels';
@@ -104,9 +108,11 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
   const contacts: DMContact[] = useMemo(() => {
     const result: DMContact[] = [];
+    const seen = new Set<string>();
 
     if (matrixDmRoomMap) {
       for (const [matrixUserId] of matrixDmRoomMap) {
+        seen.add(matrixUserId);
         const user = users.find(u => u.matrixUserId === matrixUserId);
         const msgs = matrixDmMessages?.get(matrixUserId);
         const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
@@ -119,11 +125,18 @@ export function useDMStore(options: DMStoreOptions): DMStore {
         result.push({
           id: matrixUserId,
           displayName,
-          avatarUrl: user?.avatarUrl,
+          avatarUrl: user?.avatarUrl ?? matrixDmUserAvatarUrls?.get(matrixUserId),
           lastMessage: lastMsg?.content,
           lastMessageTime: lastMsg?.timestamp.getTime(),
           unreadCount: 0, // Matrix unread is tracked globally via matrixDmUnreadCount
         });
+      }
+    }
+
+    // Merge pending Matrix contacts (first-time DMs before room is created)
+    for (const [id, pc] of pendingMatrixContacts) {
+      if (!seen.has(id)) {
+        result.push(pc);
       }
     }
 
@@ -140,7 +153,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
     result.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
     return result;
-  }, [matrixDmRoomMap, matrixDmMessages, matrixDmUserDisplayNames, users, mumbleContacts, mumbleMessages]);
+  }, [matrixDmRoomMap, matrixDmMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, users, pendingMatrixContacts, mumbleContacts, mumbleMessages]);
 
   // ---- Selected contact ----------------------------------------------------
 
@@ -184,14 +197,28 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     }
   }, [fetchDMHistory]);
 
-  const startDM = useCallback((matrixUserId: string, _displayName: string) => {
+  const startDM = useCallback((matrixUserId: string, displayName: string) => {
+    // Add a pending contact if no DM room exists yet (first-time DM)
+    if (!matrixDmRoomMap?.has(matrixUserId)) {
+      setPendingMatrixContacts(prev => {
+        if (prev.has(matrixUserId)) return prev;
+        const next = new Map(prev);
+        next.set(matrixUserId, {
+          id: matrixUserId,
+          displayName,
+          unreadCount: 0,
+        });
+        return next;
+      });
+    }
+
     setSelectedContactId(matrixUserId);
     setAppMode('dm');
 
     if (fetchDMHistory) {
       fetchDMHistory(matrixUserId).catch(console.warn);
     }
-  }, [fetchDMHistory]);
+  }, [fetchDMHistory, matrixDmRoomMap]);
 
   const clearSelection = useCallback(() => {
     setSelectedContactId(null);

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -6,17 +6,13 @@ import type { ChatMessage, User } from '../types';
 // ---------------------------------------------------------------------------
 
 export interface DMContact {
-  /** Primary key: Matrix user ID for Brmble users, "mumble:session:{id}" for Mumble-only */
+  /** Primary key: Matrix user ID (e.g. "@5:noscope.it") */
   id: string;
   displayName: string;
   avatarUrl?: string;
   lastMessage?: string;
   lastMessageTime?: number;
   unreadCount: number;
-  /** true for Mumble-only contacts (no Matrix ID, ephemeral session) */
-  isEphemeral: boolean;
-  /** Mumble session ID, used for Mumble fallback sends */
-  sessionId?: number;
 }
 
 export interface DMStoreOptions {
@@ -27,7 +23,6 @@ export interface DMStoreOptions {
   fetchDMHistory: ((targetMatrixUserId: string) => Promise<void>) | undefined;
   users: User[];
   username: string;
-  bridgeSend: (event: string, data: unknown) => void;
 }
 
 export interface DMStore {
@@ -41,18 +36,8 @@ export interface DMStore {
   clearSelection: () => void;
   toggleMode: () => void;
   closeDM: (id: string) => void;
-  receiveMumbleDM: (senderSession: number, senderName: string, text: string, media?: ChatMessage['media']) => void;
-  mumbleUnreadCount: number;
   appModeRef: React.RefObject<'channels' | 'dm'>;
   selectedContactIdRef: React.RefObject<string | null>;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function mumbleContactId(sessionId: number): string {
-  return `mumble:session:${sessionId}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -68,15 +53,12 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     fetchDMHistory,
     users,
     username,
-    bridgeSend,
   } = options;
 
   // ---- Core state ----------------------------------------------------------
 
   const [appMode, setAppMode] = useState<'channels' | 'dm'>('channels');
   const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
-  const [mumbleDmMessages, setMumbleDmMessages] = useState<Map<string, ChatMessage[]>>(new Map());
-  const [mumbleContacts, setMumbleContacts] = useState<DMContact[]>([]);
   const [pendingMessages, setPendingMessages] = useState<Map<string, ChatMessage[]>>(new Map());
 
   // ---- Refs for bridge callbacks -------------------------------------------
@@ -98,8 +80,6 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     if (users.length === 0) {
       setAppMode('channels');
       setSelectedContactId(null);
-      setMumbleDmMessages(new Map());
-      setMumbleContacts([]);
       setPendingMessages(new Map());
       appModeRef.current = 'channels';
       selectedContactIdRef.current = null;
@@ -108,10 +88,10 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
   // ---- Matrix contacts derived from matrixDmRoomMap ------------------------
 
-  const matrixContacts: DMContact[] = useMemo(() => {
+  const contacts: DMContact[] = useMemo(() => {
     if (!matrixDmRoomMap) return [];
 
-    const contacts: DMContact[] = [];
+    const result: DMContact[] = [];
     for (const [matrixUserId] of matrixDmRoomMap) {
       const user = users.find(u => u.matrixUserId === matrixUserId);
       const msgs = matrixDmMessages?.get(matrixUserId);
@@ -122,27 +102,19 @@ export function useDMStore(options: DMStoreOptions): DMStore {
         ?? user?.name
         ?? matrixUserId.split(':')[0].replace('@', '');
 
-      contacts.push({
+      result.push({
         id: matrixUserId,
         displayName,
         avatarUrl: user?.avatarUrl,
         lastMessage: lastMsg?.content,
         lastMessageTime: lastMsg?.timestamp.getTime(),
         unreadCount: 0, // Matrix unread is tracked globally via matrixDmUnreadCount
-        isEphemeral: false,
       });
     }
 
-    return contacts;
+    result.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
+    return result;
   }, [matrixDmRoomMap, matrixDmMessages, matrixDmUserDisplayNames, users]);
-
-  // ---- Combined contacts ---------------------------------------------------
-
-  const contacts: DMContact[] = useMemo(() => {
-    const merged = [...matrixContacts, ...mumbleContacts];
-    merged.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
-    return merged;
-  }, [matrixContacts, mumbleContacts]);
 
   // ---- Selected contact ----------------------------------------------------
 
@@ -155,15 +127,10 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
   const messages: ChatMessage[] = useMemo(() => {
     if (!selectedContactId) return [];
-
-    if (!selectedContactId.startsWith('mumble:session:')) {
-      const matrixMsgs = matrixDmMessages?.get(selectedContactId) ?? [];
-      const pending = pendingMessages.get(selectedContactId) ?? [];
-      return [...matrixMsgs, ...pending];
-    }
-
-    return mumbleDmMessages.get(selectedContactId) ?? [];
-  }, [selectedContactId, matrixDmMessages, mumbleDmMessages, pendingMessages]);
+    const matrixMsgs = matrixDmMessages?.get(selectedContactId) ?? [];
+    const pending = pendingMessages.get(selectedContactId) ?? [];
+    return [...matrixMsgs, ...pending];
+  }, [selectedContactId, matrixDmMessages, pendingMessages]);
 
   // ---- Actions -------------------------------------------------------------
 
@@ -171,17 +138,8 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     setSelectedContactId(id);
     setAppMode('dm');
 
-    // Fetch Matrix DM history if it's a Matrix contact
-    const isMumble = id.startsWith('mumble:session:');
-    if (!isMumble && fetchDMHistory) {
+    if (fetchDMHistory) {
       fetchDMHistory(id).catch(console.warn);
-    }
-
-    // Clear unread for mumble contacts
-    if (isMumble) {
-      setMumbleContacts(prev =>
-        prev.map(c => c.id === id ? { ...c, unreadCount: 0 } : c)
-      );
     }
   }, [fetchDMHistory]);
 
@@ -199,169 +157,49 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   }, []);
 
   const toggleMode = useCallback(() => {
-    setAppMode(prev => {
-      const next = prev === 'channels' ? 'dm' : 'channels';
-      return next;
-    });
+    setAppMode(prev => prev === 'channels' ? 'dm' : 'channels');
   }, []);
 
   const sendMessage = useCallback((content: string) => {
     if (!selectedContactId) return;
 
-    if (selectedContactId.startsWith('mumble:session:')) {
-      // Mumble fallback path
-      const now = new Date();
-      const msg: ChatMessage = {
-        id: crypto.randomUUID(),
-        channelId: selectedContactId,
-        sender: username,
-        content,
-        timestamp: now,
-      };
-
-      setMumbleDmMessages(prev => {
-        const existing = prev.get(selectedContactId!) ?? [];
-        const updated = new Map(prev);
-        updated.set(selectedContactId!, [...existing, msg]);
-        return updated;
-      });
-
-      // Update last message on contact
-      setMumbleContacts(prev =>
-        prev.map(c =>
-          c.id === selectedContactId
-            ? { ...c, lastMessage: content, lastMessageTime: now.getTime() }
-            : c
-        )
-      );
-
-      const contact = contacts.find(c => c.id === selectedContactId);
-      if (contact?.sessionId != null) {
-        bridgeSend('voice.sendPrivateMessage', {
-          targetSession: contact.sessionId,
-          message: content,
-        });
-      }
-    } else {
-      // Matrix path — insert optimistic local echo
-      const optimisticMsg: ChatMessage = {
-        id: `pending-${Date.now()}-${Math.random()}`,
-        channelId: selectedContactId,
-        sender: username,
-        content,
-        timestamp: new Date(),
-        pending: true,
-      };
-      setPendingMessages(prev => {
-        const next = new Map(prev);
-        const existing = next.get(selectedContactId!) ?? [];
-        next.set(selectedContactId!, [...existing, optimisticMsg]);
-        return next;
-      });
-
-      if (sendMatrixDM) {
-        sendMatrixDM(selectedContactId, content)
-          .then(() => {
-            // Remove optimistic message -- the real one arrives via sync
-            setPendingMessages(prev => {
-              const next = new Map(prev);
-              const existing = next.get(selectedContactId!) ?? [];
-              next.set(selectedContactId!, existing.filter(m => m.id !== optimisticMsg.id));
-              return next;
-            });
-          })
-          .catch(console.error);
-      }
-    }
-  }, [selectedContactId, contacts, username, bridgeSend, sendMatrixDM]);
-
-  const receiveMumbleDM = useCallback((
-    senderSession: number,
-    senderName: string,
-    text: string,
-    media?: ChatMessage['media'],
-  ) => {
-    // Skip if sender has a Matrix user ID (Matrix handles it)
-    const senderUser = users.find(u => u.session === senderSession);
-    if (senderUser?.matrixUserId) return;
-
-    const contactId = mumbleContactId(senderSession);
-    const now = new Date();
-
-    const msg: ChatMessage = {
-      id: crypto.randomUUID(),
-      channelId: contactId,
-      sender: senderName,
-      content: text,
-      timestamp: now,
-      ...(media && { media }),
+    // Insert optimistic local echo
+    const optimisticMsg: ChatMessage = {
+      id: `pending-${Date.now()}-${Math.random()}`,
+      channelId: selectedContactId,
+      sender: username,
+      content,
+      timestamp: new Date(),
+      pending: true,
     };
-
-    // Add message
-    setMumbleDmMessages(prev => {
-      const existing = prev.get(contactId) ?? [];
-      const updated = new Map(prev);
-      updated.set(contactId, [...existing, msg]);
-      return updated;
+    setPendingMessages(prev => {
+      const next = new Map(prev);
+      const existing = next.get(selectedContactId!) ?? [];
+      next.set(selectedContactId!, [...existing, optimisticMsg]);
+      return next;
     });
 
-    // Create or update contact
-    setMumbleContacts(prev => {
-      const existing = prev.find(c => c.id === contactId);
-      if (existing) {
-        return prev.map(c =>
-          c.id === contactId
-            ? {
-                ...c,
-                lastMessage: text,
-                lastMessageTime: now.getTime(),
-                unreadCount: (appModeRef.current === 'dm' && selectedContactIdRef.current === contactId) ? c.unreadCount : c.unreadCount + 1,
-              }
-            : c
-        );
-      }
-
-      return [
-        ...prev,
-        {
-          id: contactId,
-          displayName: senderName,
-          lastMessage: text,
-          lastMessageTime: now.getTime(),
-          unreadCount: (appModeRef.current === 'dm' && selectedContactIdRef.current === contactId) ? 0 : 1,
-          isEphemeral: true,
-          sessionId: senderSession,
-        },
-      ];
-    });
-  }, [users]);
+    if (sendMatrixDM) {
+      sendMatrixDM(selectedContactId, content)
+        .then(() => {
+          // Remove optimistic message -- the real one arrives via sync
+          setPendingMessages(prev => {
+            const next = new Map(prev);
+            const existing = next.get(selectedContactId!) ?? [];
+            next.set(selectedContactId!, existing.filter(m => m.id !== optimisticMsg.id));
+            return next;
+          });
+        })
+        .catch(console.error);
+    }
+  }, [selectedContactId, username, sendMatrixDM]);
 
   const closeDM = useCallback((id: string) => {
-    if (id.startsWith('mumble:session:')) {
-      // Remove mumble contact and messages
-      setMumbleContacts(prev => prev.filter(c => c.id !== id));
-      setMumbleDmMessages(prev => {
-        const updated = new Map(prev);
-        updated.delete(id);
-        return updated;
-      });
-
-      if (selectedContactId === id) {
-        setSelectedContactId(null);
-      }
-    } else {
-      // Matrix contacts can't be "closed" — just deselect if active
-      if (selectedContactId === id) {
-        setSelectedContactId(null);
-      }
+    // Matrix contacts can't truly be "closed" — just deselect if active
+    if (selectedContactId === id) {
+      setSelectedContactId(null);
     }
   }, [selectedContactId]);
-
-  // ---- Mumble unread count -------------------------------------------------
-
-  const mumbleUnreadCount = useMemo(() => {
-    return mumbleContacts.reduce((sum, c) => sum + c.unreadCount, 0);
-  }, [mumbleContacts]);
 
   // ---- Return --------------------------------------------------------------
 
@@ -376,8 +214,6 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     clearSelection,
     toggleMode,
     closeDM,
-    receiveMumbleDM,
-    mumbleUnreadCount,
     appModeRef,
     selectedContactIdRef,
   };

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -77,6 +77,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   const [selectedContactId, setSelectedContactId] = useState<string | null>(null);
   const [mumbleDmMessages, setMumbleDmMessages] = useState<Map<string, ChatMessage[]>>(new Map());
   const [mumbleContacts, setMumbleContacts] = useState<DMContact[]>([]);
+  const [pendingMessages, setPendingMessages] = useState<Map<string, ChatMessage[]>>(new Map());
 
   // ---- Refs for bridge callbacks -------------------------------------------
 
@@ -99,6 +100,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       setSelectedContactId(null);
       setMumbleDmMessages(new Map());
       setMumbleContacts([]);
+      setPendingMessages(new Map());
       appModeRef.current = 'channels';
       selectedContactIdRef.current = null;
     }
@@ -147,14 +149,16 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   // ---- Messages for selected contact ---------------------------------------
 
   const messages: ChatMessage[] = useMemo(() => {
-    if (!selectedContact) return [];
+    if (!selectedContactId) return [];
 
-    if (selectedContact.isEphemeral) {
-      return mumbleDmMessages.get(selectedContact.id) ?? [];
+    if (!selectedContactId.startsWith('mumble:session:')) {
+      const matrixMsgs = matrixDmMessages?.get(selectedContactId) ?? [];
+      const pending = pendingMessages.get(selectedContactId) ?? [];
+      return [...matrixMsgs, ...pending];
     }
 
-    return matrixDmMessages?.get(selectedContact.id) ?? [];
-  }, [selectedContact, matrixDmMessages, mumbleDmMessages]);
+    return mumbleDmMessages.get(selectedContactId) ?? [];
+  }, [selectedContactId, matrixDmMessages, mumbleDmMessages, pendingMessages]);
 
   // ---- Actions -------------------------------------------------------------
 
@@ -197,46 +201,74 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   }, []);
 
   const sendMessage = useCallback((content: string) => {
-    if (!selectedContact) return;
+    if (!selectedContactId) return;
 
-    if (selectedContact.isEphemeral) {
+    if (selectedContactId.startsWith('mumble:session:')) {
       // Mumble fallback path
       const now = new Date();
       const msg: ChatMessage = {
         id: crypto.randomUUID(),
-        channelId: selectedContact.id,
+        channelId: selectedContactId,
         sender: username,
         content,
         timestamp: now,
       };
 
       setMumbleDmMessages(prev => {
-        const existing = prev.get(selectedContact.id) ?? [];
+        const existing = prev.get(selectedContactId!) ?? [];
         const updated = new Map(prev);
-        updated.set(selectedContact.id, [...existing, msg]);
+        updated.set(selectedContactId!, [...existing, msg]);
         return updated;
       });
 
       // Update last message on contact
       setMumbleContacts(prev =>
         prev.map(c =>
-          c.id === selectedContact.id
+          c.id === selectedContactId
             ? { ...c, lastMessage: content, lastMessageTime: now.getTime() }
             : c
         )
       );
 
-      bridgeSend('voice.sendPrivateMessage', {
-        sessionId: selectedContact.sessionId,
-        message: content,
-      });
+      const contact = contacts.find(c => c.id === selectedContactId);
+      if (contact?.sessionId != null) {
+        bridgeSend('voice.sendPrivateMessage', {
+          sessionId: contact.sessionId,
+          message: content,
+        });
+      }
     } else {
-      // Matrix path
+      // Matrix path — insert optimistic local echo
+      const optimisticMsg: ChatMessage = {
+        id: `pending-${Date.now()}-${Math.random()}`,
+        channelId: selectedContactId,
+        sender: username,
+        content,
+        timestamp: new Date(),
+        pending: true,
+      };
+      setPendingMessages(prev => {
+        const next = new Map(prev);
+        const existing = next.get(selectedContactId!) ?? [];
+        next.set(selectedContactId!, [...existing, optimisticMsg]);
+        return next;
+      });
+
       if (sendMatrixDM) {
-        sendMatrixDM(selectedContact.id, content).catch(console.warn);
+        sendMatrixDM(selectedContactId, content)
+          .then(() => {
+            // Remove optimistic message -- the real one arrives via sync
+            setPendingMessages(prev => {
+              const next = new Map(prev);
+              const existing = next.get(selectedContactId!) ?? [];
+              next.set(selectedContactId!, existing.filter(m => m.id !== optimisticMsg.id));
+              return next;
+            });
+          })
+          .catch(console.error);
       }
     }
-  }, [selectedContact, username, bridgeSend, sendMatrixDM]);
+  }, [selectedContactId, contacts, username, bridgeSend, sendMatrixDM]);
 
   const receiveMumbleDM = useCallback((
     senderSession: number,

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -45,6 +45,8 @@ export interface DMStore {
   appModeRef: React.RefObject<'channels' | 'dm'>;
   selectedContactIdRef: React.RefObject<string | null>;
   receiveMumbleDM: (certHash: string, sessionId: number, displayName: string, text: string) => void;
+  /** Inject a received message into a Matrix DM contact's message list (e.g. Mumble PM from a hybrid user). */
+  addIncomingDMMessage: (matrixUserId: string, senderName: string, text: string) => void;
   updateMumbleSession: (certHash: string, sessionId: number | null, displayName?: string) => void;
   clearMumbleContacts: () => void;
   startMumbleDM: (certHash: string, sessionId: number, displayName: string) => void;
@@ -220,6 +222,48 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     }
   }, [fetchDMHistory, matrixDmRoomMap]);
 
+  const addIncomingDMMessage = useCallback((matrixUserId: string, senderName: string, text: string) => {
+    // Ensure contact exists (first-time DM from hybrid user via Mumble PM)
+    if (!matrixDmRoomMap?.has(matrixUserId)) {
+      setPendingMatrixContacts(prev => {
+        if (prev.has(matrixUserId)) return prev;
+        const next = new Map(prev);
+        next.set(matrixUserId, {
+          id: matrixUserId,
+          displayName: senderName,
+          unreadCount: 0,
+        });
+        return next;
+      });
+    }
+
+    const msg: ChatMessage = {
+      id: `mumble-routed-${Date.now()}-${Math.random()}`,
+      channelId: matrixUserId,
+      sender: senderName,
+      content: text,
+      timestamp: new Date(),
+    };
+    setPendingMessages(prev => {
+      const next = new Map(prev);
+      const existing = next.get(matrixUserId) ?? [];
+      next.set(matrixUserId, [...existing, msg]);
+      return next;
+    });
+
+    // Increment unread if not currently viewing this contact
+    if (selectedContactIdRef.current !== matrixUserId || appModeRef.current !== 'dm') {
+      setPendingMatrixContacts(prev => {
+        const next = new Map(prev);
+        const contact = next.get(matrixUserId);
+        if (contact) {
+          next.set(matrixUserId, { ...contact, unreadCount: contact.unreadCount + 1 });
+        }
+        return next;
+      });
+    }
+  }, [matrixDmRoomMap]);
+
   const clearSelection = useCallback(() => {
     setSelectedContactId(null);
   }, []);
@@ -389,6 +433,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     appModeRef,
     selectedContactIdRef,
     receiveMumbleDM,
+    addIncomingDMMessage,
     updateMumbleSession,
     clearMumbleContacts,
     startMumbleDM,

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -272,26 +272,105 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
     };
 
     const onMyMembership = (room: Room, membership: string) => {
-      if (membership === KnownMembership.Invite && room.getDMInviter()) {
-        client.joinRoom(room.roomId).then(() => {
-          const inviter = room.getDMInviter();
-          if (inviter) {
-            // Update local DM maps so timeline handler can route messages immediately
-            setDmRoomMap(prev => new Map(prev).set(inviter, room.roomId));
-            dmRoomMapRef.current = new Map(dmRoomMapRef.current).set(inviter, room.roomId);
-            roomIdToDMUserIdRef.current = new Map(roomIdToDMUserIdRef.current).set(room.roomId, inviter);
+      const inviter = room.getDMInviter();
+      if (!inviter) return;
 
-            // Update m.direct account data
-            const directEvent = client.getAccountData(EventType.Direct);
-            const directContent = (directEvent?.getContent() ?? {}) as Record<string, string[]>;
-            if (!directContent[inviter]?.includes(room.roomId)) {
-              directContent[inviter] = [room.roomId, ...(directContent[inviter] ?? [])];
-              client.setAccountData(EventType.Direct, directContent).catch(console.warn);
-            }
-          }
+      if (membership === KnownMembership.Invite) {
+        // Auto-join DM invites
+        client.joinRoom(room.roomId).then(() => {
+          trackDMRoom(room.roomId, inviter);
         }).catch(err => {
           console.warn(`[Matrix] Failed to auto-join DM room ${room.roomId}:`, err);
         });
+      } else if (membership === KnownMembership.Join) {
+        // Already joined — ensure it's tracked (covers rooms created by the other user
+        // that we joined but never added to m.direct)
+        if (!roomIdToDMUserIdRef.current.has(room.roomId)) {
+          trackDMRoom(room.roomId, inviter);
+        }
+      }
+    };
+
+    /** Add a DM room to local maps, persist to m.direct, and backfill messages from SDK timeline */
+    const trackDMRoom = (roomId: string, otherUserId: string) => {
+      // Update local DM maps so timeline handler can route messages immediately
+      setDmRoomMap(prev => new Map(prev).set(otherUserId, roomId));
+      dmRoomMapRef.current = new Map(dmRoomMapRef.current).set(otherUserId, roomId);
+      roomIdToDMUserIdRef.current = new Map(roomIdToDMUserIdRef.current).set(roomId, otherUserId);
+
+      // Update m.direct account data
+      const directEvent = client.getAccountData(EventType.Direct);
+      const directContent = (directEvent?.getContent() ?? {}) as Record<string, string[]>;
+      if (!directContent[otherUserId]?.includes(roomId)) {
+        directContent[otherUserId] = [roomId, ...(directContent[otherUserId] ?? [])];
+        client.setAccountData(EventType.Direct, directContent).catch(console.warn);
+      }
+
+      // Backfill: the SDK already has timeline events for this room that we missed
+      // because the room wasn't in our maps when onTimeline fired
+      const sdkRoom = client.getRoom(roomId);
+      if (sdkRoom) {
+        const timelineEvents = sdkRoom.getLiveTimeline().getEvents();
+        const backfillMsgs: ChatMessage[] = [];
+        for (const ev of timelineEvents) {
+          if (ev.getType() !== EventType.RoomMessage) continue;
+          const senderId = ev.getSender() ?? 'Unknown';
+          const senderMember = sdkRoom.getMember(senderId);
+          const displayName = senderMember?.rawDisplayName || senderMember?.name || senderId;
+
+          const content = ev.getContent() as {
+            body?: string;
+            msgtype?: string;
+            url?: string;
+            info?: { thumbnail_url?: string; w?: number; h?: number; mimetype?: string; size?: number };
+          };
+
+          let media: MediaAttachment[] | undefined;
+          if (content.msgtype === 'm.image' && content.url) {
+            const cl = clientRef.current;
+            const fullUrl = cl?.mxcUrlToHttp(content.url) ?? content.url;
+            const thumbUrl = content.info?.thumbnail_url
+              ? (cl?.mxcUrlToHttp(content.info.thumbnail_url, 400, 400, 'scale') ?? undefined)
+              : (cl?.mxcUrlToHttp(content.url, 400, 400, 'scale') ?? undefined);
+            media = [{
+              type: content.info?.mimetype?.toLowerCase() === 'image/gif' ? 'gif' : 'image',
+              url: fullUrl,
+              thumbnailUrl: thumbUrl,
+              width: content.info?.w,
+              height: content.info?.h,
+              mimetype: content.info?.mimetype,
+              size: content.info?.size,
+            }];
+          }
+
+          const rawBody = content.body ?? '';
+          const isBridgeBotSender = /^@brmble[_-]?/.test(senderId);
+          const bridgeMatch = isBridgeBotSender ? rawBody.match(/^\[(.+?)\]:\s*/) : null;
+          const messageSender = bridgeMatch ? bridgeMatch[1] : displayName;
+          const messageContent = bridgeMatch ? rawBody.slice(bridgeMatch[0].length) : rawBody;
+
+          backfillMsgs.push({
+            id: ev.getId() ?? crypto.randomUUID(),
+            channelId: otherUserId,
+            sender: messageSender,
+            senderMatrixUserId: senderId,
+            content: messageContent,
+            timestamp: new Date(ev.getTs()),
+            ...(media && { media }),
+          });
+        }
+
+        if (backfillMsgs.length > 0) {
+          setDmMessages(prev => {
+            const existing = prev.get(otherUserId) ?? [];
+            let merged = existing;
+            for (const msg of backfillMsgs) {
+              merged = insertMessage(merged, msg);
+            }
+            if (merged === existing) return prev;
+            return new Map(prev).set(otherUserId, merged);
+          });
+        }
       }
     };
 

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -400,5 +400,32 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
     return null;
   }, []);
 
-  return { messages, sendMessage, fetchHistory, dmMessages, dmRoomMap, sendDMMessage, fetchDMHistory, fetchAvatarUrl, client };
+  // Resolve display names for DM partners from Matrix room membership.
+  // This works even when the other user isn't connected to Mumble.
+  const dmUserDisplayNames = useMemo(() => {
+    const names = new Map<string, string>();
+    if (!client || !dmRoomMap) return names;
+    const myUserId = credentials?.userId;
+    for (const [matrixUserId, roomId] of dmRoomMap) {
+      const room = client.getRoom(roomId);
+      if (!room) continue;
+      // Try to find the other member's display name from room state
+      const member = room.getMember(matrixUserId);
+      if (member?.name && member.name !== matrixUserId) {
+        names.set(matrixUserId, member.name);
+      } else {
+        // Fallback: scan all joined/invited members for anyone who isn't us
+        const members = room.getMembers();
+        for (const m of members) {
+          if (m.userId !== myUserId && m.name && m.name !== m.userId) {
+            names.set(matrixUserId, m.name);
+            break;
+          }
+        }
+      }
+    }
+    return names;
+  }, [client, dmRoomMap, credentials?.userId]);
+
+  return { messages, sendMessage, fetchHistory, dmMessages, dmRoomMap, dmUserDisplayNames, sendDMMessage, fetchDMHistory, fetchAvatarUrl, client };
 }

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { createClient, RoomEvent, ClientEvent, EventType, MsgType, Preset } from 'matrix-js-sdk';
+import { createClient, RoomEvent, ClientEvent, EventType, MsgType, Preset, KnownMembership } from 'matrix-js-sdk';
 import type { MatrixClient, MatrixEvent, Room } from 'matrix-js-sdk';
 import type { ChatMessage, MediaAttachment } from '../types';
 import { useServiceStatus } from './useServiceStatus';
@@ -255,13 +255,39 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       refreshDMRoomMaps(event.getContent() as Record<string, string[]>);
     };
 
+    const onMyMembership = (room: Room, membership: string) => {
+      if (membership === KnownMembership.Invite && room.getDMInviter()) {
+        client.joinRoom(room.roomId).then(() => {
+          const inviter = room.getDMInviter();
+          if (inviter) {
+            // Update local DM maps so timeline handler can route messages immediately
+            setDmRoomMap(prev => new Map(prev).set(inviter, room.roomId));
+            dmRoomMapRef.current = new Map(dmRoomMapRef.current).set(inviter, room.roomId);
+            roomIdToDMUserIdRef.current = new Map(roomIdToDMUserIdRef.current).set(room.roomId, inviter);
+
+            // Update m.direct account data
+            const directEvent = client.getAccountData(EventType.Direct);
+            const directContent = (directEvent?.getContent() ?? {}) as Record<string, string[]>;
+            if (!directContent[inviter]?.includes(room.roomId)) {
+              directContent[inviter] = [room.roomId, ...(directContent[inviter] ?? [])];
+              client.setAccountData(EventType.Direct, directContent).catch(console.warn);
+            }
+          }
+        }).catch(err => {
+          console.warn(`[Matrix] Failed to auto-join DM room ${room.roomId}:`, err);
+        });
+      }
+    };
+
     client.on(ClientEvent.Sync, onSync);
     client.on(ClientEvent.AccountData, onAccountData);
+    client.on(RoomEvent.MyMembership, onMyMembership);
 
     return () => {
       client.off(RoomEvent.Timeline, onTimeline);
       client.off(ClientEvent.Sync, onSync);
       client.off(ClientEvent.AccountData, onAccountData);
+      client.off(RoomEvent.MyMembership, onMyMembership);
       client.stopClient();
       clientRef.current = null;
       setClient(null);

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -506,5 +506,24 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
     return names;
   }, [client, dmRoomMap, credentials?.userId]);
 
-  return { messages, sendMessage, fetchHistory, dmMessages, dmRoomMap, dmUserDisplayNames, sendDMMessage, fetchDMHistory, fetchAvatarUrl, client };
+  // Resolve avatar URLs for DM partners from Matrix room membership.
+  // This works even when the other user isn't connected to Mumble.
+  const dmUserAvatarUrls = useMemo(() => {
+    const urls = new Map<string, string>();
+    if (!client || !dmRoomMap) return urls;
+    for (const [matrixUserId, roomId] of dmRoomMap) {
+      const room = client.getRoom(roomId);
+      if (!room) continue;
+      const member = room.getMember(matrixUserId);
+      if (member) {
+        const avatarUrl = member.getAvatarUrl(client.baseUrl, 128, 128, 'crop', false, false);
+        if (avatarUrl) {
+          urls.set(matrixUserId, avatarUrl);
+        }
+      }
+    }
+    return urls;
+  }, [client, dmRoomMap]);
+
+  return { messages, sendMessage, fetchHistory, dmMessages, dmRoomMap, dmUserDisplayNames, dmUserAvatarUrls, sendDMMessage, fetchDMHistory, fetchAvatarUrl, client };
 }

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -78,6 +78,9 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       userId: credentials.userId,
     });
 
+    let isPrepared = false;
+    const bufferedDmEvents: Array<{ room: Room | undefined; event: MatrixEvent }> = [];
+
     const onTimeline = (event: MatrixEvent, room: Room | undefined) => {
       if (event.getType() !== EventType.RoomMessage) return;
       const channelId = roomIdToChannelId.get(room?.roomId ?? '');
@@ -140,7 +143,12 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
 
       // DM message handling
       const dmUserId = roomIdToDMUserIdRef.current.get(room?.roomId ?? '');
-      if (!dmUserId) return;
+      if (!dmUserId) {
+        if (!isPrepared && room?.roomId) {
+          bufferedDmEvents.push({ room, event });
+        }
+        return;
+      }
 
       const dmSenderId = event.getSender() ?? 'Unknown';
       const dmSenderMember = room?.getMember(dmSenderId);
@@ -222,10 +230,17 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       if (state === 'PREPARED' || state === 'SYNCING') {
         derivedState = 'connected';
         if (state === 'PREPARED') {
+          isPrepared = true;
           const directEvent = client.getAccountData(EventType.Direct);
           if (directEvent) {
             refreshDMRoomMaps(directEvent.getContent() as Record<string, string[]>);
           }
+
+          // Replay any DM timeline events that arrived before room maps were ready
+          for (const { room, event } of bufferedDmEvents) {
+            onTimeline(event, room);
+          }
+          bufferedDmEvents.length = 0;
         }
       } else if (state === 'ERROR') {
         derivedState = 'disconnected';

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -46,6 +46,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
   useEffect(() => { dmRoomMapRef.current = dmRoomMap; }, [dmRoomMap]);
 
   const roomIdToDMUserIdRef = useRef<Map<string, string>>(new Map());
+  const pendingRoomCreations = useRef(new Map<string, Promise<string>>());
   const lastSyncStateRef = useRef<string | null>(null);
 
   // Reverse lookup: matrixRoomId → mumbleChannelId
@@ -317,25 +318,42 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
 
     let roomId = dmRoomMapRef.current.get(targetMatrixUserId);
 
-    // Create DM room if it doesn't exist
     if (!roomId) {
-      const createResult = await client.createRoom({
-        is_direct: true,
-        invite: [targetMatrixUserId],
-        preset: Preset.TrustedPrivateChat,
-      });
-      roomId = createResult.room_id;
+      // Check if a room creation is already in flight for this user
+      const pending = pendingRoomCreations.current.get(targetMatrixUserId);
+      if (pending) {
+        roomId = await pending;
+      } else {
+        // Create room with mutex
+        const createPromise = (async () => {
+          const createResult = await client.createRoom({
+            is_direct: true,
+            invite: [targetMatrixUserId],
+            preset: Preset.TrustedPrivateChat,
+          });
+          const newRoomId = createResult.room_id;
 
-      // Update m.direct account data
-      const directEvent = client.getAccountData(EventType.Direct);
-      const directContent = (directEvent?.getContent() ?? {}) as Record<string, string[]>;
-      directContent[targetMatrixUserId] = [roomId, ...(directContent[targetMatrixUserId] ?? [])];
-      await client.setAccountData(EventType.Direct, directContent);
+          // Update m.direct account data
+          const directEvent = client.getAccountData(EventType.Direct);
+          const directContent = (directEvent?.getContent() ?? {}) as Record<string, string[]>;
+          directContent[targetMatrixUserId] = [newRoomId, ...(directContent[targetMatrixUserId] ?? [])];
+          await client.setAccountData(EventType.Direct, directContent);
 
-      // Update local state
-      setDmRoomMap(prev => new Map(prev).set(targetMatrixUserId, roomId!));
-      dmRoomMapRef.current = new Map(dmRoomMapRef.current).set(targetMatrixUserId, roomId);
-      roomIdToDMUserIdRef.current = new Map(roomIdToDMUserIdRef.current).set(roomId, targetMatrixUserId);
+          // Update local maps
+          setDmRoomMap(prev => new Map(prev).set(targetMatrixUserId, newRoomId));
+          dmRoomMapRef.current = new Map(dmRoomMapRef.current).set(targetMatrixUserId, newRoomId);
+          roomIdToDMUserIdRef.current = new Map(roomIdToDMUserIdRef.current).set(newRoomId, targetMatrixUserId);
+
+          return newRoomId;
+        })();
+
+        pendingRoomCreations.current.set(targetMatrixUserId, createPromise);
+        try {
+          roomId = await createPromise;
+        } finally {
+          pendingRoomCreations.current.delete(targetMatrixUserId);
+        }
+      }
     }
 
     await client.sendMessage(roomId, { msgtype: MsgType.Text, body: text });

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -25,6 +25,7 @@ export interface User {
   comment?: string;
   prioritySpeaker?: boolean;
   avatarUrl?: string;
+  certHash?: string;
 }
 
 export interface MediaAttachment {

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -26,6 +26,7 @@ export interface User {
   prioritySpeaker?: boolean;
   avatarUrl?: string;
   certHash?: string;
+  isBrmbleClient?: boolean;
 }
 
 export interface MediaAttachment {

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -50,14 +50,6 @@ export interface ChatMessage {
   pending?: boolean;
 }
 
-export interface DMConversation {
-  id: string;
-  recipientId: string;
-  recipientName: string;
-  messages: ChatMessage[];
-  unreadCount: number;
-}
-
 export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'failed' | 'disconnected';
 
 export type ServiceName = 'voice' | 'chat' | 'server' | 'livekit';

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -47,6 +47,7 @@ export interface ChatMessage {
   type?: 'system';
   html?: boolean;
   media?: MediaAttachment[];
+  pending?: boolean;
 }
 
 export interface DMConversation {

--- a/tests/Brmble.Server.Tests/Auth/AuthServiceRegistrationTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthServiceRegistrationTests.cs
@@ -35,8 +35,10 @@ public class AuthServiceRegistrationTests
         _mockReg = new Mock<IMumbleRegistrationService>();
         _mockSession = new Mock<ISessionMappingService>();
         var mockMatrix = new Mock<IMatrixAppService>();
+        var mockEventBus = new Mock<IBrmbleEventBus>();
+        mockEventBus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
         _authService = new AuthService(repo, mockMatrix.Object, NullLogger<AuthService>.Instance,
-            _mockReg.Object, _mockSession.Object);
+            _mockReg.Object, _mockSession.Object, mockEventBus.Object);
     }
 
     [TestCleanup]

--- a/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
@@ -43,8 +43,10 @@ public class AuthServiceTests
                    .ReturnsAsync("syt_refresh_token");
         _mockMumbleReg = new Mock<IMumbleRegistrationService>();
         _mockSessionMapping = new Mock<ISessionMappingService>();
+        var mockEventBus = new Mock<IBrmbleEventBus>();
+        mockEventBus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
         _svc = new AuthService(repo, _mockMatrix.Object, NullLogger<AuthService>.Instance,
-            _mockMumbleReg.Object, _mockSessionMapping.Object);
+            _mockMumbleReg.Object, _mockSessionMapping.Object, mockEventBus.Object);
     }
 
     [TestCleanup]

--- a/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
@@ -18,6 +18,7 @@ public class SessionMappingHandlerTests
     private UserRepository _repo = null!;
     private Mock<ISessionMappingService> _mapping = null!;
     private Mock<IBrmbleEventBus> _bus = null!;
+    private Mock<IActiveBrmbleSessions> _activeSessions = null!;
     private SessionMappingHandler _handler = null!;
 
     [TestInitialize]
@@ -33,7 +34,8 @@ public class SessionMappingHandlerTests
         _mapping = new Mock<ISessionMappingService>();
         _bus = new Mock<IBrmbleEventBus>();
         _bus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
-        _handler = new SessionMappingHandler(_mapping.Object, _bus.Object, _repo, NullLogger<SessionMappingHandler>.Instance);
+        _activeSessions = new Mock<IActiveBrmbleSessions>();
+        _handler = new SessionMappingHandler(_mapping.Object, _bus.Object, _repo, _activeSessions.Object, NullLogger<SessionMappingHandler>.Instance);
     }
 
     [TestCleanup]


### PR DESCRIPTION
## Summary

Complete rebuild of the Direct Message subsystem for Brmble, implemented in three phases plus bugfixes.

- **Phase 1:** Makes Matrix the single source of truth for Brmble-to-Brmble DMs (persistent, encrypted, with history)
- **Phase 2:** Adds Mumble DM support so Brmble users can DM pure Mumble users via Mumble's native private message system (ephemeral)
- **Phase 3:** Adds `isBrmbleClient` flag so the frontend can distinguish users on Brmble clients vs Mumble clients, enabling correct DM routing for "hybrid users" (Brmble-registered users connecting via plain Mumble clients)

## Phase 1: Matrix DM Subsystem (11 tasks)

Replaces the previous DM implementation with a centralized `useDMStore` hook and Matrix-backed messaging.

- **`useDMStore` hook** — Centralized DM state management: contacts, messages, selected contact, send/receive, mode toggling between channels and DM views
- **Auto-join DM invites** — Listens for `RoomEvent.MyMembership` to automatically accept incoming DM room invites (uses `Room.getDMInviter()` to distinguish DMs from group rooms)
- **Duplicate room prevention** — Prevents race conditions when rapidly sending DMs to a new contact
- **Event buffering** — Buffers Matrix timeline events that fire before the PREPARED sync state, replays them after sync completes
- **Display name resolution** — Priority chain: Matrix room membership > Mumble user list > parse Matrix ID
- **Circular dependency fix** — `totalDmUnreadCount` computed outside `useDMStore` in App.tsx to break circular hook dependency
- **Local echo** — Optimistic message display for sent DMs
- **Per-contact unread counts** — Wired from `useUnreadTracker` to the DM contact list
- **Joined room backfill** — Handles DM rooms that are joined but missing from `m.direct`

## Phase 2: Mumble DM Support (8 tasks)

Adds ephemeral DM support for pure Mumble users who don't have Matrix accounts.

- **`certHash` bridge events** — Added `certHash` (certificate hash) to `voice.userJoined`, `voice.message`, and `voice.userLeft` bridge payloads from MumbleAdapter
- **Frontend `certHash` wiring** — Added `certHash` to the `User` type and all relevant event handlers in App.tsx, with preservation logic to prevent overwrite by later updates
- **`useDMStore` Mumble extensions** — `receiveMumbleDM()`, `startMumbleDM()`, `updateMumbleSession()`, `clearMumbleContacts()` for ephemeral Mumble DM contacts and messages
- **App.tsx Mumble DM wiring** — Routes incoming private Mumble messages to `useDMStore`, wires session updates for online/offline state
- **Ephemeral DM UI** — Ephemeral tag on Mumble contacts, offline state display, disabled input when contact is offline, top notice explaining ephemeral nature
- **Offline user avatars** — Fallback avatar resolution from Matrix room membership data

## Phase 3: `isBrmbleClient` Flag (6 tasks)

Solves the "hybrid user" problem: a Brmble-registered user connecting via a plain Mumble client has a `matrixUserId` but should NOT get Matrix DMs (we can't send messages as them in Matrix).

### Server changes
- **`SessionMapping` record** — Added `bool IsBrmbleClient` field
- **`SessionMappingHandler`** — Injects `IActiveBrmbleSessions`, includes `isBrmbleClient` in `userMappingAdded` broadcast and snapshot
- **`AuthService`** — Broadcasts `brmbleClientActivated` after `POST /auth/token` (solves timing issue: Mumble UserState fires before auth), broadcasts `brmbleClientDeactivated` on disconnect
- **`SessionMappingService`** — Added `TryUpdateBrmbleStatus()` to update the flag on existing mappings

### Client C# changes (MumbleAdapter)
- Parses `isBrmbleClient` from all session mapping WebSocket messages
- Handles new `brmbleClientActivated`/`brmbleClientDeactivated` events
- Includes `isBrmbleClient` in `voice.userJoined` and `voice.connected` payloads

### Frontend changes
- Added `isBrmbleClient` to `User` interface and all event handlers
- **DM routing**: `isBrmbleClient=true` → Matrix DM (persistent), otherwise `certHash` → Mumble DM (ephemeral)
- **Brmble badge**: Only shown for users on actual Brmble clients
- **Avatar style**: Mumble-style for non-Brmble-client users

## Bugfixes

- **Post-Phase-2 batch** (8 fixes): first-time Matrix DM contact creation, `certHash` preservation on user updates, `certHash` in `voice.connected` payload, Mumble avatar in contact list, ephemeral chat notice, offline user avatars (contact list + message bubbles), duplicate contact prevention
- **Hybrid DM routing revert**: Attempted Matrix routing for hybrid users, reverted due to unread badge, avatar, and persistence issues
- **HTML stripping**: Mumble clients send messages as HTML (Qt rich text) — strip tags and decode entities for plain-text display in DMs

## Files Changed

**25 files**, ~3200 insertions, ~430 deletions

### New files
- `src/Brmble.Web/src/hooks/useDMStore.ts` — Centralized DM state management (396 lines)
- `docs/plans/` — Design docs and implementation plans (4 files)

### Key modified files
- `src/Brmble.Web/src/App.tsx` — Major refactor: DM wiring, event handlers, isBrmbleClient
- `src/Brmble.Web/src/hooks/useMatrixClient.ts` — DM room management, invite handling, event buffering
- `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` — certHash, session mappings, isBrmbleClient piping
- `src/Brmble.Server/Auth/AuthService.cs` — brmbleClientActivated/Deactivated broadcasts
- `src/Brmble.Server/Events/*` — SessionMapping record, service, handler updates

## Testing notes

- All three layers build clean (server, client, frontend)
- Server tests compile (known pre-existing hang issue)
- Manual testing confirms Mumble DM send/receive works between Brmble and Mumble clients
- `isBrmbleClient` flag requires the updated server to be deployed — badge and DM routing distinction won't work against old servers