### PR TITLE
Fix DM badge count, theme-aware native icons, and Lemon Drop rename

### DIFF
--- a/docs/superpowers/plans/2026-03-29-dm-badge-and-themed-icons.md
+++ b/docs/superpowers/plans/2026-03-29-dm-badge-and-themed-icons.md
@@ -1,0 +1,782 @@
+# DM Badge Fix & Theme-Aware Native Icons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the DM button badge to show contact count instead of message count, make tray/taskbar icons theme-aware, and rename the "Lemon Drop Martini" theme.
+
+**Architecture:** Two-sided change. Frontend sends a `notification.theme` bridge message on init and theme change. C# loads theme-specific .ico files and draws accent-colored badge dots. The DM count fix is a pure frontend change in the unread tracker and App.tsx useMemo.
+
+**Tech Stack:** React/TypeScript (frontend), C# with Win32 P/Invoke (native client), WebView2 bridge (communication)
+
+**Spec:** `docs/superpowers/specs/2026-03-29-dm-badge-and-themed-icons-design.md`
+
+---
+
+### Task 1: Fix DM Badge Count (Frontend)
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useUnreadTracker.ts:497-505`
+- Modify: `src/Brmble.Web/src/App.tsx:415-424`
+
+- [ ] **Step 1: Change useUnreadTracker to count contacts instead of summing messages**
+
+In `src/Brmble.Web/src/hooks/useUnreadTracker.ts`, find this block around line 497:
+
+```typescript
+  // Compute totals from the current state (derived, not stored)
+  let totalUnreadCount = 0;
+  let totalDmUnreadCount = 0;
+  for (const [roomId, state] of roomUnreads) {
+    totalUnreadCount += state.notificationCount;
+    if (dmRoomIds.has(roomId)) {
+      totalDmUnreadCount += state.notificationCount;
+    }
+  }
+```
+
+Change line 503 from:
+```typescript
+      totalDmUnreadCount += state.notificationCount;
+```
+to:
+```typescript
+      totalDmUnreadCount += state.notificationCount > 0 ? 1 : 0;
+```
+
+`totalUnreadCount` (channel unreads) stays as a sum -- only the DM count changes.
+
+- [ ] **Step 2: Change App.tsx ephemeral contact counting**
+
+In `src/Brmble.Web/src/App.tsx`, find the `totalDmUnreadCount` useMemo around line 415:
+
+```typescript
+  const totalDmUnreadCount = useMemo(() => {
+    let total = unreadTracker.totalDmUnreadCount;
+    // Add Mumble DM unreads
+    for (const contact of dmStore.contacts) {
+      if (contact.isEphemeral) {
+        total += contact.unreadCount;
+      }
+    }
+    return total;
+  }, [unreadTracker.totalDmUnreadCount, dmStore.contacts]);
+```
+
+Change line 420 from:
+```typescript
+        total += contact.unreadCount;
+```
+to:
+```typescript
+        total += contact.unreadCount > 0 ? 1 : 0;
+```
+
+- [ ] **Step 3: Build frontend to verify no type errors**
+
+Run: `npm run build` in `src/Brmble.Web`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useUnreadTracker.ts src/Brmble.Web/src/App.tsx
+git commit -m "fix: DM badge shows contact count instead of total message count (#403)"
+```
+
+---
+
+### Task 2: Add Theme Color Map to C# (Shared Utility)
+
+**Files:**
+- Create: `src/Brmble.Client/ThemeColors.cs`
+
+- [ ] **Step 1: Create ThemeColors.cs**
+
+Create `src/Brmble.Client/ThemeColors.cs`:
+
+```csharp
+namespace Brmble.Client;
+
+/// <summary>
+/// Maps theme IDs to their accent-primary RGB colors for native icon rendering.
+/// These values must stay in sync with the --accent-primary CSS tokens in src/Brmble.Web/src/themes/.
+/// </summary>
+internal static class ThemeColors
+{
+    public static (byte R, byte G, byte B) GetAccent(string? themeName)
+    {
+        return themeName switch
+        {
+            "classic"        => (0xD4, 0x14, 0x5A), // #d4145a
+            "clean"          => (0xD4, 0x14, 0x5A), // #d4145a (inherits classic)
+            "blue-lagoon"    => (0x00, 0xB4, 0xD8), // #00b4d8
+            "cosmopolitan"   => (0xE6, 0x39, 0x62), // #e63962
+            "aperol-spritz"  => (0xE8, 0x65, 0x1A), // #e8651a
+            "midori-sour"    => (0x00, 0xC8, 0x53), // #00c853
+            "lemon-drop"     => (0xF5, 0xC5, 0x18), // #f5c518
+            "retro-terminal" => (0x33, 0xFF, 0x00), // #33ff00
+            _                => (0xD4, 0x14, 0x5A), // default to classic
+        };
+    }
+
+    /// <summary>
+    /// Resolves the path to a theme's brmble.ico file.
+    /// Falls back to the root Resources/brmble.ico if the theme folder doesn't exist.
+    /// </summary>
+    public static string GetIconPath(string? themeName)
+    {
+        if (!string.IsNullOrEmpty(themeName))
+        {
+            var themed = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", themeName, "brmble.ico");
+            if (File.Exists(themed)) return themed;
+        }
+        return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "brmble.ico");
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `dotnet build` from the repo root.
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Client/ThemeColors.cs
+git commit -m "feat: add ThemeColors utility for theme-to-accent mapping"
+```
+
+---
+
+### Task 3: Make TrayIcon Theme-Aware
+
+**Files:**
+- Modify: `src/Brmble.Client/TrayIcon.cs`
+
+This task modifies `TrayIcon.cs` to:
+1. Load the theme-specific .ico for the normal icon
+2. Create the badge variant by drawing the accent-colored dot on top of the loaded .ico pixels (instead of drawing a programmatic green circle)
+3. Add a `SetTheme()` method
+
+- [ ] **Step 1: Update CreateColoredIconWithBadge to accept badge color parameters**
+
+The existing `CreateColoredIconWithBadge` method hardcodes the red dot color `(180, 30, 30)`. Change its signature to accept accent color parameters.
+
+Find the existing method (around line 230):
+```csharp
+    private static IntPtr CreateColoredIconWithBadge(byte r, byte g, byte b)
+```
+
+Change to:
+```csharp
+    private static IntPtr CreateColoredIconWithBadge(byte r, byte g, byte b, byte badgeR, byte badgeG, byte badgeB)
+```
+
+And in the `DrawBadge` call within that method, change from:
+```csharp
+        DrawBadge(pixels, size, 180, 30, 30);
+```
+to:
+```csharp
+        DrawBadge(pixels, size, badgeR, badgeG, badgeB);
+```
+
+- [ ] **Step 2: Add theme field and refactor icon creation**
+
+In `src/Brmble.Client/TrayIcon.cs`, add a new field to track the current theme name. Near the existing static fields (around line 86):
+
+Add after `private static bool _hasBadge;` (line 94):
+```csharp
+    private static string? _currentTheme;
+```
+
+Replace the existing `CreateIcons()` method (lines ~195-215) with:
+
+```csharp
+    private static void CreateIcons(string? themeName = null)
+    {
+        // Destroy previous icons
+        DestroyIconSafe(ref _iconNormal);
+        DestroyIconSafe(ref _iconMuted);
+        DestroyIconSafe(ref _iconDeafened);
+        DestroyIconSafe(ref _iconNormalBadge);
+        DestroyIconSafe(ref _iconMutedBadge);
+        DestroyIconSafe(ref _iconDeafenedBadge);
+
+        // Normal: load theme-specific .ico
+        var icoPath = ThemeColors.GetIconPath(themeName);
+        if (File.Exists(icoPath))
+            _iconNormal = LoadImage(IntPtr.Zero, icoPath, IMAGE_ICON, 16, 16, LR_LOADFROMFILE);
+        if (_iconNormal == IntPtr.Zero)
+            _iconNormal = CreateColoredIcon(0x00, 0xC8, 0x50); // fallback green circle
+
+        // Muted / Deafened: stay as programmatic colored circles
+        _iconMuted = CreateColoredIcon(0xE8, 0xB0, 0x00);
+        _iconDeafened = CreateColoredIcon(0xD4, 0x14, 0x5A);
+
+        // Badge variants: draw accent-colored dot on top
+        var (ar, ag, ab) = ThemeColors.GetAccent(themeName);
+        _iconNormalBadge = CreateBadgeFromIcon(_iconNormal, ar, ag, ab);
+        _iconMutedBadge = CreateColoredIconWithBadge(0xE8, 0xB0, 0x00, ar, ag, ab);
+        _iconDeafenedBadge = CreateColoredIconWithBadge(0xD4, 0x14, 0x5A, ar, ag, ab);
+    }
+```
+
+- [ ] **Step 3: Add CreateBadgeFromIcon method**
+
+This method reads the pixels from an existing icon, draws the badge dot on top, and returns a new icon. Add this after the existing `CreateColoredIcon` method:
+
+```csharp
+    /// <summary>
+    /// Creates a badge variant of an existing icon by extracting its pixels
+    /// and drawing an accent-colored dot in the top-right corner.
+    /// </summary>
+    private static IntPtr CreateBadgeFromIcon(IntPtr sourceIcon, byte badgeR, byte badgeG, byte badgeB)
+    {
+        if (sourceIcon == IntPtr.Zero) return IntPtr.Zero;
+
+        const int size = 16;
+        var biHeader = new BITMAPINFOHEADER
+        {
+            biSize = (uint)Marshal.SizeOf<BITMAPINFOHEADER>(),
+            biWidth = size,
+            biHeight = -size, // top-down
+            biPlanes = 1,
+            biBitCount = 32,
+            biCompression = 0,
+        };
+
+        var hdc = CreateCompatibleDC(IntPtr.Zero);
+        var hBitmap = CreateDIBSection(hdc, ref biHeader, 0, out var bits, IntPtr.Zero, 0);
+        var oldBmp = SelectObject(hdc, hBitmap);
+
+        // Draw the source icon onto our DIB
+        DrawIconEx(hdc, 0, 0, sourceIcon, size, size, 0, IntPtr.Zero, DI_NORMAL);
+
+        SelectObject(hdc, oldBmp);
+
+        // Read pixels, draw badge dot, write back
+        var pixels = new byte[size * size * 4];
+        Marshal.Copy(bits, pixels, 0, pixels.Length);
+        DrawBadge(pixels, size, badgeR, badgeG, badgeB);
+        Marshal.Copy(pixels, 0, bits, pixels.Length);
+
+        // Create mask (all zeros = fully opaque, alpha is in the color bitmap)
+        var hMono = CreateBitmap(size, size, 1, 1, IntPtr.Zero);
+
+        var iconInfo = new ICONINFO { fIcon = true, hbmMask = hMono, hbmColor = hBitmap };
+        var result = CreateIconIndirect(ref iconInfo);
+
+        DeleteObject(hMono);
+        DeleteObject(hBitmap);
+        DeleteDC(hdc);
+
+        return result;
+    }
+```
+
+- [ ] **Step 4: Add missing P/Invoke declarations**
+
+Add these P/Invoke declarations to `TrayIcon.cs` alongside the existing ones (near the top of the file):
+
+```csharp
+    private const uint DI_NORMAL = 0x0003;
+
+    [DllImport("user32.dll")]
+    private static extern bool DrawIconEx(IntPtr hdc, int xLeft, int yTop, IntPtr hIcon,
+        int cxWidth, int cyWidth, uint istepIfAniCur, IntPtr hbrFlickerFreeDraw, uint diFlags);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr SelectObject(IntPtr hdc, IntPtr h);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateBitmap(int nWidth, int nHeight, uint nPlanes, uint nBitCount, IntPtr lpBits);
+```
+
+Note: Check if `CreateCompatibleDC`, `SelectObject`, `DeleteDC`, `CreateDIBSection`, `CreateIconIndirect`, and `DeleteObject` already exist in the file. Only add the ones that are missing. `DrawIconEx` and `CreateBitmap` are definitely new.
+
+- [ ] **Step 5: Add DestroyIconSafe helper and SetTheme public method**
+
+Add near the existing `Destroy()` method:
+
+```csharp
+    private static void DestroyIconSafe(ref IntPtr icon)
+    {
+        if (icon != IntPtr.Zero)
+        {
+            DestroyIcon(icon);
+            icon = IntPtr.Zero;
+        }
+    }
+
+    /// <summary>
+    /// Switches tray icons to match the given theme.
+    /// Call from the UI thread.
+    /// </summary>
+    public static void SetTheme(string themeName)
+    {
+        _currentTheme = themeName;
+        CreateIcons(themeName);
+        UpdateIconAndTooltip();
+    }
+```
+
+- [ ] **Step 6: Verify the Create method still compiles**
+
+In the existing `Create(IntPtr hwnd)` method, the call to `CreateIcons()` should still work since the new signature has a default parameter `string? themeName = null`. Verify this compiles.
+
+- [ ] **Step 7: Add LoadImage import if not already present**
+
+Check if `LoadImage` is already imported in `TrayIcon.cs`. If not, add:
+
+```csharp
+    private const uint LR_LOADFROMFILE = 0x00000010;
+    private const uint IMAGE_ICON = 1;
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr LoadImage(IntPtr hInst, string name, uint type, int cx, int cy, uint fuLoad);
+```
+
+- [ ] **Step 8: Build to verify**
+
+Run: `dotnet build` from the repo root.
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Brmble.Client/TrayIcon.cs
+git commit -m "feat: make tray icon theme-aware with accent-colored badge dot"
+```
+
+---
+
+### Task 4: Make Taskbar Overlay Theme-Aware
+
+**Files:**
+- Modify: `src/Brmble.Client/TaskbarBadge.cs`
+
+Replace the Brmble logo overlay with a small accent-colored dot.
+
+- [ ] **Step 1: Replace LoadBrmbleOverlayIcon with CreateAccentDotIcon**
+
+In `src/Brmble.Client/TaskbarBadge.cs`, replace the `LoadBrmbleOverlayIcon()` method and the fallback `CreateSmallBrmbleIcon()` method with a single new method:
+
+```csharp
+    /// <summary>
+    /// Creates a small filled circle icon in the given accent color.
+    /// Used as the taskbar overlay badge.
+    /// </summary>
+    private static IntPtr CreateAccentDotIcon(byte r, byte g, byte b)
+    {
+        const int size = 16;
+        var biHeader = new BITMAPINFOHEADER
+        {
+            biSize = (uint)Marshal.SizeOf<BITMAPINFOHEADER>(),
+            biWidth = size,
+            biHeight = -size, // top-down
+            biPlanes = 1,
+            biBitCount = 32,
+            biCompression = 0,
+        };
+
+        var hdc = CreateCompatibleDC(IntPtr.Zero);
+        var hBitmap = CreateDIBSection(hdc, ref biHeader, 0, out var bits, IntPtr.Zero, 0);
+        DeleteDC(hdc);
+
+        var pixels = new byte[size * size * 4];
+
+        float cx = (size - 1) / 2f;
+        float cy = (size - 1) / 2f;
+        float outerRadius = size / 2f;
+        float innerRadius = outerRadius - 1f;
+
+        for (int y = 0; y < size; y++)
+        {
+            for (int x = 0; x < size; x++)
+            {
+                float dx = x - cx;
+                float dy = y - cy;
+                float dist = MathF.Sqrt(dx * dx + dy * dy);
+                int offset = (y * size + x) * 4;
+
+                if (dist <= innerRadius)
+                {
+                    pixels[offset + 0] = b; // B
+                    pixels[offset + 1] = g; // G
+                    pixels[offset + 2] = r; // R
+                    pixels[offset + 3] = 255; // A
+                }
+                else if (dist <= outerRadius)
+                {
+                    float alpha = 1f - (dist - innerRadius);
+                    byte a = (byte)(alpha * 255);
+                    pixels[offset + 0] = b;
+                    pixels[offset + 1] = g;
+                    pixels[offset + 2] = r;
+                    pixels[offset + 3] = a;
+                }
+                // else: transparent (already 0)
+            }
+        }
+
+        Marshal.Copy(pixels, 0, bits, pixels.Length);
+
+        var hMono = CreateBitmap(size, size, 1, 1, IntPtr.Zero);
+        var iconInfo = new ICONINFO { fIcon = true, hbmMask = hMono, hbmColor = hBitmap };
+        var result = CreateIconIndirect(ref iconInfo);
+
+        DeleteObject(hMono);
+        DeleteObject(hBitmap);
+
+        return result;
+    }
+```
+
+- [ ] **Step 2: Add missing P/Invoke declarations**
+
+Add to `TaskbarBadge.cs` if not already present (check existing imports first):
+
+```csharp
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateBitmap(int nWidth, int nHeight, uint nPlanes, uint nBitCount, IntPtr lpBits);
+```
+
+Also verify that `CreateDIBSection`, `CreateIconIndirect`, `DeleteObject`, `BITMAPINFOHEADER`, and `ICONINFO` are already declared. They should be from the existing `CreateSmallBrmbleIcon` code.
+
+- [ ] **Step 3: Add SetTheme method**
+
+Add this public method:
+
+```csharp
+    /// <summary>
+    /// Updates the overlay badge icon to use the given theme's accent color.
+    /// Call from the UI thread.
+    /// </summary>
+    public static void SetTheme(string themeName)
+    {
+        // Destroy old badge icon
+        if (_badgeIcon != IntPtr.Zero)
+        {
+            DestroyIcon(_badgeIcon);
+            _badgeIcon = IntPtr.Zero;
+        }
+
+        var (r, g, b) = ThemeColors.GetAccent(themeName);
+        _badgeIcon = CreateAccentDotIcon(r, g, b);
+
+        // If badge is currently shown, re-apply with new icon
+        if (_hasBadge && _initialized && _taskbarList != null && _badgeIcon != IntPtr.Zero)
+        {
+            _taskbarList.SetOverlayIcon(_hwnd, _badgeIcon, "Unread messages");
+        }
+    }
+```
+
+- [ ] **Step 4: Update Initialize to use default accent color**
+
+In the `Initialize` method (around line 85), replace:
+```csharp
+        _badgeIcon = LoadBrmbleOverlayIcon();
+```
+with:
+```csharp
+        var (r, g, b) = ThemeColors.GetAccent(null); // default accent until theme message arrives
+        _badgeIcon = CreateAccentDotIcon(r, g, b);
+```
+
+- [ ] **Step 5: Remove old LoadBrmbleOverlayIcon and CreateSmallBrmbleIcon methods**
+
+Delete the `LoadBrmbleOverlayIcon()` method and the `CreateSmallBrmbleIcon()` method entirely -- they are no longer used.
+
+- [ ] **Step 6: Build to verify**
+
+Run: `dotnet build` from the repo root.
+Expected: Build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Client/TaskbarBadge.cs
+git commit -m "feat: replace taskbar overlay with theme-colored accent dot"
+```
+
+---
+
+### Task 5: Add WM_SETICON Support to Win32Window
+
+**Files:**
+- Modify: `src/Brmble.Client/Win32Window.cs`
+
+- [ ] **Step 1: Add WM_SETICON constant and SendMessage P/Invoke**
+
+In `src/Brmble.Client/Win32Window.cs`, add these constants near the other `WM_` constants (around line 13-25):
+
+```csharp
+    public const uint WM_SETICON = 0x0080;
+    public const IntPtr ICON_SMALL = 0;
+    public const IntPtr ICON_BIG = 1;
+```
+
+Add the `SendMessage` P/Invoke near the other DllImport declarations:
+
+```csharp
+    [DllImport("user32.dll")]
+    public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+```
+
+- [ ] **Step 2: Add SetWindowIcon helper method**
+
+Add this helper method after the existing `LoadAppIcon` method (around line 265):
+
+```csharp
+    /// <summary>
+    /// Updates the window's icon (taskbar and title bar) to the theme-specific .ico.
+    /// Falls back to the default Resources/brmble.ico if theme folder doesn't exist.
+    /// </summary>
+    public static void SetWindowIcon(IntPtr hwnd, string? themeName)
+    {
+        var icoPath = ThemeColors.GetIconPath(themeName);
+        if (!File.Exists(icoPath)) return;
+
+        var hIconSm = LoadImage(IntPtr.Zero, icoPath, IMAGE_ICON, 16, 16, LR_LOADFROMFILE);
+        var hIconLg = LoadImage(IntPtr.Zero, icoPath, IMAGE_ICON, 32, 32, LR_LOADFROMFILE);
+
+        if (hIconSm != IntPtr.Zero)
+            SendMessage(hwnd, WM_SETICON, ICON_SMALL, hIconSm);
+        if (hIconLg != IntPtr.Zero)
+            SendMessage(hwnd, WM_SETICON, ICON_BIG, hIconLg);
+    }
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `dotnet build` from the repo root.
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Client/Win32Window.cs
+git commit -m "feat: add WM_SETICON support for dynamic window icon updates"
+```
+
+---
+
+### Task 6: Add notification.theme Bridge Handler (C#)
+
+**Files:**
+- Modify: `src/Brmble.Client/Program.cs`
+
+- [ ] **Step 1: Register the notification.theme handler**
+
+In `src/Brmble.Client/Program.cs`, find the `notification.badge` handler (around line 374). Add the new handler directly after the closing `});` of the badge handler (after line 381):
+
+```csharp
+        _bridge.RegisterHandler("notification.theme", data =>
+        {
+            var theme = data.TryGetProperty("theme", out var t) ? t.GetString() : null;
+            if (!string.IsNullOrEmpty(theme))
+            {
+                TrayIcon.SetTheme(theme);
+                TaskbarBadge.SetTheme(theme);
+                Win32Window.SetWindowIcon(_hwnd, theme);
+            }
+            return Task.CompletedTask;
+        });
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `dotnet build` from the repo root.
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Client/Program.cs
+git commit -m "feat: add notification.theme bridge handler for themed native icons"
+```
+
+---
+
+### Task 7: Send notification.theme from Frontend
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+
+- [ ] **Step 1: Add useEffect to send theme to native bridge**
+
+In `src/Brmble.Web/src/App.tsx`, find the existing useEffect that pushes badge state (around line 1563):
+
+```typescript
+  // Push DM badge state to native side whenever unread count changes
+  useEffect(() => {
+    updateBadge(totalDmUnreadCount, hasPendingInvite);
+  }, [totalDmUnreadCount, hasPendingInvite, updateBadge]);
+```
+
+Add a new useEffect directly after it:
+
+```typescript
+  // Push current theme to native side for themed tray/taskbar icons
+  useEffect(() => {
+    const theme = document.documentElement.getAttribute('data-theme');
+    if (theme) {
+      bridge.send('notification.theme', { theme });
+    }
+  }, [bridge]);
+```
+
+This sends the theme on mount. For theme changes, we also need to observe them. Since theme changes happen via `applyTheme()` which sets the `data-theme` attribute, we need to also send the message when theme changes. The simplest approach is to use a MutationObserver:
+
+Replace the above with:
+
+```typescript
+  // Push current theme to native side for themed tray/taskbar icons
+  useEffect(() => {
+    const sendTheme = () => {
+      const theme = document.documentElement.getAttribute('data-theme');
+      if (theme) {
+        bridge.send('notification.theme', { theme });
+      }
+    };
+
+    // Send current theme on mount
+    sendTheme();
+
+    // Watch for theme changes (applyTheme sets data-theme attribute)
+    const observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        if (m.attributeName === 'data-theme') {
+          sendTheme();
+          break;
+        }
+      }
+    });
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+    return () => observer.disconnect();
+  }, [bridge]);
+```
+
+- [ ] **Step 2: Build frontend to verify**
+
+Run: `npm run build` in `src/Brmble.Web`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx
+git commit -m "feat: send notification.theme to native bridge on init and theme change"
+```
+
+---
+
+### Task 8: Rename "Lemon Drop Martini" to "Lemon Drop" (#342)
+
+**Files:**
+- Modify: `src/Brmble.Web/src/themes/theme-registry.ts:47`
+- Modify: `src/Brmble.Web/src/themes/lemon-drop.css:2,4`
+- Modify: `src/Brmble.Web/src/themes/_template.css:620`
+
+- [ ] **Step 1: Update display name in theme registry**
+
+In `src/Brmble.Web/src/themes/theme-registry.ts`, line 47, change:
+```typescript
+    name: 'Lemon Drop Martini',
+```
+to:
+```typescript
+    name: 'Lemon Drop',
+```
+
+- [ ] **Step 2: Update CSS comments in lemon-drop.css**
+
+In `src/Brmble.Web/src/themes/lemon-drop.css`, line 2, change:
+```css
+   Brmble Lemon Drop Martini Theme — Premium Gold
+```
+to:
+```css
+   Brmble Lemon Drop Theme — Premium Gold
+```
+
+On line 4, change:
+```css
+   Cocktail:   Lemon Drop Martini (vodka, triple sec, lemon juice)
+```
+to:
+```css
+   Cocktail:   Lemon Drop (vodka, triple sec, lemon juice)
+```
+
+- [ ] **Step 3: Update CSS comment in _template.css**
+
+In `src/Brmble.Web/src/themes/_template.css`, line 620, change:
+```css
+       Lemon Drop Martini: Sora + Plus Jakarta Sans
+```
+to:
+```css
+       Lemon Drop:         Sora + Plus Jakarta Sans
+```
+
+(Adjust spacing to keep alignment with other theme names in the list.)
+
+- [ ] **Step 4: Build frontend to verify**
+
+Run: `npm run build` in `src/Brmble.Web`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/themes/theme-registry.ts src/Brmble.Web/src/themes/lemon-drop.css src/Brmble.Web/src/themes/_template.css
+git commit -m "fix: rename 'Lemon Drop Martini' theme to 'Lemon Drop' (#342)"
+```
+
+---
+
+### Task 9: Full Build Verification
+
+- [ ] **Step 1: Build everything**
+
+Run from repo root:
+```bash
+dotnet build
+```
+Expected: Build succeeds with no errors.
+
+Then:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+dotnet test
+```
+Expected: All tests pass.
+
+- [ ] **Step 3: Verify complete**
+
+All changes are committed on branch `fix/dm-badge-count-contacts`. Ready for PR.

--- a/docs/superpowers/specs/2026-03-29-dm-badge-and-themed-icons-design.md
+++ b/docs/superpowers/specs/2026-03-29-dm-badge-and-themed-icons-design.md
@@ -1,0 +1,152 @@
+# DM Badge Fix & Theme-Aware Native Icons
+
+**Date:** 2026-03-29
+**Issues:** #403 (DM badge count), #342 (Lemon Drop rename)
+**Branch:** `fix/dm-badge-count-contacts`
+
+## Summary
+
+Three problems to fix:
+
+1. The DM button badge shows total unread messages instead of the number of contacts with unreads.
+2. The system tray icon switches from the real Brmble logo to a programmatic green circle when there are unreads.
+3. The taskbar overlay shows a redundant Brmble logo on top of the Brmble logo.
+
+Additionally, native icons should follow the user's selected theme, and the "Lemon Drop Martini" display name should be shortened to "Lemon Drop".
+
+## Change 1: DM Badge Count
+
+**Problem:** `useUnreadTracker.ts` sums `notificationCount` across all DM rooms. If Alice has 3 unreads and Bob has 2, the badge shows "5". It should show "2".
+
+**Fix (useUnreadTracker.ts, ~line 503):**
+Change `totalDmUnreadCount += state.notificationCount` to `totalDmUnreadCount += state.notificationCount > 0 ? 1 : 0`.
+
+**Fix (App.tsx, ~line 422):**
+The `totalDmUnreadCount` useMemo also adds Mumble ephemeral contact unreads. Change `total += contact.unreadCount` to `total += contact.unreadCount > 0 ? 1 : 0`.
+
+**No other changes.** The badge rendering in `UserPanel.tsx` (9+ cap, animation) stays the same. Per-contact badges in `DMContactList.tsx` stay the same. The bridge still sends a boolean to C#.
+
+## Change 2: Theme-Aware System Tray Icon
+
+**Problem:** `_iconNormal` loads the real `Resources/brmble.ico` but `_iconNormalBadge` draws a programmatic green circle with a red dot. They look completely different.
+
+**Fix:**
+
+### 2a. Theme bridge message
+
+The frontend sends a `notification.theme` message via the bridge:
+- On app init (after theme is loaded from localStorage and applied)
+- Whenever the user changes theme via the settings UI
+
+This is implemented as a `useEffect` in `App.tsx` that watches the current theme ID and calls `bridge.send('notification.theme', { theme: currentThemeId })`.
+
+Payload: `{ theme: "aperol-spritz" }`
+
+The C# handler in `Program.cs` receives this and calls `TrayIcon.SetTheme(themeName)` and `TaskbarBadge.SetTheme(themeName)`.
+
+### 2b. TrayIcon loads theme-specific .ico
+
+`TrayIcon.SetTheme(string themeName)`:
+1. Loads `Resources/{themeName}/brmble.ico` at 16x16 via `LoadImage`. Falls back to `Resources/brmble.ico` if the theme folder or .ico doesn't exist (handles `clean` theme which has no folder).
+2. Sets `_iconNormal` to this loaded icon.
+3. Creates `_iconNormalBadge` by reading the pixels of the loaded .ico and drawing the accent-color dot on top (same position and size as the current red dot: center (11,2), radius 2).
+4. Muted and deafened variants remain programmatic colored circles (yellow/red) -- these are state indicators, not branding.
+5. Calls `UpdateIconAndTooltip()` to apply immediately.
+
+### 2c. Theme-to-accent-color map
+
+C# needs a hardcoded map from theme name to accent RGB for the badge dot:
+
+| Theme ID | Accent RGB | Hex |
+|---|---|---|
+| `classic` | (212, 20, 90) | `#d4145a` |
+| `clean` | (212, 20, 90) | `#d4145a` |
+| `blue-lagoon` | (0, 180, 216) | `#00b4d8` |
+| `cosmopolitan` | (230, 57, 98) | `#e63962` |
+| `aperol-spritz` | (232, 101, 26) | `#e8651a` |
+| `midori-sour` | (0, 200, 83) | `#00c853` |
+| `lemon-drop` | (245, 197, 24) | `#f5c518` |
+| `retro-terminal` | (51, 255, 0) | `#33ff00` |
+
+Default (unknown theme): fall back to `classic` accent `(212, 20, 90)`.
+
+## Change 3: Taskbar Overlay
+
+**Problem:** The overlay icon is the Brmble .ico itself. This shows a small Brmble logo on top of the main Brmble taskbar icon -- redundant and confusing.
+
+**Fix:** Replace `LoadBrmbleOverlayIcon()` with `CreateAccentDotIcon()` that draws a small filled circle (12x12 or 16x16) in the theme's accent color. Same color map as above. When theme changes, regenerate the overlay icon.
+
+`TaskbarBadge.SetTheme(string themeName)`:
+1. Look up accent RGB from the theme map.
+2. Create a new overlay icon: a small filled circle in that color with anti-aliased edges.
+3. Store as `_badgeIcon`.
+4. If badge is currently shown, re-apply via `SetOverlayIcon` to update the color immediately.
+
+## Change 4: Theme-Aware Taskbar Icon
+
+**Problem:** The main taskbar icon always shows the root `Resources/brmble.ico` regardless of theme.
+
+**Fix:** When `notification.theme` is received, also update the main window icon:
+
+1. Load `Resources/{themeName}/brmble.ico` at 16x16 (ICON_SMALL) and 32x32 (ICON_BIG).
+2. Send `WM_SETICON` with both `ICON_SMALL` and `ICON_BIG` to the main window handle.
+3. Fall back to `Resources/brmble.ico` if the theme folder doesn't exist.
+
+This logic lives in `Program.cs` alongside the existing `notification.theme` handler, or in a small helper method on `Win32Window`.
+
+## Change 5: Rename "Lemon Drop Martini" to "Lemon Drop" (#342)
+
+**Files to change:**
+- `src/Brmble.Web/src/themes/theme-registry.ts` line 47: `name: 'Lemon Drop Martini'` -> `name: 'Lemon Drop'`
+- `src/Brmble.Web/src/themes/lemon-drop.css` line 2: update CSS comment
+- `src/Brmble.Web/src/themes/lemon-drop.css` line 4: update CSS comment
+- `src/Brmble.Web/src/themes/_template.css`: update comments referencing "Lemon Drop Martini" (lines ~620, ~697, ~701, ~728)
+
+No folder rename needed -- the folder is already `lemon-drop`. No ID change needed.
+
+## Data Flow
+
+```
+Frontend (theme change or init)
+  |
+  |--> bridge.send('notification.theme', { theme: 'aperol-spritz' })
+  |
+  v
+Program.cs handler
+  |
+  |--> TrayIcon.SetTheme('aperol-spritz')
+  |      |-> Load Resources/aperol-spritz/brmble.ico (16x16)
+  |      |-> Set _iconNormal = loaded .ico
+  |      |-> Create _iconNormalBadge = loaded .ico + accent dot overlay
+  |      |-> UpdateIconAndTooltip()
+  |
+  |--> TaskbarBadge.SetTheme('aperol-spritz')
+  |      |-> Create _badgeIcon = accent-colored dot
+  |      |-> If badge active, re-apply overlay
+  |
+  |--> Win32Window.SetIcon(hwnd, 'aperol-spritz')
+         |-> Load 16x16 + 32x32 from Resources/aperol-spritz/brmble.ico
+         |-> SendMessage(WM_SETICON, ICON_SMALL, ...)
+         |-> SendMessage(WM_SETICON, ICON_BIG, ...)
+```
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `src/Brmble.Web/src/hooks/useUnreadTracker.ts` | Count contacts instead of summing messages |
+| `src/Brmble.Web/src/App.tsx` | Count ephemeral contacts instead of summing unreads; send `notification.theme` on init and theme change |
+| `src/Brmble.Client/Program.cs` | Add `notification.theme` bridge handler |
+| `src/Brmble.Client/TrayIcon.cs` | Add `SetTheme()`, load theme .ico, draw themed badge dot on real icon |
+| `src/Brmble.Client/TaskbarBadge.cs` | Add `SetTheme()`, replace logo overlay with accent dot |
+| `src/Brmble.Client/Win32Window.cs` | Add `SetIcon()` helper for WM_SETICON |
+| `src/Brmble.Web/src/themes/theme-registry.ts` | Rename "Lemon Drop Martini" to "Lemon Drop" |
+| `src/Brmble.Web/src/themes/lemon-drop.css` | Update comments |
+| `src/Brmble.Web/src/themes/_template.css` | Update comments |
+
+## Out of Scope
+
+- Per-contact badges in `DMContactList.tsx` -- already correct
+- Numeric counts in tray/taskbar -- staying boolean
+- Muted/deafened tray icon variants -- staying as programmatic colored circles
+- `clean` theme .ico -- falls back to root `Resources/brmble.ico` (no dedicated folder)

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -379,6 +379,18 @@ static class Program
             TaskbarBadge.SetHasBadge(hasUnreadDMs || hasPendingInvite);
             return Task.CompletedTask;
         });
