### PR TITLE
fix: include isBrmbleClient in auth response and client-side session mapping parse

### DIFF
--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1199,7 +1199,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                         var matrixId = prop.Value.TryGetProperty("matrixUserId", out var m) ? m.GetString() : null;
                         var name = prop.Value.TryGetProperty("mumbleName", out var n) ? n.GetString() : null;
                         if (matrixId is not null && name is not null)
-                            _sessionMappings[sid] = new SessionMappingEntry(matrixId, name);
+                        {
+                            var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b) && b.GetBoolean();
+                            _sessionMappings[sid] = new SessionMappingEntry(matrixId, name, isBrmble);
+                        }
                     }
                 }
             }

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -62,7 +62,31 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     })
     { Timeout = TimeSpan.FromSeconds(5) };
 
-    private record SessionMappingEntry(string MatrixUserId, string MumbleName, bool IsBrmbleClient = false);
+    internal record SessionMappingEntry(string MatrixUserId, string MumbleName, bool IsBrmbleClient = false);
+
+    /// <summary>
+    /// Parses a JSON object whose keys are session IDs and values contain
+    /// matrixUserId, mumbleName, and optionally isBrmbleClient into a dictionary.
+    /// Shared by the auth-response and WebSocket snapshot parsers.
+    /// </summary>
+    internal static Dictionary<uint, SessionMappingEntry> ParseSessionMappings(System.Text.Json.JsonElement mappingsElement)
+    {
+        var result = new Dictionary<uint, SessionMappingEntry>();
+        foreach (var prop in mappingsElement.EnumerateObject())
+        {
+            if (uint.TryParse(prop.Name, out var sid))
+            {
+                var matrixId = prop.Value.TryGetProperty("matrixUserId", out var m) ? m.GetString() : null;
+                var name = prop.Value.TryGetProperty("mumbleName", out var n) ? n.GetString() : null;
+                if (matrixId is not null && name is not null)
+                {
+                    var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b) && b.GetBoolean();
+                    result[sid] = new SessionMappingEntry(matrixId, name, isBrmble);
+                }
+            }
+        }
+        return result;
+    }
 
     public string ServiceName => "mumble";
 
@@ -1192,19 +1216,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             if (credentials.Value.TryGetProperty("sessionMappings", out var sessionMappingsElement))
             {
                 _sessionMappings.Clear();
-                foreach (var prop in sessionMappingsElement.EnumerateObject())
-                {
-                    if (uint.TryParse(prop.Name, out var sid))
-                    {
-                        var matrixId = prop.Value.TryGetProperty("matrixUserId", out var m) ? m.GetString() : null;
-                        var name = prop.Value.TryGetProperty("mumbleName", out var n) ? n.GetString() : null;
-                        if (matrixId is not null && name is not null)
-                        {
-                            var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b) && b.GetBoolean();
-                            _sessionMappings[sid] = new SessionMappingEntry(matrixId, name, isBrmble);
-                        }
-                    }
-                }
+                foreach (var (sid, entry) in ParseSessionMappings(sessionMappingsElement))
+                    _sessionMappings[sid] = entry;
             }
 
             // The server returns its internal homeserverUrl (e.g. http://localhost:6167).
