### PR TITLE
feat: add Watch Stream option to user context menu

### DIFF
--- a/docs/superpowers/plans/2026-03-30-watch-stream-context-menu.md
+++ b/docs/superpowers/plans/2026-03-30-watch-stream-context-menu.md
@@ -1,0 +1,56 @@
+# Watch Stream Context Menu Item Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add "Watch Stream" as the first option in the user right-click context menu, appearing only when the user is currently sharing their screen.
+
+**Architecture:** Single task adding a conditional menu item to the existing user context menu in ChannelTree.tsx.
+
+**Tech Stack:** React, TypeScript
+
+---
+
+### Task 1: Add Watch Stream Menu Item
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx:427-464`
+
+- [ ] **Step 1: Add Watch Stream item to context menu items**
+
+Find the context menu items array (starts around line 431). Add the Watch Stream item as the **first item** in the array, before Direct Message. The item should only appear when `contextMenu.userId` matches `sharingUserSession`.
+
+Insert this code block at the beginning of the items array (around line 432):
+
+```tsx
+...(contextMenu.userId === String(sharingUserSession) ? [{
+  type: 'item' as const,
+  label: 'Watch Stream',
+  icon: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+      <line x1="8" y1="21" x2="16" y2="21"/>
+      <line x1="12" y1="17" x2="12" y2="21"/>
+    </svg>
+  ),
+  onClick: () => {
+    const channelId = contextMenu.channelId ?? currentChannelId;
+    onWatchScreenShare?.(`channel-${channelId}`);
+  },
+}] : []),
+```
+
+- [ ] **Step 2: Test the implementation**
+
+1. Start the dev server: `cd src/Brmble.Web && npm run dev`
+2. Start the client: `dotnet run --project src/Brmble.Client`
+3. Right-click on a user who is not sharing - "Watch Stream" should not appear
+4. Have a user start screen sharing
+5. Right-click on the sharing user - "Watch Stream" should appear
+6. Click "Watch Stream" - should open their screen share
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+git commit -m "feat: add Watch Stream to user context menu"
+```

--- a/docs/superpowers/specs/2026-03-30-watch-stream-context-menu-design.md
+++ b/docs/superpowers/specs/2026-03-30-watch-stream-context-menu-design.md
@@ -8,7 +8,7 @@ Add "Watch Stream" to the user context menu in the channel list. The item appear
 
 ## Placement
 - Position: **First item** in the context menu (before Direct Message)
-- Only rendered when `user.session === sharingUserSession`
+- Only rendered when `contextMenu.userId === String(sharingUserSession) && onWatchScreenShare`
 
 ## Behavior
 | State | Visibility | Click Action |
@@ -28,7 +28,7 @@ Inside the user context menu items array (~line 432, as first item)
 
 ### Code
 ```tsx
-...(user.session === sharingUserSession ? [{
+...(contextMenu.userId === String(sharingUserSession) && onWatchScreenShare ? [{
   type: 'item' as const,
   label: 'Watch Stream',
   icon: (
@@ -38,7 +38,10 @@ Inside the user context menu items array (~line 432, as first item)
       <line x1="12" y1="17" x2="12" y2="21"/>
     </svg>
   ),
-  onClick: () => onWatchScreenShare?.(`channel-${channel.id}`),
+  onClick: () => {
+    const channelId = contextMenu.channelId ?? currentChannelId;
+    onWatchScreenShare?.(`channel-${channelId}`);
+  },
 }] : []),
 ```
 

--- a/docs/superpowers/specs/2026-03-30-watch-stream-context-menu-design.md
+++ b/docs/superpowers/specs/2026-03-30-watch-stream-context-menu-design.md
@@ -7,7 +7,7 @@ Approved
 Add "Watch Stream" to the user context menu in the channel list. The item appears near the top alongside "Direct Message" and "User Info", but only when the right-clicked user is currently sharing their screen.
 
 ## Placement
-- Position: After "User Info" in the context menu
+- Position: **First item** in the context menu (before Direct Message)
 - Only rendered when `user.session === sharingUserSession`
 
 ## Behavior
@@ -24,7 +24,7 @@ Add "Watch Stream" to the user context menu in the channel list. The item appear
 `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`
 
 ### Location