+
+        _bridge.RegisterHandler("notification.theme", data =>
+        {
+            var theme = data.TryGetProperty("theme", out var t) ? t.GetString() : null;
+            if (!string.IsNullOrEmpty(theme))
+            {
+                TrayIcon.SetTheme(theme);
+                TaskbarBadge.SetTheme(theme);
+                Win32Window.SetWindowIcon(_hwnd, theme);
+            }
+            return Task.CompletedTask;
+        });
     }
  
     private static void TryAutoConnect()

--- a/src/Brmble.Client/TaskbarBadge.cs
+++ b/src/Brmble.Client/TaskbarBadge.cs
@@ -1,4 +1,3 @@
-using System.Drawing;
 using System.Runtime.InteropServices;
 
 namespace Brmble.Client;
@@ -70,7 +69,14 @@ internal static class TaskbarBadge
     private static extern bool DestroyIcon(IntPtr hIcon);
 
     [DllImport("gdi32.dll")]
-    private static extern IntPtr CreateBitmap(int nWidth, int nHeight, uint cPlanes, uint cBitsPerPel, byte[]? lpvBits);
+    private static extern IntPtr CreateBitmap(int nWidth, int nHeight, uint nPlanes, uint nBitCount, IntPtr lpBits);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteDC(IntPtr hdc);
 
     [StructLayout(LayoutKind.Sequential)]
     private struct ICONINFO
