### PR TITLE
fix: remove vestigial username from ServerEntry to fix profile-scoped connections

### DIFF
--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -402,7 +402,6 @@ static class Program
             apiUrl = server.ApiUrl,
             host = server.Host,
             port = server.Port,
-            username = server.Username,
         });
     }
 

--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -145,9 +145,14 @@ internal sealed class AppConfigService : IAppConfigService
             var i = _servers.FindIndex(s => s.Id == server.Id);
             if (i >= 0)
             {
-                // Replace the existing entry wholesale with the incoming server entry.
-                // The frontend sends a full ServerEntry on edit, so this allows fields to be cleared.
-                _servers[i] = server;
+                // Preserve the existing password when the incoming update omits it.
+                // Registration-status updates from the frontend don't carry the password
+                // (it's kept in secure storage, not localStorage), so a wholesale replace
+                // would wipe it.
+                var merged = string.IsNullOrEmpty(server.Password)
+                    ? server with { Password = _servers[i].Password }
+                    : server;
+                _servers[i] = merged;
                 Save();
                 return _servers[i];
             }

--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -409,7 +409,6 @@ internal sealed class AppConfigService : IAppConfigService
             return null;
 
         var label = data.TryGetProperty("label", out var labelEl) ? labelEl.GetString() ?? "" : "";
-        var username = data.TryGetProperty("username", out var usernameEl) ? usernameEl.GetString() ?? "" : "";
         var apiUrl = data.TryGetProperty("apiUrl", out var apiEl) ? apiEl.GetString() : null;
         var passwordRaw = data.TryGetProperty("password", out var pwEl) ? pwEl.GetString() ?? "" : "";
         var password = TryDecryptPassword(passwordRaw, passwordStorage);
@@ -422,7 +421,6 @@ internal sealed class AppConfigService : IAppConfigService
             apiUrl,
             data.TryGetProperty("host", out var hostEl) ? hostEl.GetString() : null,
             data.TryGetProperty("port", out var portEl) && portEl.ValueKind == System.Text.Json.JsonValueKind.Number ? portEl.GetInt32() : null,
-            username,
             password,
             registered,
             registeredName);

--- a/src/Brmble.Client/Services/Serverlist/IServerlistService.cs
+++ b/src/Brmble.Client/Services/Serverlist/IServerlistService.cs
@@ -6,7 +6,6 @@ public record ServerEntry(
     string? ApiUrl,
     string? Host,
     int? Port,
-    string Username,
     string Password = "",
     bool Registered = false,
     string? RegisteredName = null

--- a/src/Brmble.Client/Services/Serverlist/ServerlistService.cs
+++ b/src/Brmble.Client/Services/Serverlist/ServerlistService.cs
@@ -88,7 +88,11 @@ internal sealed class ServerlistService : IServerlistService
             var index = _servers.FindIndex(s => s.Id == server.Id);
             if (index >= 0)
             {
-                _servers[index] = server;
+                // Preserve the existing password when the incoming update omits it.
+                var merged = string.IsNullOrEmpty(server.Password)
+                    ? server with { Password = _servers[index].Password }
+                    : server;
+                _servers[index] = merged;
                 Save();
                 return _servers[index];
             }

--- a/src/Brmble.Client/Services/Serverlist/ServerlistService.cs
+++ b/src/Brmble.Client/Services/Serverlist/ServerlistService.cs
@@ -130,8 +130,7 @@ internal sealed class ServerlistService : IServerlistService
 
     private static ServerEntry? ParseServerEntry(JsonElement data)
     {
-        if (!data.TryGetProperty("label", out var label) ||
-            !data.TryGetProperty("username", out var username))
+        if (!data.TryGetProperty("label", out var label))
         {
             return null;
         }
@@ -149,7 +148,6 @@ internal sealed class ServerlistService : IServerlistService
             apiUrl,
             data.TryGetProperty("host", out var hostEl) ? hostEl.GetString() : null,
             data.TryGetProperty("port", out var portEl) && portEl.ValueKind == JsonValueKind.Number ? portEl.GetInt32() : null,
-            username.GetString() ?? "",
             password
         );
     }

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -629,7 +629,9 @@ function App() {
         }
       }
 