@@ -1359,19 +1372,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                     _sessionMappings.Clear();
                     if (root.TryGetProperty("mappings", out var mappings))
                     {
-                        foreach (var prop in mappings.EnumerateObject())
-                        {
-                            if (uint.TryParse(prop.Name, out var sid))
-                            {
-                                var matrixId = prop.Value.TryGetProperty("matrixUserId", out var m) ? m.GetString() : null;
-                                var name = prop.Value.TryGetProperty("mumbleName", out var n) ? n.GetString() : null;
-                                if (matrixId is not null && name is not null)
-                                {
-                                    var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b) && b.GetBoolean();
-                                    _sessionMappings[sid] = new SessionMappingEntry(matrixId, name, isBrmble);
-                                }
-                            }
-                        }
+                        foreach (var (sid, entry) in ParseSessionMappings(mappings))
+                            _sessionMappings[sid] = entry;
                     }
                     _bridge?.Send("voice.sessionMappingSnapshot",
                         new { mappings = _sessionMappings.ToDictionary(k => k.Key, k => new { k.Value.MatrixUserId, k.Value.MumbleName, k.Value.IsBrmbleClient }) });

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -143,7 +143,7 @@ public static class AuthEndpoints
                 sessionMappings = sessionMapping.GetSnapshot()
                     .ToDictionary(
                         kvp => kvp.Key.ToString(),
-                        kvp => new { matrixUserId = kvp.Value.MatrixUserId, mumbleName = kvp.Value.MumbleName }),
+                        kvp => new { matrixUserId = kvp.Value.MatrixUserId, mumbleName = kvp.Value.MumbleName, isBrmbleClient = kvp.Value.IsBrmbleClient }),
                 registered = result.IsRegistered,
                 registeredName = result.DisplayName,
                 livekit = (object?)null

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -85,13 +85,26 @@ public static class AuthEndpoints
             {
                 if (sessionMapping.TryAddMatrixUser(sid, result.MatrixUserId, resolvedName, result.UserId))
                 {
+                    // This user just authenticated via Brmble, so mark them as a Brmble client
+                    // immediately. Authenticate() may have failed to update the mapping if
+                    // TryAddMatrixUser hadn't been called yet (race with SessionMappingHandler).
+                    sessionMapping.TryUpdateBrmbleStatus(sid, true);
                     await eventBus.BroadcastAsync(new
                     {
                         type = "userMappingAdded",
                         sessionId = sid,
                         matrixUserId = result.MatrixUserId,
-                        mumbleName = resolvedName
+                        mumbleName = resolvedName,
+                        isBrmbleClient = true
                     });
+                }
+                else
+                {
+                    // Mapping already existed (created by SessionMappingHandler.OnUserConnected).
+                    // Ensure Brmble status is up to date — Authenticate() sets _activeSessions
+                    // but TryUpdateBrmbleStatus may not have been called if the mapping
+                    // was created before auth completed.
+                    sessionMapping.TryUpdateBrmbleStatus(sid, true);
                 }
             }
 

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Brmble.Client.Services.Voice;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -43,5 +44,80 @@ public class MumbleAdapterParseTests
     {
         var text = "Welcome!<!--brmble:{'apiUrl':'https://noscope.it:1912'}-->";
         Assert.AreEqual("https://noscope.it:1912", MumbleAdapter.ParseBrmbleApiUrl(text));
+    }
+
+    [TestMethod]
+    public void ParseSessionMappings_WithIsBrmbleClient_RoundTrips()
+    {
+        var json = JsonDocument.Parse("""
+        {
+            "1": { "matrixUserId": "@alice:localhost", "mumbleName": "Alice", "isBrmbleClient": true },
+            "2": { "matrixUserId": "@bob:localhost", "mumbleName": "Bob", "isBrmbleClient": false }
+        }
+        """);
+
+        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
+
+        Assert.AreEqual(2, result.Count);
+        Assert.IsTrue(result[1].IsBrmbleClient, "Alice should be a Brmble client");
+        Assert.IsFalse(result[2].IsBrmbleClient, "Bob should not be a Brmble client");
+        Assert.AreEqual("@alice:localhost", result[1].MatrixUserId);
+        Assert.AreEqual("Bob", result[2].MumbleName);
+    }
+
+    [TestMethod]
+    public void ParseSessionMappings_MissingIsBrmbleClient_DefaultsToFalse()
+    {
+        var json = JsonDocument.Parse("""
+        {
+            "5": { "matrixUserId": "@user:localhost", "mumbleName": "User" }
+        }
+        """);
+
+        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.IsFalse(result[5].IsBrmbleClient, "Missing isBrmbleClient should default to false");
+    }
+
+    [TestMethod]
+    public void ParseSessionMappings_SkipsEntriesWithMissingRequiredFields()
+    {
+        var json = JsonDocument.Parse("""
+        {
+            "1": { "matrixUserId": "@alice:localhost" },
+            "2": { "mumbleName": "Bob" },
+            "3": { "matrixUserId": "@charlie:localhost", "mumbleName": "Charlie" }
+        }
+        """);
+
+        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
+
+        Assert.AreEqual(1, result.Count, "Only the complete entry should be parsed");
+        Assert.IsTrue(result.ContainsKey(3));
+    }
+
+    [TestMethod]
+    public void ParseSessionMappings_SkipsNonNumericKeys()
+    {
+        var json = JsonDocument.Parse("""
+        {
+            "abc": { "matrixUserId": "@x:localhost", "mumbleName": "X" },
+            "42": { "matrixUserId": "@y:localhost", "mumbleName": "Y" }
+        }
+        """);
+
+        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.IsTrue(result.ContainsKey(42));
+    }
+
+    [TestMethod]
+    public void ParseSessionMappings_EmptyObject_ReturnsEmpty()
+    {
+        var json = JsonDocument.Parse("{}");
+        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
+        Assert.AreEqual(0, result.Count);
     }
 }