@@ -91,7 +97,8 @@ internal static class TaskbarBadge
             _taskbarList = (ITaskbarList3)new TaskbarList();
             _taskbarList.HrInit();
 
-            _badgeIcon = LoadBrmbleOverlayIcon();
+            var (r, g, b) = ThemeColors.GetAccent(null); // default accent until theme message arrives
+            _badgeIcon = CreateAccentDotIcon(r, g, b);
             _initialized = true;
         }
         catch
@@ -100,54 +107,96 @@ internal static class TaskbarBadge
         }
     }
 
-    private static IntPtr LoadBrmbleOverlayIcon()
+    /// <summary>
+    /// Creates a small filled circle icon in the given accent color.
+    /// Used as the taskbar overlay badge.
+    /// </summary>
+    private static IntPtr CreateAccentDotIcon(byte r, byte g, byte b)
     {
-        try
+        const int size = 16;
+        var biHeader = new BITMAPINFOHEADER
         {
-            return Win32Window.LoadAppIcon(16);
-        }
-        catch
-        {
-            return CreateSmallBrmbleIcon();
-        }
-    }
+            biSize = (uint)Marshal.SizeOf<BITMAPINFOHEADER>(),
+            biWidth = size,
+            biHeight = -size, // top-down
+            biPlanes = 1,
+            biBitCount = 32,
+            biCompression = 0,
+        };
 