-      // Persist Mumble registration status to the saved server entry
+      // Persist Mumble registration status to the saved server entry.
+      // Password is intentionally omitted here (not stored in localStorage);
+      // the backend preserves the existing password when an update omits it.
       const reg = data as { registered?: boolean; registeredName?: string } | undefined;
       if (reg?.registered) {
         try {
@@ -637,9 +639,8 @@ function App() {
           if (stored) {
             const savedServer = JSON.parse(stored) as SavedServer;
             if (savedServer.id) {
-              const { password } = savedServer;
               const updated = { ...savedServer, registered: true, registeredName: reg.registeredName };
-              bridge.send('servers.update', { ...updated, password });
+              bridge.send('servers.update', updated);
               localStorage.setItem('brmble-server', JSON.stringify(updated));
             }
           }
@@ -651,9 +652,8 @@ function App() {
           if (stored) {
             const savedServer = JSON.parse(stored) as SavedServer;
             if (savedServer.id && savedServer.registered) {
-              const { password } = savedServer;
               const updated = { ...savedServer, registered: false, registeredName: undefined };
-              bridge.send('servers.update', { ...updated, password });
+              bridge.send('servers.update', updated);
               localStorage.setItem('brmble-server', JSON.stringify(updated));
             }
           }
@@ -1148,13 +1148,14 @@ function App() {
     const onRegistrationStatus = (data: unknown) => {
       const d = data as { serverId?: string; registered?: boolean; registeredName?: string } | undefined;
       if (!d?.registered || !d.serverId) return;
+      // Password is intentionally omitted (not in localStorage);
+      // the backend preserves the existing password when an update omits it.
       try {
         const stored = localStorage.getItem('brmble-server');
         if (stored) {
           const savedServer = JSON.parse(stored) as SavedServer;
           if (savedServer.id === d.serverId) {
-            const { password, ...safeServerData } = savedServer;
-            const updated = { ...safeServerData, registered: true, registeredName: d.registeredName };
+            const updated = { ...savedServer, registered: true, registeredName: d.registeredName };
             bridge.send('servers.update', updated);
             localStorage.setItem('brmble-server', JSON.stringify(updated));
           }

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -638,7 +638,7 @@ function App() {
             const savedServer = JSON.parse(stored) as SavedServer;
             if (savedServer.id) {
               const { password } = savedServer;
-              const updated = { ...savedServer, registered: true, username: reg.registeredName ?? savedServer.username, registeredName: reg.registeredName };
+              const updated = { ...savedServer, registered: true, registeredName: reg.registeredName };
               bridge.send('servers.update', { ...updated, password });
               localStorage.setItem('brmble-server', JSON.stringify(updated));
             }
@@ -1061,7 +1061,7 @@ function App() {
     };
 
     const onAutoConnect = (data: unknown) => {
-      const server = data as { id: string; label: string; apiUrl?: string; host?: string; port?: number; username: string } | undefined;
+      const server = data as { id: string; label: string; apiUrl?: string; host?: string; port?: number } | undefined;
       if (server) {
         setServerLabel(server.label || `${server.host}:${server.port}`);
         handleConnect({
@@ -1070,7 +1070,7 @@ function App() {
           apiUrl: server.apiUrl,
           host: server.host || '',
           port: server.port || 0,
-          username: server.username || activeProfileName || 'Brmble User',
+          username: activeProfileName || 'Brmble User',
           password: '',
         });
       }
@@ -1154,7 +1154,7 @@ function App() {
           const savedServer = JSON.parse(stored) as SavedServer;
           if (savedServer.id === d.serverId) {
             const { password, ...safeServerData } = savedServer;
-            const updated = { ...safeServerData, registered: true, registeredName: d.registeredName, username: d.registeredName ?? savedServer.username };
+            const updated = { ...safeServerData, registered: true, registeredName: d.registeredName };
             bridge.send('servers.update', updated);
             localStorage.setItem('brmble-server', JSON.stringify(updated));
           }
@@ -1308,7 +1308,7 @@ const handleConnect = (serverData: SavedServer) => {
       apiUrl: server.apiUrl,
       host: server.host,
       port: server.port,
-      username: server.username || activeProfileName || 'Brmble User',
+      username: (server.registered ? server.registeredName : null) || activeProfileName || 'Brmble User',
       password: server.password || '',
       registered: server.registered,
       registeredName: server.registeredName,

--- a/src/Brmble.Web/src/components/ServerList/ServerList.tsx
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.tsx
@@ -17,7 +17,7 @@ export function ServerList({ onConnect, connectionError, onClearError, activePro
   const { servers, loading, addServer, updateServer, removeServer } = useServerlist();
   const [editing, setEditing] = useState<ServerEntry | null>(null);
   const [isAdding, setIsAdding] = useState(false);
-  const [form, setForm] = useState({ label: '', host: '', port: '64738', username: '', password: '' });
+  const [form, setForm] = useState({ label: '', host: '', port: '64738', password: '' });
   const [showPassword, setShowPassword] = useState(false);
   const [passwordFocused, setPasswordFocused] = useState(false);
   const [toggleFocused, setToggleFocused] = useState(false);
@@ -34,7 +34,7 @@ export function ServerList({ onConnect, connectionError, onClearError, activePro
       addServer(server);
       setIsAdding(false);
     }
-    setForm({ label: '', host: '', port: '64738', username: '', password: '' });
+    setForm({ label: '', host: '', port: '64738', password: '' });
     setShowPassword(false);
     setToggleFocused(false);
   };
@@ -45,7 +45,6 @@ export function ServerList({ onConnect, connectionError, onClearError, activePro
       label: server.label,
       host: server.host,
       port: String(server.port),
-      username: server.username,
       password: server.password || ''
     });
     setIsAdding(false);
@@ -56,7 +55,7 @@ export function ServerList({ onConnect, connectionError, onClearError, activePro
   const handleCancel = () => {
     setEditing(null);
     setIsAdding(false);
-    setForm({ label: '', host: '', port: '64738', username: '', password: '' });
+    setForm({ label: '', host: '', port: '64738', password: '' });
     setShowPassword(false);
     setToggleFocused(false);
   };
@@ -78,7 +77,7 @@ export function ServerList({ onConnect, connectionError, onClearError, activePro
       if (e.key === 'Escape') {
         setEditing(null);
         setIsAdding(false);
-        setForm({ label: '', host: '', port: '64738', username: '', password: '' });
+        setForm({ label: '', host: '', port: '64738', password: '' });
         setShowPassword(false);
         setToggleFocused(false);
       }
@@ -253,8 +252,7 @@ export function ServerList({ onConnect, connectionError, onClearError, activePro
                   <input
                     className="brmble-input server-list-input server-list-input-registered"
                     placeholder="Username"
-                    value={editing.registeredName ?? form.username}
-                    onChange={e => setForm(f => ({ ...f, username: e.target.value }))}
+                    value={editing.registeredName ?? ''}
                     disabled
                   />
                   <svg className="server-list-registered-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-label="Registered">

--- a/src/Brmble.Web/src/hooks/useServerlist.ts
+++ b/src/Brmble.Web/src/hooks/useServerlist.ts
@@ -7,7 +7,6 @@ export interface ServerEntry {
   apiUrl?: string;
   host: string;
   port: number;
-  username: string;
   password: string;
   registered?: boolean;
   registeredName?: string;

--- a/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
@@ -66,7 +66,7 @@ public class AppConfigServiceTests
     public void SavesAndReloads_Servers()
     {
         var svc = new AppConfigService(_tempDir, null);
-        var server = new ServerEntry("id1", "My Server", null, "localhost", 64738, "alice");
+        var server = new ServerEntry("id1", "My Server", null, "localhost", 64738);
 
         svc.AddServer(server);
         var svc2 = new AppConfigService(_tempDir, null);
@@ -100,7 +100,7 @@ public class AppConfigServiceTests
     public void MigratesPlainTextPasswords_ToEncrypted()
     {
         var svc = new AppConfigService(_tempDir, null);
-        var server = new ServerEntry("id1", "Test", null, "localhost", 64738, "alice", "plainTextPassword123");
+        var server = new ServerEntry("id1", "Test", null, "localhost", 64738, "plainTextPassword123");
 
         svc.AddServer(server);
 
@@ -188,7 +188,7 @@ public class AppConfigServiceTests
     public void AutoConnect_ClearsServerId_WhenServerRemoved()
     {
         var svc = new AppConfigService(_tempDir, null);
-        svc.AddServer(new ServerEntry("srv1", "Test Server", null, "localhost", 64738, "alice"));
+        svc.AddServer(new ServerEntry("srv1", "Test Server", null, "localhost", 64738));
         svc.SetSettings(svc.GetSettings() with { AutoConnectEnabled = true, AutoConnectServerId = "srv1" });
 
         svc.RemoveServer("srv1");


### PR DESCRIPTION
## Summary

- **Fixes** the "Wrong certificate or password for existing user" error when connecting with a newly created profile to a server where a previous profile was registered
- **Removes** the vestigial `username` field from `ServerEntry` which was global (per-server) but got overwritten to the registered name on every connection, causing new profiles to send the wrong username
- **Changes** the connect fallback chain to resolve username from `registeredName` (when registered for the current profile) or `activeProfileName`, instead of a stale server-level `username` field

## Root Cause

The `username` field on `ServerEntry` was overwritten to Profile A's `registeredName` after a successful connection. When switching to Profile B (new profile), `SwapProfileRegistrations` correctly cleared `registered`/`registeredName` but did not touch `username`. The connect fallback chain (`server.username || activeProfileName || 'Brmble User'`) then sent Profile A's name with Profile B's certificate, triggering the Mumble rejection.

## Changes

- Removed `Username` from C# `ServerEntry` record and both `ParseServerEntry` methods
- Removed `username` from TypeScript `ServerEntry` interface and `ServerList` form state
- Changed `handleServerConnect` to use `(server.registered ? server.registeredName : null) || activeProfileName`
- Changed `onAutoConnect` to use `activeProfileName` directly
- Stopped `onVoiceConnected` and `onRegistrationStatus` from back-writing `username` to server entries
- Removed `username` from auto-connect bridge message in `Program.cs`
- Updated test `ServerEntry` constructor calls

## Testing

- Build: 0 errors, 0 warnings
- All tests pass (1 pre-existing DPAPI test failure unrelated)
- Manually verified: new profile connects with correct name to server where previous profile was registered