--- a/tests/Brmble.Server.Tests/Integration/AuthTokenTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/AuthTokenTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using Brmble.Server.Events;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Brmble.Server.Tests.Integration;
@@ -65,5 +67,69 @@ public class AuthTokenTests : IDisposable
 
         var json = await response.Content.ReadAsStringAsync();
         Assert.IsTrue(json.Contains("sessionMappings"), "Response should contain sessionMappings field");
+    }
+
+    [TestMethod]
+    public async Task PostAuthToken_SessionMappings_IncludeIsBrmbleClient()
+    {
+        // Seed a session mapping with isBrmbleClient = true before authenticating
+        using var factory = new BrmbleServerFactory();
+        using var client = factory.CreateClient();
+
+        var sessionMapping = factory.Services.GetRequiredService<ISessionMappingService>();
+        sessionMapping.SetNameForSession("OtherUser", 42);
+        sessionMapping.TryAddMatrixUser(42, "@other:localhost", "OtherUser", 999);
+        sessionMapping.TryUpdateBrmbleStatus(42, true);
+
+        var response = await client.PostAsync("/auth/token", null);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsTrue(root.TryGetProperty("sessionMappings", out var mappings),
+            "Response should contain sessionMappings");
+
+        // Find the seeded session mapping and verify isBrmbleClient round-trips as true
+        Assert.IsTrue(mappings.TryGetProperty("42", out var entry),
+            "sessionMappings should contain session 42");
+        Assert.IsTrue(entry.TryGetProperty("isBrmbleClient", out var isBrmble),
+            "Session mapping entry should contain isBrmbleClient");
+        Assert.IsTrue(isBrmble.GetBoolean(),
+            "isBrmbleClient should be true for the seeded Brmble client");
+    }
+
+    [TestMethod]
+    public async Task PostAuthToken_SelfSession_IsBrmbleClient_True()
+    {
+        // Verify that the authenticating user's own session gets isBrmbleClient = true
+        // even when the mapping was created with IsBrmbleClient = false (race condition fix)
+        using var factory = new BrmbleServerFactory();
+        using var client = factory.CreateClient();
+
+        // Pre-seed the name→session mapping so the endpoint can find the session
+        var sessionMapping = factory.Services.GetRequiredService<ISessionMappingService>();
+        sessionMapping.SetNameForSession("TestUser", 1);
+
+        // Authenticate with a mumbleUsername so the endpoint can resolve the session
+        var body = new StringContent(
+            JsonSerializer.Serialize(new { mumbleUsername = "TestUser" }),
+            Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/auth/token", body);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.IsTrue(root.TryGetProperty("sessionMappings", out var mappings),
+            "Response should contain sessionMappings");
+        Assert.IsTrue(mappings.TryGetProperty("1", out var entry),
+            "sessionMappings should contain session 1 (self)");
+        Assert.IsTrue(entry.TryGetProperty("isBrmbleClient", out var isBrmble),
+            "Session mapping entry should contain isBrmbleClient");
+        Assert.IsTrue(isBrmble.GetBoolean(),
+            "Self session should have isBrmbleClient = true after auth");
     }
 }


### PR DESCRIPTION
## Summary

- Fixes the missing green "Brmble user" dot indicator next to users in the channel tree
- The `/auth/token` endpoint was omitting `isBrmbleClient` from its `sessionMappings` response, and the client was not reading it when parsing the auth response

## Root Cause

Two bugs introduced when PR #375 added `isBrmbleClient` support — the initial auth response path was missed:

1. **Server (`AuthEndpoints.cs`)**: The `/auth/token` endpoint projected `sessionMappings` with only `matrixUserId` and `mumbleName`, excluding `isBrmbleClient` even though the `SessionMapping` record has the field.
2. **Client (`MumbleAdapter.cs`)**: When parsing `sessionMappings` from the auth response, the code created `SessionMappingEntry(matrixId, name)` without reading `isBrmbleClient` from the JSON, so it defaulted to `false` for all users.

The WebSocket `sessionMappingSnapshot` handler already included `isBrmbleClient` correctly — only the initial HTTP auth path was affected.

## Changes

- `AuthEndpoints.cs`: Added `isBrmbleClient = kvp.Value.IsBrmbleClient` to the session mappings projection
- `MumbleAdapter.cs`: Added `isBrmbleClient` parsing from the auth response JSON, matching the pattern already used in the WebSocket handler