-    private static IntPtr CreateSmallBrmbleIcon()
-    {
-        // Create a small 12x12 Brmble-style circle (green gradient)
-        const int size = 12;
+        var hdc = CreateCompatibleDC(IntPtr.Zero);
+        var hBitmap = CreateDIBSection(hdc, ref biHeader, 0, out var bits, IntPtr.Zero, 0);
+        DeleteDC(hdc);
+
         var pixels = new byte[size * size * 4];
+
+        float cx = (size - 1) / 2f;
+        float cy = (size - 1) / 2f;
+        float outerRadius = size / 2f;
+        float innerRadius = outerRadius - 1f;
 
         for (int y = 0; y < size; y++)
         {
             for (int x = 0; x < size; x++)
             {
-                var dx = x - 5.5;
-                var dy = y - 5.5;
-                var dist = Math.Sqrt(dx * dx + dy * dy);
-                var idx = (y * size + x) * 4;
+                float dx = x - cx;
+                float dy = y - cy;
+                float dist = MathF.Sqrt(dx * dx + dy * dy);
+                int offset = (y * size + x) * 4;
 
-                if (dist <= 4.5)
+                if (dist <= innerRadius)
                 {
-                    // Brmble green gradient from center
-                    var factor = 1.0 - (dist / 5.0);
-                    pixels[idx + 0] = (byte)(0x50 * factor + 0x30);  // Blue
-                    pixels[idx + 1] = (byte)(0xC8 * factor + 0x80);  // Green
-                    pixels[idx + 2] = (byte)(0x00 * factor + 0x20);  // Red
-                    pixels[idx + 3] = 0xFF;  // Alpha
+                    pixels[offset + 0] = b; // B
+                    pixels[offset + 1] = g; // G
+                    pixels[offset + 2] = r; // R
+                    pixels[offset + 3] = 255; // A
                 }
-                else if (dist <= 5.5)
+                else if (dist <= outerRadius)
                 {
-                    var alpha = (byte)(255 * (5.5 - dist));
-                    pixels[idx + 0] = 0x40;
-                    pixels[idx + 1] = 0xC0;
-                    pixels[idx + 2] = 0x20;
-                    pixels[idx + 3] = alpha;
+                    float alpha = 1f - (dist - innerRadius);
+                    byte a = (byte)(alpha * 255);
+                    pixels[offset + 0] = b;
+                    pixels[offset + 1] = g;
+                    pixels[offset + 2] = r;
+                    pixels[offset + 3] = a;
                 }
+                // else: transparent (already 0)
             }
         }
 
-        return CreateIconFromArgb(size, pixels);
+        Marshal.Copy(pixels, 0, bits, pixels.Length);
+
+        var hMono = CreateBitmap(size, size, 1, 1, IntPtr.Zero);
+        var iconInfo = new ICONINFO { fIcon = true, hbmMask = hMono, hbmColor = hBitmap };
+        var result = CreateIconIndirect(ref iconInfo);
+
+        DeleteObject(hMono);
+        DeleteObject(hBitmap);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Updates the overlay badge icon to use the given theme's accent color.
+    /// Call from the UI thread.
+    /// </summary>
+    public static void SetTheme(string themeName)
+    {
+        // Destroy old badge icon
+        if (_badgeIcon != IntPtr.Zero)
+        {
+            DestroyIcon(_badgeIcon);
+            _badgeIcon = IntPtr.Zero;
+        }
+
+        var (r, g, b) = ThemeColors.GetAccent(themeName);
+        _badgeIcon = CreateAccentDotIcon(r, g, b);
+
+        // If badge is currently shown, re-apply with new icon
+        if (_hasBadge && _initialized && _taskbarList != null && _badgeIcon != IntPtr.Zero)
+        {
+            _taskbarList.SetOverlayIcon(_hwnd, _badgeIcon, "Unread messages");
+        }
     }
 
     public static void SetHasBadge(bool hasBadge)
@@ -165,42 +214,6 @@ internal static class TaskbarBadge
         {
             _taskbarList.SetOverlayIcon(_hwnd, IntPtr.Zero, "");
         }
-    }
-
-    private static IntPtr CreateIconFromArgb(int size, byte[] pixels)
-    {
-        var bmi = new BITMAPINFOHEADER
-        {
-            biSize = (uint)Marshal.SizeOf<BITMAPINFOHEADER>(),
-            biWidth = size,
-            biHeight = -size,
-            biPlanes = 1,
-            biBitCount = 32,
-            biCompression = 0
-        };
-
-        var hbmColor = CreateDIBSection(IntPtr.Zero, ref bmi, 0, out var bits, IntPtr.Zero, 0);
-        if (hbmColor == IntPtr.Zero || bits == IntPtr.Zero) return IntPtr.Zero;
-
-        Marshal.Copy(pixels, 0, bits, pixels.Length);
-
-        var stride = ((size + 15) / 16) * 2;
-        var maskBits = new byte[stride * size];
-        var hbmMask = CreateBitmap(size, size, 1, 1, maskBits);
-
-        var iconInfo = new ICONINFO
-        {
-            fIcon = true,
-            hbmMask = hbmMask,
-            hbmColor = hbmColor
-        };
-
-        var hIcon = CreateIconIndirect(ref iconInfo);
-
-        DeleteObject(hbmColor);
-        DeleteObject(hbmMask);
-
-        return hIcon;
     }
 
     public static void Destroy()

