### PR TITLE
fix: eliminate server-root chat lag (#297)

### DIFF
--- a/docs/superpowers/plans/2026-03-30-server-root-chat-lag.md
+++ b/docs/superpowers/plans/2026-03-30-server-root-chat-lag.md
@@ -1,0 +1,664 @@
+# Server/Root Chat Lag Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate server-root chat lag by adding message classification, ephemeral purging on disconnect, a hard cap of 200 messages, and debounced localStorage writes.
+
+**Architecture:** The `server-root` channel stores messages in localStorage via `useChatStore`. We add a `systemType` field to classify messages as ephemeral or persistent, purge ephemeral messages on disconnect, enforce a 200-message cap, and debounce localStorage writes with a 500ms window. All changes are scoped to `server-root` only.
+
+**Tech Stack:** React, TypeScript, Vitest, `@testing-library/react`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/Brmble.Web/src/types/index.ts` | Modify (line 42-54) | Add `systemType` to `ChatMessage` interface |
+| `src/Brmble.Web/src/hooks/useChatStore.ts` | Modify (all) | Debounce, cap, purge, `systemType` propagation |
+| `src/Brmble.Web/src/App.tsx` | Modify (lines 785-795, 664-707) | Pass `systemType`, call purge on disconnect |
+| `src/Brmble.Web/src/hooks/useChatStore.test.ts` | Create | Tests for cap, purge, debounce |
+
+---
+
+### Task 1: Add `systemType` to `ChatMessage` Interface
+
+**Files:**
+- Modify: `src/Brmble.Web/src/types/index.ts:42-54`
+
+- [ ] **Step 1: Add the field**
+
+In `src/Brmble.Web/src/types/index.ts`, add `systemType` to the `ChatMessage` interface. Insert after the `type` field (line 49):
+
+```typescript
+export interface ChatMessage {
+  id: string;
+  channelId: string;
+  sender: string;
+  senderMatrixUserId?: string;
+  content: string;
+  timestamp: Date;
+  type?: 'system';
+  systemType?: string;
+  html?: boolean;
+  media?: MediaAttachment[];
+  pending?: boolean;
+  error?: boolean;
+}
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `npx tsc --noEmit` from `src/Brmble.Web/`
+Expected: No new errors (adding an optional field is backward-compatible).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Web/src/types/index.ts
+git commit -m "feat: add systemType field to ChatMessage interface"
+```
+
+---
+
+### Task 2: Update `useChatStore` — Add `systemType` to Write Functions, Cap, and Purge
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useChatStore.ts`
+- Create: `src/Brmble.Web/src/hooks/useChatStore.test.ts`
+
+- [ ] **Step 1: Write tests for the new behavior**
+
+Create `src/Brmble.Web/src/hooks/useChatStore.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useChatStore, addMessageToStore, purgeEphemeralMessages, flushPendingWrites } from './useChatStore';
+
+const STORAGE_KEY = 'brmble_chat_server-root';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useChatStore systemType', () => {
+  it('stores systemType on messages added via addMessage', () => {
+    const { result } = renderHook(() => useChatStore('server-root'));
+
+    act(() => {
+      result.current.addMessage('Server', 'Alice connected', 'system', false, undefined, 'userJoined');
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].systemType).toBe('userJoined');
+  });
+
+  it('stores systemType via addMessageToStore', () => {
+    addMessageToStore('server-root', 'Server', 'Bob left', 'system', false, undefined, 'userLeft');
+
+    // Flush debounce
+    vi.advanceTimersByTime(600);
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].systemType).toBe('userLeft');
+  });
+});
+
+describe('useChatStore hard cap (server-root)', () => {
+  it('trims oldest messages when exceeding 200 via addMessage', () => {
+    const { result } = renderHook(() => useChatStore('server-root'));
+
+    act(() => {
+      for (let i = 0; i < 210; i++) {
+        result.current.addMessage('Server', `msg-${i}`, 'system', false, undefined, 'userJoined');
+      }
+    });
+
+    expect(result.current.messages).toHaveLength(200);
+    // Oldest messages trimmed — first message should be msg-10
+    expect(result.current.messages[0].content).toBe('msg-10');
+    expect(result.current.messages[199].content).toBe('msg-209');
+  });
+
+  it('does NOT cap non-server-root channels', () => {
+    const { result } = renderHook(() => useChatStore('channel-5'));
+
+    act(() => {
+      for (let i = 0; i < 210; i++) {
+        result.current.addMessage('User', `msg-${i}`);
+      }
+    });
+
+    expect(result.current.messages).toHaveLength(210);
+  });
+
+  it('trims oldest messages when exceeding 200 via addMessageToStore', () => {
+    // Pre-fill with 195 messages
+    const existing = Array.from({ length: 195 }, (_, i) => ({
+      id: `id-${i}`,
+      channelId: 'server-root',
+      sender: 'Server',
+      content: `old-${i}`,
+      timestamp: new Date().toISOString(),
+      type: 'system',
+      systemType: 'userJoined',
+    }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(existing));
+
+    // Add 10 more (total 205 > 200)
+    for (let i = 0; i < 10; i++) {
+      addMessageToStore('server-root', 'Server', `new-${i}`, 'system', false, undefined, 'userLeft');
+    }
+
+    // Flush debounce
+    vi.advanceTimersByTime(600);
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(200);
+    // Oldest should have been trimmed
+    expect(stored[0].content).toBe('old-5');
+  });
+});
+
+describe('purgeEphemeralMessages', () => {
+  it('removes ephemeral messages and keeps persistent ones', () => {
+    const messages = [
+      { id: '1', channelId: 'server-root', sender: 'Server', content: 'Connecting...', timestamp: new Date().toISOString(), type: 'system', systemType: 'connecting' },
+      { id: '2', channelId: 'server-root', sender: 'Server', content: 'Welcome!', timestamp: new Date().toISOString(), type: 'system', systemType: 'welcome' },
+      { id: '3', channelId: 'server-root', sender: 'Server', content: 'Alice joined', timestamp: new Date().toISOString(), type: 'system', systemType: 'userJoined' },
+      { id: '4', channelId: 'server-root', sender: 'Server', content: 'You were kicked', timestamp: new Date().toISOString(), type: 'system', systemType: 'kicked' },
+      { id: '5', channelId: 'server-root', sender: 'User', content: 'Hello', timestamp: new Date().toISOString() },
+      { id: '6', channelId: 'server-root', sender: 'Server', content: 'Bob left', timestamp: new Date().toISOString(), type: 'system', systemType: 'userLeft' },
+    ];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+
+    purgeEphemeralMessages('server-root');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(2);
+    expect(stored[0].content).toBe('You were kicked');
+    expect(stored[1].content).toBe('Hello');
+  });
+
+  it('handles empty localStorage gracefully', () => {
+    purgeEphemeralMessages('server-root');
+    // Should not throw
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('flushes debounce buffer before purging', () => {
+    // Add a message via background store (debounced)
+    addMessageToStore('server-root', 'Server', 'Alice joined', 'system', false, undefined, 'userJoined');
+    // Also add a persistent message
+    addMessageToStore('server-root', 'Server', 'You were banned', 'system', false, undefined, 'banned');
+
+    // Don't advance timers — buffer is not flushed yet
+    // Purge should flush first, then purge ephemeral
+    purgeEphemeralMessages('server-root');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toBe('You were banned');
+  });
+});
+
+describe('debounced localStorage writes', () => {
+  it('does not write to localStorage immediately for server-root', () => {
+    const { result } = renderHook(() => useChatStore('server-root'));
+
+    act(() => {
+      result.current.addMessage('Server', 'test msg', 'system', false, undefined, 'userJoined');
+    });
+
+    // React state updated immediately
+    expect(result.current.messages).toHaveLength(1);
+
+    // localStorage not yet written (debounce pending)
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // Should not contain the new message yet
+      expect(parsed.find((m: { content: string }) => m.content === 'test msg')).toBeUndefined();
+    }
+  });
+
+  it('writes to localStorage after debounce period', () => {
+    const { result } = renderHook(() => useChatStore('server-root'));
+
+    act(() => {
+      result.current.addMessage('Server', 'test msg', 'system', false, undefined, 'userJoined');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toBe('test msg');
+  });
+
+  it('writes immediately for non-server-root channels', () => {
+    const { result } = renderHook(() => useChatStore('channel-5'));
+
+    act(() => {
+      result.current.addMessage('User', 'hello');
+    });
+
+    const stored = JSON.parse(localStorage.getItem('brmble_chat_channel-5')!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toBe('hello');
+  });
+
+  it('flushPendingWrites forces immediate write', () => {
+    addMessageToStore('server-root', 'Server', 'msg1', 'system', false, undefined, 'userJoined');
+    addMessageToStore('server-root', 'Server', 'msg2', 'system', false, undefined, 'userLeft');
+
+    // Not flushed yet
+    flushPendingWrites('server-root');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/hooks/useChatStore.test.ts` from `src/Brmble.Web/`
+Expected: FAIL — `purgeEphemeralMessages` and `flushPendingWrites` don't exist yet, `addMessage` doesn't accept `systemType`.
+
+- [ ] **Step 3: Implement the updated `useChatStore.ts`**
+
+Replace the contents of `src/Brmble.Web/src/hooks/useChatStore.ts` with:
+
+```typescript
+import { useState, useEffect, useCallback } from 'react';
+import type { ChatMessage, MediaAttachment } from '../types';
+
+const STORAGE_KEY_PREFIX = 'brmble_chat_';
+const SERVER_ROOT_KEY = 'server-root';
+const SERVER_ROOT_MAX_MESSAGES = 200;
+const DEBOUNCE_MS = 500;
+
+const EPHEMERAL_TYPES = new Set(['connecting', 'welcome', 'userJoined', 'userLeft']);
+
+// --- Debounce infrastructure for server-root background writes ---
+
+let bgBuffer: ChatMessage[] = [];
+let bgTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flushBgBuffer() {
+  if (bgTimer !== null) {
+    clearTimeout(bgTimer);
+    bgTimer = null;
+  }
+  if (bgBuffer.length === 0) return;
+
+  const fullKey = `${STORAGE_KEY_PREFIX}${SERVER_ROOT_KEY}`;
+  let messages: ChatMessage[] = [];
+  const stored = localStorage.getItem(fullKey);
+  if (stored) {
+    try {
+      messages = JSON.parse(stored);
+    } catch {
+      messages = [];
+    }
+  }
+
+  messages.push(...bgBuffer);
+  bgBuffer = [];
+
+  if (messages.length > SERVER_ROOT_MAX_MESSAGES) {
+    messages = messages.slice(messages.length - SERVER_ROOT_MAX_MESSAGES);
+  }
+
+  localStorage.setItem(fullKey, JSON.stringify(messages));
+}
+
+/**
+ * Flush any pending debounced writes for a given channel.
+ * Currently only server-root has debounced writes.
+ */
+export function flushPendingWrites(channelId: string) {
+  if (channelId === SERVER_ROOT_KEY) {
+    flushBgBuffer();
+  }
+}
+
+/**
+ * Purge ephemeral messages (connecting, welcome, userJoined, userLeft)
+ * from localStorage for the given channel. Flushes the debounce buffer first.
+ */
+export function purgeEphemeralMessages(channelId: string) {
+  flushPendingWrites(channelId);
+
+  const fullKey = `${STORAGE_KEY_PREFIX}${channelId}`;
+  const stored = localStorage.getItem(fullKey);
+  if (!stored) return;
+
+  let messages: ChatMessage[];
+  try {
+    messages = JSON.parse(stored);
+  } catch {
+    return;
+  }
+
+  const filtered = messages.filter(
+    (m) => !m.systemType || !EPHEMERAL_TYPES.has(m.systemType)
+  );
+
+  if (filtered.length === 0) {
+    localStorage.removeItem(fullKey);
+  } else {
+    localStorage.setItem(fullKey, JSON.stringify(filtered));
+  }
+}
+
+// --- Hook-based debounce timer for server-root ---
+
+let hookTimer: ReturnType<typeof setTimeout> | null = null;
+
+function debouncedSave(fullKey: string, msgs: ChatMessage[]) {
+  if (hookTimer !== null) {
+    clearTimeout(hookTimer);
+  }
+  hookTimer = setTimeout(() => {
+    hookTimer = null;
+    localStorage.setItem(fullKey, JSON.stringify(msgs));
+  }, DEBOUNCE_MS);
+}
+
+export function useChatStore(channelId: string) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const isServerRoot = channelId === SERVER_ROOT_KEY;
+
+  useEffect(() => {
+    // On mount / channel switch, flush any pending server-root writes
+    // so we read the latest data.
+    if (isServerRoot) {
+      flushBgBuffer();
+      if (hookTimer !== null) {
+        clearTimeout(hookTimer);
+        hookTimer = null;
+      }
+    }
+
+    const stored = localStorage.getItem(`${STORAGE_KEY_PREFIX}${channelId}`);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        setMessages(parsed.map((m: ChatMessage) => ({
+          ...m,
+          timestamp: new Date(m.timestamp)
+        })));
+      } catch {
+        setMessages([]);
+      }
+    } else {
+      setMessages([]);
+    }
+  }, [channelId, isServerRoot]);
+
+  const saveMessages = useCallback((msgs: ChatMessage[]) => {
+    const fullKey = `${STORAGE_KEY_PREFIX}${channelId}`;
+    if (isServerRoot) {
+      debouncedSave(fullKey, msgs);
+    } else {
+      localStorage.setItem(fullKey, JSON.stringify(msgs));
+    }
+  }, [channelId, isServerRoot]);
+
+  const addMessage = useCallback((
+    sender: string,
+    content: string,
+    type?: 'system',
+    html?: boolean,
+    media?: MediaAttachment[],
+    systemType?: string,
+  ) => {
+    const newMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      channelId,
+      sender,
+      content,
+      timestamp: new Date(),
+      ...(type && { type }),
+      ...(systemType && { systemType }),
+      ...(html && { html }),
+      ...(media && media.length > 0 && { media }),
+    };
+    setMessages(prev => {
+      let updated = [...prev, newMessage];
+      if (isServerRoot && updated.length > SERVER_ROOT_MAX_MESSAGES) {
+        updated = updated.slice(updated.length - SERVER_ROOT_MAX_MESSAGES);
+      }
+      saveMessages(updated);
+      return updated;
+    });
+  }, [channelId, isServerRoot, saveMessages]);
+
+  const clearMessages = useCallback(() => {
+    setMessages([]);
+    localStorage.removeItem(`${STORAGE_KEY_PREFIX}${channelId}`);
+  }, [channelId]);
+
+  return { messages, addMessage, clearMessages };
+}
+
+/**
+ * Write a message directly to a specific store key in localStorage,
+ * bypassing React state. Used for background message storage when
+ * the user is viewing a different chat panel.
+ *
+ * For server-root, writes are debounced. For other channels, writes are immediate.
+ */
+export function addMessageToStore(
+  storeKey: string,
+  sender: string,
+  content: string,
+  type?: 'system',
+  html?: boolean,
+  media?: MediaAttachment[],
+  systemType?: string,
+) {
+  const newMessage: ChatMessage = {
+    id: crypto.randomUUID(),
+    channelId: storeKey,
+    sender,
+    content,
+    timestamp: new Date(),
+    ...(type && { type }),
+    ...(systemType && { systemType }),
+    ...(html && { html }),
+    ...(media && media.length > 0 && { media }),
+  };
+
+  if (storeKey === SERVER_ROOT_KEY) {
+    bgBuffer.push(newMessage);
+    if (bgTimer !== null) {
+      clearTimeout(bgTimer);
+    }
+    bgTimer = setTimeout(flushBgBuffer, DEBOUNCE_MS);
+    return;
+  }
+
+  // Non-server-root: immediate write
+  const fullKey = `${STORAGE_KEY_PREFIX}${storeKey}`;
+  let messages: ChatMessage[] = [];
+  const stored = localStorage.getItem(fullKey);
+  if (stored) {
+    try {
+      messages = JSON.parse(stored);
+    } catch {
+      messages = [];
+    }
+  }
+  messages.push(newMessage);
+  localStorage.setItem(fullKey, JSON.stringify(messages));
+}
+
+/** Clear all chat messages from localStorage.
+ *  Preserves server-root messages since those are current-session system messages. */
+export function clearChatStorage() {
+  const serverRootKey = `${STORAGE_KEY_PREFIX}${SERVER_ROOT_KEY}`;
+  Object.keys(localStorage)
+    .filter(k => k.startsWith(STORAGE_KEY_PREFIX) && k !== serverRootKey)
+    .forEach(k => localStorage.removeItem(k));
+}
+
+export function useAllChats() {
+  const getAllChannelIds = useCallback(() => {
+    const keys = Object.keys(localStorage).filter(k => k.startsWith(STORAGE_KEY_PREFIX));
+    return keys.map(k => k.replace(STORAGE_KEY_PREFIX, ''));
+  }, []);
+
+  const clearAllChats = useCallback(() => {
+    getAllChannelIds().forEach(channelId => {
+      localStorage.removeItem(`${STORAGE_KEY_PREFIX}${channelId}`);
+    });
+  }, [getAllChannelIds]);
+
+  return { getAllChannelIds, clearAllChats };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/hooks/useChatStore.test.ts` from `src/Brmble.Web/`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useChatStore.ts src/Brmble.Web/src/hooks/useChatStore.test.ts
+git commit -m "feat: add systemType, hard cap, debounce, and purge to useChatStore"
+```
+
+---
+
+### Task 3: Update App.tsx — Pass `systemType` and Call Purge on Disconnect
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx:28,785-795,664-707`
+
+- [ ] **Step 1: Update the import**
+
+In `src/Brmble.Web/src/App.tsx`, update the import on line 28 to include `purgeEphemeralMessages`:
+
+Change:
+```typescript
+import { useChatStore, addMessageToStore, clearChatStorage } from './hooks/useChatStore';
+```
+
+To:
+```typescript
+import { useChatStore, addMessageToStore, clearChatStorage, purgeEphemeralMessages } from './hooks/useChatStore';
+```
+
+- [ ] **Step 2: Pass `systemType` through in `onVoiceSystem`**
+
+In `src/Brmble.Web/src/App.tsx`, update the `onVoiceSystem` handler (lines 785-795). The current code:
+
+```typescript
+    const onVoiceSystem = ((data: unknown) => {
+      const d = data as { message: string; systemType?: string; html?: boolean } | undefined;
+      if (d?.message) {
+        const currentKey = currentChannelIdRef.current;
+        if (currentKey === 'server-root') {
+          addMessageRef.current('Server', d.message, 'system', d.html);
+        } else {
+          addMessageToStore('server-root', 'Server', d.message, 'system', d.html);
+        }
+      }
+    });
+```
+
+Change to:
+
+```typescript
+    const onVoiceSystem = ((data: unknown) => {
+      const d = data as { message: string; systemType?: string; html?: boolean } | undefined;
+      if (d?.message) {
+        const currentKey = currentChannelIdRef.current;
+        if (currentKey === 'server-root') {
+          addMessageRef.current('Server', d.message, 'system', d.html, undefined, d.systemType);
+        } else {
+          addMessageToStore('server-root', 'Server', d.message, 'system', d.html, undefined, d.systemType);
+        }
+      }
+    });
+```
+
+- [ ] **Step 3: Call `purgeEphemeralMessages` on disconnect**
+
+In `src/Brmble.Web/src/App.tsx`, in the `onVoiceDisconnected` handler (line 664), add the purge call right after `clearPendingAction()` on line 665. Change:
+
+```typescript
+    const onVoiceDisconnected = (data: unknown) => {
+      clearPendingAction();
+      const d = data as { reconnectAvailable?: boolean } | null;
+```
+
+To:
+
+```typescript
+    const onVoiceDisconnected = (data: unknown) => {
+      clearPendingAction();
+      purgeEphemeralMessages('server-root');
+      const d = data as { reconnectAvailable?: boolean } | null;
+```
+
+- [ ] **Step 4: Verify no type errors**
+
+Run: `npx tsc --noEmit` from `src/Brmble.Web/`
+Expected: No new errors.
+
+- [ ] **Step 5: Run all tests**
+
+Run: `npx vitest run` from `src/Brmble.Web/`
+Expected: All tests PASS (both new and existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx
+git commit -m "feat: pass systemType to chat store and purge ephemeral messages on disconnect"
+```
+
+---
+
+### Task 4: Integration Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npx vitest run` from `src/Brmble.Web/`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Run type check**
+
+Run: `npx tsc --noEmit` from `src/Brmble.Web/`
+Expected: No errors.
+
+- [ ] **Step 3: Build the frontend**
+
+Run: `npm run build` from `src/Brmble.Web/`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Verify localStorage behavior manually (if dev server available)**
+
+1. Start the dev server and connect to a Mumble server.
+2. Open DevTools > Application > Local Storage > `brmble_chat_server-root`.
+3. Verify messages have `systemType` field.
+4. Verify the array stays at or below 200 entries.
+5. Disconnect and verify ephemeral messages are removed.
+6. Verify kick/ban messages (if applicable) survive disconnect.

--- a/docs/superpowers/specs/2026-03-30-server-root-chat-lag-design.md
+++ b/docs/superpowers/specs/2026-03-30-server-root-chat-lag-design.md
@@ -1,0 +1,123 @@
+# Server/Root Chat Lag Fix
+
+**Issue:** #297
+**Branch:** `fix/server-root-chat-lag`
+**Date:** 2026-03-30
+
+## Problem
+
+The `server-root` chat experiences significant lag from two sources:
+
+1. **On tab switch:** Deserializing the entire message history from localStorage and rendering all DOM nodes at once.
+2. **During active use:** Every new message triggers `JSON.stringify` of the entire message array back to localStorage, plus a full React re-render of the message list.
+
+The root cause is that `server-root` messages are stored in localStorage via `useChatStore` with no cap, no cleanup, and no write batching. High-frequency events (`userJoined`, `userLeft`) accumulate indefinitely across sessions.
+
+## Scope
+
+This fix targets the data/storage layer only. Virtual scrolling and DOM optimization are out of scope and can be assessed separately after this fix lands.
+
+Only the `server-root` channel is affected. Matrix-backed channels use `useMatrixClient` with bounded sync limits and are not part of this change.
+
+## Architecture Context
+
+### Current Flow
+
+Messages arrive via the C# bridge as `voice.system` events. The backend (`MumbleAdapter.cs`) sends a `systemType` field with each event, but the frontend ignores it. All messages are stored in localStorage under key `brmble_chat_server-root` as a single JSON array. There is no cap, no expiry, and no cleanup on disconnect.
+
+### Message Types
+
+| systemType | Example | Frequency | Classification |
+|---|---|---|---|
+| `connecting` | "Connecting to host:port..." | Once per connect | Ephemeral |
+| `welcome` | Server MOTD (HTML) | Once per connect | Ephemeral |
+| `userJoined` | "Alice connected to the server" | High on busy servers | Ephemeral |
+| `userLeft` | "Bob disconnected from the server" | High on busy servers | Ephemeral |
+| `banned` | "You were banned by Admin: reason" | Rare | Persistent |
+| `kicked` | "You were kicked by Admin: reason" | Rare | Persistent |
+| (none) | User-typed text messages | Variable | Persistent |
+
+Ephemeral messages are re-generated each session and have no value after disconnect. Persistent messages contain information the user may need to reference later.
+
+## Design
+
+### 1. Message Classification
+
+Add an optional `systemType?: string` field to the `ChatMessage` interface in `types/index.ts`.
+
+Propagate the `systemType` from the `voice.system` bridge event through:
+- The `onVoiceSystem` handler in `App.tsx` (lines 785-795)
+- `addMessage()` in `useChatStore.ts`
+- `addMessageToStore()` in `useChatStore.ts`
+
+The ephemeral set is: `connecting`, `welcome`, `userJoined`, `userLeft`.
+Everything else (including messages with no `systemType`) is persistent.
+
+### 2. Purge Ephemeral Messages on Disconnect
+
+Add a `purgeEphemeralMessages(channelId: string)` function to `useChatStore.ts` (module-level, not inside the hook):
+1. Flush the debounce buffer for the channel (see section 4).
+2. Read the stored messages from localStorage for the given channel.
+3. Filter out messages where `systemType` is in the ephemeral set.
+4. Write the filtered array back to localStorage.
+
+React state does not need updating here -- the purge runs on disconnect, and server-root messages are re-loaded from localStorage on the next `useChatStore('server-root')` mount when the user reconnects.
+
+Call `purgeEphemeralMessages('server-root')` from the `onVoiceDisconnected` handler in `App.tsx` (line 664). This is the primary disconnect handler that fires in all disconnect scenarios.
+
+The debounce buffer (see section 4) must be flushed before purging to avoid stale data.
+
+### 3. Hard Cap (200 Messages, Server-Root Only)
+
+Add a `SERVER_ROOT_MAX_MESSAGES = 200` constant to `useChatStore.ts`.
+
+Enforce the cap in both write paths:
+- `addMessage()` — after appending, if `channelId === 'server-root'` and length exceeds cap, slice from the end (keep newest).
+- `addMessageToStore()` — same logic when `storeKey === 'server-root'`.
+
+Trimming is type-agnostic: oldest messages are dropped first regardless of classification. 200 is generous enough that persistent kick/ban messages won't be pushed out under normal use.
+
+### 4. Debounced localStorage Writes (Server-Root Only)
+
+Replace immediate `localStorage.setItem` calls with a debounced write for `server-root`:
+
+**React state path (`addMessage`):**
+- Messages are added to React state immediately (UI updates instantly).
+- The `saveMessages` localStorage write is debounced with a 500ms delay.
+- If another message arrives within the window, the timer resets.
+- Only one write happens with the latest state after the burst settles.
+
+**Background path (`addMessageToStore`):**
+- Messages accumulate in a module-level in-memory buffer.
+- A 500ms debounce timer flushes the buffer to localStorage.
+- On flush: read current localStorage, merge buffered messages, enforce cap, write back.
+
+**Disconnect safety:**
+- `purgeEphemeralMessages` flushes the debounce buffer before reading localStorage.
+- Any unflushed messages during disconnect are ephemeral join/leave events that would be purged anyway.
+
+Non-server-root channels continue with immediate writes (their volume doesn't warrant debouncing).
+
+## Files Changed
+
+| File | Changes |
+|---|---|
+| `src/Brmble.Web/src/types/index.ts` | Add `systemType?: string` to `ChatMessage` |
+| `src/Brmble.Web/src/hooks/useChatStore.ts` | Debounce logic, cap enforcement, `purgeEphemeralMessages()`, propagate `systemType` through `addMessage` and `addMessageToStore` |
+| `src/Brmble.Web/src/App.tsx` | Pass `systemType` from bridge event, call `purgeEphemeralMessages` on disconnect |
+
+## Not in Scope
+
+- Virtual scrolling / DOM virtualization for ChatPanel
+- Join/leave message collapsing ("5 users connected")
+- Consolidating the scattered disconnect cleanup logic (noted as inconsistent across `onVoiceDisconnected`, `handleBackToServerList`, `onVoiceReconnectFailed`)
+- Changes to Matrix-backed channel message handling
+
+## Testing
+
+- Connect to a server, verify `systemType` is stored in messages.
+- Disconnect and verify ephemeral messages are purged from localStorage.
+- Send >200 messages to server-root, verify oldest are trimmed.
+- Rapid join/leave burst: verify only one localStorage write per ~500ms window.
+- Verify kick/ban messages survive disconnect.
+- Verify non-server-root localStorage channels are unaffected by cap and debounce.

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -25,7 +25,7 @@ import { CloseDialog } from './components/CloseDialog/CloseDialog';
 import { CertWizard } from './components/CertWizard/CertWizard';
 import { Version } from './components/Version/Version';
 import { ZoomIndicator } from './components/ZoomIndicator/ZoomIndicator';
-import { useChatStore, addMessageToStore, clearChatStorage } from './hooks/useChatStore';
+import { useChatStore, addMessageToStore, clearChatStorage, purgeEphemeralMessages } from './hooks/useChatStore';
 import { parseMessageMedia } from './utils/parseMessageMedia';
 import { useDMStore } from './hooks/useDMStore';
 import { DMContactList } from './components/DMContactList/DMContactList';
@@ -663,6 +663,7 @@ function App() {
 
     const onVoiceDisconnected = (data: unknown) => {
       clearPendingAction();
+      purgeEphemeralMessages('server-root');
       const d = data as { reconnectAvailable?: boolean } | null;
 
       if (d?.reconnectAvailable && userSawConnectedRef.current) {
@@ -787,9 +788,9 @@ function App() {
       if (d?.message) {
         const currentKey = currentChannelIdRef.current;
         if (currentKey === 'server-root') {
-          addMessageRef.current('Server', d.message, 'system', d.html);
+          addMessageRef.current('Server', d.message, 'system', d.html, undefined, d.systemType);
         } else {
-          addMessageToStore('server-root', 'Server', d.message, 'system', d.html);
+          addMessageToStore('server-root', 'Server', d.message, 'system', d.html, undefined, d.systemType);
         }
       }
     });

--- a/src/Brmble.Web/src/hooks/useChatStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.test.ts
@@ -152,6 +152,33 @@ describe('purgeEphemeralMessages', () => {
     expect(stored).toHaveLength(1);
     expect(stored[0].content).toBe('You were banned');
   });
+
+  it('flushes hook-based debounce before purging and prevents stale overwrite', () => {
+    const { result } = renderHook(() => useChatStore('server-root'));
+
+    // Add an ephemeral and a persistent message via the hook (debounce pending)
+    act(() => {
+      result.current.addMessage('Server', 'Alice joined', 'system', false, undefined, 'userJoined');
+      result.current.addMessage('Server', 'You were kicked', 'system', false, undefined, 'kicked');
+    });
+
+    // React state has both messages, localStorage write is still debounced
+    expect(result.current.messages).toHaveLength(2);
+
+    // Purge should flush the hook debounce first, then remove ephemeral messages
+    purgeEphemeralMessages('server-root');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toBe('You were kicked');
+
+    // Advance timers — the old hookTimer should NOT fire and overwrite with stale data
+    vi.advanceTimersByTime(600);
+
+    const afterTimer = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(afterTimer).toHaveLength(1);
+    expect(afterTimer[0].content).toBe('You were kicked');
+  });
 });
 
 describe('debounced localStorage writes', () => {

--- a/src/Brmble.Web/src/hooks/useChatStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.test.ts
@@ -149,12 +149,10 @@ describe('debounced localStorage writes', () => {
     expect(result.current.messages).toHaveLength(1);
 
     // localStorage not yet written (debounce pending)
+    // Either null (never written) or stale (doesn't contain the new message)
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      // Should not contain the new message yet
-      expect(parsed.find((m: { content: string }) => m.content === 'test msg')).toBeUndefined();
-    }
+    const parsed = stored ? JSON.parse(stored) : [];
+    expect(parsed.find((m: { content: string }) => m.content === 'test msg')).toBeUndefined();
   });
 
   it('writes to localStorage after debounce period', () => {

--- a/src/Brmble.Web/src/hooks/useChatStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.test.ts
@@ -115,6 +115,23 @@ describe('purgeEphemeralMessages', () => {
     expect(stored[1].content).toBe('Hello');
   });
 
+  it('purges legacy server messages without systemType', () => {
+    const messages = [
+      { id: '1', channelId: 'server-root', sender: 'Server', content: 'Alice disconnected from the server', timestamp: new Date().toISOString(), type: 'system' },
+      { id: '2', channelId: 'server-root', sender: 'Server', content: 'Bob connected to the server', timestamp: new Date().toISOString(), type: 'system' },
+      { id: '3', channelId: 'server-root', sender: 'User', content: 'Hello everyone', timestamp: new Date().toISOString() },
+      { id: '4', channelId: 'server-root', sender: 'Server', content: 'You were kicked', timestamp: new Date().toISOString(), type: 'system', systemType: 'kicked' },
+    ];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+
+    purgeEphemeralMessages('server-root');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(2);
+    expect(stored[0].content).toBe('Hello everyone');
+    expect(stored[1].content).toBe('You were kicked');
+  });
+
   it('handles empty localStorage gracefully', () => {
     purgeEphemeralMessages('server-root');
     // Should not throw

--- a/src/Brmble.Web/src/hooks/useChatStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useChatStore, addMessageToStore, purgeEphemeralMessages, flushPendingWrites } from './useChatStore';
+
+const STORAGE_KEY = 'brmble_chat_server-root';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+  // Flush any leftover bgBuffer from previous tests
+  flushPendingWrites('server-root');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useChatStore systemType', () => {
+  it('stores systemType on messages added via addMessage', () => {
+    const { result } = renderHook(() => useChatStore('server-root'));
+
+    act(() => {
+      result.current.addMessage('Server', 'Alice connected', 'system', false, undefined, 'userJoined');
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].systemType).toBe('userJoined');
+  });
+
+  it('stores systemType via addMessageToStore', () => {
+    addMessageToStore('server-root', 'Server', 'Bob left', 'system', false, undefined, 'userLeft');
+
+    // Flush debounce
+    vi.advanceTimersByTime(600);
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].systemType).toBe('userLeft');
+  });
+});
+
+describe('useChatStore hard cap (server-root)', () => {
+  it('trims oldest messages when exceeding 200 via addMessage', () => {
+    const { result } = renderHook(() => useChatStore('server-root'));
+
+    act(() => {
+      for (let i = 0; i < 210; i++) {
+        result.current.addMessage('Server', `msg-${i}`, 'system', false, undefined, 'userJoined');
+      }
+    });
+
+    expect(result.current.messages).toHaveLength(200);
+    // Oldest messages trimmed — first message should be msg-10
+    expect(result.current.messages[0].content).toBe('msg-10');
+    expect(result.current.messages[199].content).toBe('msg-209');
+  });
+
+  it('does NOT cap non-server-root channels', () => {
+    const { result } = renderHook(() => useChatStore('channel-5'));
+
+    act(() => {
+      for (let i = 0; i < 210; i++) {
+        result.current.addMessage('User', `msg-${i}`);
+      }
+    });
+
+    expect(result.current.messages).toHaveLength(210);
+  });
+
+  it('trims oldest messages when exceeding 200 via addMessageToStore', () => {
+    // Pre-fill with 195 messages
+    const existing = Array.from({ length: 195 }, (_, i) => ({
+      id: `id-${i}`,
+      channelId: 'server-root',
+      sender: 'Server',
+      content: `old-${i}`,
+      timestamp: new Date().toISOString(),
+      type: 'system',
+      systemType: 'userJoined',
+    }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(existing));
+
+    // Add 10 more (total 205 > 200)
+    for (let i = 0; i < 10; i++) {
+      addMessageToStore('server-root', 'Server', `new-${i}`, 'system', false, undefined, 'userLeft');
+    }
+
+    // Flush debounce
+    vi.advanceTimersByTime(600);
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(200);
+    // Oldest should have been trimmed
+    expect(stored[0].content).toBe('old-5');
+  });
+});
+
+describe('purgeEphemeralMessages', () => {
+  it('removes ephemeral messages and keeps persistent ones', () => {
+    const messages = [
+      { id: '1', channelId: 'server-root', sender: 'Server', content: 'Connecting...', timestamp: new Date().toISOString(), type: 'system', systemType: 'connecting' },
+      { id: '2', channelId: 'server-root', sender: 'Server', content: 'Welcome!', timestamp: new Date().toISOString(), type: 'system', systemType: 'welcome' },
+      { id: '3', channelId: 'server-root', sender: 'Server', content: 'Alice joined', timestamp: new Date().toISOString(), type: 'system', systemType: 'userJoined' },
+      { id: '4', channelId: 'server-root', sender: 'Server', content: 'You were kicked', timestamp: new Date().toISOString(), type: 'system', systemType: 'kicked' },
+      { id: '5', channelId: 'server-root', sender: 'User', content: 'Hello', timestamp: new Date().toISOString() },
+      { id: '6', channelId: 'server-root', sender: 'Server', content: 'Bob left', timestamp: new Date().toISOString(), type: 'system', systemType: 'userLeft' },
+    ];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+
+    purgeEphemeralMessages('server-root');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(2);
+    expect(stored[0].content).toBe('You were kicked');
+    expect(stored[1].content).toBe('Hello');
+  });
+
+  it('handles empty localStorage gracefully', () => {
+    purgeEphemeralMessages('server-root');
+    // Should not throw
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('flushes debounce buffer before purging', () => {
+    // Add a message via background store (debounced)
+    addMessageToStore('server-root', 'Server', 'Alice joined', 'system', false, undefined, 'userJoined');
+    // Also add a persistent message
+    addMessageToStore('server-root', 'Server', 'You were banned', 'system', false, undefined, 'banned');
+
+    // Don't advance timers — buffer is not flushed yet
+    // Purge should flush first, then purge ephemeral
+    purgeEphemeralMessages('server-root');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toBe('You were banned');
+  });
+});
+
+describe('debounced localStorage writes', () => {
+  it('does not write to localStorage immediately for server-root', () => {
+    const { result } = renderHook(() => useChatStore('server-root'));
+
+    act(() => {
+      result.current.addMessage('Server', 'test msg', 'system', false, undefined, 'userJoined');
+    });
+
+    // React state updated immediately
+    expect(result.current.messages).toHaveLength(1);
+
+    // localStorage not yet written (debounce pending)
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // Should not contain the new message yet
+      expect(parsed.find((m: { content: string }) => m.content === 'test msg')).toBeUndefined();
+    }
+  });
+
+  it('writes to localStorage after debounce period', () => {
+    const { result } = renderHook(() => useChatStore('server-root'));
+
+    act(() => {
+      result.current.addMessage('Server', 'test msg', 'system', false, undefined, 'userJoined');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toBe('test msg');
+  });
+
+  it('writes immediately for non-server-root channels', () => {
+    const { result } = renderHook(() => useChatStore('channel-5'));
+
+    act(() => {
+      result.current.addMessage('User', 'hello');
+    });
+
+    const stored = JSON.parse(localStorage.getItem('brmble_chat_channel-5')!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toBe('hello');
+  });
+
+  it('flushPendingWrites forces immediate write', () => {
+    addMessageToStore('server-root', 'Server', 'msg1', 'system', false, undefined, 'userJoined');
+    addMessageToStore('server-root', 'Server', 'msg2', 'system', false, undefined, 'userLeft');
+
+    // Not flushed yet
+    flushPendingWrites('server-root');
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(2);
+  });
+});

--- a/src/Brmble.Web/src/hooks/useChatStore.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.ts
@@ -2,11 +2,113 @@ import { useState, useEffect, useCallback } from 'react';
 import type { ChatMessage, MediaAttachment } from '../types';
 
 const STORAGE_KEY_PREFIX = 'brmble_chat_';
+const SERVER_ROOT_KEY = 'server-root';
+const SERVER_ROOT_MAX_MESSAGES = 200;
+const DEBOUNCE_MS = 500;
+
+const EPHEMERAL_TYPES = new Set(['connecting', 'welcome', 'userJoined', 'userLeft']);
+
+// --- Debounce infrastructure for server-root background writes ---
+
+let bgBuffer: ChatMessage[] = [];
+let bgTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flushBgBuffer() {
+  if (bgTimer !== null) {
+    clearTimeout(bgTimer);
+    bgTimer = null;
+  }
+  if (bgBuffer.length === 0) return;
+
+  const fullKey = `${STORAGE_KEY_PREFIX}${SERVER_ROOT_KEY}`;
+  let messages: ChatMessage[] = [];
+  const stored = localStorage.getItem(fullKey);
+  if (stored) {
+    try {
+      messages = JSON.parse(stored);
+    } catch {
+      messages = [];
+    }
+  }
+
+  messages.push(...bgBuffer);
+  bgBuffer = [];
+
+  if (messages.length > SERVER_ROOT_MAX_MESSAGES) {
+    messages = messages.slice(messages.length - SERVER_ROOT_MAX_MESSAGES);
+  }
+
+  localStorage.setItem(fullKey, JSON.stringify(messages));
+}
+
+/**
+ * Flush any pending debounced writes for a given channel.
+ * Currently only server-root has debounced writes.
+ */
+export function flushPendingWrites(channelId: string) {
+  if (channelId === SERVER_ROOT_KEY) {
+    flushBgBuffer();
+  }
+}
+
+/**
+ * Purge ephemeral messages (connecting, welcome, userJoined, userLeft)
+ * from localStorage for the given channel. Flushes the debounce buffer first.
+ */
+export function purgeEphemeralMessages(channelId: string) {
+  flushPendingWrites(channelId);
+
+  const fullKey = `${STORAGE_KEY_PREFIX}${channelId}`;
+  const stored = localStorage.getItem(fullKey);
+  if (!stored) return;
+
+  let messages: ChatMessage[];
+  try {
+    messages = JSON.parse(stored);
+  } catch {
+    return;
+  }
+
+  const filtered = messages.filter(
+    (m) => !m.systemType || !EPHEMERAL_TYPES.has(m.systemType)
+  );
+
+  if (filtered.length === 0) {
+    localStorage.removeItem(fullKey);
+  } else {
+    localStorage.setItem(fullKey, JSON.stringify(filtered));
+  }
+}
+
+// --- Hook-based debounce timer for server-root ---
+
+let hookTimer: ReturnType<typeof setTimeout> | null = null;
+
+function debouncedSave(fullKey: string, msgs: ChatMessage[]) {
+  if (hookTimer !== null) {
+    clearTimeout(hookTimer);
+  }
+  hookTimer = setTimeout(() => {
+    hookTimer = null;
+    localStorage.setItem(fullKey, JSON.stringify(msgs));
+  }, DEBOUNCE_MS);
+}
 
 export function useChatStore(channelId: string) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const isServerRoot = channelId === SERVER_ROOT_KEY;
 
   useEffect(() => {
+    // On mount / channel switch, flush any pending server-root writes
+    // so we read the latest data.
+    if (isServerRoot) {
+      flushBgBuffer();
+      if (hookTimer !== null) {
+        clearTimeout(hookTimer);
+        hookTimer = null;
+      }
+    }
+
     const stored = localStorage.getItem(`${STORAGE_KEY_PREFIX}${channelId}`);
     if (stored) {
       try {
@@ -21,13 +123,25 @@ export function useChatStore(channelId: string) {
     } else {
       setMessages([]);
     }
-  }, [channelId]);
+  }, [channelId, isServerRoot]);
 
   const saveMessages = useCallback((msgs: ChatMessage[]) => {
-    localStorage.setItem(`${STORAGE_KEY_PREFIX}${channelId}`, JSON.stringify(msgs));
-  }, [channelId]);
+    const fullKey = `${STORAGE_KEY_PREFIX}${channelId}`;
+    if (isServerRoot) {
+      debouncedSave(fullKey, msgs);
+    } else {
+      localStorage.setItem(fullKey, JSON.stringify(msgs));
+    }
+  }, [channelId, isServerRoot]);
 
-  const addMessage = useCallback((sender: string, content: string, type?: 'system', html?: boolean, media?: MediaAttachment[]) => {
+  const addMessage = useCallback((
+    sender: string,
+    content: string,
+    type?: 'system',
+    html?: boolean,
+    media?: MediaAttachment[],
+    systemType?: string,
+  ) => {
     const newMessage: ChatMessage = {
       id: crypto.randomUUID(),
       channelId,
@@ -35,15 +149,19 @@ export function useChatStore(channelId: string) {
       content,
       timestamp: new Date(),
       ...(type && { type }),
+      ...(systemType && { systemType }),
       ...(html && { html }),
       ...(media && media.length > 0 && { media }),
     };
     setMessages(prev => {
-      const updated = [...prev, newMessage];
+      let updated = [...prev, newMessage];
+      if (isServerRoot && updated.length > SERVER_ROOT_MAX_MESSAGES) {
+        updated = updated.slice(updated.length - SERVER_ROOT_MAX_MESSAGES);
+      }
       saveMessages(updated);
       return updated;
     });
-  }, [channelId, saveMessages]);
+  }, [channelId, isServerRoot, saveMessages]);
 
   const clearMessages = useCallback(() => {
     setMessages([]);
@@ -57,8 +175,40 @@ export function useChatStore(channelId: string) {
  * Write a message directly to a specific store key in localStorage,
  * bypassing React state. Used for background message storage when
  * the user is viewing a different chat panel.
+ *
+ * For server-root, writes are debounced. For other channels, writes are immediate.
  */
-export function addMessageToStore(storeKey: string, sender: string, content: string, type?: 'system', html?: boolean, media?: MediaAttachment[]) {
+export function addMessageToStore(
+  storeKey: string,
+  sender: string,
+  content: string,
+  type?: 'system',
+  html?: boolean,
+  media?: MediaAttachment[],
+  systemType?: string,
+) {
+  const newMessage: ChatMessage = {
+    id: crypto.randomUUID(),
+    channelId: storeKey,
+    sender,
+    content,
+    timestamp: new Date(),
+    ...(type && { type }),
+    ...(systemType && { systemType }),
+    ...(html && { html }),
+    ...(media && media.length > 0 && { media }),
+  };
+
+  if (storeKey === SERVER_ROOT_KEY) {
+    bgBuffer.push(newMessage);
+    if (bgTimer !== null) {
+      clearTimeout(bgTimer);
+    }
+    bgTimer = setTimeout(flushBgBuffer, DEBOUNCE_MS);
+    return;
+  }
+
+  // Non-server-root: immediate write
   const fullKey = `${STORAGE_KEY_PREFIX}${storeKey}`;
   let messages: ChatMessage[] = [];
   const stored = localStorage.getItem(fullKey);
@@ -69,16 +219,6 @@ export function addMessageToStore(storeKey: string, sender: string, content: str
       messages = [];
     }
   }
-  const newMessage: ChatMessage = {
-    id: crypto.randomUUID(),
-    channelId: storeKey,
-    sender,
-    content,
-    timestamp: new Date(),
-    ...(type && { type }),
-    ...(html && { html }),
-    ...(media && media.length > 0 && { media }),
-  };
   messages.push(newMessage);
   localStorage.setItem(fullKey, JSON.stringify(messages));
 }
@@ -86,7 +226,7 @@ export function addMessageToStore(storeKey: string, sender: string, content: str
 /** Clear all chat messages from localStorage.
  *  Preserves server-root messages since those are current-session system messages. */
 export function clearChatStorage() {
-  const serverRootKey = `${STORAGE_KEY_PREFIX}server-root`;
+  const serverRootKey = `${STORAGE_KEY_PREFIX}${SERVER_ROOT_KEY}`;
   Object.keys(localStorage)
     .filter(k => k.startsWith(STORAGE_KEY_PREFIX) && k !== serverRootKey)
     .forEach(k => localStorage.removeItem(k));

--- a/src/Brmble.Web/src/hooks/useChatStore.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.ts
@@ -8,7 +8,15 @@ const DEBOUNCE_MS = 500;
 
 const EPHEMERAL_TYPES = new Set(['connecting', 'welcome', 'userJoined', 'userLeft']);
 
-// --- Debounce infrastructure for server-root background writes ---
+// --- Debounce infrastructure for server-root ---
+//
+// Two independent debounce paths exist for server-root localStorage writes:
+//   1. bgBuffer/bgTimer — used by addMessageToStore() when the user is NOT viewing server-root
+//   2. hookTimer/debouncedSave — used by the useChatStore hook when the user IS viewing server-root
+//
+// These paths are mutually exclusive by design: App.tsx routes messages through addMessageToStore
+// when server-root is not the active channel, and through the hook's addMessage when it is.
+// The useChatStore useEffect flushes bgBuffer on mount to prevent data loss on channel switch.
 
 let bgBuffer: ChatMessage[] = [];
 let bgTimer: ReturnType<typeof setTimeout> | null = null;
@@ -42,8 +50,9 @@ function flushBgBuffer() {
 }
 
 /**
- * Flush any pending debounced writes for a given channel.
- * Currently only server-root has debounced writes.
+ * Flush any pending background (addMessageToStore) writes for a given channel.
+ * Does not flush the hook-based debounce timer — that is flushed automatically
+ * when the hook unmounts or the channel changes.
  */
 export function flushPendingWrites(channelId: string) {
   if (channelId === SERVER_ROOT_KEY) {

--- a/src/Brmble.Web/src/hooks/useChatStore.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.ts
@@ -61,8 +61,10 @@ export function flushPendingWrites(channelId: string) {
 }
 
 /**
- * Purge ephemeral messages (connecting, welcome, userJoined, userLeft)
- * from localStorage for the given channel. Flushes the debounce buffer first.
+ * Purge ephemeral messages from localStorage for the given channel.
+ * Removes messages with ephemeral systemType (connecting, welcome, userJoined, userLeft)
+ * AND legacy server messages that predate the systemType field.
+ * Flushes the debounce buffer first.
  */
 export function purgeEphemeralMessages(channelId: string) {
   flushPendingWrites(channelId);
@@ -78,9 +80,14 @@ export function purgeEphemeralMessages(channelId: string) {
     return;
   }
 
-  const filtered = messages.filter(
-    (m) => !m.systemType || !EPHEMERAL_TYPES.has(m.systemType)
-  );
+  const filtered = messages.filter((m) => {
+    // New messages: purge if systemType is ephemeral
+    if (m.systemType) return !EPHEMERAL_TYPES.has(m.systemType);
+    // Legacy server messages without systemType: purge (predates classification)
+    if (m.sender === 'Server') return false;
+    // User-sent messages: always keep
+    return true;
+  });
 
   if (filtered.length === 0) {
     localStorage.removeItem(fullKey);

--- a/src/Brmble.Web/src/hooks/useChatStore.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.ts
@@ -50,13 +50,15 @@ function flushBgBuffer() {
 }
 
 /**
- * Flush any pending background (addMessageToStore) writes for a given channel.
- * Does not flush the hook-based debounce timer — that is flushed automatically
- * when the hook unmounts or the channel changes.
+ * Flush any pending debounced writes for a given channel.
+ * Flushes both the background buffer (addMessageToStore) and the hook-based
+ * debounce timer (useChatStore's saveMessages) to ensure localStorage is
+ * fully up-to-date before reads or purges.
  */
 export function flushPendingWrites(channelId: string) {
   if (channelId === SERVER_ROOT_KEY) {
     flushBgBuffer();
+    flushHookTimer();
   }
 }
 
@@ -97,16 +99,39 @@ export function purgeEphemeralMessages(channelId: string) {
 }
 
 // --- Hook-based debounce timer for server-root ---
+//
+// The pending payload (hookPendingKey/hookPendingMsgs) is stored at module level
+// so that flushPendingWrites() can flush both the background buffer AND the hook
+// debounce path. This prevents purgeEphemeralMessages() from missing pending
+// hook writes that could overwrite the purge result.
 
 let hookTimer: ReturnType<typeof setTimeout> | null = null;
+let hookPendingKey: string | null = null;
+let hookPendingMsgs: ChatMessage[] | null = null;
+
+function flushHookTimer() {
+  if (hookTimer !== null) {
+    clearTimeout(hookTimer);
+    hookTimer = null;
+  }
+  if (hookPendingKey !== null && hookPendingMsgs !== null) {
+    localStorage.setItem(hookPendingKey, JSON.stringify(hookPendingMsgs));
+    hookPendingKey = null;
+    hookPendingMsgs = null;
+  }
+}
 
 function debouncedSave(fullKey: string, msgs: ChatMessage[]) {
   if (hookTimer !== null) {
     clearTimeout(hookTimer);
   }
+  hookPendingKey = fullKey;
+  hookPendingMsgs = msgs;
   hookTimer = setTimeout(() => {
     hookTimer = null;
     localStorage.setItem(fullKey, JSON.stringify(msgs));
+    hookPendingKey = null;
+    hookPendingMsgs = null;
   }, DEBOUNCE_MS);
 }
 
@@ -119,10 +144,7 @@ export function useChatStore(channelId: string) {
     // so we read the latest data.
     if (isServerRoot) {
       flushBgBuffer();
-      if (hookTimer !== null) {
-        clearTimeout(hookTimer);
-        hookTimer = null;
-      }
+      flushHookTimer();
     }
 
     const stored = localStorage.getItem(`${STORAGE_KEY_PREFIX}${channelId}`);
@@ -139,6 +161,14 @@ export function useChatStore(channelId: string) {
     } else {
       setMessages([]);
     }
+
+    // Cleanup: flush pending hook writes on unmount or channel change
+    // to prevent stale/unpurged data from being written after disconnect.
+    return () => {
+      if (isServerRoot) {
+        flushHookTimer();
+      }
+    };
   }, [channelId, isServerRoot]);
 
   const saveMessages = useCallback((msgs: ChatMessage[]) => {

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -47,6 +47,7 @@ export interface ChatMessage {
   content: string;
   timestamp: Date;
   type?: 'system';
+  systemType?: string;
   html?: boolean;
   media?: MediaAttachment[];
   pending?: boolean;


### PR DESCRIPTION
## Summary

- **Message classification**: Added `systemType` field to `ChatMessage` to distinguish ephemeral (`connecting`, `welcome`, `userJoined`, `userLeft`) from persistent (`kicked`, `banned`, user text) messages
- **Ephemeral purge on disconnect**: Removes ephemeral and legacy server messages from localStorage when disconnecting, keeping kicked/banned/user messages
- **200-message hard cap**: Server-root messages are capped at 200 (oldest trimmed first), preventing unbounded growth across sessions
- **Debounced localStorage writes**: Server-root writes are batched with a 500ms debounce window, reducing JSON.stringify overhead during join/leave bursts

All changes are scoped to `server-root` only. Matrix-backed channels are unaffected.

## Files Changed

| File | Change |
|---|---|
| `src/Brmble.Web/src/types/index.ts` | Added `systemType?: string` to `ChatMessage` |
| `src/Brmble.Web/src/hooks/useChatStore.ts` | Debounce, cap, purge, systemType propagation |
| `src/Brmble.Web/src/hooks/useChatStore.test.ts` | 13 tests covering all new behavior |
| `src/Brmble.Web/src/App.tsx` | Wire systemType through bridge events, call purge on disconnect |

## Test Plan

- [x] Connect to server — messages have `systemType` field in localStorage
- [x] Disconnect — ephemeral messages purged, kicked/banned messages survive
- [x] Legacy messages (without `systemType`) from before this fix are also purged on disconnect
- [x] Message cap of 200 enforced
- [x] 13 unit tests passing, tsc clean, build succeeds

Closes #297