### PR TITLE
fix: restore MumbleRegistrationService accidentally deleted in 6aa94d8

### DIFF
--- a/src/Brmble.Server/Mumble/IMumbleRegistrationService.cs
+++ b/src/Brmble.Server/Mumble/IMumbleRegistrationService.cs
@@ -1,0 +1,53 @@
+// src/Brmble.Server/Mumble/IMumbleRegistrationService.cs
+namespace Brmble.Server.Mumble;
+
+/// <summary>
+/// Wraps Mumble ICE server proxy registration methods.
+/// Mumble is the single source of truth for usernames.
+/// </summary>
+public interface IMumbleRegistrationService
+{
+    /// <summary>
+    /// Check if the connected user (by Mumble session ID) is registered.
+    /// Returns (true, userId) if registered, (false, -1) if not.
+    /// </summary>
+    Task<(bool IsRegistered, int UserId)> GetRegistrationStatusAsync(int sessionId);
+
+    /// <summary>
+    /// Get the registered name for a Mumble user ID.
+    /// Returns null if not registered or registration has no name.
+    /// </summary>
+    Task<string?> GetRegisteredNameAsync(int userId);
+
+    /// <summary>
+    /// Register a username bound to a certificate hash in Mumble.
+    /// Returns the new Mumble user ID on success.
+    /// Throws MumbleNameConflictException if the name is already taken.
+    /// Throws MumbleRegistrationException for other ICE failures.
+    /// </summary>
+    Task<int> RegisterUserAsync(string name, string certHash);
+
+    /// <summary>
+    /// Get all registered users matching the optional filter.
+    /// Returns a dictionary mapping user IDs to usernames.
+    /// </summary>
+    Task<Dictionary<int, string>> GetRegisteredUsersAsync(string filter = "");
+}
+
+/// <summary>Thrown when a requested username is already registered in Mumble.</summary>
+public class MumbleNameConflictException : Exception
+{
+    public string RequestedName { get; }
+    public MumbleNameConflictException(string name)
+        : base($"Username '{name}' is already registered in Mumble.")
+    {
+        RequestedName = name;
+    }
+}
+
+/// <summary>Thrown when Mumble ICE is unavailable or returns an unexpected error.</summary>
+public class MumbleRegistrationException : Exception
+{
+    public MumbleRegistrationException(string message, Exception? inner = null)
+        : base(message, inner) { }
+}