--- a/src/Brmble.Client/TaskbarBadge.cs
+++ b/src/Brmble.Client/TaskbarBadge.cs
@@ -97,8 +97,9 @@ internal static class TaskbarBadge
             _taskbarList = (ITaskbarList3)new TaskbarList();
             _taskbarList.HrInit();
 
-            var (r, g, b) = ThemeColors.GetAccent(null); // default accent until theme message arrives
-            _badgeIcon = CreateAccentDotIcon(r, g, b);
+            var (r, g, b) = ThemeColors.GetAccent(null);
+            var (rr, rg, rb) = ThemeColors.GetBgDeep(null);
+            _badgeIcon = CreateAccentDotIcon(r, g, b, rr, rg, rb);
             _initialized = true;
         }
         catch
@@ -108,12 +109,25 @@ internal static class TaskbarBadge
     }
 
     /// <summary>
-    /// Creates a small filled circle icon in the given accent color.
+    /// Creates a filled circle icon with accent color and a thin ring outline.
     /// Used as the taskbar overlay badge.
     /// </summary>
-    private static IntPtr CreateAccentDotIcon(byte r, byte g, byte b)
+    private static IntPtr CreateAccentDotIcon(byte r, byte g, byte b, byte ringR, byte ringG, byte ringB)
     {
+        // Centered dot with a thin ring on a 16x16 canvas.
+        // Windows always renders overlays in the bottom-right corner of
+        // the taskbar button. The ring (using --bg-deep) visually separates
+        // the dot from the icon behind it.
         const int size = 16;
+        const float center = 7.5f;
+
+        // Layer radii (outside-in): ring edge -> ring solid -> accent edge -> accent solid
+        // Thin 1px ring around the accent dot
+        const float ringOuter = 7.5f;   // anti-alias outer edge of ring
+        const float ringSolid = 6.5f;   // solid ring starts here
+        const float accentOuter = 6.0f; // anti-alias edge of accent dot (1px gap = ring)
+        const float accentSolid = 5.0f; // solid accent core
+
         var biHeader = new BITMAPINFOHEADER
         {
             biSize = (uint)Marshal.SizeOf<BITMAPINFOHEADER>(),
@@ -130,37 +144,51 @@ internal static class TaskbarBadge
 
         var pixels = new byte[size * size * 4];
 
-        float cx = (size - 1) / 2f;
-        float cy = (size - 1) / 2f;
-        float outerRadius = size / 2f;
-        float innerRadius = outerRadius - 1f;
-
         for (int y = 0; y < size; y++)
         {
             for (int x = 0; x < size; x++)
             {
-                float dx = x - cx;
-                float dy = y - cy;
+                float dx = x - center;
+                float dy = y - center;
                 float dist = MathF.Sqrt(dx * dx + dy * dy);
                 int offset = (y * size + x) * 4;
 
-                if (dist <= innerRadius)
+                if (dist <= accentSolid)
                 {
-                    pixels[offset + 0] = b; // B
-                    pixels[offset + 1] = g; // G
-                    pixels[offset + 2] = r; // R
-                    pixels[offset + 3] = 255; // A
-                }
-                else if (dist <= outerRadius)
-                {
-                    float alpha = 1f - (dist - innerRadius);
-                    byte a = (byte)(alpha * 255);
+                    // Solid accent fill
                     pixels[offset + 0] = b;
                     pixels[offset + 1] = g;
                     pixels[offset + 2] = r;
+                    pixels[offset + 3] = 255;
+                }
+                else if (dist <= accentOuter)
+                {
+                    // Anti-aliased accent-to-ring transition
+                    float accentAlpha = 1f - (dist - accentSolid);
+                    pixels[offset + 0] = (byte)(b * accentAlpha + ringB * (1f - accentAlpha));
+                    pixels[offset + 1] = (byte)(g * accentAlpha + ringG * (1f - accentAlpha));
+                    pixels[offset + 2] = (byte)(r * accentAlpha + ringR * (1f - accentAlpha));
+                    pixels[offset + 3] = 255;
+                }
+                else if (dist <= ringSolid)
+                {
+                    // Solid ring fill
+                    pixels[offset + 0] = ringB;
+                    pixels[offset + 1] = ringG;
+                    pixels[offset + 2] = ringR;
+                    pixels[offset + 3] = 255;
+                }
+                else if (dist <= ringOuter)
+                {
+                    // Anti-aliased ring outer edge
+                    float edgeAlpha = 1f - (dist - ringSolid);
+                    byte a = (byte)(255 * edgeAlpha);
+                    pixels[offset + 0] = ringB;
+                    pixels[offset + 1] = ringG;
+                    pixels[offset + 2] = ringR;
                     pixels[offset + 3] = a;
                 }
-                // else: transparent (already 0)
+                // else: transparent
             }
         }
 
@@ -190,7 +218,8 @@ internal static class TaskbarBadge
         }
 
         var (r, g, b) = ThemeColors.GetAccent(themeName);
-        _badgeIcon = CreateAccentDotIcon(r, g, b);
+        var (rr, rg, rb) = ThemeColors.GetBgDeep(themeName);
+        _badgeIcon = CreateAccentDotIcon(r, g, b, rr, rg, rb);
 
         // If badge is currently shown, re-apply with new icon
         if (_hasBadge && _initialized && _taskbarList != null && _badgeIcon != IntPtr.Zero)

--- a/src/Brmble.Client/TaskbarBadge.cs
+++ b/src/Brmble.Client/TaskbarBadge.cs
@@ -139,8 +139,23 @@ internal static class TaskbarBadge
         };
 
         var hdc = CreateCompatibleDC(IntPtr.Zero);
