### PR TITLE
fix: channel context menu not showing items

### DIFF
--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -367,6 +367,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
 
     const items = [
       {
+        type: 'item' as const,
         label: 'Join',
         onClick: () => {
           onJoinChannel(channelContextMenu.channelId);
@@ -386,6 +387,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
 
     if (hasEditPermission) {
       adminItems.push({
+        type: 'item' as const,
         label: 'Edit',
         onClick: () => {
           setEditChannelDialog({ id: channelContextMenu.channelId, name: channelContextMenu.channelName });
@@ -396,6 +398,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
 
     if (hasAddSubchannelPermission) {
       adminItems.push({
+        type: 'item' as const,
         label: 'Add Subchannel',
         onClick: () => {
           setAddSubchannelDialog({ parentId: channelContextMenu.channelId });
@@ -406,6 +409,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
 
     if (hasRemovePermission) {
       adminItems.push({
+        type: 'item' as const,
         label: 'Remove',
         onClick: () => {
           setRemoveChannelDialog({ id: channelContextMenu.channelId, name: channelContextMenu.channelName });
@@ -414,7 +418,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
       });
     }
 
-    return [...items, { label: '', isDivider: true } as any, ...adminItems];
+    return [...items, { type: 'divider' as const }, ...adminItems];
   }, [channelContextMenu, hasPermission, onJoinChannel]);
 
   return (


### PR DESCRIPTION
## Summary
- Add missing `type: 'item'` property to channel context menu items (Join, Edit, Add Subchannel, Remove)
- Fix divider to use `type: 'divider'` instead of non-standard `isDivider: true`

## Problem
Right-clicking on a channel opened the context menu at the correct position, but no items were visible. The `ContextMenu` component requires items to have a `type: 'item'` property to render them, and dividers to have `type: 'divider'`. The channel menu items were missing these properties.

## Testing
- Built successfully with `npm run build`
- Can be tested by right-clicking on any channel in the sidebar