--- a/src/Brmble.Server/Mumble/MumbleRegistrationService.cs
+++ b/src/Brmble.Server/Mumble/MumbleRegistrationService.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging;
+
+namespace Brmble.Server.Mumble;
+
+public class MumbleRegistrationService : IMumbleRegistrationService
+{
+    private readonly ILogger<MumbleRegistrationService> _logger;
+    private volatile MumbleServer.ServerPrx? _serverProxy;
+
+    public MumbleRegistrationService(ILogger<MumbleRegistrationService> logger)
+    {
+        _logger = logger;
+    }
+
+    internal void SetServerProxy(MumbleServer.ServerPrx proxy) => _serverProxy = proxy;
+
+    private MumbleServer.ServerPrx GetProxy()
+    {
+        return _serverProxy ?? throw new MumbleRegistrationException(
+            "Mumble ICE server proxy is not available. Cannot perform registration operations.");
+    }
+
+    public async Task<(bool IsRegistered, int UserId)> GetRegistrationStatusAsync(int sessionId)
+    {
+        var proxy = GetProxy();
+        try
+        {
+            var state = await proxy.getStateAsync(sessionId);
+            var isRegistered = state.userid >= 0;
+            _logger.LogDebug(
+                "Registration status for session {SessionId}: registered={IsRegistered}, userid={UserId}",
+                sessionId, isRegistered, state.userid);
+            return (isRegistered, state.userid);
+        }
+        catch (MumbleServer.InvalidSessionException)
+        {
+            throw new MumbleRegistrationException($"Mumble session {sessionId} not found.");
+        }
+        catch (Exception ex) when (ex is not MumbleRegistrationException)
+        {
+            throw new MumbleRegistrationException($"ICE error checking session {sessionId}.", ex);
+        }
+    }
+
+    public async Task<string?> GetRegisteredNameAsync(int userId)
+    {
+        var proxy = GetProxy();
+        try
+        {
+            var info = await proxy.getRegistrationAsync(userId);
+            info.TryGetValue(MumbleServer.UserInfo.UserName, out var name);
+            return name;
+        }
+        catch (MumbleServer.InvalidUserException)
+        {
+            return null;
+        }
+        catch (Exception ex) when (ex is not MumbleRegistrationException)
+        {
+            throw new MumbleRegistrationException($"ICE error getting registration for user {userId}.", ex);
+        }
+    }
+
+    public async Task<int> RegisterUserAsync(string name, string certHash)
+    {
+        var proxy = GetProxy();
+        var info = new Dictionary<MumbleServer.UserInfo, string>
+        {
+            { MumbleServer.UserInfo.UserName, name },
+            { MumbleServer.UserInfo.UserHash, certHash }
+        };
+
+        try
+        {
+            var newUserId = await proxy.registerUserAsync(info);
+            _logger.LogInformation(
+                "Registered user '{Name}' in Mumble with userId={UserId}",
+                name, newUserId);
+            return newUserId;
+        }
+        catch (MumbleServer.InvalidUserException)
+        {
+            throw new MumbleNameConflictException(name);
+        }
+        catch (Exception ex) when (ex is not MumbleNameConflictException)
+        {
+            throw new MumbleRegistrationException($"ICE error registering user '{name}'.", ex);
+        }
+    }
+
+    public async Task<Dictionary<int, string>> GetRegisteredUsersAsync(string filter = "")
+    {
+        var proxy = GetProxy();
+        try
+        {
+            var users = await proxy.getRegisteredUsersAsync(filter);
+            _logger.LogDebug("Retrieved {Count} registered users from Mumble", users.Count);
+            return users;
+        }
+        catch (Exception ex)
+        {
+            throw new MumbleRegistrationException($"ICE error getting registered users.", ex);
+        }
+    }
+}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1892,7 +1892,7 @@ const handleConnect = (serverData: SavedServer) => {
         initialTab={settingsTab}
         username={username}
         connected={connected}
-<        currentUser={{ name: username || 'Unknown', matrixUserId: matrixCredentials?.userId, avatarUrl: currentUserAvatarUrl }}
+        currentUser={{ name: username || 'Unknown', matrixUserId: matrixCredentials?.userId, avatarUrl: currentUserAvatarUrl }}
         onUploadAvatar={onUploadAvatar}
         onRemoveAvatar={onRemoveAvatar}
         brmblegotchiEnabled={brmblegotchiEnabled}

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -67,10 +67,6 @@ function MenuItem({ item, depth, onItemClick }: MenuItemProps) {
   const isDisabled = item.disabled;
   const [isFocused, setIsFocused] = useState(false);
 
-  if (item.isDivider) {
-    return <div key={depth} className="context-menu-divider" />;
-  }
-
   return (
     <div className="context-menu-item-wrapper">
       <button


### PR DESCRIPTION
## Summary
- **Restore `IMumbleRegistrationService.cs` and `MumbleRegistrationService.cs`** — these were accidentally deleted in 6aa94d8 alongside the intentional `MumbleAdminEndpoints` removal. They are core auth infrastructure used by `AuthService` and `MumbleIceService`, not admin-only code.
- **Fix stray `<` in `App.tsx:1895`** — syntax error that broke the frontend build.
- **Remove dead `item.isDivider` check in `ContextMenu.tsx`** — TypeScript error on a code path already handled by the `isDivider()` guard above it.

## Context
Commit 6aa94d8 ("feat: add Registered Users tab with placeholder") correctly deleted `MumbleAdminEndpoints.cs` and its route, but also swept up the registration service files that share the `Mumble` namespace. This broke the .NET build since `AuthService`, `MumbleIceService`, and `MumbleExtensions` all depend on these types.

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `npm run build` passes (0 errors)
- [ ] `dotnet test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)