+        if (hdc == IntPtr.Zero)
+        {
+            return IntPtr.Zero;
+        }
+
         var hBitmap = CreateDIBSection(hdc, ref biHeader, 0, out var bits, IntPtr.Zero, 0);
         DeleteDC(hdc);
+
+        if (hBitmap == IntPtr.Zero || bits == IntPtr.Zero)
+        {
+            if (hBitmap != IntPtr.Zero)
+            {
+                DeleteObject(hBitmap);
+            }
+
+            return IntPtr.Zero;
+        }
 
         var pixels = new byte[size * size * 4];
 

--- a/src/Brmble.Client/ThemeColors.cs
+++ b/src/Brmble.Client/ThemeColors.cs
@@ -1,0 +1,38 @@
+namespace Brmble.Client;
+
+/// <summary>
+/// Maps theme IDs to their accent-primary RGB colors for native icon rendering.
+/// These values must stay in sync with the --accent-primary CSS tokens in src/Brmble.Web/src/themes/.
+/// </summary>
+internal static class ThemeColors
+{
+    public static (byte R, byte G, byte B) GetAccent(string? themeName)
+    {
+        return themeName switch
+        {
+            "classic"        => (0xD4, 0x14, 0x5A), // #d4145a
+            "clean"          => (0xD4, 0x14, 0x5A), // #d4145a (inherits classic)
+            "blue-lagoon"    => (0x00, 0xB4, 0xD8), // #00b4d8
+            "cosmopolitan"   => (0xE6, 0x39, 0x62), // #e63962
+            "aperol-spritz"  => (0xE8, 0x65, 0x1A), // #e8651a
+            "midori-sour"    => (0x00, 0xC8, 0x53), // #00c853
+            "lemon-drop"     => (0xF5, 0xC5, 0x18), // #f5c518
+            "retro-terminal" => (0x33, 0xFF, 0x00), // #33ff00
+            _                => (0xD4, 0x14, 0x5A), // default to classic
+        };
+    }
+
+    /// <summary>
+    /// Resolves the path to a theme's brmble.ico file.
+    /// Falls back to the root Resources/brmble.ico if the theme folder doesn't exist.
+    /// </summary>
+    public static string GetIconPath(string? themeName)
+    {
+        if (!string.IsNullOrEmpty(themeName))
+        {
+            var themed = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", themeName, "brmble.ico");
+            if (File.Exists(themed)) return themed;
+        }
+        return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "brmble.ico");
+    }
+}

--- a/src/Brmble.Client/ThemeColors.cs
+++ b/src/Brmble.Client/ThemeColors.cs
@@ -48,11 +48,31 @@ internal static class ThemeColors
     /// </summary>
     public static string GetIconPath(string? themeName)
     {
-        if (!string.IsNullOrEmpty(themeName))
+        if (IsValidThemeName(themeName))
         {
-            var themed = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", themeName, "brmble.ico");
+            var themed = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", themeName!, "brmble.ico");
             if (File.Exists(themed)) return themed;
         }
         return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "brmble.ico");
+    }
+
+    /// <summary>
+    /// Returns true if the provided theme name is one of the known valid themes.
+    /// This acts as a whitelist to prevent arbitrary paths being used for icon resolution.
+    /// </summary>
+    private static bool IsValidThemeName(string? themeName)
+    {
+        return themeName switch
+        {
+            "classic"        => true,
+            "clean"          => true,
+            "blue-lagoon"    => true,
+            "cosmopolitan"   => true,
+            "aperol-spritz"  => true,
+            "midori-sour"    => true,
+            "lemon-drop"     => true,
+            "retro-terminal" => true,
+            _                => false,
+        };
     }
 }

--- a/src/Brmble.Client/ThemeColors.cs
+++ b/src/Brmble.Client/ThemeColors.cs
@@ -23,6 +23,26 @@ internal static class ThemeColors
     }
 
     /// <summary>
+    /// Returns the --bg-deep color for the given theme.
+    /// These values must stay in sync with the CSS tokens in src/Brmble.Web/src/themes/.
+    /// </summary>
+    public static (byte R, byte G, byte B) GetBgDeep(string? themeName)
+    {
+        return themeName switch
+        {
+            "classic"        => (0x0F, 0x0A, 0x14), // #0f0a14
+            "clean"          => (0x0F, 0x0A, 0x14), // #0f0a14 (inherits classic)
+            "blue-lagoon"    => (0x0B, 0x13, 0x18), // #0b1318
+            "cosmopolitan"   => (0x14, 0x0A, 0x0D), // #140a0d
+            "aperol-spritz"  => (0x14, 0x0E, 0x08), // #140e08
+            "midori-sour"    => (0x08, 0x12, 0x10), // #081210
+            "lemon-drop"     => (0x13, 0x11, 0x08), // #131108
+            "retro-terminal" => (0x00, 0x00, 0x00), // #000000
+            _                => (0x0F, 0x0A, 0x14), // default to classic
+        };
+    }
+
+    /// <summary>
     /// Resolves the path to a theme's brmble.ico file.
     /// Falls back to the root Resources/brmble.ico if the theme folder doesn't exist.
     /// </summary>

--- a/src/Brmble.Client/TrayIcon.cs
+++ b/src/Brmble.Client/TrayIcon.cs
@@ -82,6 +82,27 @@ internal static class TrayIcon
     [DllImport("user32.dll")]
     private static extern bool DestroyIcon(IntPtr hIcon);
 