-Inside the user context menu items array (~line 453, after User Info)
+Inside the user context menu items array (~line 432, as first item)
 
 ### Code
 ```tsx

--- a/docs/superpowers/specs/2026-03-30-watch-stream-context-menu-design.md
+++ b/docs/superpowers/specs/2026-03-30-watch-stream-context-menu-design.md
@@ -1,0 +1,52 @@
+# Watch Stream Context Menu Item
+
+## Status
+Approved
+
+## Overview
+Add "Watch Stream" to the user context menu in the channel list. The item appears near the top alongside "Direct Message" and "User Info", but only when the right-clicked user is currently sharing their screen.
+
+## Placement
+- Position: After "User Info" in the context menu
+- Only rendered when `user.session === sharingUserSession`
+
+## Behavior
+| State | Visibility | Click Action |
+|-------|------------|---------------|
+| User is sharing | Visible | Opens their stream via `onWatchScreenShare()` |
+| User is not sharing | Hidden | N/A |
+| Different user sharing | Hidden | N/A |
+| Already watching | Visible | Opens their stream (no toggle needed) |
+
+## Implementation Details
+
+### File
+`src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`
+
+### Location
+Inside the user context menu items array (~line 453, after User Info)
+
+### Code
+```tsx
+...(user.session === sharingUserSession ? [{
+  type: 'item' as const,
+  label: 'Watch Stream',
+  icon: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+      <line x1="8" y1="21" x2="16" y2="21"/>
+      <line x1="12" y1="17" x2="12" y2="21"/>
+    </svg>
+  ),
+  onClick: () => onWatchScreenShare?.(`channel-${channel.id}`),
+}] : []),
+```
+
+### Icon
+Uses the same screen share icon already present in user rows when someone is sharing.
+
+## Testing Considerations
+- Verify item appears when right-clicking the sharing user
+- Verify item does not appear when right-clicking non-sharing users
+- Verify clicking the item opens the screen share stream
+- Verify existing context menu items still work correctly

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -439,7 +439,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
                   <line x1="12" y1="17" x2="12" y2="21"/>
                 </svg>
               ),
-              onClick: () => {
+onClick: () => {
                 const channelId = contextMenu.channelId ?? currentChannelId;
                 onWatchScreenShare?.(`channel-${channelId}`);
               },

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -429,7 +429,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
           x={contextMenu.x}
           y={contextMenu.y}
           items={[
-            ...(contextMenu.userId === String(sharingUserSession) ? [{
+            ...(contextMenu.userId === String(sharingUserSession) && onWatchScreenShare ? [{
               type: 'item' as const,
               label: 'Watch Stream',
               icon: (

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -429,6 +429,21 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
           x={contextMenu.x}
           y={contextMenu.y}
           items={[
+            ...(contextMenu.userId === String(sharingUserSession) ? [{
+              type: 'item' as const,
+              label: 'Watch Stream',
+              icon: (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+                  <line x1="8" y1="21" x2="16" y2="21"/>
+                  <line x1="12" y1="17" x2="12" y2="21"/>
+                </svg>
+              ),
+              onClick: () => {
+                const channelId = contextMenu.channelId ?? currentChannelId;
+                onWatchScreenShare?.(`channel-${channelId}`);
+              },
+            }] : []),
             ...(!contextMenu.isSelf && onStartDM ? [{
               type: 'item' as const,
               label: 'Direct Message',


### PR DESCRIPTION
## Summary

Added "Watch Stream" to the user right-click context menu in the channel list sidebar.

### What was implemented
- New menu item appears as the **first option** in the user context menu
- Only visible when the right-clicked user is currently sharing their screen
- Clicking it opens their screen share stream

### Implementation details
- **File modified:** `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`
- Uses existing screen sharing infrastructure (`sharingUserSession` prop, `onWatchScreenShare` callback)
- Condition: `contextMenu.userId === String(sharingUserSession)` - ensures the item only appears for the user who is sharing

### Code structure
```tsx
...(contextMenu.userId === String(sharingUserSession) ? [{
  type: 'item' as const,
  label: 'Watch Stream',
  icon: <ScreenShareIcon />,
  onClick: () => {
    const channelId = contextMenu.channelId ?? currentChannelId;
    onWatchScreenShare?.(\`channel-\${channelId}\`);
  },
}] : []),
```

## ⚠️ Testing Required

**This feature has NOT been runtime-tested yet.**

### Manual testing steps needed
1. Start the dev server: `cd src/Brmble.Web && npm run dev`
2. Start the client: `dotnet run --project src/Brmble.Client`
3. Have a user start screen sharing
4. Right-click on the sharing user → "Watch Stream" should appear at the top
5. Right-click on a non-sharing user → "Watch Stream" should NOT appear
6. Click "Watch Stream" → should open their screen share stream

### Verification checklist
- [ ] "Watch Stream" visible when right-clicking the sharing user
- [ ] "Watch Stream" hidden when right-clicking non-sharing users
- [ ] Clicking "Watch Stream" successfully opens the stream
- [ ] Existing context menu items still work correctly

## Files changed

| File | Change |
|------|--------|
| `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx` | +15 lines - Added Watch Stream menu item |
| `docs/superpowers/specs/2026-03-30-watch-stream-context-menu-design.md` | Design spec |
| `docs/superpowers/plans/2026-03-30-watch-stream-context-menu.md` | Implementation plan |

## Test Plan
- [ ] **Manual testing required** - See testing steps above