+    private const uint DI_NORMAL = 0x0003;
+    private const uint LR_LOADFROMFILE = 0x00000010;
+    private const uint IMAGE_ICON = 1;
+
+    [DllImport("user32.dll")]
+    private static extern bool DrawIconEx(IntPtr hdc, int xLeft, int yTop, IntPtr hIcon,
+        int cxWidth, int cyWidth, uint istepIfAniCur, IntPtr hbrFlickerFreeDraw, uint diFlags);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr LoadImage(IntPtr hInst, string name, uint type, int cx, int cy, uint fuLoad);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr SelectObject(IntPtr hdc, IntPtr h);
+
+    [DllImport("gdi32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DeleteDC(IntPtr hdc);
+
     private static NOTIFYICONDATA _nid;
     private static IntPtr _iconNormal;
     private static IntPtr _iconMuted;
@@ -92,6 +113,7 @@ internal static class TrayIcon
     private static bool _muted;
     private static bool _deafened;
     private static bool _hasBadge;
+    private static string? _currentTheme;
 
     /// <summary>
     /// Creates the tray icon and adds it to the notification area.
@@ -192,26 +214,52 @@ internal static class TrayIcon
         if (_iconDeafenedBadge != IntPtr.Zero) DestroyIcon(_iconDeafenedBadge);
     }
 
-    private static void CreateIcons()
+    private static void DestroyIconSafe(ref IntPtr icon)
     {
-        // Use the actual Brmble logo for normal state
-        _iconNormal = Win32Window.LoadAppIcon(16);
-        if (_iconNormal == IntPtr.Zero)
+        if (icon != IntPtr.Zero)
         {
-            // Fallback: programmatic green circle if .ico is missing
-            _iconNormal = CreateColoredIcon(0x00, 0xC8, 0x50);
+            DestroyIcon(icon);
+            icon = IntPtr.Zero;
         }
+    }
 
-        _iconMuted = CreateColoredIcon(0xE8, 0xB0, 0x00);    // yellow/amber
-        _iconDeafened = CreateColoredIcon(0xD4, 0x14, 0x5A); // berry red
+    /// <summary>
+    /// Switches tray icons to match the given theme.
+    /// Call from the UI thread.
+    /// </summary>
+    public static void SetTheme(string themeName)
+    {
+        _currentTheme = themeName;
+        CreateIcons(themeName);
+        UpdateIconAndTooltip();
+    }
 
-        Debug.WriteLine($"[TrayIcon] Icons created: normal={_iconNormal}, muted={_iconMuted}, deafened={_iconDeafened}");
+    private static void CreateIcons(string? themeName = null)
+    {
+        // Destroy previous icons
+        DestroyIconSafe(ref _iconNormal);
+        DestroyIconSafe(ref _iconMuted);
+        DestroyIconSafe(ref _iconDeafened);
+        DestroyIconSafe(ref _iconNormalBadge);
+        DestroyIconSafe(ref _iconMutedBadge);
+        DestroyIconSafe(ref _iconDeafenedBadge);
 
-        _iconNormalBadge = CreateColoredIconWithBadge(0x00, 0xC8, 0x50);
-        _iconMutedBadge = CreateColoredIconWithBadge(0xE8, 0xB0, 0x00);
-        _iconDeafenedBadge = CreateColoredIconWithBadge(0xD4, 0x14, 0x5A);
+        // Normal: load theme-specific .ico
+        var icoPath = ThemeColors.GetIconPath(themeName);
+        if (File.Exists(icoPath))
+            _iconNormal = LoadImage(IntPtr.Zero, icoPath, IMAGE_ICON, 16, 16, LR_LOADFROMFILE);
+        if (_iconNormal == IntPtr.Zero)
+            _iconNormal = CreateColoredIcon(0x00, 0xC8, 0x50); // fallback green circle
 
-        Debug.WriteLine($"[TrayIcon] Badge icons created: normal={_iconNormalBadge}, muted={_iconMutedBadge}, deafened={_iconDeafenedBadge}");
+        // Muted / Deafened: stay as programmatic colored circles
+        _iconMuted = CreateColoredIcon(0xE8, 0xB0, 0x00);
+        _iconDeafened = CreateColoredIcon(0xD4, 0x14, 0x5A);
+
+        // Badge variants: draw accent-colored dot on top
+        var (ar, ag, ab) = ThemeColors.GetAccent(themeName);
+        _iconNormalBadge = CreateBadgeFromIcon(_iconNormal, ar, ag, ab);
+        _iconMutedBadge = CreateColoredIconWithBadge(0xE8, 0xB0, 0x00, ar, ag, ab);
+        _iconDeafenedBadge = CreateColoredIconWithBadge(0xD4, 0x14, 0x5A, ar, ag, ab);
     }
 
     private static IntPtr CreateColoredIcon(byte r, byte g, byte b)
@@ -249,7 +297,54 @@ internal static class TrayIcon
         return CreateIconFromArgb(size, pixels);
     }
 
-    private static IntPtr CreateColoredIconWithBadge(byte r, byte g, byte b)
+    /// <summary>
+    /// Creates a badge variant of an existing icon by extracting its pixels
+    /// and drawing an accent-colored dot in the top-right corner.
+    /// </summary>
+    private static IntPtr CreateBadgeFromIcon(IntPtr sourceIcon, byte badgeR, byte badgeG, byte badgeB)
+    {
+        if (sourceIcon == IntPtr.Zero) return IntPtr.Zero;
+
+        const int size = 16;
+        var biHeader = new BITMAPINFOHEADER
+        {
+            biSize = (uint)Marshal.SizeOf<BITMAPINFOHEADER>(),
+            biWidth = size,
+            biHeight = -size, // top-down
+            biPlanes = 1,
+            biBitCount = 32,
+            biCompression = 0,
+        };
+
+        var hdc = CreateCompatibleDC(IntPtr.Zero);
+        var hBitmap = CreateDIBSection(hdc, ref biHeader, 0, out var bits, IntPtr.Zero, 0);
+        var oldBmp = SelectObject(hdc, hBitmap);
+
+        // Draw the source icon onto our DIB
+        DrawIconEx(hdc, 0, 0, sourceIcon, size, size, 0, IntPtr.Zero, DI_NORMAL);
+
+        SelectObject(hdc, oldBmp);
+
+        // Read pixels, draw badge dot, write back
+        var pixels = new byte[size * size * 4];
+        Marshal.Copy(bits, pixels, 0, pixels.Length);
+        DrawBadge(pixels, size, badgeR, badgeG, badgeB);
+        Marshal.Copy(pixels, 0, bits, pixels.Length);
+
+        // Create mask (all zeros = fully opaque, alpha is in the color bitmap)
+        var hMono = CreateBitmap(size, size, 1, 1, IntPtr.Zero);
+
+        var iconInfo = new ICONINFO { fIcon = true, hbmMask = hMono, hbmColor = hBitmap };
+        var result = CreateIconIndirect(ref iconInfo);
+
+        DeleteObject(hMono);
+        DeleteObject(hBitmap);
+        DeleteDC(hdc);
+
+        return result;
+    }
+
+    private static IntPtr CreateColoredIconWithBadge(byte r, byte g, byte b, byte badgeR, byte badgeG, byte badgeB)
     {
         const int size = 16;
         var pixels = new byte[size * size * 4];
@@ -281,8 +376,8 @@ internal static class TrayIcon
             }
         }
 
-        // Draw badge in top-right corner (darker red: RGB 180, 30, 30)
-        DrawBadge(pixels, size, 180, 30, 30);
+        // Draw badge in top-right corner
+        DrawBadge(pixels, size, badgeR, badgeG, badgeB);
 
         return CreateIconFromArgb(size, pixels);
     }
@@ -345,6 +440,9 @@ internal static class TrayIcon
 
     [DllImport("gdi32.dll")]
     private static extern IntPtr CreateBitmap(int nWidth, int nHeight, uint cPlanes, uint cBitsPerPel, byte[]? lpvBits);
+
+    [DllImport("gdi32.dll", EntryPoint = "CreateBitmap")]
+    private static extern IntPtr CreateBitmap(int nWidth, int nHeight, uint cPlanes, uint cBitsPerPel, IntPtr lpvBits);
 
     [DllImport("gdi32.dll")]
     private static extern IntPtr CreateDIBSection(IntPtr hdc, ref BITMAPINFOHEADER pbmi, uint iUsage, out IntPtr ppvBits, IntPtr hSection, uint dwOffset);

--- a/src/Brmble.Client/TrayIcon.cs
+++ b/src/Brmble.Client/TrayIcon.cs
@@ -113,7 +113,6 @@ internal static class TrayIcon
     private static bool _muted;
     private static bool _deafened;
     private static bool _hasBadge;
-    private static string? _currentTheme;
 
     /// <summary>
     /// Creates the tray icon and adds it to the notification area.
@@ -229,7 +228,6 @@ internal static class TrayIcon
     /// </summary>
     public static void SetTheme(string themeName)
     {
-        _currentTheme = themeName;
         CreateIcons(themeName);
         UpdateIconAndTooltip();
     }
@@ -317,7 +315,16 @@ internal static class TrayIcon
         };
 
         var hdc = CreateCompatibleDC(IntPtr.Zero);
+        if (hdc == IntPtr.Zero) return IntPtr.Zero;
+
         var hBitmap = CreateDIBSection(hdc, ref biHeader, 0, out var bits, IntPtr.Zero, 0);
+        if (hBitmap == IntPtr.Zero || bits == IntPtr.Zero)
+        {
+            DeleteDC(hdc);
+            if (hBitmap != IntPtr.Zero) DeleteObject(hBitmap);
+            return IntPtr.Zero;
+        }
+
         var oldBmp = SelectObject(hdc, hBitmap);
 
         // Draw the source icon onto our DIB

--- a/src/Brmble.Client/Win32Window.cs
+++ b/src/Brmble.Client/Win32Window.cs
@@ -23,6 +23,9 @@ internal static class Win32Window
     public const uint WM_RBUTTONUP = 0x0205;
     public const uint WM_INPUT = 0x00FF;
     public const uint WM_HOTKEY = 0x0312;
+    public const uint WM_SETICON = 0x0080;
+    public const IntPtr ICON_SMALL = 0;
+    public const IntPtr ICON_BIG = 1;
 
     public const uint RIM_INPUT = 0x00;
     public const uint RIM_INPUTSINK = 0x01;
@@ -194,6 +197,9 @@ internal static class Win32Window
     public static extern bool PostMessage(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
 
     [DllImport("user32.dll")]
+    public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll")]
     public static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
 
     [DllImport("user32.dll")]
@@ -262,6 +268,24 @@ internal static class Win32Window
         var icoPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "brmble.ico");
         if (!File.Exists(icoPath)) return IntPtr.Zero;
         return LoadImage(IntPtr.Zero, icoPath, IMAGE_ICON, size, size, LR_LOADFROMFILE);
+    }
+
+    /// <summary>
+    /// Updates the window's icon (taskbar and title bar) to the theme-specific .ico.
+    /// Falls back to the default Resources/brmble.ico if theme folder doesn't exist.
+    /// </summary>
+    public static void SetWindowIcon(IntPtr hwnd, string? themeName)
+    {
+        var icoPath = ThemeColors.GetIconPath(themeName);
+        if (!File.Exists(icoPath)) return;
+
+        var hIconSm = LoadImage(IntPtr.Zero, icoPath, IMAGE_ICON, 16, 16, LR_LOADFROMFILE);
+        var hIconLg = LoadImage(IntPtr.Zero, icoPath, IMAGE_ICON, 32, 32, LR_LOADFROMFILE);
+
+        if (hIconSm != IntPtr.Zero)
+            SendMessage(hwnd, WM_SETICON, ICON_SMALL, hIconSm);
+        if (hIconLg != IntPtr.Zero)
+            SendMessage(hwnd, WM_SETICON, ICON_BIG, hIconLg);
     }
 
     public static IntPtr Create(string className, string title, int x, int y, int width, int height, WndProc wndProc)

--- a/src/Brmble.Client/Win32Window.cs
+++ b/src/Brmble.Client/Win32Window.cs
@@ -230,8 +230,15 @@ internal static class Win32Window
     private static extern IntPtr LoadImage(IntPtr hInst, string name, uint type,
         int cx, int cy, uint fuLoad);
 
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool DestroyIcon(IntPtr hIcon);
+
     private const uint IMAGE_ICON = 1;
     private const uint LR_LOADFROMFILE = 0x0010;
+
+    private static IntPtr _currentSmallIcon;
+    private static IntPtr _currentBigIcon;
 
     [DllImport("gdi32.dll")]
     private static extern IntPtr CreateSolidBrush(uint crColor);
@@ -283,9 +290,19 @@ internal static class Win32Window
         var hIconLg = LoadImage(IntPtr.Zero, icoPath, IMAGE_ICON, 32, 32, LR_LOADFROMFILE);
 
         if (hIconSm != IntPtr.Zero)
+        {
             SendMessage(hwnd, WM_SETICON, ICON_SMALL, hIconSm);
+            if (_currentSmallIcon != IntPtr.Zero)
+                DestroyIcon(_currentSmallIcon);
+            _currentSmallIcon = hIconSm;
+        }
         if (hIconLg != IntPtr.Zero)
+        {
             SendMessage(hwnd, WM_SETICON, ICON_BIG, hIconLg);
+            if (_currentBigIcon != IntPtr.Zero)
+                DestroyIcon(_currentBigIcon);
+            _currentBigIcon = hIconLg;
+        }
     }
 
     public static IntPtr Create(string className, string title, int x, int y, int width, int height, WndProc wndProc)

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1565,6 +1565,32 @@ const handleConnect = (serverData: SavedServer) => {
     updateBadge(totalDmUnreadCount, hasPendingInvite);
   }, [totalDmUnreadCount, hasPendingInvite, updateBadge]);
 
+  // Push current theme to native side for themed tray/taskbar icons
+  useEffect(() => {
+    const sendTheme = () => {
+      const theme = document.documentElement.getAttribute('data-theme');
+      if (theme) {
+        bridge.send('notification.theme', { theme });
+      }
+    };
+
+    // Send current theme on mount
+    sendTheme();
+
+    // Watch for theme changes (applyTheme sets data-theme attribute)
+    const observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        if (m.attributeName === 'data-theme') {
+          sendTheme();
+          break;
+        }
+      }
+    });
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+    return () => observer.disconnect();
+  }, []);
+
   const handleStartDMFromContextMenu = useCallback((sessionIdStr: string, userName: string) => {
     const user = users.find(u => String(u.session) === sessionIdStr);
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -417,7 +417,7 @@ function App() {
     // Add Mumble DM unreads
     for (const contact of dmStore.contacts) {
       if (contact.isEphemeral) {
-        total += contact.unreadCount;
+        total += contact.unreadCount > 0 ? 1 : 0;
       }
     }
     return total;

--- a/src/Brmble.Web/src/hooks/useUnreadTracker.ts
+++ b/src/Brmble.Web/src/hooks/useUnreadTracker.ts
@@ -500,7 +500,7 @@ export function useUnreadTracker(
   for (const [roomId, state] of roomUnreads) {
     totalUnreadCount += state.notificationCount;
     if (dmRoomIds.has(roomId)) {
-      totalDmUnreadCount += state.notificationCount;
+      totalDmUnreadCount += state.notificationCount > 0 ? 1 : 0;
     }
   }
 

--- a/src/Brmble.Web/src/themes/_template.css
+++ b/src/Brmble.Web/src/themes/_template.css
@@ -617,7 +617,7 @@
        Cosmopolitan:      Bodoni Moda + Manrope
        Aperol Spritz:     Fraunces + Nunito
        Midori Sour:       Space Mono + Lexend
-       Lemon Drop Martini: Sora + Plus Jakarta Sans
+        Lemon Drop:         Sora + Plus Jakarta Sans
        Retro Terminal:    VT323 + IBM Plex Mono
      ───────────────────────────────────────────────────────────────────── */
 

--- a/src/Brmble.Web/src/themes/lemon-drop.css
+++ b/src/Brmble.Web/src/themes/lemon-drop.css
@@ -1,7 +1,7 @@
 /* ═══════════════════════════════════════════════════
-   Brmble Lemon Drop Martini Theme — Premium Gold
+   Brmble Lemon Drop Theme — Premium Gold
 
-   Cocktail:   Lemon Drop Martini (vodka, triple sec, lemon juice)
+   Cocktail:   Lemon Drop (vodka, triple sec, lemon juice)
    Vibe:       Bright optimism, premium gold — the brightest,
                most cheerful theme. Golden accent against warm
                darks. A sugar-rimmed glass catching candlelight.

--- a/src/Brmble.Web/src/themes/theme-registry.ts
+++ b/src/Brmble.Web/src/themes/theme-registry.ts
@@ -44,7 +44,7 @@ export const themes: ThemeDefinition[] = [
   },
   {
     id: 'lemon-drop',
-    name: 'Lemon Drop Martini',
+    name: 'Lemon Drop',
     description: 'Bright lemon gold — premium optimism',
     fontUrl: 'https://fonts.googleapis.com/css2?family=Sora:wght@300;400;500;600;700&family=Plus+Jakarta+Sans:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap',
   },


### PR DESCRIPTION
## Summary

This PR addresses three related issues and adds a cohesive set of improvements to the native client experience:

- **Fix DM badge count** (#403) -- The DM button badge now shows the number of *contacts* with unread messages, not the total unread message count. Previously, 10 messages from 1 person showed "10"; now it correctly shows "1".
- **Theme-aware native icons** -- The system tray icon, taskbar icon, and taskbar overlay badge all dynamically update when the user switches themes, matching the selected theme's accent color and icon set.
- **Rename "Lemon Drop Martini" to "Lemon Drop"** (#342) -- Shortened the theme display name in the theme picker and updated associated CSS comments.

## What changed

### Frontend (TypeScript/React)
- `useUnreadTracker.ts` -- Changed DM badge to count unique sender IDs instead of summing message counts
- `App.tsx` -- Added `notification.theme` bridge message sent on mount and on theme changes via MutationObserver on `data-theme`
- `theme-registry.ts` / `lemon-drop.css` / `_template.css` -- Renamed "Lemon Drop Martini" to "Lemon Drop"

### Native Client (C#)
- **`ThemeColors.cs`** (new) -- Maps theme names to `--accent-primary` and `--bg-deep` RGB values for native rendering
- **`TrayIcon.cs`** -- Theme-aware tray icons with accent-colored badge dots composited onto the theme's `.ico` file
- **`TaskbarBadge.cs`** -- Accent-colored overlay dot with a thin `--bg-deep` ring for contrast; centered on a 16x16 canvas (Windows places it bottom-right)
- **`Win32Window.cs`** -- Added `WM_SETICON` / `SendMessage` support for dynamic window icon updates
- **`Program.cs`** -- Added `notification.theme` bridge handler that routes theme changes to TrayIcon, TaskbarBadge, and Win32Window

### Design & Planning
- Full design spec and 9-task implementation plan in `docs/superpowers/`

## How it works

```
Frontend (theme change) 
  → notification.theme { theme: "blue-lagoon" }
    → NativeBridge 
      → ThemeColors.GetAccent() / GetBgDeep() / GetIconPath()
        → TrayIcon.SetTheme()      // swaps .ico + redraws badge
        → TaskbarBadge.SetTheme()   // rebuilds overlay dot
        → Win32Window.SetWindowIcon() // updates ALT+TAB icon
```

## Testing done

- Verified DM badge shows correct contact count (not message count)
- Tested theme switching across multiple themes -- tray icon, taskbar icon, and overlay badge all update correctly
- Confirmed "Lemon Drop" name in theme picker (no "Martini")
- Build passes with zero errors

Closes #403, closes #342