### PR TITLE
feat: UI improvements for channel moderator ACL system

### DIFF
--- a/docs/superpowers/plans/2026-03-30-channel-moderator-acl-implementation.md
+++ b/docs/superpowers/plans/2026-03-30-channel-moderator-acl-implementation.md
@@ -1,0 +1,2336 @@
+# Channel Moderator ACL System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a channel-level moderator permission system where admins can assign users as moderators for specific voice channels with configurable powers (kick, deny-enter, rename, password, description).
+
+**Architecture:** Dual-validation system using Brmble DB as source of truth with Mumble group sync for UI consistency. Admin actions bypass moderator permission checks. Failed Mumble syncs queue for retry.
+
+**Tech Stack:** C# (.NET), SQLite (existing Database.cs pattern), MumbleSharp ICE, TypeScript/React frontend
+
+---
+
+## File Structure Overview
+
+```
+Brmble.Server/
+├── Data/
+│   ├── Database.cs              # Add new table migrations
+│   ├── ModeratorRoleRepository.cs # NEW - CRUD for roles
+│   └── ModeratorAssignmentRepository.cs # NEW - CRUD for assignments
+├── Moderator/
+│   ├── ModeratorService.cs      # NEW - Business logic
+│   ├── MumbleGroupSyncService.cs # NEW - Sync to Mumble groups
+│   ├── PermissionEnforcer.cs     # NEW - Dual-validation
+│   └── ModeratorEndpoints.cs     # NEW - API endpoints
+└── Program.cs                    # Register services
+
+Brmble.Web/src/
+├── hooks/
+│   ├── useModeratorPermissions.ts # NEW - Check moderator permissions
+│   └── useModeratorStore.ts     # NEW - Moderator roles/assignments state
+├── components/
+│   ├── ChannelEditModal/         # NEW - Edit window with tabs
+│   │   ├── ChannelEditModal.tsx
+│   │   ├── ManageModeratorsTab.tsx
+│   │   └── ModeratorRoleModal.tsx
+│   └── SettingsModal/
+│       └── ModeratorRolesTab.tsx # NEW - Admin role management
+└── bridge.ts                     # Add moderator handlers
+```
+
+---
+
+## Task 1: Database Schema
+
+**Files:**
+- Modify: `src/Brmble.Server/Data/Database.cs:18-64`
+
+- [ ] **Step 1: Add table migrations**
+
+Add after existing migrations in `Database.cs`:
+
+```csharp
+// Migrate: add moderator_roles table
+var hasModeratorRoles = conn.ExecuteScalar<int>(
+    "SELECT COUNT(*) FROM pragma_table_info('moderator_roles') WHERE name='id'");
+if (hasModeratorRoles == 0)
+    conn.Execute("""
+        CREATE TABLE moderator_roles (
+            id          TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            permissions INTEGER NOT NULL DEFAULT 0,
+            created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+    """);
+
+// Migrate: add moderator_assignments table
+var hasModeratorAssignments = conn.ExecuteScalar<int>(
+    "SELECT COUNT(*) FROM pragma_table_info('moderator_assignments') WHERE name='id'");
+if (hasModeratorAssignments == 0)
+    conn.Execute("""
+        CREATE TABLE moderator_assignments (
+            id          TEXT PRIMARY KEY,
+            role_id     TEXT NOT NULL,
+            channel_id  INTEGER NOT NULL,
+            user_id     INTEGER NOT NULL,
+            assigned_by INTEGER NOT NULL,
+            assigned_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (role_id) REFERENCES moderator_roles(id) ON DELETE CASCADE,
+            UNIQUE (channel_id, user_id)
+        )
+    """);
+
+// Migrate: add sync_failed_assignments table for retry queue
+var hasSyncFailed = conn.ExecuteScalar<int>(
+    "SELECT COUNT(*) FROM pragma_table_info('sync_failed_assignments') WHERE name='id'");
+if (hasSyncFailed == 0)
+    conn.Execute("""
+        CREATE TABLE sync_failed_assignments (
+            id              TEXT PRIMARY KEY,
+            assignment_id    TEXT NOT NULL,
+            action          TEXT NOT NULL,
+            error_message   TEXT,
+            retry_count     INTEGER NOT NULL DEFAULT 0,
+            next_retry_at   DATETIME NOT NULL,
+            created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (assignment_id) REFERENCES moderator_assignments(id) ON DELETE CASCADE
+        )
+    """);
+```
+
+- [ ] **Step 2: Add permission bit constants**
+
+Add to `ModeratorPermissions.cs` (create new file):
+
+```csharp
+namespace Brmble.Server.Moderator;
+
+[Flags]
+public enum ModeratorPermission
+{
+    None = 0,
+    Kick = 0x001,
+    DenyEnter = 0x002,
+    RenameChannel = 0x004,
+    SetPassword = 0x008,
+    EditDesc = 0x010,
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Server/Data/Database.cs src/Brmble.Server/Moderator/ModeratorPermissions.cs
+git commit -m "feat: add moderator ACL database tables"
+```
+
+---
+
+## Task 2: Repository Layer
+
+**Files:**
+- Create: `src/Brmble.Server/Data/ModeratorRoleRepository.cs`
+- Create: `src/Brmble.Server/Data/ModeratorAssignmentRepository.cs`
+- Create: `src/Brmble.Server/Data/SyncFailedAssignmentRepository.cs`
+
+- [ ] **Step 1: Write tests for ModeratorRoleRepository**
+
+Create `tests/Brmble.Server.Tests/ModeratorRoleRepositoryTests.cs`:
+
+```csharp
+using Brmble.Server.Data;
+using Brmble.Server.Moderator;
+using Xunit;
+
+namespace Brmble.Server.Tests;
+
+public class ModeratorRoleRepositoryTests
+{
+    private readonly Database _db;
+    private readonly ModeratorRoleRepository _repo;
+
+    public ModeratorRoleRepositoryTests()
+    {
+        _db = new Database("DataSource=:memory:");
+        _db.Initialize();
+        _repo = new ModeratorRoleRepository(_db);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsRoleWithId()
+    {
+        var role = await _repo.CreateAsync("Test Role", ModeratorPermission.Kick | ModeratorPermission.DenyEnter);
+        
+        Assert.NotNull(role.Id);
+        Assert.Equal("Test Role", role.Name);
+        Assert.Equal(ModeratorPermission.Kick | ModeratorPermission.DenyEnter, role.Permissions);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsRole()
+    {
+        var created = await _repo.CreateAsync("Test Role", ModeratorPermission.Kick);
+        var retrieved = await _repo.GetByIdAsync(created.Id);
+        
+        Assert.NotNull(retrieved);
+        Assert.Equal(created.Id, retrieved.Id);
+        Assert.Equal("Test Role", retrieved.Name);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllRoles()
+    {
+        await _repo.CreateAsync("Role 1", ModeratorPermission.Kick);
+        await _repo.CreateAsync("Role 2", ModeratorPermission.DenyEnter);
+        
+        var roles = await _repo.GetAllAsync();
+        
+        Assert.Equal(2, roles.Count);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ModifiesRole()
+    {
+        var role = await _repo.CreateAsync("Original", ModeratorPermission.Kick);
+        await _repo.UpdateAsync(role.Id, "Updated", ModeratorPermission.DenyEnter);
+        
+        var updated = await _repo.GetByIdAsync(role.Id);
+        Assert.Equal("Updated", updated?.Name);
+        Assert.Equal(ModeratorPermission.DenyEnter, updated?.Permissions);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesRole()
+    {
+        var role = await _repo.CreateAsync("To Delete", ModeratorPermission.Kick);
+        await _repo.DeleteAsync(role.Id);
+        
+        var deleted = await _repo.GetByIdAsync(role.Id);
+        Assert.Null(deleted);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "ModeratorRoleRepositoryTests"
+```
+
+Expected: FAIL (types not defined)
+
+- [ ] **Step 3: Implement ModeratorRoleRepository**
+
+Create `src/Brmble.Server/Data/ModeratorRoleRepository.cs`:
+
+```csharp
+using Dapper;
+using Brmble.Server.Moderator;
+
+namespace Brmble.Server.Data;
+
+public class ModeratorRole
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Name { get; set; } = string.Empty;
+    public ModeratorPermission Permissions { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class ModeratorRoleRepository
+{
+    private readonly Database _db;
+
+    public ModeratorRoleRepository(Database db)
+    {
+        _db = db;
+    }
+
+    public async Task<ModeratorRole> CreateAsync(string name, ModeratorPermission permissions)
+    {
+        using var conn = _db.CreateConnection();
+        var role = new ModeratorRole { Name = name, Permissions = permissions };
+        await conn.ExecuteAsync(
+            "INSERT INTO moderator_roles (id, name, permissions, created_at, updated_at) VALUES (@Id, @Name, @Permissions, @CreatedAt, @UpdatedAt)",
+            role);
+        return role;
+    }
+
+    public async Task<ModeratorRole?> GetByIdAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        return await conn.QuerySingleOrDefaultAsync<ModeratorRole>(
+            "SELECT * FROM moderator_roles WHERE id = @Id", new { Id = id });
+    }
+
+    public async Task<IReadOnlyList<ModeratorRole>> GetAllAsync()
+    {
+        using var conn = _db.CreateConnection();
+        var result = await conn.QueryAsync<ModeratorRole>("SELECT * FROM moderator_roles ORDER BY name");
+        return result.ToList();
+    }
+
+    public async Task UpdateAsync(string id, string? name = null, ModeratorPermission? permissions = null)
+    {
+        using var conn = _db.CreateConnection();
+        var existing = await GetByIdAsync(id);
+        if (existing == null) return;
+
+        await conn.ExecuteAsync(
+            "UPDATE moderator_roles SET name = @Name, permissions = @Permissions, updated_at = @UpdatedAt WHERE id = @Id",
+            new { Id = id, Name = name ?? existing.Name, Permissions = permissions ?? existing.Permissions, UpdatedAt = DateTime.UtcNow });
+    }
+
+    public async Task DeleteAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        await conn.ExecuteAsync("DELETE FROM moderator_roles WHERE id = @Id", new { Id = id });
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "ModeratorRoleRepositoryTests"
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Write tests for ModeratorAssignmentRepository**
+
+Create `tests/Brmble.Server.Tests/ModeratorAssignmentRepositoryTests.cs`:
+
+```csharp
+using Brmble.Server.Data;
+using Brmble.Server.Moderator;
+using Xunit;
+
+namespace Brmble.Server.Tests;
+
+public class ModeratorAssignmentRepositoryTests
+{
+    private readonly Database _db;
+    private readonly ModeratorRoleRepository _roleRepo;
+    private readonly ModeratorAssignmentRepository _repo;
+
+    public ModeratorAssignmentRepositoryTests()
+    {
+        _db = new Database("DataSource=:memory:");
+        _db.Initialize();
+        _roleRepo = new ModeratorRoleRepository(_db);
+        _repo = new ModeratorAssignmentRepository(_db);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ReturnsAssignment()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermission.Kick);
+        var assignment = await _repo.CreateAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+        
+        Assert.NotNull(assignment.Id);
+        Assert.Equal(role.Id, assignment.RoleId);
+        Assert.Equal(5, assignment.ChannelId);
+        Assert.Equal(123, assignment.UserId);
+    }
+
+    [Fact]
+    public async Task GetByChannelAsync_ReturnsAssignmentsForChannel()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermission.Kick);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 1, assignedBy: 1);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 2, assignedBy: 1);
+        await _repo.CreateAsync(role.Id, channelId: 6, userId: 1, assignedBy: 1);
+        
+        var channel5Assignments = await _repo.GetByChannelAsync(5);
+        
+        Assert.Equal(2, channel5Assignments.Count);
+    }
+
+    [Fact]
+    public async Task GetByUserAndChannelAsync_ReturnsSpecificAssignment()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermission.Kick);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+        
+        var assignment = await _repo.GetByUserAndChannelAsync(userId: 123, channelId: 5);
+        
+        Assert.NotNull(assignment);
+        Assert.Equal(123, assignment.UserId);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesAssignment()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermission.Kick);
+        var assignment = await _repo.CreateAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+        await _repo.DeleteAsync(assignment.Id);
+        
+        var deleted = await _repo.GetByIdAsync(assignment.Id);
+        Assert.Null(deleted);
+    }
+
+    [Fact]
+    public async Task GetByChannelAndUserIdsAsync_ReturnsMatchingAssignments()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermission.Kick);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 1, assignedBy: 1);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 2, assignedBy: 1);
+        await _repo.CreateAsync(role.Id, channelId: 6, userId: 3, assignedBy: 1);
+        
+        var assignments = await _repo.GetByChannelAndUserIdsAsync(5, new[] { 1, 2, 3 });
+        
+        Assert.Equal(2, assignments.Count);
+    }
+}
+```
+
+- [ ] **Step 6: Implement ModeratorAssignmentRepository**
+
+Create `src/Brmble.Server/Data/ModeratorAssignmentRepository.cs`:
+
+```csharp
+using Dapper;
+
+namespace Brmble.Server.Data;
+
+public class ModeratorAssignment
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string RoleId { get; set; } = string.Empty;
+    public int ChannelId { get; set; }
+    public int UserId { get; set; }
+    public int AssignedBy { get; set; }
+    public DateTime AssignedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class ModeratorAssignmentWithRole : ModeratorAssignment
+{
+    public string RoleName { get; set; } = string.Empty;
+    public ModeratorPermission RolePermissions { get; set; }
+}
+
+public class ModeratorAssignmentRepository
+{
+    private readonly Database _db;
+
+    public ModeratorAssignmentRepository(Database db)
+    {
+        _db = db;
+    }
+
+    public async Task<ModeratorAssignment> CreateAsync(string roleId, int channelId, int userId, int assignedBy)
+    {
+        using var conn = _db.CreateConnection();
+        var assignment = new ModeratorAssignment
+        {
+            RoleId = roleId,
+            ChannelId = channelId,
+            UserId = userId,
+            AssignedBy = assignedBy
+        };
+        await conn.ExecuteAsync(
+            @"INSERT INTO moderator_assignments (id, role_id, channel_id, user_id, assigned_by, assigned_at)
+              VALUES (@Id, @RoleId, @ChannelId, @UserId, @AssignedBy, @AssignedAt)",
+            assignment);
+        return assignment;
+    }
+
+    public async Task<ModeratorAssignment?> GetByIdAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        return await conn.QuerySingleOrDefaultAsync<ModeratorAssignment>(
+            "SELECT * FROM moderator_assignments WHERE id = @Id", new { Id = id });
+    }
+
+    public async Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetByChannelAsync(int channelId)
+    {
+        using var conn = _db.CreateConnection();
+        var result = await conn.QueryAsync<ModeratorAssignmentWithRole>(
+            @"SELECT ma.*, mr.name as RoleName, mr.permissions as RolePermissions
+              FROM moderator_assignments ma
+              JOIN moderator_roles mr ON ma.role_id = mr.id
+              WHERE ma.channel_id = @ChannelId
+              ORDER BY mr.name, ma.assigned_at",
+            new { ChannelId = channelId });
+        return result.ToList();
+    }
+
+    public async Task<ModeratorAssignmentWithRole?> GetByUserAndChannelAsync(int userId, int channelId)
+    {
+        using var conn = _db.CreateConnection();
+        return await conn.QuerySingleOrDefaultAsync<ModeratorAssignmentWithRole>(
+            @"SELECT ma.*, mr.name as RoleName, mr.permissions as RolePermissions
+              FROM moderator_assignments ma
+              JOIN moderator_roles mr ON ma.role_id = mr.id
+              WHERE ma.user_id = @UserId AND ma.channel_id = @ChannelId",
+            new { UserId = userId, ChannelId = channelId });
+    }
+
+    public async Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetByChannelAndUserIdsAsync(int channelId, IEnumerable<int> userIds)
+    {
+        using var conn = _db.CreateConnection();
+        var result = await conn.QueryAsync<ModeratorAssignmentWithRole>(
+            @"SELECT ma.*, mr.name as RoleName, mr.permissions as RolePermissions
+              FROM moderator_assignments ma
+              JOIN moderator_roles mr ON ma.role_id = mr.id
+              WHERE ma.channel_id = @ChannelId AND ma.user_id IN @UserIds",
+            new { ChannelId = channelId, UserIds = userIds.ToList() });
+        return result.ToList();
+    }
+
+    public async Task DeleteAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        await conn.ExecuteAsync("DELETE FROM moderator_assignments WHERE id = @Id", new { Id = id });
+    }
+
+    public async Task DeleteByChannelAsync(int channelId)
+    {
+        using var conn = _db.CreateConnection();
+        await conn.ExecuteAsync("DELETE FROM moderator_assignments WHERE channel_id = @ChannelId", new { ChannelId = channelId });
+    }
+}
+```
+
+- [ ] **Step 7: Run assignment tests to verify they pass**
+
+```bash
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "ModeratorAssignmentRepositoryTests"
+```
+
+Expected: PASS
+
+- [ ] **Step 8: Implement SyncFailedAssignmentRepository (minimal for retry queue)**
+
+Create `src/Brmble.Server/Data/SyncFailedAssignmentRepository.cs`:
+
+```csharp
+using Dapper;
+
+namespace Brmble.Server.Data;
+
+public class SyncFailedAssignment
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string AssignmentId { get; set; } = string.Empty;
+    public string Action { get; set; } = string.Empty; // "add" or "remove"
+    public string? ErrorMessage { get; set; }
+    public int RetryCount { get; set; }
+    public DateTime NextRetryAt { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class SyncFailedAssignmentRepository
+{
+    private readonly Database _db;
+    private static readonly int[] RetryDelays = { 30, 60, 120, 240, 480 }; // seconds
+
+    public SyncFailedAssignmentRepository(Database db)
+    {
+        _db = db;
+    }
+
+    public async Task AddAsync(string assignmentId, string action, string errorMessage)
+    {
+        using var conn = _db.CreateConnection();
+        var failed = new SyncFailedAssignment
+        {
+            AssignmentId = assignmentId,
+            Action = action,
+            ErrorMessage = errorMessage,
+            RetryCount = 0,
+            NextRetryAt = DateTime.UtcNow.AddSeconds(RetryDelays[0])
+        };
+        await conn.ExecuteAsync(
+            @"INSERT INTO sync_failed_assignments (id, assignment_id, action, error_message, retry_count, next_retry_at, created_at)
+              VALUES (@Id, @AssignmentId, @Action, @ErrorMessage, @RetryCount, @NextRetryAt, @CreatedAt)",
+            failed);
+    }
+
+    public async Task<IReadOnlyList<SyncFailedAssignment>> GetPendingAsync()
+    {
+        using var conn = _db.CreateConnection();
+        var result = await conn.QueryAsync<SyncFailedAssignment>(
+            "SELECT * FROM sync_failed_assignments WHERE next_retry_at <= @Now ORDER BY next_retry_at",
+            new { Now = DateTime.UtcNow });
+        return result.ToList();
+    }
+
+    public async Task IncrementRetryAsync(string id, string errorMessage)
+    {
+        using var conn = _db.CreateConnection();
+        var existing = await conn.QuerySingleOrDefaultAsync<SyncFailedAssignment>(
+            "SELECT * FROM sync_failed_assignments WHERE id = @Id", new { Id = id });
+        if (existing == null) return;
+
+        var nextDelayIndex = Math.Min(existing.RetryCount, RetryDelays.Length - 1);
+        var nextRetryAt = DateTime.UtcNow.AddSeconds(RetryDelays[nextDelayIndex]);
+        var retryCount = existing.RetryCount + 1;
+
+        await conn.ExecuteAsync(
+            @"UPDATE sync_failed_assignments SET retry_count = @RetryCount, next_retry_at = @NextRetryAt, error_message = @ErrorMessage
+              WHERE id = @Id",
+            new { Id = id, RetryCount = retryCount, NextRetryAt = nextRetryAt, ErrorMessage = errorMessage });
+    }
+
+    public async Task RemoveAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        await conn.ExecuteAsync("DELETE FROM sync_failed_assignments WHERE id = @Id", new { Id = id });
+    }
+}
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Brmble.Server/Data/ModeratorRoleRepository.cs src/Brmble.Server/Data/ModeratorAssignmentRepository.cs src/Brmble.Server/Data/SyncFailedAssignmentRepository.cs
+git commit -m "feat: add moderator repositories"
+```
+
+---
+
+## Task 3: Mumble Group Sync Service
+
+**Files:**
+- Create: `src/Brmble.Server/Moderator/MumbleGroupSyncService.cs`
+- Modify: `src/Brmble.Server/Program.cs` (register service)
+
+- [ ] **Step 1: Write interface**
+
+Create `src/Brmble.Server/Moderator/IMumbleGroupSyncService.cs`:
+
+```csharp
+namespace Brmble.Server.Moderator;
+
+public interface IMumbleGroupSyncService
+{
+    Task AddUserToChannelGroupAsync(int userId, int channelId);
+    Task RemoveUserFromChannelGroupAsync(int userId, int channelId);
+    Task<bool> SyncAssignmentAsync(string assignmentId, int userId, int channelId, bool add);
+}
+```
+
+- [ ] **Step 2: Implement MumbleGroupSyncService**
+
+Create `src/Brmble.Server/Moderator/MumbleGroupSyncService.cs`:
+
+```csharp
+using Microsoft.Extensions.Logging;
+
+namespace Brmble.Server.Moderator;
+
+public class MumbleGroupSyncService : IMumbleGroupSyncService
+{
+    private readonly IMumbleRegistrationService _mumbleRegistration;
+    private readonly ILogger<MumbleGroupSyncService> _logger;
+
+    public MumbleGroupSyncService(
+        IMumbleRegistrationService mumbleRegistration,
+        ILogger<MumbleGroupSyncService> logger)
+    {
+        _mumbleRegistration = mumbleRegistration;
+        _logger = logger;
+    }
+
+    private static string GetGroupName(int channelId) => $"brmble_mod_{channelId}";
+
+    public async Task AddUserToChannelGroupAsync(int userId, int channelId)
+    {
+        var groupName = GetGroupName(channelId);
+        _logger.LogInformation("Adding user {UserId} to Mumble group {GroupName}", userId, groupName);
+        
+        // TODO: Implement actual Mumble ICE call to add user to ACL group
+        // This requires looking up the Mumble ICE API for ACL group management
+        // Expected call pattern similar to MumbleRegistrationService
+        
+        _logger.LogDebug("Mumble group add: user {UserId} to group {GroupName} (stub)", userId, groupName);
+    }
+
+    public async Task RemoveUserFromChannelGroupAsync(int userId, int channelId)
+    {
+        var groupName = GetGroupName(channelId);
+        _logger.LogInformation("Removing user {UserId} from Mumble group {GroupName}", userId, groupName);
+        
+        // TODO: Implement actual Mumble ICE call to remove user from ACL group
+        
+        _logger.LogDebug("Mumble group remove: user {UserId} from group {GroupName} (stub)", userId, groupName);
+    }
+
+    public async Task<bool> SyncAssignmentAsync(string assignmentId, int userId, int channelId, bool add)
+    {
+        try
+        {
+            if (add)
+            {
+                await AddUserToChannelGroupAsync(userId, channelId);
+            }
+            else
+            {
+                await RemoveUserFromChannelGroupAsync(userId, channelId);
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to sync assignment {AssignmentId} to Mumble", assignmentId);
+            return false;
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Register service in Program.cs**
+
+Find the service registration section in `Program.cs` and add:
+
+```csharp
+services.AddSingleton<IMumbleGroupSyncService, MumbleGroupSyncService>();
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Server/Moderator/MumbleGroupSyncService.cs src/Brmble.Server/Program.cs
+git commit -m "feat: add Mumble group sync service"
+```
+
+---
+
+## Task 4: Permission Enforcer Service
+
+**Files:**
+- Create: `src/Brmble.Server/Moderator/PermissionEnforcer.cs`
+- Create: `src/Brmble.Server/Moderator/ModeratorService.cs`
+
+- [ ] **Step 1: Write tests for PermissionEnforcer**
+
+Create `tests/Brmble.Server.Tests/PermissionEnforcerTests.cs`:
+
+```csharp
+using Brmble.Server.Data;
+using Brmble.Server.Moderator;
+using Moq;
+using Xunit;
+
+namespace Brmble.Server.Tests;
+
+public class PermissionEnforcerTests
+{
+    private readonly Mock<IModeratorPermissionChecker> _checkerMock;
+    private readonly PermissionEnforcer _enforcer;
+
+    public PermissionEnforcerTests()
+    {
+        _checkerMock = new Mock<IModeratorPermissionChecker>();
+        _enforcer = new PermissionEnforcer(_checkerMock.Object);
+    }
+
+    [Fact]
+    public async Task HasModeratorPermission_ReturnsTrue_WhenUserHasPermission()
+    {
+        _checkerMock.Setup(x => x.GetModeratorPermissionsAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(ModeratorPermission.Kick | ModeratorPermission.DenyEnter);
+
+        var result = await _enforcer.HasModeratorPermissionAsync(userId: 123, channelId: 5, ModeratorPermission.Kick);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task HasModeratorPermission_ReturnsFalse_WhenUserLacksPermission()
+    {
+        _checkerMock.Setup(x => x.GetModeratorPermissionsAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(ModeratorPermission.Kick);
+
+        var result = await _enforcer.HasModeratorPermissionAsync(userId: 123, channelId: 5, ModeratorPermission.DenyEnter);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task HasModeratorPermission_ReturnsFalse_WhenUserHasNoModeratorRole()
+    {
+        _checkerMock.Setup(x => x.GetModeratorPermissionsAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(ModeratorPermission.None);
+
+        var result = await _enforcer.HasModeratorPermissionAsync(userId: 123, channelId: 5, ModeratorPermission.Kick);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task RequireModeratorPermission_Throws_WhenUserLacksPermission()
+    {
+        _checkerMock.Setup(x => x.GetModeratorPermissionsAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(ModeratorPermission.None);
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => _enforcer.RequireModeratorPermissionAsync(userId: 123, channelId: 5, ModeratorPermission.Kick));
+    }
+}
+```
+
+- [ ] **Step 2: Define IModeratorPermissionChecker**
+
+Create `src/Brmble.Server/Moderator/IModeratorPermissionChecker.cs`:
+
+```csharp
+namespace Brmble.Server.Moderator;
+
+public interface IModeratorPermissionChecker
+{
+    Task<ModeratorPermission> GetModeratorPermissionsAsync(int userId, int channelId);
+}
+```
+
+- [ ] **Step 3: Implement PermissionEnforcer**
+
+Create `src/Brmble.Server/Moderator/PermissionEnforcer.cs`:
+
+```csharp
+namespace Brmble.Server.Moderator;
+
+public class PermissionEnforcer
+{
+    private readonly IModeratorPermissionChecker _permissionChecker;
+
+    public PermissionEnforcer(IModeratorPermissionChecker permissionChecker)
+    {
+        _permissionChecker = permissionChecker;
+    }
+
+    public async Task<bool> HasModeratorPermissionAsync(int userId, int channelId, ModeratorPermission required)
+    {
+        var permissions = await _permissionChecker.GetModeratorPermissionsAsync(userId, channelId);
+        return permissions.HasFlag(required);
+    }
+
+    public async Task RequireModeratorPermissionAsync(int userId, int channelId, ModeratorPermission required)
+    {
+        if (!await HasModeratorPermissionAsync(userId, channelId, required))
+        {
+            throw new UnauthorizedAccessException(
+                $"User {userId} lacks required permission {required} for channel {channelId}");
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "PermissionEnforcerTests"
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Implement ModeratorService (business logic combining repositories, sync, enforcer)**
+
+Create `src/Brmble.Server/Moderator/ModeratorService.cs`:
+
+```csharp
+using Brmble.Server.Data;
+
+namespace Brmble.Server.Moderator;
+
+public interface IModeratorService
+{
+    // Role management
+    Task<IReadOnlyList<ModeratorRole>> GetRolesAsync();
+    Task<ModeratorRole> CreateRoleAsync(string name, ModeratorPermission permissions);
+    Task UpdateRoleAsync(string id, string? name, ModeratorPermission? permissions);
+    Task DeleteRoleAsync(string id);
+    
+    // Assignment management
+    Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetChannelModeratorsAsync(int channelId);
+    Task<ModeratorAssignment> AssignModeratorAsync(string roleId, int channelId, int userId, int assignedBy);
+    Task RemoveModeratorAsync(string assignmentId);
+    Task CleanupChannelAssignmentsAsync(int channelId);
+    
+    // Permission checking
+    Task<ModeratorPermission> GetUserPermissionsForChannelAsync(int userId, int channelId);
+}
+
+public class ModeratorService : IModeratorService, IModeratorPermissionChecker
+{
+    private readonly ModeratorRoleRepository _roleRepo;
+    private readonly ModeratorAssignmentRepository _assignmentRepo;
+    private readonly SyncFailedAssignmentRepository _syncFailedRepo;
+    private readonly IMumbleGroupSyncService _mumbleSync;
+    private readonly ILogger<ModeratorService> _logger;
+
+    public ModeratorService(
+        ModeratorRoleRepository roleRepo,
+        ModeratorAssignmentRepository assignmentRepo,
+        SyncFailedAssignmentRepository syncFailedRepo,
+        IMumbleGroupSyncService mumbleSync,
+        ILogger<ModeratorService> logger)
+    {
+        _roleRepo = roleRepo;
+        _assignmentRepo = assignmentRepo;
+        _syncFailedRepo = syncFailedRepo;
+        _mumbleSync = mumbleSync;
+        _logger = logger;
+    }
+
+    // Role management
+    public async Task<IReadOnlyList<ModeratorRole>> GetRolesAsync() => await _roleRepo.GetAllAsync();
+    
+    public async Task<ModeratorRole> CreateRoleAsync(string name, ModeratorPermission permissions)
+    {
+        return await _roleRepo.CreateAsync(name, permissions);
+    }
+    
+    public async Task UpdateRoleAsync(string id, string? name, ModeratorPermission? permissions)
+    {
+        await _roleRepo.UpdateAsync(id, name, permissions);
+    }
+    
+    public async Task DeleteRoleAsync(string id)
+    {
+        await _roleRepo.DeleteAsync(id);
+    }
+
+    // Assignment management
+    public async Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetChannelModeratorsAsync(int channelId)
+    {
+        return await _assignmentRepo.GetByChannelAsync(channelId);
+    }
+
+    public async Task<ModeratorAssignment> AssignModeratorAsync(string roleId, int channelId, int userId, int assignedBy)
+    {
+        var assignment = await _assignmentRepo.CreateAsync(roleId, channelId, userId, assignedBy);
+        
+        // Sync to Mumble
+        var success = await _mumbleSync.SyncAssignmentAsync(assignment.Id, userId, channelId, add: true);
+        if (!success)
+        {
+            _logger.LogWarning("Mumble sync failed for assignment {AssignmentId}, queuing for retry", assignment.Id);
+            await _syncFailedRepo.AddAsync(assignment.Id, "add", "Initial sync failed");
+        }
+        
+        return assignment;
+    }
+
+    public async Task RemoveModeratorAsync(string assignmentId)
+    {
+        var assignment = await _assignmentRepo.GetByIdAsync(assignmentId);
+        if (assignment == null) return;
+
+        var userId = assignment.UserId;
+        var channelId = assignment.ChannelId;
+        
+        await _assignmentRepo.DeleteAsync(assignmentId);
+        
+        // Sync removal to Mumble
+        var success = await _mumbleSync.SyncAssignmentAsync(assignmentId, userId, channelId, add: false);
+        if (!success)
+        {
+            _logger.LogWarning("Mumble sync removal failed for assignment {AssignmentId}, queuing for retry", assignmentId);
+            await _syncFailedRepo.AddAsync(assignmentId, "remove", "Removal sync failed");
+        }
+    }
+
+    public async Task CleanupChannelAssignmentsAsync(int channelId)
+    {
+        // Get assignments before deletion for Mumble cleanup
+        var assignments = await _assignmentRepo.GetByChannelAsync(channelId);
+        
+        await _assignmentRepo.DeleteByChannelAsync(channelId);
+        
+        // Sync removals to Mumble
+        foreach (var assignment in assignments)
+        {
+            var success = await _mumbleSync.SyncAssignmentAsync(assignment.Id, assignment.UserId, channelId, add: false);
+            if (!success)
+            {
+                await _syncFailedRepo.AddAsync(assignment.Id, "remove", "Cleanup sync failed");
+            }
+        }
+    }
+
+    // Permission checking
+    public async Task<ModeratorPermission> GetUserPermissionsForChannelAsync(int userId, int channelId)
+    {
+        var assignment = await _assignmentRepo.GetByUserAndChannelAsync(userId, channelId);
+        return assignment?.RolePermissions ?? ModeratorPermission.None;
+    }
+
+    Task<ModeratorPermission> IModeratorPermissionChecker.GetModeratorPermissionsAsync(int userId, int channelId)
+    {
+        return GetUserPermissionsForChannelAsync(userId, channelId);
+    }
+}
+```
+
+- [ ] **Step 6: Register ModeratorService in Program.cs**
+
+Find service registration section and add:
+
+```csharp
+services.AddSingleton<ModeratorRoleRepository>();
+services.AddSingleton<ModeratorAssignmentRepository>();
+services.AddSingleton<SyncFailedAssignmentRepository>();
+services.AddSingleton<IModeratorService, ModeratorService>();
+services.AddSingleton<IModeratorPermissionChecker>(sp => sp.GetRequiredService<IModeratorService>());
+services.AddSingleton<PermissionEnforcer>();
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Server/Moderator/ModeratorService.cs src/Brmble.Server/Moderator/PermissionEnforcer.cs
+git commit -m "feat: add moderator service and permission enforcer"
+```
+
+---
+
+## Task 5: API Endpoints
+
+**Files:**
+- Create: `src/Brmble.Server/Moderator/ModeratorEndpoints.cs`
+- Modify: `src/Brmble.Server/Program.cs` (register endpoints)
+
+- [ ] **Step 1: Implement ModeratorEndpoints**
+
+Create `src/Brmble.Server/Moderator/ModeratorEndpoints.cs`:
+
+```csharp
+using Brmble.Server.Data;
+
+namespace Brmble.Server.Moderator;
+
+public static class ModeratorEndpoints
+{
+    public static IEndpointRouteBuilder MapModeratorEndpoints(this IEndpointRouteBuilder app)
+    {
+        // Role management (admin only - add admin auth check)
+        app.MapGet("/api/admin/moderator-roles", async (IModeratorService moderatorService) =>
+        {
+            var roles = await moderatorService.GetRolesAsync();
+            return Results.Ok(roles.Select(r => new
+            {
+                r.Id,
+                r.Name,
+                Permissions = (int)r.Permissions
+            }));
+        });
+
+        app.MapPost("/api/admin/moderator-roles", async (
+            IModeratorService moderatorService,
+            CreateRoleRequest request) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.Name))
+                return Results.BadRequest("Role name is required");
+            
+            var role = await moderatorService.CreateRoleAsync(request.Name, request.Permissions);
+            return Results.Created($"/api/admin/moderator-roles/{role.Id}", new
+            {
+                role.Id,
+                role.Name,
+                Permissions = (int)role.Permissions
+            });
+        });
+
+        app.MapPut("/api/admin/moderator-roles/{id}", async (
+            IModeratorService moderatorService,
+            string id,
+            UpdateRoleRequest request) =>
+        {
+            await moderatorService.UpdateRoleAsync(id, request.Name, request.Permissions);
+            return Results.NoContent();
+        });
+
+        app.MapDelete("/api/admin/moderator-roles/{id}", async (
+            IModeratorService moderatorService,
+            string id) =>
+        {
+            await moderatorService.DeleteRoleAsync(id);
+            return Results.NoContent();
+        });
+
+        // Assignment management
+        app.MapGet("/api/channels/{channelId}/moderators", async (
+            IModeratorService moderatorService,
+            int channelId) =>
+        {
+            var moderators = await moderatorService.GetChannelModeratorsAsync(channelId);
+            return Results.Ok(moderators.Select(m => new
+            {
+                m.Id,
+                m.UserId,
+                m.RoleId,
+                m.RoleName,
+                m.RolePermissions,
+                m.AssignedAt
+            }));
+        });
+
+        app.MapPost("/api/channels/{channelId}/moderators", async (
+            IModeratorService moderatorService,
+            int channelId,
+            CreateAssignmentRequest request) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.RoleId))
+                return Results.BadRequest("Role ID is required");
+            
+            // assignedBy should come from auth context - using 0 for now as placeholder
+            var assignment = await moderatorService.AssignModeratorAsync(
+                request.RoleId, channelId, request.UserId, assignedBy: 0);
+            
+            return Results.Created($"/api/channels/{channelId}/moderators/{assignment.Id}", new
+            {
+                assignment.Id,
+                assignment.UserId,
+                assignment.RoleId,
+                assignment.AssignedAt
+            });
+        });
+
+        app.MapDelete("/api/channels/{channelId}/moderators/{assignmentId}", async (
+            IModeratorService moderatorService,
+            int channelId,
+            string assignmentId) =>
+        {
+            await moderatorService.RemoveModeratorAsync(assignmentId);
+            return Results.NoContent();
+        });
+
+        return app;
+    }
+}
+
+public record CreateRoleRequest(string Name, ModeratorPermission Permissions);
+public record UpdateRoleRequest(string? Name, ModeratorPermission? Permissions);
+public record CreateAssignmentRequest(string RoleId, int UserId);
+```
+
+- [ ] **Step 2: Register endpoints in Program.cs**
+
+Find endpoint registration and add:
+
+```csharp
+app.MapModeratorEndpoints();
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Server/Moderator/ModeratorEndpoints.cs src/Brmble.Server/Program.cs
+git commit -m "feat: add moderator API endpoints"
+```
+
+---
+
+## Task 6: Frontend - Permission Hook
+
+**Files:**
+- Create: `src/Brmble.Web/src/hooks/useModeratorPermissions.ts`
+- Modify: `src/Brmble.Web/src/bridge.ts`
+
+- [ ] **Step 1: Implement useModeratorPermissions hook**
+
+Create `src/Brmble.Web/src/hooks/useModeratorPermissions.ts`:
+
+```typescript
+import { useState, useEffect, useCallback } from 'react';
+import bridge from '../bridge';
+
+export interface ModeratorRole {
+  id: string;
+  name: string;
+  permissions: number;
+}
+
+export interface ModeratorAssignment {
+  id: string;
+  userId: number;
+  roleId: string;
+  roleName: string;
+  rolePermissions: number;
+  assignedAt: string;
+}
+
+export const ModeratorPermission = {
+  Kick: 0x001,
+  DenyEnter: 0x002,
+  RenameChannel: 0x004,
+  SetPassword: 0x008,
+  EditDesc: 0x010,
+} as const;
+
+export function useModeratorPermissions(channelId: number | null) {
+  const [roles, setRoles] = useState<ModeratorRole[]>([]);
+  const [moderators, setModerators] = useState<ModeratorAssignment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [currentUserPermissions, setCurrentUserPermissions] = useState<number>(0);
+
+  const loadRoles = useCallback(() => {
+    bridge.send('moderator.getRoles');
+  }, []);
+
+  const loadModerators = useCallback((chId: number) => {
+    setLoading(true);
+    bridge.send('moderator.getChannelModerators', { channelId: chId });
+  }, []);
+
+  const createRole = useCallback((name: string, permissions: number) => {
+    bridge.send('moderator.createRole', { name, permissions });
+  }, []);
+
+  const updateRole = useCallback((id: string, name?: string, permissions?: number) => {
+    bridge.send('moderator.updateRole', { id, name, permissions });
+  }, []);
+
+  const deleteRole = useCallback((id: string) => {
+    bridge.send('moderator.deleteRole', { id });
+  }, []);
+
+  const assignModerator = useCallback((roleId: string, userId: number) => {
+    if (channelId === null) return;
+    bridge.send('moderator.assign', { channelId, roleId, userId });
+  }, [channelId]);
+
+  const removeModerator = useCallback((assignmentId: string) => {
+    if (channelId === null) return;
+    bridge.send('moderator.remove', { channelId, assignmentId });
+  }, [channelId]);
+
+  useEffect(() => {
+    const handleRoles = (data: unknown) => {
+      setRoles(data as ModeratorRole[]);
+    };
+
+    const handleModerators = (data: unknown) => {
+      setModerators(data as ModeratorAssignment[]);
+      setLoading(false);
+    };
+
+    const handleCurrentUserPermissions = (data: unknown) => {
+      const payload = data as { channelId: number; permissions: number };
+      if (channelId !== null && payload.channelId === channelId) {
+        setCurrentUserPermissions(payload.permissions);
+      }
+    };
+
+    bridge.on('moderator.roles', handleRoles);
+    bridge.on('moderator.channelModerators', handleModerators);
+    bridge.on('moderator.currentUserPermissions', handleCurrentUserPermissions);
+
+    loadRoles();
+
+    return () => {
+      bridge.off('moderator.roles', handleRoles);
+      bridge.off('moderator.channelModerators', handleModerators);
+      bridge.off('moderator.currentUserPermissions', handleCurrentUserPermissions);
+    };
+  }, [loadRoles]);
+
+  useEffect(() => {
+    if (channelId !== null) {
+      loadModerators(channelId);
+      bridge.send('moderator.getCurrentUserPermissions', { channelId });
+    }
+  }, [channelId, loadModerators]);
+
+  const hasPermission = useCallback((permission: number): boolean => {
+    return (currentUserPermissions & permission) !== 0;
+  }, [currentUserPermissions]);
+
+  const hasAnyModeratorRole = currentUserPermissions > 0;
+
+  return {
+    roles,
+    moderators,
+    loading,
+    currentUserPermissions,
+    hasPermission,
+    hasAnyModeratorRole,
+    loadRoles,
+    loadModerators,
+    createRole,
+    updateRole,
+    deleteRole,
+    assignModerator,
+    removeModerator,
+  };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useModeratorPermissions.ts
+git commit -m "feat: add useModeratorPermissions hook"
+```
+
+---
+
+## Task 7: Frontend - Manage Moderators Tab Component
+
+**Files:**
+- Create: `src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.tsx`
+- Create: `src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.css`
+- Create: `src/Brmble.Web/src/components/ManageModeratorsTab/ModeratorRoleModal.tsx`
+
+- [ ] **Step 1: Implement ManageModeratorsTab**
+
+Create `src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.tsx`:
+
+```typescript
+import { useState } from 'react';
+import { useModeratorPermissions, ModeratorPermission } from '../../hooks/useModeratorPermissions';
+import bridge from '../../bridge';
+import { prompt, confirm } from '../../hooks/usePrompt';
+import './ManageModeratorsTab.css';
+
+interface ManageModeratorsTabProps {
+  channelId: number;
+  isAdmin: boolean;
+}
+
+export function ManageModeratorsTab({ channelId, isAdmin }: ManageModeratorsTabProps) {
+  const {
+    roles,
+    moderators,
+    loading,
+    hasAnyModeratorRole,
+    createRole,
+    updateRole,
+    deleteRole,
+    assignModerator,
+    removeModerator,
+  } = useModeratorPermissions(channelId);
+
+  const [showRoleModal, setShowRoleModal] = useState(false);
+  const [editingRole, setEditingRole] = useState<{ id: string; name: string; permissions: number } | null>(null);
+  const [selectedUserId, setSelectedUserId] = useState<string>('');
+  const [selectedRoleId, setSelectedRoleId] = useState<string>('');
+
+  const canEdit = isAdmin;
+
+  const handleAddModerator = async () => {
+    const userIdStr = await prompt({
+      title: 'Add Moderator',
+      message: 'Enter the user ID to assign as moderator:',
+      placeholder: 'User ID',
+    });
+    if (userIdStr === null) return;
+
+    const userId = parseInt(userIdStr, 10);
+    if (isNaN(userId)) {
+      alert('Invalid user ID');
+      return;
+    }
+
+    const roleId = await prompt({
+      title: 'Select Role',
+      message: 'Select a role for this moderator:',
+      options: roles.map(r => ({ label: r.name, value: r.id })),
+    });
+    if (!roleId) return;
+
+    assignModerator(roleId, userId);
+  };
+
+  const handleRemoveModerator = async (assignmentId: string, userId: number) => {
+    const confirmed = await confirm({
+      title: 'Remove Moderator',
+      message: `Remove moderator (User ID: ${userId}) from this channel?`,
+      confirmLabel: 'Remove',
+    });
+    if (!confirmed) return;
+
+    removeModerator(assignmentId);
+  };
+
+  const handleCreateRole = () => {
+    setEditingRole(null);
+    setShowRoleModal(true);
+  };
+
+  const handleEditRole = (role: { id: string; name: string; permissions: number }) => {
+    setEditingRole(role);
+    setShowRoleModal(true);
+  };
+
+  const handleSaveRole = (name: string, permissions: number) => {
+    if (editingRole) {
+      updateRole(editingRole.id, name, permissions);
+    } else {
+      createRole(name, permissions);
+    }
+    setShowRoleModal(false);
+  };
+
+  const handleDeleteRole = async (roleId: string, roleName: string) => {
+    const confirmed = await confirm({
+      title: 'Delete Role',
+      message: `Delete role "${roleName}"? This will remove all assignments using this role.`,
+      confirmLabel: 'Delete',
+    });
+    if (!confirmed) return;
+
+    deleteRole(roleId);
+  };
+
+  const getPermissionLabel = (perm: number): string => {
+    switch (perm) {
+      case ModeratorPermission.Kick: return 'Kick';
+      case ModeratorPermission.DenyEnter: return 'Deny Enter';
+      case ModeratorPermission.RenameChannel: return 'Rename Channel';
+      case ModeratorPermission.SetPassword: return 'Set Password';
+      case ModeratorPermission.EditDesc: return 'Edit Description';
+      default: return 'Unknown';
+    }
+  };
+
+  const renderPermission = (perm: number, checked: boolean) => (
+    <span key={perm} className={`permission-badge ${checked ? 'granted' : ''}`}>
+      {checked ? '✓' : '✗'} {getPermissionLabel(perm)}
+    </span>
+  );
+
+  return (
+    <div className="manage-moderators-tab">
+      {!canEdit && !hasAnyModeratorRole && (
+        <div className="moderator-view-only-banner">
+          View only — Contact an admin to modify moderator settings.
+        </div>
+      )}
+
+      {!canEdit && hasAnyModeratorRole && (
+        <div className="moderator-view-banner">
+          You are a moderator of this channel.
+        </div>
+      )}
+
+      <div className="moderators-section">
+        <div className="section-header">
+          <h4 className="heading-label">Channel Moderators</h4>
+          {canEdit && (
+            <button className="btn btn-primary btn-sm" onClick={handleAddModerator}>
+              Add Moderator
+            </button>
+          )}
+        </div>
+
+        {loading && <div className="loading">Loading...</div>}
+
+        {!loading && moderators.length === 0 && (
+          <div className="empty-state">No moderators assigned to this channel.</div>
+        )}
+
+        {!loading && moderators.length > 0 && (
+          <div className="moderator-list">
+            {moderators.map(mod => (
+              <div key={mod.id} className="moderator-row">
+                <div className="moderator-info">
+                  <span className="moderator-user-id">User #{mod.userId}</span>
+                  <span className="moderator-role-name">{mod.roleName}</span>
+                  <div className="moderator-permissions">
+                    {[ModeratorPermission.Kick, ModeratorPermission.DenyEnter, ModeratorPermission.RenameChannel, ModeratorPermission.SetPassword, ModeratorPermission.EditDesc].map(perm =>
+                      renderPermission(perm, (mod.rolePermissions & perm) !== 0)
+                    )}
+                  </div>
+                </div>
+                {canEdit && (
+                  <button
+                    className="btn btn-danger btn-sm"
+                    onClick={() => handleRemoveModerator(mod.id, mod.userId)}
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {canEdit && (
+        <div className="roles-section">
+          <div className="section-header">
+            <h4 className="heading-label">Moderator Roles</h4>
+            <button className="btn btn-secondary btn-sm" onClick={handleCreateRole}>
+              Create Role
+            </button>
+          </div>
+
+          {roles.length === 0 && (
+            <div className="empty-state">No roles defined. Create one to get started.</div>
+          )}
+
+          {roles.length > 0 && (
+            <div className="role-list">
+              {roles.map(role => (
+                <div key={role.id} className="role-row">
+                  <div className="role-info">
+                    <span className="role-name">{role.name}</span>
+                    <div className="role-permissions">
+                      {[ModeratorPermission.Kick, ModeratorPermission.DenyEnter, ModeratorPermission.RenameChannel, ModeratorPermission.SetPassword, ModeratorPermission.EditDesc].map(perm =>
+                        renderPermission(perm, (role.permissions & perm) !== 0)
+                      )}
+                    </div>
+                  </div>
+                  <div className="role-actions">
+                    <button
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => handleEditRole(role)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className="btn btn-danger btn-sm"
+                      onClick={() => handleDeleteRole(role.id, role.name)}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {showRoleModal && (
+        <ModeratorRoleModal
+          role={editingRole}
+          onSave={handleSaveRole}
+          onClose={() => setShowRoleModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ModeratorRoleModal({
+  role,
+  onSave,
+  onClose,
+}: {
+  role: { id: string; name: string; permissions: number } | null;
+  onSave: (name: string, permissions: number) => void;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState(role?.name ?? '');
+  const [permissions, setPermissions] = useState(role?.permissions ?? 0);
+
+  const togglePermission = (perm: number) => {
+    setPermissions(prev => prev ^ perm);
+  };
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+    onSave(name, permissions);
+  };
+
+  const permissionItems = [
+    { perm: ModeratorPermission.Kick, label: 'Kick users from channel' },
+    { perm: ModeratorPermission.DenyEnter, label: 'Deny user from entering channel' },
+    { perm: ModeratorPermission.RenameChannel, label: 'Rename channel' },
+    { perm: ModeratorPermission.SetPassword, label: 'Set/change channel password' },
+    { perm: ModeratorPermission.EditDesc, label: 'Edit channel description' },
+  ];
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="prompt glass-panel animate-slide-up" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="heading-title modal-title">
+            {role ? 'Edit Role' : 'Create Role'}
+          </h2>
+        </div>
+
+        <div className="modal-body">
+          <div className="form-group">
+            <label className="form-label">Role Name</label>
+            <input
+              type="text"
+              className="brmble-input"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Enter role name..."
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Permissions</label>
+            <div className="permission-checkboxes">
+              {permissionItems.map(({ perm, label }) => (
+                <label key={perm} className="permission-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={(permissions & perm) !== 0}
+                    onChange={() => togglePermission(perm)}
+                  />
+                  <span>{label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="prompt-footer">
+          <button className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handleSave}
+            disabled={!name.trim()}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create CSS**
+
+Create `src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.css`:
+
+```css
+.manage-moderators-tab {
+  padding: var(--spacing-md);
+}
+
+.moderator-view-only-banner,
+.moderator-view-banner {
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+}
+
+.moderator-view-only-banner {
+  background: var(--color-warning-bg, rgba(255, 193, 7, 0.1));
+  border: 1px solid var(--color-warning, #ffc107);
+  color: var(--color-warning-text, #856404);
+}
+
+.moderator-view-banner {
+  background: var(--color-info-bg, rgba(0, 123, 255, 0.1));
+  border: 1px solid var(--color-info, #007bff);
+  color: var(--color-info-text, #004085);
+}
+
+.moderators-section,
+.roles-section {
+  margin-bottom: var(--spacing-lg);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-md);
+}
+
+.moderator-list,
+.role-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.moderator-row,
+.role-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+}
+
+.moderator-info,
+.role-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.moderator-user-id {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.moderator-role-name,
+.role-name {
+  font-weight: 500;
+}
+
+.moderator-permissions,
+.role-permissions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.permission-badge {
+  padding: 2px var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+}
+
+.permission-badge.granted {
+  background: var(--color-success-bg, rgba(40, 167, 69, 0.1));
+  color: var(--color-success, #28a745);
+}
+
+.role-actions {
+  display: flex;
+  gap: var(--spacing-xs);
+}
+
+.form-group {
+  margin-bottom: var(--spacing-md);
+}
+
+.form-label {
+  display: block;
+  margin-bottom: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.permission-checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.permission-checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  cursor: pointer;
+}
+
+.permission-checkbox input {
+  width: auto;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/ManageModeratorsTab/
+git commit -m "feat: add ManageModeratorsTab component"
+```
+
+---
+
+## Task 8: Channel Edit Modal with Tabs
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`
+- Create: `src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.tsx`
+- Create: `src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.css`
+
+- [ ] **Step 1: Create ChannelEditModal component**
+
+Create `src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.tsx`:
+
+```typescript
+import { useState } from 'react';
+import { ManageModeratorsTab } from '../ManageModeratorsTab/ManageModeratorsTab';
+import bridge from '../../bridge';
+import './ChannelEditModal.css';
+
+interface ChannelEditModalProps {
+  channelId: number;
+  channelName: string;
+  isAdmin: boolean;
+  onClose: () => void;
+}
+
+export function ChannelEditModal({ channelId, channelName, isAdmin, onClose }: ChannelEditModalProps) {
+  const [activeTab, setActiveTab] = useState<'general' | 'moderators'>('general');
+  const [name, setName] = useState(channelName);
+  const [description, setDescription] = useState('');
+  const [password, setPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    bridge.send('voice.updateChannel', {
+      channelId,
+      name: name !== channelName ? name : undefined,
+      description,
+      password: password || null,
+    });
+    setSaving(false);
+    onClose();
+  };
+
+  const hasModeratorPermissions = () => {
+    // Check via bridge if user has moderator permissions for this channel
+    return true; // TODO: implement permission check
+  };
+
+  const showModeratorsTab = isAdmin || hasModeratorPermissions();
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="channel-edit-modal glass-panel animate-slide-up" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="heading-title modal-title">Edit Channel</h2>
+          <p className="modal-subtitle">{channelName}</p>
+        </div>
+
+        <div className="edit-tabs">
+          <button
+            className={`edit-tab ${activeTab === 'general' ? 'active' : ''}`}
+            onClick={() => setActiveTab('general')}
+          >
+            General
+          </button>
+          {showModeratorsTab && (
+            <button
+              className={`edit-tab ${activeTab === 'moderators' ? 'active' : ''}`}
+              onClick={() => setActiveTab('moderators')}
+            >
+              Manage Moderators
+            </button>
+          )}
+        </div>
+
+        <div className="modal-body">
+          {activeTab === 'general' && (
+            <div className="general-tab-content">
+              <div className="form-group">
+                <label className="form-label">Channel Name</label>
+                <input
+                  type="text"
+                  className="brmble-input"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                />
+              </div>
+
+              <div className="form-group">
+                <label className="form-label">Description</label>
+                <textarea
+                  className="brmble-input"
+                  value={description}
+                  onChange={e => setDescription(e.target.value)}
+                  placeholder="Channel description..."
+                  rows={3}
+                />
+              </div>
+
+              <div className="form-group">
+                <label className="form-label">Password (leave empty to clear)</label>
+                <input
+                  type="password"
+                  className="brmble-input"
+                  value={password}
+                  onChange={e => setPassword(e.target.value)}
+                  placeholder="Enter new password..."
+                />
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'moderators' && (
+            <ManageModeratorsTab
+              channelId={channelId}
+              isAdmin={isAdmin}
+            />
+          )}
+        </div>
+
+        {activeTab === 'general' && (
+          <div className="prompt-footer">
+            <button className="btn btn-secondary" onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              className="btn btn-primary"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update ChannelTree to use ChannelEditModal**
+
+Modify `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`:
+
+Replace the `editChannelDialog` state usage with the new modal:
+
+```typescript
+// In the imports section, add:
+import { ChannelEditModal } from '../ChannelEditModal/ChannelEditModal';
+
+// Change the editChannelDialog state to track admin status:
+const [editChannelDialog, setEditChannelDialog] = useState<{ id: number; name: string; isAdmin: boolean } | null>(null);
+
+// Update the channel context menu "Edit" click:
+if (hasEditPermission) {
+  adminItems.push({
+    type: 'item' as const,
+    label: 'Edit',
+    onClick: () => {
+      setEditChannelDialog({ id: channelContextMenu.channelId, name: channelContextMenu.channelName, isAdmin: hasEditPermission });
+      setChannelContextMenu(null);
+    },
+  });
+}
+
+// Replace the editChannelDialog modal rendering:
+{editChannelDialog && (
+  <ChannelEditModal
+    channelId={editChannelDialog.id}
+    channelName={editChannelDialog.name}
+    isAdmin={editChannelDialog.isAdmin}
+    onClose={() => setEditChannelDialog(null)}
+  />
+)}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/ChannelEditModal/ src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+git commit -m "feat: add channel edit modal with Manage Moderators tab"
+```
+
+---
+
+## Task 9: Bridge Integration
+
+**Files:**
+- Modify: `src/Brmble.Client/Bridge/NativeBridge.cs` (add moderator handlers)
+- Modify: `src/Brmble.Server/Mumble/MumbleAdapter.cs` (if needed for voice actions)
+
+- [ ] **Step 1: Add bridge handlers on client side**
+
+Add to `NativeBridge.cs`:
+
+```csharp
+// Moderator role management
+bridge.RegisterHandler("moderator.getRoles", _ =>
+{
+    var roles = _moderatorService.GetRoles();
+    bridge.Send("moderator.roles", roles.Select(r => new {
+        r.Id,
+        r.Name,
+        Permissions = (int)r.Permissions
+    }));
+});
+
+bridge.RegisterHandler("moderator.createRole", data =>
+{
+    if (data is not JsonElement e) return;
+    var name = e.GetProperty("name").GetString() ?? "";
+    var permissions = (ModeratorPermission)e.GetProperty("permissions").GetInt32();
+    var role = _moderatorService.CreateRole(name, permissions);
+    bridge.Send("moderator.roleCreated", new { role.Id });
+});
+
+bridge.RegisterHandler("moderator.updateRole", data =>
+{
+    if (data is not JsonElement e) return;
+    var id = e.GetProperty("id").GetString();
+    string? name = null;
+    ModeratorPermission? permissions = null;
+    if (e.TryGetProperty("name", out var nameEl) && nameEl.ValueKind != JsonValueKind.Null)
+        name = nameEl.GetString();
+    if (e.TryGetProperty("permissions", out var permEl) && permEl.ValueKind != JsonValueKind.Null)
+        permissions = (ModeratorPermission)permEl.GetInt32();
+    _moderatorService.UpdateRole(id!, name, permissions);
+    bridge.Send("moderator.roleUpdated", new { id });
+});
+
+bridge.RegisterHandler("moderator.deleteRole", data =>
+{
+    if (data is not JsonElement e) return;
+    var id = e.GetProperty("id").GetString();
+    _moderatorService.DeleteRole(id!);
+    bridge.Send("moderator.roleDeleted", new { id });
+});
+
+// Channel moderator management
+bridge.RegisterHandler("moderator.getChannelModerators", data =>
+{
+    if (data is not JsonElement e) return;
+    var channelId = e.GetProperty("channelId").GetUInt32();
+    var moderators = _moderatorService.GetChannelModerators((int)channelId);
+    bridge.Send("moderator.channelModerators", moderators.Select(m => new {
+        m.Id,
+        m.UserId,
+        m.RoleId,
+        m.RoleName,
+        RolePermissions = (int)m.RolePermissions,
+        m.AssignedAt
+    }));
+});
+
+bridge.RegisterHandler("moderator.assign", data =>
+{
+    if (data is not JsonElement e) return;
+    var channelId = e.GetProperty("channelId").GetUInt32();
+    var roleId = e.GetProperty("roleId").GetString();
+    var userId = e.GetProperty("userId").GetInt32();
+    var assignment = _moderatorService.AssignModerator(roleId!, (int)channelId, userId, assignedBy: 0);
+    bridge.Send("moderator.assigned", new { assignment.Id });
+});
+
+bridge.RegisterHandler("moderator.remove", data =>
+{
+    if (data is not JsonElement e) return;
+    var assignmentId = e.GetProperty("assignmentId").GetString();
+    _moderatorService.RemoveModerator(assignmentId!);
+    bridge.Send("moderator.removed", new { assignmentId });
+});
+
+bridge.RegisterHandler("moderator.getCurrentUserPermissions", data =>
+{
+    if (data is not JsonElement e) return;
+    var channelId = e.GetProperty("channelId").GetUInt32();
+    var permissions = _moderatorService.GetUserPermissionsForChannel(_localUserId, (int)channelId);
+    bridge.Send("moderator.currentUserPermissions", new {
+        channelId,
+        permissions = (int)permissions
+    });
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Brmble.Client/Bridge/NativeBridge.cs
+git commit -m "feat: add moderator bridge handlers"
+```
+
+---
+
+## Task 10: Sync Retry Background Service
+
+**Files:**
+- Create: `src/Brmble.Server/Moderator/SyncRetryBackgroundService.cs`
+- Modify: `src/Brmble.Server/Program.cs` (register hosted service)
+
+- [ ] **Step 1: Implement background retry service**
+
+Create `src/Brmble.Server/Moderator/SyncRetryBackgroundService.cs`:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Brmble.Server.Data;
+
+namespace Brmble.Server.Moderator;
+
+public class SyncRetryBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<SyncRetryBackgroundService> _logger;
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
+
+    public SyncRetryBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<SyncRetryBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Sync retry background service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessFailedSyncsAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing failed syncs");
+            }
+
+            await Task.Delay(PollInterval, stoppingToken);
+        }
+    }
+
+    private async Task ProcessFailedSyncsAsync(CancellationToken stoppingToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var syncFailedRepo = scope.ServiceProvider.GetRequiredService<SyncFailedAssignmentRepository>();
+        var assignmentRepo = scope.ServiceProvider.GetRequiredService<ModeratorAssignmentRepository>();
+        var mumbleSync = scope.ServiceProvider.GetRequiredService<IMumbleGroupSyncService>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<SyncRetryBackgroundService>>();
+
+        var pending = await syncFailedRepo.GetPendingAsync();
+        if (pending.Count == 0) return;
+
+        logger.LogInformation("Processing {Count} pending sync failures", pending.Count);
+
+        foreach (var failed in pending)
+        {
+            if (stoppingToken.IsCancellationRequested) break;
+
+            if (failed.RetryCount >= 5)
+            {
+                logger.LogWarning("Max retries exceeded for sync {Id}, marking as failed permanently", failed.Id);
+                await syncFailedRepo.RemoveAsync(failed.Id);
+                continue;
+            }
+
+            var assignment = await assignmentRepo.GetByIdAsync(failed.AssignmentId);
+            if (assignment == null)
+            {
+                logger.LogInformation("Assignment {Id} no longer exists, removing sync record", failed.AssignmentId);
+                await syncFailedRepo.RemoveAsync(failed.Id);
+                continue;
+            }
+
+            try
+            {
+                var success = await mumbleSync.SyncAssignmentAsync(
+                    failed.AssignmentId,
+                    assignment.UserId,
+                    assignment.ChannelId,
+                    failed.Action == "add");
+
+                if (success)
+                {
+                    logger.LogInformation("Successfully synced assignment {Id} on retry", failed.AssignmentId);
+                    await syncFailedRepo.RemoveAsync(failed.Id);
+                }
+                else
+                {
+                    await syncFailedRepo.IncrementRetryAsync(failed.Id, "Retry failed");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error retrying sync {Id}", failed.Id);
+                await syncFailedRepo.IncrementRetryAsync(failed.Id, ex.Message);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register hosted service in Program.cs**
+
+```csharp
+services.AddHostedService<SyncRetryBackgroundService>();
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Server/Moderator/SyncRetryBackgroundService.cs src/Brmble.Server/Program.cs
+git commit -m "feat: add sync retry background service"
+```
+
+---
+
+## Task 11: Integration Tests
+
+**Files:**
+- Create: `tests/Brmble.Server.Tests/ModeratorServiceIntegrationTests.cs`
+
+- [ ] **Step 1: Write integration test**
+
+Create `tests/Brmble.Server.Tests/ModeratorServiceIntegrationTests.cs`:
+
+```csharp
+using Brmble.Server.Data;
+using Brmble.Server.Moderator;
+using Moq;
+using Xunit;
+
+namespace Brmble.Server.Tests;
+
+public class ModeratorServiceIntegrationTests
+{
+    private readonly Database _db;
+    private readonly ModeratorRoleRepository _roleRepo;
+    private readonly ModeratorAssignmentRepository _assignmentRepo;
+    private readonly SyncFailedAssignmentRepository _syncFailedRepo;
+    private readonly Mock<IMumbleGroupSyncService> _mumbleSyncMock;
+    private readonly ModeratorService _service;
+
+    public ModeratorServiceIntegrationTests()
+    {
+        _db = new Database("DataSource=:memory:");
+        _db.Initialize();
+        _roleRepo = new ModeratorRoleRepository(_db);
+        _assignmentRepo = new ModeratorAssignmentRepository(_db);
+        _syncFailedRepo = new SyncFailedAssignmentRepository(_db);
+        _mumbleSyncMock = new Mock<IMumbleGroupSyncService>();
+        
+        var logger = new Microsoft.Extensions.Logging.Abstractions.NullLogger<ModeratorService>();
+        _service = new ModeratorService(
+            _roleRepo,
+            _assignmentRepo,
+            _syncFailedRepo,
+            _mumbleSyncMock.Object,
+            logger);
+    }
+
+    [Fact]
+    public async Task CreateAndAssignModerator_SyncsToMumble()
+    {
+        // Arrange
+        var role = await _service.CreateRoleAsync("Test Mod", ModeratorPermission.Kick);
+        _mumbleSyncMock.Setup(x => x.SyncAssignmentAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), true))
+            .ReturnsAsync(true);
+
+        // Act
+        var assignment = await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+
+        // Assert
+        Assert.NotNull(assignment);
+        _mumbleSyncMock.Verify(x => x.SyncAssignmentAsync(
+            assignment.Id, 123, 5, true), Times.Once);
+    }
+
+    [Fact]
+    public async Task RemoveModerator_SyncsToMumble()
+    {
+        // Arrange
+        var role = await _service.CreateRoleAsync("Test Mod", ModeratorPermission.Kick);
+        _mumbleSyncMock.Setup(x => x.SyncAssignmentAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>()))
+            .ReturnsAsync(true);
+        var assignment = await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+
+        _mumbleSyncMock.Invocations.Clear();
+
+        // Act
+        await _service.RemoveModeratorAsync(assignment.Id);
+
+        // Assert
+        _mumbleSyncMock.Verify(x => x.SyncAssignmentAsync(
+            assignment.Id, 123, 5, false), Times.Once);
+    }
+
+    [Fact]
+    public async Task FailedSync_QueuesForRetry()
+    {
+        // Arrange
+        var role = await _service.CreateRoleAsync("Test Mod", ModeratorPermission.Kick);
+        _mumbleSyncMock.Setup(x => x.SyncAssignmentAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), true))
+            .ReturnsAsync(false);
+
+        // Act
+        await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+
+        // Assert
+        var pending = await _syncFailedRepo.GetPendingAsync();
+        Assert.Single(pending);
+        Assert.Equal("add", pending[0].Action);
+    }
+
+    [Fact]
+    public async Task GetUserPermissionsForChannel_ReturnsCorrectPermissions()
+    {
+        // Arrange
+        var role = await _service.CreateRoleAsync("Full Mod", 
+            ModeratorPermission.Kick | ModeratorPermission.DenyEnter | ModeratorPermission.RenameChannel);
+        await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+
+        // Act
+        var perms = await _service.GetUserPermissionsForChannelAsync(123, 5);
+
+        // Assert
+        Assert.Equal(ModeratorPermission.Kick | ModeratorPermission.DenyEnter | ModeratorPermission.RenameChannel, perms);
+    }
+
+    [Fact]
+    public async Task GetUserPermissionsForChannel_NoAssignment_ReturnsNone()
+    {
+        // Act
+        var perms = await _service.GetUserPermissionsForChannelAsync(999, 5);
+
+        // Assert
+        Assert.Equal(ModeratorPermission.None, perms);
+    }
+
+    [Fact]
+    public async Task CleanupChannelAssignments_DeletesAllAssignments()
+    {
+        // Arrange
+        var role = await _service.CreateRoleAsync("Test Mod", ModeratorPermission.Kick);
+        _mumbleSyncMock.Setup(x => x.SyncAssignmentAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>()))
+            .ReturnsAsync(true);
+        
+        await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 1, assignedBy: 1);
+        await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 2, assignedBy: 1);
+        await _service.AssignModeratorAsync(role.Id, channelId: 6, userId: 1, assignedBy: 1);
+
+        // Act
+        await _service.CleanupChannelAssignmentsAsync(5);
+
+        // Assert
+        var remaining = await _service.GetChannelModeratorsAsync(5);
+        Assert.Empty(remaining);
+        
+        var otherChannel = await _service.GetChannelModeratorsAsync(6);
+        Assert.Single(otherChannel);
+    }
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "ModeratorServiceIntegrationTests"
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Brmble.Server.Tests/ModeratorServiceIntegrationTests.cs
+git commit -m "test: add moderator service integration tests"
+```
+
+---
+
+## Verification
+
+After all tasks complete, run the full test suite:
+
+```bash
+dotnet build
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj
+```
+
+Build the frontend:
+
+```bash
+cd src/Brmble.Web && npm run build
+```

--- a/docs/superpowers/specs/2026-03-30-channel-moderator-acl-design.md
+++ b/docs/superpowers/specs/2026-03-30-channel-moderator-acl-design.md
@@ -111,11 +111,21 @@ Confirmation to UI
    - Admin can force re-sync from the channel edit UI
    - Shows sync status per channel: "synced", "pending", "failed"
 
+### Channel Deletion Cleanup
+
+When a channel is deleted in Brmble:
+
+1. Delete all `ModeratorAssignment` records where `channel_id` matches
+2. Send command to Mumble to remove the `brmble_mod_<channelId>` ACL group
+3. Log deletion for audit purposes
+
+If Mumble cleanup fails, log error and add to retry queue (similar to sync failures above).
+
 ## Permission Enforcement
 
 ### Dual-Validation Flow
 
-1. Client sends moderation action (kick, ban, rename, etc.)
+1. Client sends moderation action (kick, deny-enter, rename, etc.)
 2. Server extracts: requesting user, target channel, action type
 3. **Brmble validation:**
    - Query `ModeratorAssignment` for user + channel
@@ -127,6 +137,16 @@ Confirmation to UI
 5. **Decision:**
    - Both pass → Execute action
    - Either fails → Reject with 403 Forbidden
+
+### Admin Override
+
+Global admins always bypass moderator permission checks. The PermissionEnforcer checks admin status **before** evaluating moderator role permissions:
+
+1. Is requesting user a global admin?
+   - Yes → Allow action, skip remaining checks
+   - No → Continue to moderator permission validation
+
+This ensures an admin assigning themselves a lower moderator role cannot accidentally lock themselves out of admin capabilities.
 
 ### Actions and Required Permissions
 

--- a/docs/superpowers/specs/2026-03-30-channel-moderator-acl-design.md
+++ b/docs/superpowers/specs/2026-03-30-channel-moderator-acl-design.md
@@ -1,0 +1,219 @@
+# Channel Moderator ACL System
+
+## Overview
+
+Implement a channel-level moderator permission system where admins can assign users as moderators for specific voice channels. Moderators gain configurable powers (kick, ban, rename, password, description) scoped to their assigned channels. The system uses dual-validation (Brmble DB + Mumble) for robust permission enforcement.
+
+## Background
+
+Brmble currently has basic permission bits for channels but lacks a moderator assignment system. This feature enables:
+
+- Admins to define moderator roles with specific permissions
+- Assigning registered users as moderators for specific channels
+- Moderators to perform channel management actions within their granted scope
+- Consistent permission enforcement across Brmble and Mumble
+
+## Data Model
+
+### Database Tables
+
+**ModeratorRole**
+| Column | Type | Description |
+|--------|------|-------------|
+| id | UUID | Primary key |
+| name | TEXT | Role display name (e.g., "Senior Moderator") |
+| permissions | INTEGER | Bitmask of allowed actions |
+| created_at | TIMESTAMP | Creation timestamp |
+| updated_at | TIMESTAMP | Last update timestamp |
+
+**ModeratorAssignment**
+| Column | Type | Description |
+|--------|------|-------------|
+| id | UUID | Primary key |
+| role_id | UUID | FK → ModeratorRole |
+| channel_id | INTEGER | Mumble channel ID |
+| user_id | INTEGER | Mumble user session ID |
+| assigned_by | INTEGER | User ID who made the assignment |
+| assigned_at | TIMESTAMP | Assignment timestamp |
+
+### Permission Bits
+
+```
+Kick          = 0x001  (1)
+Ban           = 0x002  (2)
+RenameChannel = 0x004  (4)
+SetPassword   = 0x008  (8)
+EditDesc      = 0x010  (16)
+```
+
+### Constraints
+
+- Only registered Mumble users can be assigned as moderators
+- A user can have multiple assignments (different channels, different roles)
+- The same role can be assigned to multiple users per channel
+
+## Architecture
+
+### Components
+
+1. **ModeratorStore** - Server-side service managing CRUD for roles and assignments
+2. **MumbleGroupSync** - Syncs moderator assignments to Mumble ACL groups
+3. **PermissionEnforcer** - Dual-validation middleware for moderation actions
+4. **Frontend UI** - Channel edit window with "Manage Moderators" tab
+
+### Data Flow
+
+```
+Admin Action (UI)
+    ↓
+Brmble.Server (ModeratorStore)
+    ↓
+Database (ModeratorRole, ModeratorAssignment)
+    ↓
+MumbleGroupSync (sync to Mumble ACL group brmble_mod_<channelId>)
+    ↓
+Confirmation to UI
+```
+
+### Mumble Group Sync
+
+**Group naming:** `brmble_mod_<channelId>` (e.g., `brmble_mod_5`)
+
+**Sync triggers:**
+- Assignment created → Add user to Mumble group
+- Assignment deleted → Remove user from Mumble group
+- Role permissions changed → No sync needed (permissions enforced by Brmble, not Mumble ACL)
+
+**Scope:** Groups are applied on the specific channel only, not inherited by child channels.
+
+## Permission Enforcement
+
+### Dual-Validation Flow
+
+1. Client sends moderation action (kick, ban, rename, etc.)
+2. Server extracts: requesting user, target channel, action type
+3. **Brmble validation:**
+   - Query `ModeratorAssignment` for user + channel
+   - Get associated `ModeratorRole.permissions`
+   - Check required permission bit is set
+4. **Mumble validation:**
+   - Send permission query to Mumble for the channel
+   - Verify user has equivalent Mumble ACL permissions
+5. **Decision:**
+   - Both pass → Execute action
+   - Either fails → Reject with 403 Forbidden
+
+### Actions and Required Permissions
+
+| Action | Permission Bit |
+|--------|----------------|
+| Kick user from channel | Kick (0x001) |
+| Ban user from channel | Ban (0x002) |
+| Rename channel | RenameChannel (0x004) |
+| Set/clear channel password | SetPassword (0x008) |
+| Edit channel description | EditDesc (0x010) |
+
+## API Endpoints
+
+### Role Management (Admin only)
+
+**GET /api/admin/moderator-roles**
+- Returns all moderator roles
+
+**POST /api/admin/moderator-roles**
+- Body: `{ name: string, permissions: number }`
+- Creates new role
+
+**PUT /api/admin/moderator-roles/:id**
+- Body: `{ name?: string, permissions?: number }`
+- Updates existing role
+
+**DELETE /api/admin/moderator-roles/:id**
+- Deletes role (cascades to assignments)
+
+### Assignment Management
+
+**GET /api/channels/:channelId/moderators**
+- Returns moderators for a channel
+- Accessible by: admins, moderators of that channel
+
+**POST /api/channels/:channelId/moderators**
+- Body: `{ userId: number, roleId: UUID }`
+- Creates assignment
+- Admin only
+- Syncs to Mumble group
+
+**DELETE /api/channels/:channelId/moderators/:assignmentId**
+- Removes assignment
+- Admin only
+- Syncs to Mumble group
+
+### Moderation Actions (Permission-gated)
+
+**POST /api/voice/kick**
+- Body: `{ userId: number, channelId: number, reason?: string }`
+
+**POST /api/voice/ban**
+- Body: `{ userId: number, channelId: number, duration?: number }`
+
+**PATCH /api/channels/:channelId**
+- Body: `{ name?: string, password?: string | null, description?: string }`
+
+## Frontend Components
+
+### Channel Edit Window (Brmble-style modal)
+
+- Accessed via right-click channel → "Edit"
+- Tabbed interface: General, Manage Moderators, ...
+
+### Manage Moderators Tab
+
+**Admin view:**
+- List of current moderators with role names
+- Add moderator button → opens user search + role dropdown
+- Remove button per moderator entry
+- Create/edit role buttons
+
+**Moderator view (read-only):**
+- Same list displayed
+- All controls disabled/hidden
+- Banner or indicator: "View only - contact admin to modify"
+
+### Moderator Role Modal
+
+- Role name input
+- Permission checkboxes:
+  - [ ] Kick users
+  - [ ] Ban users
+  - [ ] Rename channel
+  - [ ] Set/change channel password
+  - [ ] Edit channel description
+- Save/Cancel buttons
+
+### Contextual Actions
+
+Users with moderator permissions see additional options:
+- Right-click user in channel → Kick, Ban (if permitted)
+- Channel edit cog → Edit Name, Password, Description (if permitted)
+
+## Security Considerations
+
+1. **Registered users only** - Assignments limited to registered Mumble users
+2. **Channel scoping** - Moderators can only act on channels they're assigned to
+3. **Dual validation** - Both Brmble and Mumble must agree on permissions
+4. **Audit logging** - Log all assignment changes and moderation actions
+5. **Input validation** - Validate all IDs, UUIDs, and permission bits server-side
+
+## Dependencies
+
+- Existing MumbleSharp integration
+- Existing permission bits in `usePermissions.ts`
+- New server-side tables in Brmble database
+- New API endpoints in Brmble.Server
+
+## Out of Scope
+
+- Meta groups (@all, @in, @out, @~sub) - not implementing Mumble's full ACL system
+- Channel inheritance for moderator assignments
+- ACL rule evaluation order - using simple bitmask check
+- Moderator role templates/presets beyond basic CRUD

--- a/docs/superpowers/specs/2026-03-30-channel-moderator-acl-design.md
+++ b/docs/superpowers/specs/2026-03-30-channel-moderator-acl-design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Implement a channel-level moderator permission system where admins can assign users as moderators for specific voice channels. Moderators gain configurable powers (kick, ban, rename, password, description) scoped to their assigned channels. The system uses dual-validation (Brmble DB + Mumble) for robust permission enforcement.
+Implement a channel-level moderator permission system where admins can assign users as moderators for specific voice channels. Moderators gain configurable powers (kick, deny-enter, rename, password, description) scoped to their assigned channels. The system uses dual-validation (Brmble DB + Mumble) for robust permission enforcement.
 
 ## Background
 
@@ -32,19 +32,21 @@ Brmble currently has basic permission bits for channels but lacks a moderator as
 | id | UUID | Primary key |
 | role_id | UUID | FK → ModeratorRole |
 | channel_id | INTEGER | Mumble channel ID |
-| user_id | INTEGER | Mumble user session ID |
-| assigned_by | INTEGER | User ID who made the assignment |
+| user_id | INTEGER | Mumble registration ID (permanent ID assigned when a user registers with the server) |
+| assigned_by | INTEGER | User registration ID who made the assignment |
 | assigned_at | TIMESTAMP | Assignment timestamp |
 
 ### Permission Bits
 
 ```
 Kick          = 0x001  (1)
-Ban           = 0x002  (2)
+DenyEnter     = 0x002  (2)
 RenameChannel = 0x004  (4)
 SetPassword   = 0x008  (8)
 EditDesc      = 0x010  (16)
 ```
+
+**Note:** `DenyEnter` denies a user from entering the channel. This is a channel-level restriction, not a server-wide ban.
 
 ### Constraints
 
@@ -86,6 +88,29 @@ Confirmation to UI
 
 **Scope:** Groups are applied on the specific channel only, not inherited by child channels.
 
+### Error Handling
+
+**Sync Failure Scenarios:**
+
+1. **Brmble DB succeeds, Mumble sync fails:**
+   - DB transaction is already committed
+   - Log error with full context (assignment details, error message)
+   - Add to background retry queue
+   - UI shows success but with warning: "Assignment saved, Mumble sync pending"
+
+2. **Retry mechanism:**
+   - Background service polls failed syncs every 30 seconds
+   - Exponential backoff: 30s, 60s, 120s, 240s (max 5 retries)
+   - After max retries, mark as "sync_failed" and alert admins
+
+3. **Mumble reconnection:**
+   - On Mumble connection restored, trigger immediate sync of all pending assignments
+   - Clear retry counters on successful sync
+
+4. **Manual override:**
+   - Admin can force re-sync from the channel edit UI
+   - Shows sync status per channel: "synced", "pending", "failed"
+
 ## Permission Enforcement
 
 ### Dual-Validation Flow
@@ -108,7 +133,7 @@ Confirmation to UI
 | Action | Permission Bit |
 |--------|----------------|
 | Kick user from channel | Kick (0x001) |
-| Ban user from channel | Ban (0x002) |
+| Deny user from entering channel | DenyEnter (0x002) |
 | Rename channel | RenameChannel (0x004) |
 | Set/clear channel password | SetPassword (0x008) |
 | Edit channel description | EditDesc (0x010) |
@@ -153,8 +178,9 @@ Confirmation to UI
 **POST /api/voice/kick**
 - Body: `{ userId: number, channelId: number, reason?: string }`
 
-**POST /api/voice/ban**
-- Body: `{ userId: number, channelId: number, duration?: number }`
+**POST /api/voice/deny-enter**
+- Body: `{ userId: number, channelId: number }`
+- Adds user to channel's deny list (prevents entry)
 
 **PATCH /api/channels/:channelId**
 - Body: `{ name?: string, password?: string | null, description?: string }`
@@ -184,7 +210,7 @@ Confirmation to UI
 - Role name input
 - Permission checkboxes:
   - [ ] Kick users
-  - [ ] Ban users
+  - [ ] Deny user enter
   - [ ] Rename channel
   - [ ] Set/change channel password
   - [ ] Edit channel description
@@ -193,7 +219,7 @@ Confirmation to UI
 ### Contextual Actions
 
 Users with moderator permissions see additional options:
-- Right-click user in channel → Kick, Ban (if permitted)
+- Right-click user in channel → Kick, Deny Enter (if permitted)
 - Channel edit cog → Edit Name, Password, Description (if permitted)
 
 ## Security Considerations
@@ -203,6 +229,12 @@ Users with moderator permissions see additional options:
 3. **Dual validation** - Both Brmble and Mumble must agree on permissions
 4. **Audit logging** - Log all assignment changes and moderation actions
 5. **Input validation** - Validate all IDs, UUIDs, and permission bits server-side
+
+## Technical Notes
+
+1. **Permissions bitmask storage:** The `permissions` column uses INTEGER. With 5 bits defined, this fits in a standard 32-bit integer. If expanding beyond 31 permissions in the future, change to BIGINT.
+
+2. **Mumble group naming:** Group names follow `brmble_mod_<channelId>` format. Mumble groups are case-sensitive and have a length limit (typically 32 or 64 characters depending on version/DB backend). The generated names are well within these limits.
 
 ## Dependencies
 

--- a/src/Brmble.Client/Bridge/NativeBridge.cs
+++ b/src/Brmble.Client/Bridge/NativeBridge.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Web.WebView2.Core;
+using Brmble.Client.Services.Moderator;
 
 namespace Brmble.Client.Bridge;
 
@@ -34,6 +35,8 @@ public sealed class NativeBridge
     private readonly Dictionary<string, List<Func<JsonElement, Task>>> _handlers = new();
     private IntPtr _hwnd;
     private readonly ConcurrentQueue<string> _pendingMessages = new();
+    private readonly ModeratorService _moderatorService;
+    private int _localUserId;
 
     /// <summary>
     /// Occurs when a message is received from the frontend.
@@ -45,11 +48,107 @@ public sealed class NativeBridge
     /// </summary>
     /// <param name="webView">The WebView2 instance for message communication.</param>
     /// <param name="hwnd">The window handle for UI thread marshaling.</param>
-    public NativeBridge(CoreWebView2 webView, IntPtr hwnd)
+    /// <param name="moderatorService">The moderator service for handling moderator operations.</param>
+    public NativeBridge(CoreWebView2 webView, IntPtr hwnd, ModeratorService moderatorService)
     {
         _webView = webView;
         _hwnd = hwnd;
+        _moderatorService = moderatorService;
         _webView.WebMessageReceived += OnWebMessageReceived;
+    }
+
+    public void SetLocalUserId(int userId)
+    {
+        _localUserId = userId;
+    }
+
+    public void RegisterModeratorHandlers()
+    {
+        RegisterHandler("moderator.getRoles", async _ =>
+        {
+            var roles = await _moderatorService.GetRolesAsync();
+            Send("moderator.roles", roles.Select(r => new {
+                r.Id,
+                r.Name,
+                Permissions = (int)r.Permissions
+            }));
+        });
+
+        RegisterHandler("moderator.createRole", async data =>
+        {
+            if (data.ValueKind == JsonValueKind.Undefined || data.ValueKind == JsonValueKind.Null) return;
+            var name = data.GetProperty("name").GetString() ?? "";
+            var permissions = (ModeratorPermissions)data.GetProperty("permissions").GetInt32();
+            var role = await _moderatorService.CreateRoleAsync(name, permissions);
+            Send("moderator.roleCreated", new { role.Id });
+        });
+
+        RegisterHandler("moderator.updateRole", async data =>
+        {
+            if (data.ValueKind == JsonValueKind.Undefined || data.ValueKind == JsonValueKind.Null) return;
+            var id = data.GetProperty("id").GetString();
+            string? name = null;
+            ModeratorPermissions? permissions = null;
+            if (data.TryGetProperty("name", out var nameEl) && nameEl.ValueKind != JsonValueKind.Null)
+                name = nameEl.GetString();
+            if (data.TryGetProperty("permissions", out var permEl) && permEl.ValueKind != JsonValueKind.Null)
+                permissions = (ModeratorPermissions)permEl.GetInt32();
+            await _moderatorService.UpdateRoleAsync(id!, name, permissions);
+            Send("moderator.roleUpdated", new { id });
+        });
+
+        RegisterHandler("moderator.deleteRole", async data =>
+        {
+            if (data.ValueKind == JsonValueKind.Undefined || data.ValueKind == JsonValueKind.Null) return;
+            var id = data.GetProperty("id").GetString();
+            await _moderatorService.DeleteRoleAsync(id!);
+            Send("moderator.roleDeleted", new { id });
+        });
+
+        RegisterHandler("moderator.getChannelModerators", async data =>
+        {
+            if (data.ValueKind == JsonValueKind.Undefined || data.ValueKind == JsonValueKind.Null) return;
+            var channelId = data.GetProperty("channelId").GetUInt32();
+            var moderators = await _moderatorService.GetChannelModeratorsAsync((int)channelId);
+            Send("moderator.channelModerators", moderators.Select(m => new {
+                m.Id,
+                m.UserId,
+                m.RoleId,
+                m.RoleName,
+                RolePermissions = (int)m.RolePermissions,
+                m.AssignedAt
+            }));
+        });
+
+        RegisterHandler("moderator.assign", async data =>
+        {
+            if (data.ValueKind == JsonValueKind.Undefined || data.ValueKind == JsonValueKind.Null) return;
+            var channelId = data.GetProperty("channelId").GetUInt32();
+            var roleId = data.GetProperty("roleId").GetString();
+            var userId = data.GetProperty("userId").GetInt32();
+            var assignment = await _moderatorService.AssignModeratorAsync(roleId!, (int)channelId, userId);
+            Send("moderator.assigned", new { assignment.Id });
+        });
+
+        RegisterHandler("moderator.remove", async data =>
+        {
+            if (data.ValueKind == JsonValueKind.Undefined || data.ValueKind == JsonValueKind.Null) return;
+            var assignmentId = data.GetProperty("assignmentId").GetString();
+            var channelId = data.TryGetProperty("channelId", out var chEl) ? (int)chEl.GetUInt32() : 0;
+            await _moderatorService.RemoveModeratorAsync(assignmentId!, channelId);
+            Send("moderator.removed", new { assignmentId });
+        });
+
+        RegisterHandler("moderator.getCurrentUserPermissions", async data =>
+        {
+            if (data.ValueKind == JsonValueKind.Undefined || data.ValueKind == JsonValueKind.Null) return;
+            var channelId = data.GetProperty("channelId").GetUInt32();
+            var permissions = await _moderatorService.GetUserPermissionsForChannelAsync(_localUserId, (int)channelId);
+            Send("moderator.currentUserPermissions", new {
+                channelId,
+                permissions = (int)permissions
+            });
+        });
     }
 
     /// <summary>

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -10,6 +10,7 @@ using Brmble.Client.Services.Certificate;
 using Brmble.Client.Services.AppConfig;
 using Brmble.Client.Services.Voice;
 using Brmble.Client.Services.Update;
+using Brmble.Client.Services.Moderator;
 
 namespace Brmble.Client;
 
@@ -24,6 +25,7 @@ static class Program
     private static CertificateService? _certService;
     private static MumbleAdapter? _mumbleClient;
     private static UpdateService? _updateService;
+    private static ModeratorService? _moderatorService;
     private static IntPtr _hwnd;
     private static volatile bool _muted;
     private static volatile bool _deafened;
@@ -225,7 +227,9 @@ static class Program
             _controller.CoreWebView2.SetVirtualHostNameToFolderMapping(
                 "brmble.local", webRoot, CoreWebView2HostResourceAccessKind.Allow);
 
-            _bridge = new NativeBridge(_controller.CoreWebView2, hwnd);
+            _moderatorService = new ModeratorService(new HttpClient());
+            _bridge = new NativeBridge(_controller.CoreWebView2, hwnd, _moderatorService);
+            _bridge.RegisterModeratorHandlers();
 
             // Send zoom percentage to the frontend whenever the user zooms (Ctrl+scroll)
             // and debounce-save the zoom level to config for persistence across restarts.
@@ -280,6 +284,7 @@ static class Program
 
                 if (entry is null) return;
                 _appConfigService.UpdateServer(entry with { ApiUrl = discoveredUrl });
+                _moderatorService?.SetBaseUrl(discoveredUrl);
             };
 
             SetupBridgeHandlers();
@@ -405,6 +410,9 @@ static class Program
         var servers = _appConfigService.GetServers();
         var server = servers.FirstOrDefault(s => s.Id == targetId);
         if (server is null) return;
+
+        if (!string.IsNullOrEmpty(server.ApiUrl))
+            _moderatorService?.SetBaseUrl(server.ApiUrl);
 
         // Trigger connection via bridge — same path as manual connect
         _bridge!.Send("voice.autoConnect", new

--- a/src/Brmble.Client/Services/Moderator/ModeratorPermissions.cs
+++ b/src/Brmble.Client/Services/Moderator/ModeratorPermissions.cs
@@ -1,0 +1,12 @@
+namespace Brmble.Client.Services.Moderator;
+
+[Flags]
+public enum ModeratorPermissions
+{
+    None = 0,
+    Kick = 0x001,
+    DenyEnter = 0x002,
+    RenameChannel = 0x004,
+    SetPassword = 0x008,
+    EditDesc = 0x010,
+}

--- a/src/Brmble.Client/Services/Moderator/ModeratorService.cs
+++ b/src/Brmble.Client/Services/Moderator/ModeratorService.cs
@@ -1,0 +1,102 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace Brmble.Client.Services.Moderator;
+
+public class ModeratorRole
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public ModeratorPermissions Permissions { get; set; }
+}
+
+public class ModeratorAssignment
+{
+    public string Id { get; set; } = string.Empty;
+    public int UserId { get; set; }
+    public string RoleId { get; set; } = string.Empty;
+    public int ChannelId { get; set; }
+    public DateTime AssignedAt { get; set; }
+}
+
+public class ModeratorAssignmentWithRole : ModeratorAssignment
+{
+    public string RoleName { get; set; } = string.Empty;
+    public ModeratorPermissions RolePermissions { get; set; }
+}
+
+public class ModeratorService
+{
+    private readonly HttpClient _http;
+    private string? _baseUrl;
+
+    public ModeratorService(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public void SetBaseUrl(string? baseUrl)
+    {
+        _baseUrl = baseUrl?.TrimEnd('/');
+    }
+
+    public async Task<IReadOnlyList<ModeratorRole>> GetRolesAsync()
+    {
+        if (_baseUrl == null) return [];
+        var response = await _http.GetAsync($"{_baseUrl}/api/admin/moderator-roles");
+        response.EnsureSuccessStatusCode();
+        var roles = await response.Content.ReadFromJsonAsync<List<ModeratorRole>>();
+        return roles ?? [];
+    }
+
+    public async Task<ModeratorRole> CreateRoleAsync(string name, ModeratorPermissions permissions)
+    {
+        var response = await _http.PostAsJsonAsync($"{_baseUrl}/api/admin/moderator-roles", new { Name = name, Permissions = (int)permissions });
+        response.EnsureSuccessStatusCode();
+        var role = await response.Content.ReadFromJsonAsync<ModeratorRole>();
+        return role ?? throw new InvalidOperationException("Failed to create role");
+    }
+
+    public async Task UpdateRoleAsync(string id, string? name, ModeratorPermissions? permissions)
+    {
+        var response = await _http.PutAsJsonAsync($"{_baseUrl}/api/admin/moderator-roles/{id}", new { Name = name, Permissions = permissions.HasValue ? (int)permissions.Value : (int?)null });
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteRoleAsync(string id)
+    {
+        var response = await _http.DeleteAsync($"{_baseUrl}/api/admin/moderator-roles/{id}");
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetChannelModeratorsAsync(int channelId)
+    {
+        if (_baseUrl == null) return [];
+        var response = await _http.GetAsync($"{_baseUrl}/api/channels/{channelId}/moderators");
+        response.EnsureSuccessStatusCode();
+        var moderators = await response.Content.ReadFromJsonAsync<List<ModeratorAssignmentWithRole>>();
+        return moderators ?? [];
+    }
+
+    public async Task<ModeratorAssignment> AssignModeratorAsync(string roleId, int channelId, int userId)
+    {
+        var response = await _http.PostAsJsonAsync($"{_baseUrl}/api/channels/{channelId}/moderators", new { RoleId = roleId, UserId = userId });
+        response.EnsureSuccessStatusCode();
+        var assignment = await response.Content.ReadFromJsonAsync<ModeratorAssignment>();
+        return assignment ?? throw new InvalidOperationException("Failed to assign moderator");
+    }
+
+    public async Task RemoveModeratorAsync(string assignmentId, int channelId)
+    {
+        var response = await _http.DeleteAsync($"{_baseUrl}/api/channels/{channelId}/moderators/{assignmentId}");
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<ModeratorPermissions> GetUserPermissionsForChannelAsync(int userId, int channelId)
+    {
+        if (_baseUrl == null) return ModeratorPermissions.None;
+        var moderators = await GetChannelModeratorsAsync(channelId);
+        var userMod = moderators.FirstOrDefault(m => m.UserId == userId);
+        return userMod?.RolePermissions ?? ModeratorPermissions.None;
+    }
+}

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -2438,7 +2438,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 comment = u.Comment,
                 certHash = u.CertificateHash,
                 matrixUserId = hasMap ? sm.MatrixUserId : _userMappings.GetValueOrDefault(u.Name),
-                isBrmbleClient = hasMap && sm.IsBrmbleClient
+                isBrmbleClient = hasMap && sm.IsBrmbleClient,
+                userId = u.RegisteredUserId
             };
         }).ToList();
 

--- a/src/Brmble.Server/Data/Database.cs
+++ b/src/Brmble.Server/Data/Database.cs
@@ -61,5 +61,53 @@ public class Database
             "SELECT COUNT(*) FROM pragma_table_info('users') WHERE name='texture_hash'");
         if (hasTextureHash == 0)
             conn.Execute("ALTER TABLE users ADD COLUMN texture_hash TEXT");
+
+        // Migrate: add moderator_roles table
+        var hasModeratorRoles = conn.ExecuteScalar<int>(
+            "SELECT COUNT(*) FROM pragma_table_info('moderator_roles') WHERE name='id'");
+        if (hasModeratorRoles == 0)
+            conn.Execute("""
+                CREATE TABLE moderator_roles (
+                    id          TEXT PRIMARY KEY,
+                    name        TEXT NOT NULL,
+                    permissions INTEGER NOT NULL DEFAULT 0,
+                    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+            """);
+
+        // Migrate: add moderator_assignments table
+        var hasModeratorAssignments = conn.ExecuteScalar<int>(
+            "SELECT COUNT(*) FROM pragma_table_info('moderator_assignments') WHERE name='id'");
+        if (hasModeratorAssignments == 0)
+            conn.Execute("""
+                CREATE TABLE moderator_assignments (
+                    id          TEXT PRIMARY KEY,
+                    role_id     TEXT NOT NULL,
+                    channel_id  INTEGER NOT NULL,
+                    user_id     INTEGER NOT NULL,
+                    assigned_by INTEGER NOT NULL,
+                    assigned_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (role_id) REFERENCES moderator_roles(id) ON DELETE CASCADE,
+                    UNIQUE (channel_id, user_id)
+                )
+            """);
+
+        // Migrate: add sync_failed_assignments table for retry queue
+        var hasSyncFailed = conn.ExecuteScalar<int>(
+            "SELECT COUNT(*) FROM pragma_table_info('sync_failed_assignments') WHERE name='id'");
+        if (hasSyncFailed == 0)
+            conn.Execute("""
+                CREATE TABLE sync_failed_assignments (
+                    id              TEXT PRIMARY KEY,
+                    assignment_id    TEXT NOT NULL,
+                    action          TEXT NOT NULL,
+                    error_message   TEXT,
+                    retry_count     INTEGER NOT NULL DEFAULT 0,
+                    next_retry_at   DATETIME NOT NULL,
+                    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (assignment_id) REFERENCES moderator_assignments(id) ON DELETE CASCADE
+                )
+            """);
     }
 }

--- a/src/Brmble.Server/Data/Database.cs
+++ b/src/Brmble.Server/Data/Database.cs
@@ -63,9 +63,23 @@ public class Database
             conn.Execute("ALTER TABLE users ADD COLUMN texture_hash TEXT");
 
         // Migrate: add moderator_roles table
-        var hasModeratorRoles = conn.ExecuteScalar<int>(
-            "SELECT COUNT(*) FROM pragma_table_info('moderator_roles') WHERE name='id'");
-        if (hasModeratorRoles == 0)
+        try
+        {
+            var hasModeratorRoles = conn.ExecuteScalar<int>(
+                "SELECT COUNT(*) FROM pragma_table_info('moderator_roles') WHERE name='id'");
+            if (hasModeratorRoles == 0)
+                conn.Execute("""
+                    CREATE TABLE moderator_roles (
+                        id          TEXT PRIMARY KEY,
+                        name        TEXT NOT NULL,
+                        permissions INTEGER NOT NULL DEFAULT 0,
+                        created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+                    )
+                """);
+        }
+        catch (SqliteException)
+        {
             conn.Execute("""
                 CREATE TABLE moderator_roles (
                     id          TEXT PRIMARY KEY,
@@ -75,11 +89,29 @@ public class Database
                     updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
                 )
             """);
+        }
 
         // Migrate: add moderator_assignments table
-        var hasModeratorAssignments = conn.ExecuteScalar<int>(
-            "SELECT COUNT(*) FROM pragma_table_info('moderator_assignments') WHERE name='id'");
-        if (hasModeratorAssignments == 0)
+        try
+        {
+            var hasModeratorAssignments = conn.ExecuteScalar<int>(
+                "SELECT COUNT(*) FROM pragma_table_info('moderator_assignments') WHERE name='id'");
+            if (hasModeratorAssignments == 0)
+                conn.Execute("""
+                    CREATE TABLE moderator_assignments (
+                        id          TEXT PRIMARY KEY,
+                        role_id     TEXT NOT NULL,
+                        channel_id  INTEGER NOT NULL,
+                        user_id     INTEGER NOT NULL,
+                        assigned_by INTEGER NOT NULL,
+                        assigned_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        FOREIGN KEY (role_id) REFERENCES moderator_roles(id) ON DELETE CASCADE,
+                        UNIQUE (channel_id, user_id)
+                    )
+                """);
+        }
+        catch (SqliteException)
+        {
             conn.Execute("""
                 CREATE TABLE moderator_assignments (
                     id          TEXT PRIMARY KEY,
@@ -92,11 +124,29 @@ public class Database
                     UNIQUE (channel_id, user_id)
                 )
             """);
+        }
 
         // Migrate: add sync_failed_assignments table for retry queue
-        var hasSyncFailed = conn.ExecuteScalar<int>(
-            "SELECT COUNT(*) FROM pragma_table_info('sync_failed_assignments') WHERE name='id'");
-        if (hasSyncFailed == 0)
+        try
+        {
+            var hasSyncFailed = conn.ExecuteScalar<int>(
+                "SELECT COUNT(*) FROM pragma_table_info('sync_failed_assignments') WHERE name='id'");
+            if (hasSyncFailed == 0)
+                conn.Execute("""
+                    CREATE TABLE sync_failed_assignments (
+                        id              TEXT PRIMARY KEY,
+                        assignment_id   TEXT NOT NULL,
+                        action          TEXT NOT NULL,
+                        error_message   TEXT,
+                        retry_count     INTEGER NOT NULL DEFAULT 0,
+                        next_retry_at   DATETIME NOT NULL,
+                        created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        FOREIGN KEY (assignment_id) REFERENCES moderator_assignments(id) ON DELETE CASCADE
+                    )
+                """);
+        }
+        catch (SqliteException)
+        {
             conn.Execute("""
                 CREATE TABLE sync_failed_assignments (
                     id              TEXT PRIMARY KEY,
@@ -109,5 +159,6 @@ public class Database
                     FOREIGN KEY (assignment_id) REFERENCES moderator_assignments(id) ON DELETE CASCADE
                 )
             """);
+        }
     }
 }

--- a/src/Brmble.Server/Data/Database.cs
+++ b/src/Brmble.Server/Data/Database.cs
@@ -100,7 +100,7 @@ public class Database
             conn.Execute("""
                 CREATE TABLE sync_failed_assignments (
                     id              TEXT PRIMARY KEY,
-                    assignment_id    TEXT NOT NULL,
+                    assignment_id   TEXT NOT NULL,
                     action          TEXT NOT NULL,
                     error_message   TEXT,
                     retry_count     INTEGER NOT NULL DEFAULT 0,

--- a/src/Brmble.Server/Data/ModeratorAssignmentRepository.cs
+++ b/src/Brmble.Server/Data/ModeratorAssignmentRepository.cs
@@ -1,0 +1,102 @@
+using Dapper;
+using Brmble.Server.Moderator;
+
+namespace Brmble.Server.Data;
+
+public class ModeratorAssignment
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string RoleId { get; set; } = string.Empty;
+    public int ChannelId { get; set; }
+    public int UserId { get; set; }
+    public int AssignedBy { get; set; }
+    public DateTime AssignedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class ModeratorAssignmentWithRole : ModeratorAssignment
+{
+    public string RoleName { get; set; } = string.Empty;
+    public ModeratorPermissions RolePermissions { get; set; }
+}
+
+public class ModeratorAssignmentRepository
+{
+    private readonly Database _db;
+
+    public ModeratorAssignmentRepository(Database db)
+    {
+        _db = db;
+    }
+
+    public async Task<ModeratorAssignment> CreateAsync(string roleId, int channelId, int userId, int assignedBy)
+    {
+        using var conn = _db.CreateConnection();
+        var assignment = new ModeratorAssignment
+        {
+            RoleId = roleId,
+            ChannelId = channelId,
+            UserId = userId,
+            AssignedBy = assignedBy
+        };
+        await conn.ExecuteAsync(
+            @"INSERT INTO moderator_assignments (id, role_id, channel_id, user_id, assigned_by, assigned_at)
+              VALUES (@Id, @RoleId, @ChannelId, @UserId, @AssignedBy, @AssignedAt)",
+            assignment);
+        return assignment;
+    }
+
+    public async Task<ModeratorAssignment?> GetByIdAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        return await conn.QuerySingleOrDefaultAsync<ModeratorAssignment>(
+            "SELECT * FROM moderator_assignments WHERE id = @Id", new { Id = id });
+    }
+
+    public async Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetByChannelAsync(int channelId)
+    {
+        using var conn = _db.CreateConnection();
+        var result = await conn.QueryAsync<ModeratorAssignmentWithRole>(
+            @"SELECT ma.id as Id, ma.role_id as RoleId, ma.channel_id as ChannelId, ma.user_id as UserId, ma.assigned_by as AssignedBy, ma.assigned_at as AssignedAt, mr.name as RoleName, mr.permissions as RolePermissions
+              FROM moderator_assignments ma
+              JOIN moderator_roles mr ON ma.role_id = mr.id
+              WHERE ma.channel_id = @ChannelId
+              ORDER BY mr.name, ma.assigned_at",
+            new { ChannelId = channelId });
+        return result.ToList();
+    }
+
+    public async Task<ModeratorAssignmentWithRole?> GetByUserAndChannelAsync(int userId, int channelId)
+    {
+        using var conn = _db.CreateConnection();
+        return await conn.QuerySingleOrDefaultAsync<ModeratorAssignmentWithRole>(
+            @"SELECT ma.id as Id, ma.role_id as RoleId, ma.channel_id as ChannelId, ma.user_id as UserId, ma.assigned_by as AssignedBy, ma.assigned_at as AssignedAt, mr.name as RoleName, mr.permissions as RolePermissions
+              FROM moderator_assignments ma
+              JOIN moderator_roles mr ON ma.role_id = mr.id
+              WHERE ma.user_id = @UserId AND ma.channel_id = @ChannelId",
+            new { UserId = userId, ChannelId = channelId });
+    }
+
+    public async Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetByChannelAndUserIdsAsync(int channelId, IEnumerable<int> userIds)
+    {
+        using var conn = _db.CreateConnection();
+        var result = await conn.QueryAsync<ModeratorAssignmentWithRole>(
+            @"SELECT ma.id as Id, ma.role_id as RoleId, ma.channel_id as ChannelId, ma.user_id as UserId, ma.assigned_by as AssignedBy, ma.assigned_at as AssignedAt, mr.name as RoleName, mr.permissions as RolePermissions
+              FROM moderator_assignments ma
+              JOIN moderator_roles mr ON ma.role_id = mr.id
+              WHERE ma.channel_id = @ChannelId AND ma.user_id IN @UserIds",
+            new { ChannelId = channelId, UserIds = userIds.ToList() });
+        return result.ToList();
+    }
+
+    public async Task DeleteAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        await conn.ExecuteAsync("DELETE FROM moderator_assignments WHERE id = @Id", new { Id = id });
+    }
+
+    public async Task DeleteByChannelAsync(int channelId)
+    {
+        using var conn = _db.CreateConnection();
+        await conn.ExecuteAsync("DELETE FROM moderator_assignments WHERE channel_id = @ChannelId", new { ChannelId = channelId });
+    }
+}

--- a/src/Brmble.Server/Data/ModeratorAssignmentRepository.cs
+++ b/src/Brmble.Server/Data/ModeratorAssignmentRepository.cs
@@ -49,7 +49,7 @@ public class ModeratorAssignmentRepository
     {
         using var conn = _db.CreateConnection();
         return await conn.QuerySingleOrDefaultAsync<ModeratorAssignment>(
-            "SELECT * FROM moderator_assignments WHERE id = @Id", new { Id = id });
+            "SELECT id as Id, role_id as RoleId, channel_id as ChannelId, user_id as UserId, assigned_by as AssignedBy, assigned_at as AssignedAt FROM moderator_assignments WHERE id = @Id", new { Id = id });
     }
 
     public async Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetByChannelAsync(int channelId)

--- a/src/Brmble.Server/Data/ModeratorRoleRepository.cs
+++ b/src/Brmble.Server/Data/ModeratorRoleRepository.cs
@@ -1,0 +1,64 @@
+using Dapper;
+using Brmble.Server.Moderator;
+
+namespace Brmble.Server.Data;
+
+public class ModeratorRole
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Name { get; set; } = string.Empty;
+    public ModeratorPermissions Permissions { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class ModeratorRoleRepository
+{
+    private readonly Database _db;
+
+    public ModeratorRoleRepository(Database db)
+    {
+        _db = db;
+    }
+
+    public async Task<ModeratorRole> CreateAsync(string name, ModeratorPermissions permissions)
+    {
+        using var conn = _db.CreateConnection();
+        var role = new ModeratorRole { Name = name, Permissions = permissions };
+        await conn.ExecuteAsync(
+            "INSERT INTO moderator_roles (id, name, permissions, created_at, updated_at) VALUES (@Id, @Name, @Permissions, @CreatedAt, @UpdatedAt)",
+            role);
+        return role;
+    }
+
+    public async Task<ModeratorRole?> GetByIdAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        return await conn.QuerySingleOrDefaultAsync<ModeratorRole>(
+            "SELECT * FROM moderator_roles WHERE id = @Id", new { Id = id });
+    }
+
+    public async Task<IReadOnlyList<ModeratorRole>> GetAllAsync()
+    {
+        using var conn = _db.CreateConnection();
+        var result = await conn.QueryAsync<ModeratorRole>("SELECT * FROM moderator_roles ORDER BY name");
+        return result.ToList();
+    }
+
+    public async Task UpdateAsync(string id, string? name = null, ModeratorPermissions? permissions = null)
+    {
+        using var conn = _db.CreateConnection();
+        var existing = await GetByIdAsync(id);
+        if (existing == null) return;
+
+        await conn.ExecuteAsync(
+            "UPDATE moderator_roles SET name = @Name, permissions = @Permissions, updated_at = @UpdatedAt WHERE id = @Id",
+            new { Id = id, Name = name ?? existing.Name, Permissions = permissions ?? existing.Permissions, UpdatedAt = DateTime.UtcNow });
+    }
+
+    public async Task DeleteAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        await conn.ExecuteAsync("DELETE FROM moderator_roles WHERE id = @Id", new { Id = id });
+    }
+}

--- a/src/Brmble.Server/Data/ModeratorRoleRepository.cs
+++ b/src/Brmble.Server/Data/ModeratorRoleRepository.cs
@@ -48,12 +48,29 @@ public class ModeratorRoleRepository
     public async Task UpdateAsync(string id, string? name = null, ModeratorPermissions? permissions = null)
     {
         using var conn = _db.CreateConnection();
-        var existing = await GetByIdAsync(id);
-        if (existing == null) return;
-
-        await conn.ExecuteAsync(
-            "UPDATE moderator_roles SET name = @Name, permissions = @Permissions, updated_at = @UpdatedAt WHERE id = @Id",
-            new { Id = id, Name = name ?? existing.Name, Permissions = permissions ?? existing.Permissions, UpdatedAt = DateTime.UtcNow });
+        
+        var updates = new List<string>();
+        var args = new DynamicParameters();
+        args.Add("Id", id);
+        
+        if (name != null)
+        {
+            updates.Add("name = @Name");
+            args.Add("Name", name);
+        }
+        if (permissions != null)
+        {
+            updates.Add("permissions = @Permissions");
+            args.Add("Permissions", permissions);
+        }
+        
+        if (updates.Count == 0) return;
+        
+        updates.Add("updated_at = @UpdatedAt");
+        args.Add("UpdatedAt", DateTime.UtcNow);
+        
+        var sql = $"UPDATE moderator_roles SET {string.Join(", ", updates)} WHERE id = @Id";
+        await conn.ExecuteAsync(sql, args);
     }
 
     public async Task DeleteAsync(string id)

--- a/src/Brmble.Server/Data/SyncFailedAssignmentRepository.cs
+++ b/src/Brmble.Server/Data/SyncFailedAssignmentRepository.cs
@@ -52,18 +52,22 @@ public class SyncFailedAssignmentRepository
     public async Task IncrementRetryAsync(string id, string errorMessage)
     {
         using var conn = _db.CreateConnection();
-        var existing = await conn.QuerySingleOrDefaultAsync<SyncFailedAssignment>(
-            "SELECT * FROM sync_failed_assignments WHERE id = @Id", new { Id = id });
-        if (existing == null) return;
-
-        var nextDelayIndex = Math.Min(existing.RetryCount, RetryDelays.Length - 1);
-        var nextRetryAt = DateTime.UtcNow.AddSeconds(RetryDelays[nextDelayIndex]);
-        var retryCount = existing.RetryCount + 1;
-
-        await conn.ExecuteAsync(
-            @"UPDATE sync_failed_assignments SET retry_count = @RetryCount, next_retry_at = @NextRetryAt, error_message = @ErrorMessage
-              WHERE id = @Id",
-            new { Id = id, RetryCount = retryCount, NextRetryAt = nextRetryAt, ErrorMessage = errorMessage });
+        
+        var sql = @"
+            UPDATE sync_failed_assignments 
+            SET retry_count = retry_count + 1,
+                next_retry_at = datetime('now', '+' || 
+                    CASE 
+                        WHEN retry_count = 0 THEN 30
+                        WHEN retry_count = 1 THEN 60
+                        WHEN retry_count = 2 THEN 120
+                        WHEN retry_count = 3 THEN 240
+                        ELSE 480
+                    END || ' seconds'),
+                error_message = @ErrorMessage
+            WHERE id = @Id";
+        
+        await conn.ExecuteAsync(sql, new { Id = id, ErrorMessage = errorMessage });
     }
 
     public async Task RemoveAsync(string id)

--- a/src/Brmble.Server/Data/SyncFailedAssignmentRepository.cs
+++ b/src/Brmble.Server/Data/SyncFailedAssignmentRepository.cs
@@ -32,7 +32,7 @@ public class SyncFailedAssignmentRepository
             Action = action,
             ErrorMessage = errorMessage,
             RetryCount = 0,
-            NextRetryAt = DateTime.UtcNow.AddSeconds(RetryDelays[0])
+            NextRetryAt = DateTime.UtcNow
         };
         await conn.ExecuteAsync(
             @"INSERT INTO sync_failed_assignments (id, assignment_id, action, error_message, retry_count, next_retry_at, created_at)

--- a/src/Brmble.Server/Data/SyncFailedAssignmentRepository.cs
+++ b/src/Brmble.Server/Data/SyncFailedAssignmentRepository.cs
@@ -1,0 +1,74 @@
+using Dapper;
+
+namespace Brmble.Server.Data;
+
+public class SyncFailedAssignment
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string AssignmentId { get; set; } = string.Empty;
+    public string Action { get; set; } = string.Empty;
+    public string? ErrorMessage { get; set; }
+    public int RetryCount { get; set; }
+    public DateTime NextRetryAt { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class SyncFailedAssignmentRepository
+{
+    private readonly Database _db;
+    private static readonly int[] RetryDelays = { 30, 60, 120, 240, 480 };
+
+    public SyncFailedAssignmentRepository(Database db)
+    {
+        _db = db;
+    }
+
+    public async Task AddAsync(string assignmentId, string action, string errorMessage)
+    {
+        using var conn = _db.CreateConnection();
+        var failed = new SyncFailedAssignment
+        {
+            AssignmentId = assignmentId,
+            Action = action,
+            ErrorMessage = errorMessage,
+            RetryCount = 0,
+            NextRetryAt = DateTime.UtcNow.AddSeconds(RetryDelays[0])
+        };
+        await conn.ExecuteAsync(
+            @"INSERT INTO sync_failed_assignments (id, assignment_id, action, error_message, retry_count, next_retry_at, created_at)
+              VALUES (@Id, @AssignmentId, @Action, @ErrorMessage, @RetryCount, @NextRetryAt, @CreatedAt)",
+            failed);
+    }
+
+    public async Task<IReadOnlyList<SyncFailedAssignment>> GetPendingAsync()
+    {
+        using var conn = _db.CreateConnection();
+        var result = await conn.QueryAsync<SyncFailedAssignment>(
+            "SELECT * FROM sync_failed_assignments WHERE next_retry_at <= @Now ORDER BY next_retry_at",
+            new { Now = DateTime.UtcNow });
+        return result.ToList();
+    }
+
+    public async Task IncrementRetryAsync(string id, string errorMessage)
+    {
+        using var conn = _db.CreateConnection();
+        var existing = await conn.QuerySingleOrDefaultAsync<SyncFailedAssignment>(
+            "SELECT * FROM sync_failed_assignments WHERE id = @Id", new { Id = id });
+        if (existing == null) return;
+
+        var nextDelayIndex = Math.Min(existing.RetryCount, RetryDelays.Length - 1);
+        var nextRetryAt = DateTime.UtcNow.AddSeconds(RetryDelays[nextDelayIndex]);
+        var retryCount = existing.RetryCount + 1;
+
+        await conn.ExecuteAsync(
+            @"UPDATE sync_failed_assignments SET retry_count = @RetryCount, next_retry_at = @NextRetryAt, error_message = @ErrorMessage
+              WHERE id = @Id",
+            new { Id = id, RetryCount = retryCount, NextRetryAt = nextRetryAt, ErrorMessage = errorMessage });
+    }
+
+    public async Task RemoveAsync(string id)
+    {
+        using var conn = _db.CreateConnection();
+        await conn.ExecuteAsync("DELETE FROM sync_failed_assignments WHERE id = @Id", new { Id = id });
+    }
+}

--- a/src/Brmble.Server/Moderator/IModeratorPermissionChecker.cs
+++ b/src/Brmble.Server/Moderator/IModeratorPermissionChecker.cs
@@ -1,0 +1,6 @@
+namespace Brmble.Server.Moderator;
+
+public interface IModeratorPermissionChecker
+{
+    Task<ModeratorPermissions> GetModeratorPermissionsAsync(int userId, int channelId);
+}

--- a/src/Brmble.Server/Moderator/IMumbleGroupSyncService.cs
+++ b/src/Brmble.Server/Moderator/IMumbleGroupSyncService.cs
@@ -1,0 +1,8 @@
+namespace Brmble.Server.Moderator;
+
+public interface IMumbleGroupSyncService
+{
+    Task AddUserToChannelGroupAsync(int userId, int channelId);
+    Task RemoveUserFromChannelGroupAsync(int userId, int channelId);
+    Task<bool> SyncAssignmentAsync(string assignmentId, int userId, int channelId, bool add);
+}

--- a/src/Brmble.Server/Moderator/ModeratorEndpoints.cs
+++ b/src/Brmble.Server/Moderator/ModeratorEndpoints.cs
@@ -1,4 +1,5 @@
 using Brmble.Server.Data;
+using Microsoft.Extensions.Logging;
 
 namespace Brmble.Server.Moderator;
 
@@ -19,18 +20,29 @@ public static class ModeratorEndpoints
 
         app.MapPost("/api/admin/moderator-roles", async (
             IModeratorService moderatorService,
+            ILogger<Program> logger,
             CreateRoleRequest request) =>
         {
-            if (string.IsNullOrWhiteSpace(request.Name))
-                return Results.BadRequest("Role name is required");
-            
-            var role = await moderatorService.CreateRoleAsync(request.Name, request.Permissions);
-            return Results.Created($"/api/admin/moderator-roles/{role.Id}", new
+            try
             {
-                role.Id,
-                role.Name,
-                Permissions = (int)role.Permissions
-            });
+                logger.LogInformation("Creating role: {Name} with permissions {Permissions}", request.Name, request.Permissions);
+                if (string.IsNullOrWhiteSpace(request.Name))
+                    return Results.BadRequest("Role name is required");
+                
+                var role = await moderatorService.CreateRoleAsync(request.Name, request.Permissions);
+                logger.LogInformation("Role created: {RoleId} - {RoleName}", role.Id, role.Name);
+                return Results.Created($"/api/admin/moderator-roles/{role.Id}", new
+                {
+                    role.Id,
+                    role.Name,
+                    Permissions = (int)role.Permissions
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error creating role");
+                return Results.BadRequest(ex.Message);
+            }
         });
 
         app.MapPut("/api/admin/moderator-roles/{id}", async (

--- a/src/Brmble.Server/Moderator/ModeratorEndpoints.cs
+++ b/src/Brmble.Server/Moderator/ModeratorEndpoints.cs
@@ -1,0 +1,104 @@
+using Brmble.Server.Data;
+
+namespace Brmble.Server.Moderator;
+
+public static class ModeratorEndpoints
+{
+    public static IEndpointRouteBuilder MapModeratorEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/admin/moderator-roles", async (IModeratorService moderatorService) =>
+        {
+            var roles = await moderatorService.GetRolesAsync();
+            return Results.Ok(roles.Select(r => new
+            {
+                r.Id,
+                r.Name,
+                Permissions = (int)r.Permissions
+            }));
+        });
+
+        app.MapPost("/api/admin/moderator-roles", async (
+            IModeratorService moderatorService,
+            CreateRoleRequest request) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.Name))
+                return Results.BadRequest("Role name is required");
+            
+            var role = await moderatorService.CreateRoleAsync(request.Name, request.Permissions);
+            return Results.Created($"/api/admin/moderator-roles/{role.Id}", new
+            {
+                role.Id,
+                role.Name,
+                Permissions = (int)role.Permissions
+            });
+        });
+
+        app.MapPut("/api/admin/moderator-roles/{id}", async (
+            IModeratorService moderatorService,
+            string id,
+            UpdateRoleRequest request) =>
+        {
+            await moderatorService.UpdateRoleAsync(id, request.Name, request.Permissions);
+            return Results.NoContent();
+        });
+
+        app.MapDelete("/api/admin/moderator-roles/{id}", async (
+            IModeratorService moderatorService,
+            string id) =>
+        {
+            await moderatorService.DeleteRoleAsync(id);
+            return Results.NoContent();
+        });
+
+        app.MapGet("/api/channels/{channelId}/moderators", async (
+            IModeratorService moderatorService,
+            int channelId) =>
+        {
+            var moderators = await moderatorService.GetChannelModeratorsAsync(channelId);
+            return Results.Ok(moderators.Select(m => new
+            {
+                m.Id,
+                m.UserId,
+                m.RoleId,
+                m.RoleName,
+                RolePermissions = (int)m.RolePermissions,
+                m.AssignedAt
+            }));
+        });
+
+        app.MapPost("/api/channels/{channelId}/moderators", async (
+            IModeratorService moderatorService,
+            int channelId,
+            CreateAssignmentRequest request) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.RoleId))
+                return Results.BadRequest("Role ID is required");
+            
+            var assignment = await moderatorService.AssignModeratorAsync(
+                request.RoleId, channelId, request.UserId, assignedBy: 0);
+            
+            return Results.Created($"/api/channels/{channelId}/moderators/{assignment.Id}", new
+            {
+                assignment.Id,
+                assignment.UserId,
+                assignment.RoleId,
+                assignment.AssignedAt
+            });
+        });
+
+        app.MapDelete("/api/channels/{channelId}/moderators/{assignmentId}", async (
+            IModeratorService moderatorService,
+            int channelId,
+            string assignmentId) =>
+        {
+            await moderatorService.RemoveModeratorAsync(assignmentId);
+            return Results.NoContent();
+        });
+
+        return app;
+    }
+}
+
+public record CreateRoleRequest(string Name, ModeratorPermissions Permissions);
+public record UpdateRoleRequest(string? Name, ModeratorPermissions? Permissions);
+public record CreateAssignmentRequest(string RoleId, int UserId);

--- a/src/Brmble.Server/Moderator/ModeratorPermissions.cs
+++ b/src/Brmble.Server/Moderator/ModeratorPermissions.cs
@@ -1,7 +1,7 @@
 namespace Brmble.Server.Moderator;
 
 [Flags]
-public enum ModeratorPermission
+public enum ModeratorPermissions
 {
     None = 0,
     Kick = 0x001,

--- a/src/Brmble.Server/Moderator/ModeratorPermissions.cs
+++ b/src/Brmble.Server/Moderator/ModeratorPermissions.cs
@@ -1,0 +1,12 @@
+namespace Brmble.Server.Moderator;
+
+[Flags]
+public enum ModeratorPermission
+{
+    None = 0,
+    Kick = 0x001,
+    DenyEnter = 0x002,
+    RenameChannel = 0x004,
+    SetPassword = 0x008,
+    EditDesc = 0x010,
+}

--- a/src/Brmble.Server/Moderator/ModeratorService.cs
+++ b/src/Brmble.Server/Moderator/ModeratorService.cs
@@ -1,0 +1,123 @@
+using Brmble.Server.Data;
+using Microsoft.Extensions.Logging;
+
+namespace Brmble.Server.Moderator;
+
+public interface IModeratorService
+{
+    Task<IReadOnlyList<ModeratorRole>> GetRolesAsync();
+    Task<ModeratorRole> CreateRoleAsync(string name, ModeratorPermissions permissions);
+    Task UpdateRoleAsync(string id, string? name, ModeratorPermissions? permissions);
+    Task DeleteRoleAsync(string id);
+    
+    Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetChannelModeratorsAsync(int channelId);
+    Task<ModeratorAssignment> AssignModeratorAsync(string roleId, int channelId, int userId, int assignedBy);
+    Task RemoveModeratorAsync(string assignmentId);
+    Task CleanupChannelAssignmentsAsync(int channelId);
+    
+    Task<ModeratorPermissions> GetUserPermissionsForChannelAsync(int userId, int channelId);
+}
+
+public class ModeratorService : IModeratorService, IModeratorPermissionChecker
+{
+    private readonly ModeratorRoleRepository _roleRepo;
+    private readonly ModeratorAssignmentRepository _assignmentRepo;
+    private readonly SyncFailedAssignmentRepository _syncFailedRepo;
+    private readonly IMumbleGroupSyncService _mumbleSync;
+    private readonly ILogger<ModeratorService> _logger;
+
+    public ModeratorService(
+        ModeratorRoleRepository roleRepo,
+        ModeratorAssignmentRepository assignmentRepo,
+        SyncFailedAssignmentRepository syncFailedRepo,
+        IMumbleGroupSyncService mumbleSync,
+        ILogger<ModeratorService> logger)
+    {
+        _roleRepo = roleRepo;
+        _assignmentRepo = assignmentRepo;
+        _syncFailedRepo = syncFailedRepo;
+        _mumbleSync = mumbleSync;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<ModeratorRole>> GetRolesAsync() => await _roleRepo.GetAllAsync();
+    
+    public async Task<ModeratorRole> CreateRoleAsync(string name, ModeratorPermissions permissions)
+    {
+        return await _roleRepo.CreateAsync(name, permissions);
+    }
+    
+    public async Task UpdateRoleAsync(string id, string? name, ModeratorPermissions? permissions)
+    {
+        await _roleRepo.UpdateAsync(id, name, permissions);
+    }
+    
+    public async Task DeleteRoleAsync(string id)
+    {
+        await _roleRepo.DeleteAsync(id);
+    }
+
+    public async Task<IReadOnlyList<ModeratorAssignmentWithRole>> GetChannelModeratorsAsync(int channelId)
+    {
+        return await _assignmentRepo.GetByChannelAsync(channelId);
+    }
+
+    public async Task<ModeratorAssignment> AssignModeratorAsync(string roleId, int channelId, int userId, int assignedBy)
+    {
+        var assignment = await _assignmentRepo.CreateAsync(roleId, channelId, userId, assignedBy);
+        
+        var success = await _mumbleSync.SyncAssignmentAsync(assignment.Id, userId, channelId, add: true);
+        if (!success)
+        {
+            _logger.LogWarning("Mumble sync failed for assignment {AssignmentId}, queuing for retry", assignment.Id);
+            await _syncFailedRepo.AddAsync(assignment.Id, "add", "Initial sync failed");
+        }
+        
+        return assignment;
+    }
+
+    public async Task RemoveModeratorAsync(string assignmentId)
+    {
+        var assignment = await _assignmentRepo.GetByIdAsync(assignmentId);
+        if (assignment == null) return;
+
+        var userId = assignment.UserId;
+        var channelId = assignment.ChannelId;
+        
+        await _assignmentRepo.DeleteAsync(assignmentId);
+        
+        var success = await _mumbleSync.SyncAssignmentAsync(assignmentId, userId, channelId, add: false);
+        if (!success)
+        {
+            _logger.LogWarning("Mumble sync removal failed for assignment {AssignmentId}, queuing for retry", assignmentId);
+            await _syncFailedRepo.AddAsync(assignmentId, "remove", "Removal sync failed");
+        }
+    }
+
+    public async Task CleanupChannelAssignmentsAsync(int channelId)
+    {
+        var assignments = await _assignmentRepo.GetByChannelAsync(channelId);
+        
+        await _assignmentRepo.DeleteByChannelAsync(channelId);
+        
+        foreach (var assignment in assignments)
+        {
+            var success = await _mumbleSync.SyncAssignmentAsync(assignment.Id, assignment.UserId, channelId, add: false);
+            if (!success)
+            {
+                await _syncFailedRepo.AddAsync(assignment.Id, "remove", "Cleanup sync failed");
+            }
+        }
+    }
+
+    public async Task<ModeratorPermissions> GetUserPermissionsForChannelAsync(int userId, int channelId)
+    {
+        var assignment = await _assignmentRepo.GetByUserAndChannelAsync(userId, channelId);
+        return assignment?.RolePermissions ?? ModeratorPermissions.None;
+    }
+
+    Task<ModeratorPermissions> IModeratorPermissionChecker.GetModeratorPermissionsAsync(int userId, int channelId)
+    {
+        return GetUserPermissionsForChannelAsync(userId, channelId);
+    }
+}

--- a/src/Brmble.Server/Moderator/ModeratorService.cs
+++ b/src/Brmble.Server/Moderator/ModeratorService.cs
@@ -105,6 +105,7 @@ public class ModeratorService : IModeratorService, IModeratorPermissionChecker
             var success = await _mumbleSync.SyncAssignmentAsync(assignment.Id, assignment.UserId, channelId, add: false);
             if (!success)
             {
+                _logger.LogWarning("Mumble sync removal failed for assignment {AssignmentId} during channel cleanup, queuing for retry", assignment.Id);
                 await _syncFailedRepo.AddAsync(assignment.Id, "remove", "Cleanup sync failed");
             }
         }

--- a/src/Brmble.Server/Moderator/MumbleGroupSyncService.cs
+++ b/src/Brmble.Server/Moderator/MumbleGroupSyncService.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+using Brmble.Server.Mumble;
+
+namespace Brmble.Server.Moderator;
+
+public class MumbleGroupSyncService : IMumbleGroupSyncService
+{
+    private readonly IMumbleRegistrationService _mumbleRegistration;
+    private readonly ILogger<MumbleGroupSyncService> _logger;
+
+    public MumbleGroupSyncService(
+        IMumbleRegistrationService mumbleRegistration,
+        ILogger<MumbleGroupSyncService> logger)
+    {
+        _mumbleRegistration = mumbleRegistration;
+        _logger = logger;
+    }
+
+    private static string GetGroupName(int channelId) => $"brmble_mod_{channelId}";
+
+    public async Task AddUserToChannelGroupAsync(int userId, int channelId)
+    {
+        var groupName = GetGroupName(channelId);
+        _logger.LogInformation("Adding user {UserId} to Mumble group {GroupName}", userId, groupName);
+        
+        // TODO: Implement actual Mumble ICE call to add user to ACL group
+        // This requires looking up the Mumble ICE API for ACL group management
+        
+        _logger.LogDebug("Mumble group add: user {UserId} to group {GroupName} (stub)", userId, groupName);
+    }
+
+    public async Task RemoveUserFromChannelGroupAsync(int userId, int channelId)
+    {
+        var groupName = GetGroupName(channelId);
+        _logger.LogInformation("Removing user {UserId} from Mumble group {GroupName}", userId, groupName);
+        
+        // TODO: Implement actual Mumble ICE call to remove user from ACL group
+        
+        _logger.LogDebug("Mumble group remove: user {UserId} from group {GroupName} (stub)", userId, groupName);
+    }
+
+    public async Task<bool> SyncAssignmentAsync(string assignmentId, int userId, int channelId, bool add)
+    {
+        try
+        {
+            if (add)
+            {
+                await AddUserToChannelGroupAsync(userId, channelId);
+            }
+            else
+            {
+                await RemoveUserFromChannelGroupAsync(userId, channelId);
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to sync assignment {AssignmentId} to Mumble", assignmentId);
+            return false;
+        }
+    }
+}

--- a/src/Brmble.Server/Moderator/MumbleGroupSyncService.cs
+++ b/src/Brmble.Server/Moderator/MumbleGroupSyncService.cs
@@ -18,7 +18,7 @@ public class MumbleGroupSyncService : IMumbleGroupSyncService
 
     private static string GetGroupName(int channelId) => $"brmble_mod_{channelId}";
 
-    public async Task AddUserToChannelGroupAsync(int userId, int channelId)
+    public Task AddUserToChannelGroupAsync(int userId, int channelId)
     {
         var groupName = GetGroupName(channelId);
         _logger.LogInformation("Adding user {UserId} to Mumble group {GroupName}", userId, groupName);
@@ -27,9 +27,10 @@ public class MumbleGroupSyncService : IMumbleGroupSyncService
         // This requires looking up the Mumble ICE API for ACL group management
         
         _logger.LogDebug("Mumble group add: user {UserId} to group {GroupName} (stub)", userId, groupName);
+        return Task.CompletedTask;
     }
 
-    public async Task RemoveUserFromChannelGroupAsync(int userId, int channelId)
+    public Task RemoveUserFromChannelGroupAsync(int userId, int channelId)
     {
         var groupName = GetGroupName(channelId);
         _logger.LogInformation("Removing user {UserId} from Mumble group {GroupName}", userId, groupName);
@@ -37,6 +38,7 @@ public class MumbleGroupSyncService : IMumbleGroupSyncService
         // TODO: Implement actual Mumble ICE call to remove user from ACL group
         
         _logger.LogDebug("Mumble group remove: user {UserId} from group {GroupName} (stub)", userId, groupName);
+        return Task.CompletedTask;
     }
 
     public async Task<bool> SyncAssignmentAsync(string assignmentId, int userId, int channelId, bool add)

--- a/src/Brmble.Server/Moderator/PermissionEnforcer.cs
+++ b/src/Brmble.Server/Moderator/PermissionEnforcer.cs
@@ -1,0 +1,26 @@
+namespace Brmble.Server.Moderator;
+
+public class PermissionEnforcer
+{
+    private readonly IModeratorPermissionChecker _permissionChecker;
+
+    public PermissionEnforcer(IModeratorPermissionChecker permissionChecker)
+    {
+        _permissionChecker = permissionChecker;
+    }
+
+    public async Task<bool> HasModeratorPermissionAsync(int userId, int channelId, ModeratorPermissions required)
+    {
+        var permissions = await _permissionChecker.GetModeratorPermissionsAsync(userId, channelId);
+        return permissions.HasFlag(required);
+    }
+
+    public async Task RequireModeratorPermissionAsync(int userId, int channelId, ModeratorPermissions required)
+    {
+        if (!await HasModeratorPermissionAsync(userId, channelId, required))
+        {
+            throw new UnauthorizedAccessException(
+                $"User {userId} lacks required permission {required} for channel {channelId}");
+        }
+    }
+}

--- a/src/Brmble.Server/Moderator/SyncRetryBackgroundService.cs
+++ b/src/Brmble.Server/Moderator/SyncRetryBackgroundService.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Brmble.Server.Data;
+
+namespace Brmble.Server.Moderator;
+
+public class SyncRetryBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<SyncRetryBackgroundService> _logger;
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
+
+    public SyncRetryBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<SyncRetryBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Sync retry background service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessFailedSyncsAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing failed syncs");
+            }
+
+            await Task.Delay(PollInterval, stoppingToken);
+        }
+    }
+
+    private async Task ProcessFailedSyncsAsync(CancellationToken stoppingToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var syncFailedRepo = scope.ServiceProvider.GetRequiredService<SyncFailedAssignmentRepository>();
+        var assignmentRepo = scope.ServiceProvider.GetRequiredService<ModeratorAssignmentRepository>();
+        var mumbleSync = scope.ServiceProvider.GetRequiredService<IMumbleGroupSyncService>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<SyncRetryBackgroundService>>();
+
+        var pending = await syncFailedRepo.GetPendingAsync();
+        if (pending.Count == 0) return;
+
+        logger.LogInformation("Processing {Count} pending sync failures", pending.Count);
+
+        foreach (var failed in pending)
+        {
+            if (stoppingToken.IsCancellationRequested) break;
+
+            if (failed.RetryCount >= 5)
+            {
+                logger.LogWarning("Max retries exceeded for sync {Id}, marking as failed permanently", failed.Id);
+                await syncFailedRepo.RemoveAsync(failed.Id);
+                continue;
+            }
+
+            var assignment = await assignmentRepo.GetByIdAsync(failed.AssignmentId);
+            if (assignment == null)
+            {
+                logger.LogInformation("Assignment {Id} no longer exists, removing sync record", failed.AssignmentId);
+                await syncFailedRepo.RemoveAsync(failed.Id);
+                continue;
+            }
+
+            try
+            {
+                var success = await mumbleSync.SyncAssignmentAsync(
+                    failed.AssignmentId,
+                    assignment.UserId,
+                    assignment.ChannelId,
+                    failed.Action == "add");
+
+                if (success)
+                {
+                    logger.LogInformation("Successfully synced assignment {Id} on retry", failed.AssignmentId);
+                    await syncFailedRepo.RemoveAsync(failed.Id);
+                }
+                else
+                {
+                    await syncFailedRepo.IncrementRetryAsync(failed.Id, "Retry failed");
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error retrying sync {Id}", failed.Id);
+                await syncFailedRepo.IncrementRetryAsync(failed.Id, ex.Message);
+            }
+        }
+    }
+}

--- a/src/Brmble.Server/Program.cs
+++ b/src/Brmble.Server/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Brmble.Server.Data;
 using Brmble.Server.LiveKit;
 using Brmble.Server.Matrix;
+using Brmble.Server.Moderator;
 using Brmble.Server.Mumble;
 using Brmble.Server.ServerInfo;
 using Brmble.Server.WebSockets;
@@ -39,6 +40,7 @@ builder.Services.AddOptions<ServerInfoSettings>()
     .BindConfiguration("ServerInfo");
 builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+builder.Services.AddSingleton<IMumbleGroupSyncService, MumbleGroupSyncService>();
 
 var app = builder.Build();
 

--- a/src/Brmble.Server/Program.cs
+++ b/src/Brmble.Server/Program.cs
@@ -41,6 +41,13 @@ builder.Services.AddOptions<ServerInfoSettings>()
 builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
 builder.Services.AddSingleton<IMumbleGroupSyncService, MumbleGroupSyncService>();
+builder.Services.AddSingleton<ModeratorRoleRepository>();
+builder.Services.AddSingleton<ModeratorAssignmentRepository>();
+builder.Services.AddSingleton<SyncFailedAssignmentRepository>();
+builder.Services.AddSingleton<ModeratorService>();
+builder.Services.AddSingleton<IModeratorService>(sp => (IModeratorService)sp.GetRequiredService<ModeratorService>());
+builder.Services.AddSingleton<IModeratorPermissionChecker>(sp => (IModeratorPermissionChecker)sp.GetRequiredService<ModeratorService>());
+builder.Services.AddSingleton<PermissionEnforcer>();
 
 var app = builder.Build();
 

--- a/src/Brmble.Server/Program.cs
+++ b/src/Brmble.Server/Program.cs
@@ -60,6 +60,7 @@ app.MapDmEndpoints();
 app.Map("/ws", BrmbleWebSocketHandler.HandleAsync);
 app.MapServerInfoEndpoints();
 app.MapLiveKitEndpoints();
+app.MapModeratorEndpoints();
 app.MapReverseProxy();
 
 app.Run();

--- a/src/Brmble.Server/Program.cs
+++ b/src/Brmble.Server/Program.cs
@@ -48,6 +48,7 @@ builder.Services.AddSingleton<ModeratorService>();
 builder.Services.AddSingleton<IModeratorService>(sp => (IModeratorService)sp.GetRequiredService<ModeratorService>());
 builder.Services.AddSingleton<IModeratorPermissionChecker>(sp => (IModeratorPermissionChecker)sp.GetRequiredService<ModeratorService>());
 builder.Services.AddSingleton<PermissionEnforcer>();
+builder.Services.AddHostedService<SyncRetryBackgroundService>();
 
 var app = builder.Build();
 

--- a/src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.css
+++ b/src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.css
@@ -1,34 +1,49 @@
 .channel-edit-modal {
-  width: 500px;
+  width: 600px;
   max-width: 90vw;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
 }
 
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 var(--space-lg);
+}
+
 .edit-tabs {
   display: flex;
-  border-bottom: 1px solid var(--border-color, #333);
-  padding: 0 var(--spacing-md);
+  gap: var(--space-2xs);
+  padding: 0 var(--space-lg);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .edit-tab {
-  padding: var(--spacing-sm) var(--spacing-md);
-  background: none;
+  padding: var(--space-xs) var(--space-sm);
+  background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: var(--text-secondary);
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-weight: 500;
   cursor: pointer;
-  font-size: var(--font-size-sm);
-  transition: all 0.2s;
+  position: relative;
+  transition: color var(--transition-fast), background var(--transition-fast), transform var(--transition-fast);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 }
 
 .edit-tab:hover {
-  color: var(--text-primary);
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+}
+
+.edit-tab:active {
+  transform: translateY(1px);
 }
 
 .edit-tab.active {
-  color: var(--accent-primary);
+  color: var(--text-primary);
   border-bottom-color: var(--accent-primary);
 }
 

--- a/src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.css
+++ b/src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.css
@@ -1,0 +1,56 @@
+.channel-edit-modal {
+  width: 500px;
+  max-width: 90vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.edit-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border-color, #333);
+  padding: 0 var(--spacing-md);
+}
+
+.edit-tab {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  transition: all 0.2s;
+}
+
+.edit-tab:hover {
+  color: var(--text-primary);
+}
+
+.edit-tab.active {
+  color: var(--accent-primary);
+  border-bottom-color: var(--accent-primary);
+}
+
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-md);
+}
+
+.general-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.form-label {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}

--- a/src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.tsx
+++ b/src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.tsx
@@ -7,10 +7,11 @@ interface ChannelEditModalProps {
   channelId: number;
   channelName: string;
   isAdmin: boolean;
+  connectedUsers?: { session: number; name: string; userId?: number }[];
   onClose: () => void;
 }
 
-export function ChannelEditModal({ channelId, channelName, isAdmin, onClose }: ChannelEditModalProps) {
+export function ChannelEditModal({ channelId, channelName, isAdmin, connectedUsers, onClose }: ChannelEditModalProps) {
   const [activeTab, setActiveTab] = useState<'general' | 'moderators'>('general');
   const [name, setName] = useState(channelName);
   const [description, setDescription] = useState('');
@@ -97,6 +98,7 @@ export function ChannelEditModal({ channelId, channelName, isAdmin, onClose }: C
             <ManageModeratorsTab
               channelId={channelId}
               isAdmin={isAdmin}
+              connectedUsers={connectedUsers}
             />
           )}
         </div>

--- a/src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.tsx
+++ b/src/Brmble.Web/src/components/ChannelEditModal/ChannelEditModal.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { ManageModeratorsTab } from '../ManageModeratorsTab/ManageModeratorsTab';
+import bridge from '../../bridge';
+import './ChannelEditModal.css';
+
+interface ChannelEditModalProps {
+  channelId: number;
+  channelName: string;
+  isAdmin: boolean;
+  onClose: () => void;
+}
+
+export function ChannelEditModal({ channelId, channelName, isAdmin, onClose }: ChannelEditModalProps) {
+  const [activeTab, setActiveTab] = useState<'general' | 'moderators'>('general');
+  const [name, setName] = useState(channelName);
+  const [description, setDescription] = useState('');
+  const [password, setPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    bridge.send('voice.updateChannel', {
+      channelId,
+      name: name !== channelName ? name : undefined,
+      description,
+      password: password || null,
+    });
+    setSaving(false);
+    onClose();
+  };
+
+  const showModeratorsTab = isAdmin;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="channel-edit-modal glass-panel animate-slide-up" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="heading-title modal-title">Edit Channel</h2>
+          <p className="modal-subtitle">{channelName}</p>
+        </div>
+
+        <div className="edit-tabs">
+          <button
+            className={`edit-tab ${activeTab === 'general' ? 'active' : ''}`}
+            onClick={() => setActiveTab('general')}
+          >
+            General
+          </button>
+          {showModeratorsTab && (
+            <button
+              className={`edit-tab ${activeTab === 'moderators' ? 'active' : ''}`}
+              onClick={() => setActiveTab('moderators')}
+            >
+              Manage Moderators
+            </button>
+          )}
+        </div>
+
+        <div className="modal-body">
+          {activeTab === 'general' && (
+            <div className="general-tab-content">
+              <div className="form-group">
+                <label className="form-label">Channel Name</label>
+                <input
+                  type="text"
+                  className="brmble-input"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                />
+              </div>
+
+              <div className="form-group">
+                <label className="form-label">Description</label>
+                <textarea
+                  className="brmble-input"
+                  value={description}
+                  onChange={e => setDescription(e.target.value)}
+                  placeholder="Channel description..."
+                  rows={3}
+                />
+              </div>
+
+              <div className="form-group">
+                <label className="form-label">Password (leave empty to clear)</label>
+                <input
+                  type="password"
+                  className="brmble-input"
+                  value={password}
+                  onChange={e => setPassword(e.target.value)}
+                  placeholder="Enter new password..."
+                />
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'moderators' && (
+            <ManageModeratorsTab
+              channelId={channelId}
+              isAdmin={isAdmin}
+            />
+          )}
+        </div>
+
+        {activeTab === 'general' && (
+          <div className="prompt-footer">
+            <button className="btn btn-secondary" onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              className="btn btn-primary"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.css
+++ b/src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.css
@@ -108,21 +108,91 @@
 .permission-checkboxes {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
+  gap: var(--space-xs);
 }
 
 .permission-checkbox {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
-  cursor: pointer;
+  justify-content: space-between;
+  padding: var(--space-xs) 0;
 }
 
-.permission-checkbox input {
-  width: auto;
+.permission-checkbox label:first-child {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
 }
 
 .empty-state {
   color: var(--text-muted);
   font-style: italic;
+}
+
+.role-modal {
+  width: 400px;
+  max-height: 80vh;
+}
+
+.role-modal .modal-body {
+  padding: var(--space-md);
+}
+
+.role-modal .form-label {
+  font-weight: 500;
+  margin-bottom: var(--space-sm);
+}
+
+.role-modal .permission-checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.add-user-modal {
+  width: 400px;
+}
+
+.add-user-modal .user-list {
+  max-height: 250px;
+  overflow-y: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.add-user-modal .user-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.add-user-modal .user-item:last-child {
+  border-bottom: none;
+}
+
+.add-user-modal .user-item:hover {
+  background: var(--bg-surface);
+}
+
+.add-user-modal .user-item.selected {
+  background: var(--accent-primary);
+  color: var(--text-inverse);
+}
+
+.add-user-modal .user-item.selected .user-id {
+  color: var(--text-inverse);
+  opacity: 0.8;
+}
+
+.add-user-modal .user-name {
+  font-weight: 500;
+}
+
+.add-user-modal .user-id {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
 }

--- a/src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.css
+++ b/src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.css
@@ -1,0 +1,128 @@
+.manage-moderators-tab {
+  padding: var(--spacing-md);
+}
+
+.moderator-view-only-banner,
+.moderator-view-banner {
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+}
+
+.moderator-view-only-banner {
+  background: var(--color-warning-bg, rgba(255, 193, 7, 0.1));
+  border: 1px solid var(--color-warning, #ffc107);
+  color: var(--color-warning-text, #856404);
+}
+
+.moderator-view-banner {
+  background: var(--color-info-bg, rgba(0, 123, 255, 0.1));
+  border: 1px solid var(--color-info, #007bff);
+  color: var(--color-info-text, #004085);
+}
+
+.moderators-section,
+.roles-section {
+  margin-bottom: var(--spacing-lg);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-md);
+}
+
+.moderator-list,
+.role-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.moderator-row,
+.role-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+}
+
+.moderator-info,
+.role-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.moderator-user-id {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.moderator-role-name,
+.role-name {
+  font-weight: 500;
+}
+
+.moderator-permissions,
+.role-permissions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.permission-badge {
+  padding: 2px var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+}
+
+.permission-badge.granted {
+  background: var(--color-success-bg, rgba(40, 167, 69, 0.1));
+  color: var(--color-success, #28a745);
+}
+
+.role-actions {
+  display: flex;
+  gap: var(--spacing-xs);
+}
+
+.form-group {
+  margin-bottom: var(--spacing-md);
+}
+
+.form-label {
+  display: block;
+  margin-bottom: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.permission-checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.permission-checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  cursor: pointer;
+}
+
+.permission-checkbox input {
+  width: auto;
+}
+
+.empty-state {
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.tsx
+++ b/src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.tsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
 import { useModeratorPermissions, ModeratorPermission } from '../../hooks/useModeratorPermissions';
-import { prompt, confirm } from '../../hooks/usePrompt';
+import { confirm } from '../../hooks/usePrompt';
 import './ManageModeratorsTab.css';
 
 interface ManageModeratorsTabProps {
   channelId: number;
   isAdmin: boolean;
+  connectedUsers?: { session: number; name: string; userId?: number }[];
 }
 
-export function ManageModeratorsTab({ channelId, isAdmin }: ManageModeratorsTabProps) {
+export function ManageModeratorsTab({ channelId, isAdmin, connectedUsers = [] }: ManageModeratorsTabProps) {
   const {
     roles,
     moderators,
@@ -17,41 +18,23 @@ export function ManageModeratorsTab({ channelId, isAdmin }: ManageModeratorsTabP
     createRole,
     updateRole,
     deleteRole,
-    assignModerator,
     removeModerator,
   } = useModeratorPermissions(channelId);
 
   const [showRoleModal, setShowRoleModal] = useState(false);
   const [editingRole, setEditingRole] = useState<{ id: string; name: string; permissions: number } | null>(null);
+  const [showUserModal, setShowUserModal] = useState(false);
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
 
-  const handleAddModerator = async () => {
-    const userIdStr = await prompt({
-      title: 'Add Moderator',
-      message: 'Enter the user ID to assign as moderator:',
-      placeholder: 'User ID',
-    });
-    if (userIdStr === null) return;
+  const handleAddModerator = () => {
+    setSelectedUserId(null);
+    setShowUserModal(true);
+  };
 
-    const userId = parseInt(userIdStr, 10);
-    if (isNaN(userId)) {
-      alert('Invalid user ID');
-      return;
-    }
-
-    const roleOptions = roles.map(r => ({ label: r.name, value: r.id }));
-    if (roleOptions.length === 0) {
-      alert('No roles available. Create a role first.');
-      return;
-    }
-
-    const roleId = await prompt({
-      title: 'Select Role',
-      message: 'Select a role for this moderator:',
-      options: roleOptions,
-    });
-    if (!roleId) return;
-
-    assignModerator(roleId, userId);
+  const handleConfirmAddModerator = () => {
+    if (!selectedUserId) return;
+    console.log('[ManageModeratorsTab] Selected user:', selectedUserId);
+    setShowUserModal(false);
   };
 
   const handleRemoveModerator = async (assignmentId: string, userId: number) => {
@@ -231,6 +214,16 @@ export function ManageModeratorsTab({ channelId, isAdmin }: ManageModeratorsTabP
           onClose={() => setShowRoleModal(false)}
         />
       )}
+
+      {showUserModal && (
+        <AddModeratorModal
+          users={connectedUsers}
+          selectedUserId={selectedUserId}
+          onSelectUser={setSelectedUserId}
+          onConfirm={handleConfirmAddModerator}
+          onClose={() => setShowUserModal(false)}
+        />
+      )}
     </div>
   );
 }
@@ -264,7 +257,7 @@ function ModeratorRoleModal({ role, onSave, onClose }: ModeratorRoleModalProps) 
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="prompt glass-panel animate-slide-up" onClick={e => e.stopPropagation()}>
+      <div className="prompt glass-panel animate-slide-up role-modal" onClick={e => e.stopPropagation()}>
         <div className="modal-header">
           <h2 className="heading-title modal-title">
             {role ? 'Edit Role' : 'Create Role'}
@@ -287,14 +280,17 @@ function ModeratorRoleModal({ role, onSave, onClose }: ModeratorRoleModalProps) 
             <label className="form-label">Permissions</label>
             <div className="permission-checkboxes">
               {permissionItems.map(({ perm, label }) => (
-                <label key={perm} className="permission-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={(permissions & perm) !== 0}
-                    onChange={() => togglePermission(perm)}
-                  />
-                  <span>{label}</span>
-                </label>
+                <div key={perm} className="permission-checkbox">
+                  <label>{label}</label>
+                  <label className="brmble-toggle">
+                    <input
+                      type="checkbox"
+                      checked={(permissions & perm) !== 0}
+                      onChange={() => togglePermission(perm)}
+                    />
+                    <span className="brmble-toggle-slider"></span>
+                  </label>
+                </div>
               ))}
             </div>
           </div>
@@ -310,6 +306,68 @@ function ModeratorRoleModal({ role, onSave, onClose }: ModeratorRoleModalProps) 
             disabled={!name.trim()}
           >
             Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface AddModeratorModalProps {
+  users: { session: number; name: string; userId?: number }[];
+  selectedUserId: number | null;
+  onSelectUser: (userId: number) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+function AddModeratorModal({
+  users,
+  selectedUserId,
+  onSelectUser,
+  onConfirm,
+  onClose,
+}: AddModeratorModalProps) {
+  const usersWithId = users.filter(u => u.userId !== undefined);
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="prompt glass-panel animate-slide-up add-user-modal" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="heading-title modal-title">Select User</h2>
+        </div>
+
+        <div className="modal-body">
+          <div className="form-group">
+            {usersWithId.length === 0 ? (
+              <div className="empty-state">No registered users currently connected.</div>
+            ) : (
+              <div className="user-list">
+                {usersWithId.map(user => (
+                  <div
+                    key={user.session}
+                    className={`user-item ${selectedUserId === user.userId ? 'selected' : ''}`}
+                    onClick={() => onSelectUser(user.userId!)}
+                  >
+                    <span className="user-name">{user.name}</span>
+                    <span className="user-id">#{user.userId}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="prompt-footer">
+          <button className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={onConfirm}
+            disabled={!selectedUserId}
+          >
+            Select
           </button>
         </div>
       </div>

--- a/src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.tsx
+++ b/src/Brmble.Web/src/components/ManageModeratorsTab/ManageModeratorsTab.tsx
@@ -1,0 +1,318 @@
+import { useState } from 'react';
+import { useModeratorPermissions, ModeratorPermission } from '../../hooks/useModeratorPermissions';
+import { prompt, confirm } from '../../hooks/usePrompt';
+import './ManageModeratorsTab.css';
+
+interface ManageModeratorsTabProps {
+  channelId: number;
+  isAdmin: boolean;
+}
+
+export function ManageModeratorsTab({ channelId, isAdmin }: ManageModeratorsTabProps) {
+  const {
+    roles,
+    moderators,
+    loading,
+    hasAnyModeratorRole,
+    createRole,
+    updateRole,
+    deleteRole,
+    assignModerator,
+    removeModerator,
+  } = useModeratorPermissions(channelId);
+
+  const [showRoleModal, setShowRoleModal] = useState(false);
+  const [editingRole, setEditingRole] = useState<{ id: string; name: string; permissions: number } | null>(null);
+
+  const handleAddModerator = async () => {
+    const userIdStr = await prompt({
+      title: 'Add Moderator',
+      message: 'Enter the user ID to assign as moderator:',
+      placeholder: 'User ID',
+    });
+    if (userIdStr === null) return;
+
+    const userId = parseInt(userIdStr, 10);
+    if (isNaN(userId)) {
+      alert('Invalid user ID');
+      return;
+    }
+
+    const roleOptions = roles.map(r => ({ label: r.name, value: r.id }));
+    if (roleOptions.length === 0) {
+      alert('No roles available. Create a role first.');
+      return;
+    }
+
+    const roleId = await prompt({
+      title: 'Select Role',
+      message: 'Select a role for this moderator:',
+      options: roleOptions,
+    });
+    if (!roleId) return;
+
+    assignModerator(roleId, userId);
+  };
+
+  const handleRemoveModerator = async (assignmentId: string, userId: number) => {
+    const confirmed = await confirm({
+      title: 'Remove Moderator',
+      message: `Remove moderator (User ID: ${userId}) from this channel?`,
+      confirmLabel: 'Remove',
+    });
+    if (!confirmed) return;
+
+    removeModerator(assignmentId);
+  };
+
+  const handleCreateRole = () => {
+    setEditingRole(null);
+    setShowRoleModal(true);
+  };
+
+  const handleEditRole = (role: { id: string; name: string; permissions: number }) => {
+    setEditingRole(role);
+    setShowRoleModal(true);
+  };
+
+  const handleSaveRole = (name: string, permissions: number) => {
+    if (editingRole) {
+      updateRole(editingRole.id, name, permissions);
+    } else {
+      createRole(name, permissions);
+    }
+    setShowRoleModal(false);
+  };
+
+  const handleDeleteRole = async (roleId: string, roleName: string) => {
+    const confirmed = await confirm({
+      title: 'Delete Role',
+      message: `Delete role "${roleName}"? This will remove all assignments using this role.`,
+      confirmLabel: 'Delete',
+    });
+    if (!confirmed) return;
+
+    deleteRole(roleId);
+  };
+
+  const getPermissionLabel = (perm: number): string => {
+    switch (perm) {
+      case ModeratorPermission.Kick: return 'Kick';
+      case ModeratorPermission.DenyEnter: return 'Deny Enter';
+      case ModeratorPermission.RenameChannel: return 'Rename Channel';
+      case ModeratorPermission.SetPassword: return 'Set Password';
+      case ModeratorPermission.EditDesc: return 'Edit Description';
+      default: return 'Unknown';
+    }
+  };
+
+  const renderPermission = (perm: number, checked: boolean) => (
+    <span key={perm} className={`permission-badge ${checked ? 'granted' : ''}`}>
+      {checked ? '✓' : '✗'} {getPermissionLabel(perm)}
+    </span>
+  );
+
+  const canEdit = isAdmin;
+  const allPermissions = [
+    ModeratorPermission.Kick,
+    ModeratorPermission.DenyEnter,
+    ModeratorPermission.RenameChannel,
+    ModeratorPermission.SetPassword,
+    ModeratorPermission.EditDesc,
+  ];
+
+  return (
+    <div className="manage-moderators-tab">
+      {!canEdit && !hasAnyModeratorRole && (
+        <div className="moderator-view-only-banner">
+          View only — Contact an admin to modify moderator settings.
+        </div>
+      )}
+
+      {!canEdit && hasAnyModeratorRole && (
+        <div className="moderator-view-banner">
+          You are a moderator of this channel.
+        </div>
+      )}
+
+      <div className="moderators-section">
+        <div className="section-header">
+          <h4 className="heading-label">Channel Moderators</h4>
+          {canEdit && (
+            <button className="btn btn-primary btn-sm" onClick={handleAddModerator}>
+              Add Moderator
+            </button>
+          )}
+        </div>
+
+        {loading && <div className="loading">Loading...</div>}
+
+        {!loading && moderators.length === 0 && (
+          <div className="empty-state">No moderators assigned to this channel.</div>
+        )}
+
+        {!loading && moderators.length > 0 && (
+          <div className="moderator-list">
+            {moderators.map(mod => (
+              <div key={mod.id} className="moderator-row">
+                <div className="moderator-info">
+                  <span className="moderator-user-id">User #{mod.userId}</span>
+                  <span className="moderator-role-name">{mod.roleName}</span>
+                  <div className="moderator-permissions">
+                    {allPermissions.map(perm =>
+                      renderPermission(perm, (mod.rolePermissions & perm) !== 0)
+                    )}
+                  </div>
+                </div>
+                {canEdit && (
+                  <button
+                    className="btn btn-danger btn-sm"
+                    onClick={() => handleRemoveModerator(mod.id, mod.userId)}
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {canEdit && (
+        <div className="roles-section">
+          <div className="section-header">
+            <h4 className="heading-label">Moderator Roles</h4>
+            <button className="btn btn-secondary btn-sm" onClick={handleCreateRole}>
+              Create Role
+            </button>
+          </div>
+
+          {roles.length === 0 && (
+            <div className="empty-state">No roles defined. Create one to get started.</div>
+          )}
+
+          {roles.length > 0 && (
+            <div className="role-list">
+              {roles.map(role => (
+                <div key={role.id} className="role-row">
+                  <div className="role-info">
+                    <span className="role-name">{role.name}</span>
+                    <div className="role-permissions">
+                      {allPermissions.map(perm =>
+                        renderPermission(perm, (role.permissions & perm) !== 0)
+                      )}
+                    </div>
+                  </div>
+                  <div className="role-actions">
+                    <button
+                      className="btn btn-secondary btn-sm"
+                      onClick={() => handleEditRole(role)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className="btn btn-danger btn-sm"
+                      onClick={() => handleDeleteRole(role.id, role.name)}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {showRoleModal && (
+        <ModeratorRoleModal
+          role={editingRole}
+          onSave={handleSaveRole}
+          onClose={() => setShowRoleModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+interface ModeratorRoleModalProps {
+  role: { id: string; name: string; permissions: number } | null;
+  onSave: (name: string, permissions: number) => void;
+  onClose: () => void;
+}
+
+function ModeratorRoleModal({ role, onSave, onClose }: ModeratorRoleModalProps) {
+  const [name, setName] = useState(role?.name ?? '');
+  const [permissions, setPermissions] = useState(role?.permissions ?? 0);
+
+  const togglePermission = (perm: number) => {
+    setPermissions(prev => prev ^ perm);
+  };
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+    onSave(name, permissions);
+  };
+
+  const permissionItems = [
+    { perm: ModeratorPermission.Kick, label: 'Kick users from channel' },
+    { perm: ModeratorPermission.DenyEnter, label: 'Deny user from entering channel' },
+    { perm: ModeratorPermission.RenameChannel, label: 'Rename channel' },
+    { perm: ModeratorPermission.SetPassword, label: 'Set/change channel password' },
+    { perm: ModeratorPermission.EditDesc, label: 'Edit channel description' },
+  ];
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="prompt glass-panel animate-slide-up" onClick={e => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="heading-title modal-title">
+            {role ? 'Edit Role' : 'Create Role'}
+          </h2>
+        </div>
+
+        <div className="modal-body">
+          <div className="form-group">
+            <label className="form-label">Role Name</label>
+            <input
+              type="text"
+              className="brmble-input"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="Enter role name..."
+            />
+          </div>
+
+          <div className="form-group">
+            <label className="form-label">Permissions</label>
+            <div className="permission-checkboxes">
+              {permissionItems.map(({ perm, label }) => (
+                <label key={perm} className="permission-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={(permissions & perm) !== 0}
+                    onChange={() => togglePermission(perm)}
+                  />
+                  <span>{label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="prompt-footer">
+          <button className="btn btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={handleSave}
+            disabled={!name.trim()}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -4,6 +4,7 @@ import type { ContextMenuItem } from '../ContextMenu/ContextMenu';
 import { UserInfoDialog } from '../UserInfoDialog/UserInfoDialog';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { UserTooltip } from '../UserTooltip/UserTooltip';
+import { ChannelEditModal } from '../ChannelEditModal/ChannelEditModal';
 import { usePermissions } from '../../hooks/usePermissions';
 import { prompt } from '../../hooks/usePrompt';
 import bridge from '../../bridge';
@@ -59,7 +60,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
   const [infoDialogUser, setInfoDialogUser] = useState<{ userId: string; userName: string; isSelf: boolean } | null>(null);
   const [draggedUser, setDraggedUser] = useState<number | null>(null);
   const [dropTargetChannel, setDropTargetChannel] = useState<number | null>(null);
-  const [editChannelDialog, setEditChannelDialog] = useState<{ id: number; name: string } | null>(null);
+  const [editChannelDialog, setEditChannelDialog] = useState<{ id: number; name: string; isAdmin: boolean } | null>(null);
   const [addSubchannelDialog, setAddSubchannelDialog] = useState<{ parentId: number } | null>(null);
   const [removeChannelDialog, setRemoveChannelDialog] = useState<{ id: number; name: string } | null>(null);
   const [removeConfirmText, setRemoveConfirmText] = useState('');
@@ -390,7 +391,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
         type: 'item' as const,
         label: 'Edit',
         onClick: () => {
-          setEditChannelDialog({ id: channelContextMenu.channelId, name: channelContextMenu.channelName });
+          setEditChannelDialog({ id: channelContextMenu.channelId, name: channelContextMenu.channelName, isAdmin: hasEditPermission });
           setChannelContextMenu(null);
         },
       });
@@ -639,24 +640,12 @@ onClick: () => {
         />
       )}
       {editChannelDialog && (
-        <div className="modal-overlay" onClick={() => setEditChannelDialog(null)}>
-          <div
-            className="prompt glass-panel animate-slide-up"
-            role="dialog"
-            aria-modal="true"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="modal-header">
-              <h2 className="heading-title modal-title">Edit Channel</h2>
-              <p className="modal-subtitle">Channel editing coming soon</p>
-            </div>
-            <div className="prompt-footer">
-              <button className="btn btn-primary" onClick={() => setEditChannelDialog(null)}>
-                Close
-              </button>
-            </div>
-          </div>
-        </div>
+        <ChannelEditModal
+          channelId={editChannelDialog.id}
+          channelName={editChannelDialog.name}
+          isAdmin={editChannelDialog.isAdmin}
+          onClose={() => setEditChannelDialog(null)}
+        />
       )}
 
       {addSubchannelDialog && (

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -23,6 +23,7 @@ interface User {
   matrixUserId?: string;
   avatarUrl?: string;
   isBrmbleClient?: boolean;
+  userId?: number;
 }
 
 interface Channel {
@@ -624,6 +625,7 @@ onClick: () => {
             userName={infoDialogUser.userName}
             session={parseInt(infoDialogUser.userId)}
             isSelf={infoDialogUser.isSelf}
+            userId={user?.userId}
             comment={user?.comment}
             matrixUserId={user?.matrixUserId}
             avatarUrl={user?.avatarUrl}
@@ -644,6 +646,7 @@ onClick: () => {
           channelId={editChannelDialog.id}
           channelName={editChannelDialog.name}
           isAdmin={editChannelDialog.isAdmin}
+          connectedUsers={users}
           onClose={() => setEditChannelDialog(null)}
         />
       )}

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -502,6 +502,7 @@ export function Sidebar({
             userName={infoDialogUser.userName}
             session={parseInt(infoDialogUser.userId)}
             isSelf={infoDialogUser.isSelf}
+            userId={user?.userId}
             comment={user?.comment}
             matrixUserId={user?.matrixUserId}
             avatarUrl={user?.avatarUrl}

--- a/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.css
+++ b/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.css
@@ -57,6 +57,22 @@
   width: fit-content;
 }
 
+.user-info-id-row {
+  display: flex;
+  gap: var(--space-xs);
+  margin-top: var(--space-2xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.user-info-id-label {
+  color: var(--text-muted);
+}
+
+.user-info-id-value {
+  color: var(--text-secondary);
+}
+
 .user-info-content {
   display: flex;
   flex-direction: column;

--- a/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
+++ b/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
@@ -9,6 +9,7 @@ export interface UserInfoDialogProps {
   userName: string;
   session: number;
   isSelf: boolean;
+  userId?: number;
   comment?: string;
   matrixUserId?: string;
   avatarUrl?: string;
@@ -21,6 +22,7 @@ export function UserInfoDialog({
   userName,
   session,
   isSelf,
+  userId,
   comment,
   matrixUserId,
   avatarUrl,
@@ -157,6 +159,12 @@ export function UserInfoDialog({
             <h2 id="user-info-title" className="user-info-name">{userName}</h2>
             {isSelf && <span className="user-info-badge">you</span>}
           </div>
+          {userId !== undefined && (
+            <div className="user-info-id-row">
+              <span className="user-info-id-label">User ID:</span>
+              <span className="user-info-id-value">{userId}</span>
+            </div>
+          )}
         </div>
 
         <div className="user-info-content">

--- a/src/Brmble.Web/src/hooks/useModeratorPermissions.ts
+++ b/src/Brmble.Web/src/hooks/useModeratorPermissions.ts
@@ -78,9 +78,24 @@ export function useModeratorPermissions(channelId: number | null) {
       }
     };
 
+    const handleRoleCreated = () => loadRoles();
+    const handleRoleUpdated = () => loadRoles();
+    const handleRoleDeleted = () => loadRoles();
+    const handleAssigned = () => {
+      if (channelId !== null) loadModerators(channelId);
+    };
+    const handleRemoved = () => {
+      if (channelId !== null) loadModerators(channelId);
+    };
+
     bridge.on('moderator.roles', handleRoles);
     bridge.on('moderator.channelModerators', handleModerators);
     bridge.on('moderator.currentUserPermissions', handleCurrentUserPermissions);
+    bridge.on('moderator.roleCreated', handleRoleCreated);
+    bridge.on('moderator.roleUpdated', handleRoleUpdated);
+    bridge.on('moderator.roleDeleted', handleRoleDeleted);
+    bridge.on('moderator.assigned', handleAssigned);
+    bridge.on('moderator.removed', handleRemoved);
 
     loadRoles();
 
@@ -88,6 +103,11 @@ export function useModeratorPermissions(channelId: number | null) {
       bridge.off('moderator.roles', handleRoles);
       bridge.off('moderator.channelModerators', handleModerators);
       bridge.off('moderator.currentUserPermissions', handleCurrentUserPermissions);
+      bridge.off('moderator.roleCreated', handleRoleCreated);
+      bridge.off('moderator.roleUpdated', handleRoleUpdated);
+      bridge.off('moderator.roleDeleted', handleRoleDeleted);
+      bridge.off('moderator.assigned', handleAssigned);
+      bridge.off('moderator.removed', handleRemoved);
     };
   }, [loadRoles]);
 

--- a/src/Brmble.Web/src/hooks/useModeratorPermissions.ts
+++ b/src/Brmble.Web/src/hooks/useModeratorPermissions.ts
@@ -40,6 +40,7 @@ export function useModeratorPermissions(channelId: number | null) {
   }, []);
 
   const createRole = useCallback((name: string, permissions: number) => {
+    console.log('[useModeratorPermissions] Creating role:', { name, permissions });
     bridge.send('moderator.createRole', { name, permissions });
   }, []);
 

--- a/src/Brmble.Web/src/hooks/useModeratorPermissions.ts
+++ b/src/Brmble.Web/src/hooks/useModeratorPermissions.ts
@@ -1,0 +1,122 @@
+import { useState, useEffect, useCallback } from 'react';
+import bridge from '../bridge';
+
+export interface ModeratorRole {
+  id: string;
+  name: string;
+  permissions: number;
+}
+
+export interface ModeratorAssignment {
+  id: string;
+  userId: number;
+  roleId: string;
+  roleName: string;
+  rolePermissions: number;
+  assignedAt: string;
+}
+
+export const ModeratorPermission = {
+  Kick: 0x001,
+  DenyEnter: 0x002,
+  RenameChannel: 0x004,
+  SetPassword: 0x008,
+  EditDesc: 0x010,
+} as const;
+
+export function useModeratorPermissions(channelId: number | null) {
+  const [roles, setRoles] = useState<ModeratorRole[]>([]);
+  const [moderators, setModerators] = useState<ModeratorAssignment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [currentUserPermissions, setCurrentUserPermissions] = useState<number>(0);
+
+  const loadRoles = useCallback(() => {
+    bridge.send('moderator.getRoles');
+  }, []);
+
+  const loadModerators = useCallback((chId: number) => {
+    setLoading(true);
+    bridge.send('moderator.getChannelModerators', { channelId: chId });
+  }, []);
+
+  const createRole = useCallback((name: string, permissions: number) => {
+    bridge.send('moderator.createRole', { name, permissions });
+  }, []);
+
+  const updateRole = useCallback((id: string, name?: string, permissions?: number) => {
+    bridge.send('moderator.updateRole', { id, name, permissions });
+  }, []);
+
+  const deleteRole = useCallback((id: string) => {
+    bridge.send('moderator.deleteRole', { id });
+  }, []);
+
+  const assignModerator = useCallback((roleId: string, userId: number) => {
+    if (channelId === null) return;
+    bridge.send('moderator.assign', { channelId, roleId, userId });
+  }, [channelId]);
+
+  const removeModerator = useCallback((assignmentId: string) => {
+    if (channelId === null) return;
+    bridge.send('moderator.remove', { channelId, assignmentId });
+  }, [channelId]);
+
+  useEffect(() => {
+    const handleRoles = (data: unknown) => {
+      setRoles(data as ModeratorRole[]);
+    };
+
+    const handleModerators = (data: unknown) => {
+      setModerators(data as ModeratorAssignment[]);
+      setLoading(false);
+    };
+
+    const handleCurrentUserPermissions = (data: unknown) => {
+      const payload = data as { channelId: number; permissions: number };
+      if (channelId !== null && payload.channelId === channelId) {
+        setCurrentUserPermissions(payload.permissions);
+      }
+    };
+
+    bridge.on('moderator.roles', handleRoles);
+    bridge.on('moderator.channelModerators', handleModerators);
+    bridge.on('moderator.currentUserPermissions', handleCurrentUserPermissions);
+
+    loadRoles();
+
+    return () => {
+      bridge.off('moderator.roles', handleRoles);
+      bridge.off('moderator.channelModerators', handleModerators);
+      bridge.off('moderator.currentUserPermissions', handleCurrentUserPermissions);
+    };
+  }, [loadRoles]);
+
+  useEffect(() => {
+    if (channelId !== null) {
+      loadModerators(channelId);
+      bridge.send('moderator.getCurrentUserPermissions', { channelId });
+    }
+  }, [channelId, loadModerators]);
+
+  const hasPermission = useCallback((permission: number): boolean => {
+    return (currentUserPermissions & permission) !== 0;
+  }, [currentUserPermissions]);
+
+  const hasAnyModeratorRole = currentUserPermissions > 0;
+
+  return {
+    roles,
+    moderators,
+    loading,
+    currentUserPermissions,
+    hasPermission,
+    hasAnyModeratorRole,
+    loadRoles,
+    loadModerators,
+    createRole,
+    updateRole,
+    deleteRole,
+    assignModerator,
+    removeModerator,
+  };
+}

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -27,6 +27,7 @@ export interface User {
   avatarUrl?: string;
   certHash?: string;
   isBrmbleClient?: boolean;
+  userId?: number;
 }
 
 export interface MediaAttachment {

--- a/tests/Brmble.Server.Tests/ModeratorAssignmentRepositoryTests.cs
+++ b/tests/Brmble.Server.Tests/ModeratorAssignmentRepositoryTests.cs
@@ -1,0 +1,92 @@
+using Brmble.Server.Data;
+using Brmble.Server.Moderator;
+using Microsoft.Data.Sqlite;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests;
+
+[TestClass]
+public class ModeratorAssignmentRepositoryTests
+{
+    private SqliteConnection? _keepAlive;
+    private Database _db = null!;
+    private ModeratorRoleRepository _roleRepo = null!;
+    private ModeratorAssignmentRepository _repo = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var dbName = "testdb_" + Guid.NewGuid().ToString("N");
+        var cs = $"Data Source={dbName};Mode=Memory;Cache=Shared";
+        _keepAlive = new SqliteConnection(cs);
+        _keepAlive.Open();
+        _db = new Database(cs);
+        _db.Initialize();
+        _roleRepo = new ModeratorRoleRepository(_db);
+        _repo = new ModeratorAssignmentRepository(_db);
+    }
+
+    [TestCleanup]
+    public void Cleanup() => _keepAlive?.Dispose();
+
+    [TestMethod]
+    public async Task CreateAsync_ReturnsAssignment()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermissions.Kick);
+        var assignment = await _repo.CreateAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+        
+        Assert.IsNotNull(assignment.Id);
+        Assert.AreEqual(role.Id, assignment.RoleId);
+        Assert.AreEqual(5, assignment.ChannelId);
+        Assert.AreEqual(123, assignment.UserId);
+    }
+
+    [TestMethod]
+    public async Task GetByChannelAsync_ReturnsAssignmentsForChannel()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermissions.Kick);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 1, assignedBy: 1);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 2, assignedBy: 1);
+        await _repo.CreateAsync(role.Id, channelId: 6, userId: 1, assignedBy: 1);
+        
+        var channel5Assignments = await _repo.GetByChannelAsync(5);
+        
+        Assert.AreEqual(2, channel5Assignments.Count);
+    }
+
+    [TestMethod]
+    public async Task GetByUserAndChannelAsync_ReturnsSpecificAssignment()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermissions.Kick);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+        
+        var assignment = await _repo.GetByUserAndChannelAsync(userId: 123, channelId: 5);
+        
+        Assert.IsNotNull(assignment);
+        Assert.AreEqual(123, assignment.UserId);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_RemovesAssignment()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermissions.Kick);
+        var assignment = await _repo.CreateAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+        await _repo.DeleteAsync(assignment.Id);
+        
+        var deleted = await _repo.GetByIdAsync(assignment.Id);
+        Assert.IsNull(deleted);
+    }
+
+    [TestMethod]
+    public async Task GetByChannelAndUserIdsAsync_ReturnsMatchingAssignments()
+    {
+        var role = await _roleRepo.CreateAsync("Test Role", ModeratorPermissions.Kick);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 1, assignedBy: 1);
+        await _repo.CreateAsync(role.Id, channelId: 5, userId: 2, assignedBy: 1);
+        await _repo.CreateAsync(role.Id, channelId: 6, userId: 3, assignedBy: 1);
+        
+        var assignments = await _repo.GetByChannelAndUserIdsAsync(5, new[] { 1, 2, 3 });
+        
+        Assert.AreEqual(2, assignments.Count);
+    }
+}

--- a/tests/Brmble.Server.Tests/ModeratorRoleRepositoryTests.cs
+++ b/tests/Brmble.Server.Tests/ModeratorRoleRepositoryTests.cs
@@ -1,0 +1,82 @@
+using Brmble.Server.Data;
+using Brmble.Server.Moderator;
+using Microsoft.Data.Sqlite;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests;
+
+[TestClass]
+public class ModeratorRoleRepositoryTests
+{
+    private SqliteConnection? _keepAlive;
+    private Database _db = null!;
+    private ModeratorRoleRepository _repo = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var dbName = "testdb_" + Guid.NewGuid().ToString("N");
+        var cs = $"Data Source={dbName};Mode=Memory;Cache=Shared";
+        _keepAlive = new SqliteConnection(cs);
+        _keepAlive.Open();
+        _db = new Database(cs);
+        _db.Initialize();
+        _repo = new ModeratorRoleRepository(_db);
+    }
+
+    [TestCleanup]
+    public void Cleanup() => _keepAlive?.Dispose();
+
+    [TestMethod]
+    public async Task CreateAsync_ReturnsRoleWithId()
+    {
+        var role = await _repo.CreateAsync("Test Role", ModeratorPermissions.Kick | ModeratorPermissions.DenyEnter);
+        
+        Assert.IsNotNull(role.Id);
+        Assert.AreEqual("Test Role", role.Name);
+        Assert.AreEqual(ModeratorPermissions.Kick | ModeratorPermissions.DenyEnter, role.Permissions);
+    }
+
+    [TestMethod]
+    public async Task GetByIdAsync_ReturnsRole()
+    {
+        var created = await _repo.CreateAsync("Test Role", ModeratorPermissions.Kick);
+        var retrieved = await _repo.GetByIdAsync(created.Id);
+        
+        Assert.IsNotNull(retrieved);
+        Assert.AreEqual(created.Id, retrieved.Id);
+        Assert.AreEqual("Test Role", retrieved.Name);
+    }
+
+    [TestMethod]
+    public async Task GetAllAsync_ReturnsAllRoles()
+    {
+        await _repo.CreateAsync("Role 1", ModeratorPermissions.Kick);
+        await _repo.CreateAsync("Role 2", ModeratorPermissions.DenyEnter);
+        
+        var roles = await _repo.GetAllAsync();
+        
+        Assert.AreEqual(2, roles.Count);
+    }
+
+    [TestMethod]
+    public async Task UpdateAsync_ModifiesRole()
+    {
+        var role = await _repo.CreateAsync("Original", ModeratorPermissions.Kick);
+        await _repo.UpdateAsync(role.Id, "Updated", ModeratorPermissions.DenyEnter);
+        
+        var updated = await _repo.GetByIdAsync(role.Id);
+        Assert.AreEqual("Updated", updated?.Name);
+        Assert.AreEqual(ModeratorPermissions.DenyEnter, updated?.Permissions);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_RemovesRole()
+    {
+        var role = await _repo.CreateAsync("To Delete", ModeratorPermissions.Kick);
+        await _repo.DeleteAsync(role.Id);
+        
+        var deleted = await _repo.GetByIdAsync(role.Id);
+        Assert.IsNull(deleted);
+    }
+}

--- a/tests/Brmble.Server.Tests/ModeratorServiceIntegrationTests.cs
+++ b/tests/Brmble.Server.Tests/ModeratorServiceIntegrationTests.cs
@@ -1,0 +1,133 @@
+using Brmble.Server.Data;
+using Brmble.Server.Moderator;
+using Microsoft.Data.Sqlite;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Brmble.Server.Tests;
+
+[TestClass]
+public class ModeratorServiceIntegrationTests
+{
+    private SqliteConnection? _keepAlive;
+    private Database _db = null!;
+    private ModeratorRoleRepository _roleRepo = null!;
+    private ModeratorAssignmentRepository _assignmentRepo = null!;
+    private SyncFailedAssignmentRepository _syncFailedRepo = null!;
+    private Mock<IMumbleGroupSyncService> _mumbleSyncMock = null!;
+    private ModeratorService _service = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var dbName = "testdb_" + Guid.NewGuid().ToString("N");
+        var cs = $"Data Source={dbName};Mode=Memory;Cache=Shared";
+        _keepAlive = new SqliteConnection(cs);
+        _keepAlive.Open();
+        _db = new Database(cs);
+        _db.Initialize();
+        _roleRepo = new ModeratorRoleRepository(_db);
+        _assignmentRepo = new ModeratorAssignmentRepository(_db);
+        _syncFailedRepo = new SyncFailedAssignmentRepository(_db);
+        _mumbleSyncMock = new Mock<IMumbleGroupSyncService>();
+        
+        var logger = new Microsoft.Extensions.Logging.Abstractions.NullLogger<ModeratorService>();
+        _service = new ModeratorService(
+            _roleRepo,
+            _assignmentRepo,
+            _syncFailedRepo,
+            _mumbleSyncMock.Object,
+            logger);
+    }
+
+    [TestCleanup]
+    public void Cleanup() => _keepAlive?.Dispose();
+
+    [TestMethod]
+    public async Task CreateAndAssignModerator_SyncsToMumble()
+    {
+        var role = await _service.CreateRoleAsync("Test Mod", ModeratorPermissions.Kick);
+        _mumbleSyncMock.Setup(x => x.SyncAssignmentAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), true))
+            .ReturnsAsync(true);
+
+        var assignment = await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+
+        Assert.IsNotNull(assignment);
+        _mumbleSyncMock.Verify(x => x.SyncAssignmentAsync(
+            assignment.Id, 123, 5, true), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RemoveModerator_SyncsToMumble()
+    {
+        var role = await _service.CreateRoleAsync("Test Mod", ModeratorPermissions.Kick);
+        _mumbleSyncMock.Setup(x => x.SyncAssignmentAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>()))
+            .ReturnsAsync(true);
+        var assignment = await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+
+        _mumbleSyncMock.Invocations.Clear();
+
+        await _service.RemoveModeratorAsync(assignment.Id);
+
+        _mumbleSyncMock.Verify(x => x.SyncAssignmentAsync(
+            assignment.Id, 123, 5, false), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task FailedSync_QueuesForRetry()
+    {
+        var role = await _service.CreateRoleAsync("Test Mod", ModeratorPermissions.Kick);
+        _mumbleSyncMock.Setup(x => x.SyncAssignmentAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), true))
+            .ReturnsAsync(false);
+
+        await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+
+        var pending = await _syncFailedRepo.GetPendingAsync();
+        Assert.AreEqual(1, pending.Count);
+        Assert.AreEqual("add", pending[0].Action);
+    }
+
+    [TestMethod]
+    public async Task GetUserPermissionsForChannel_ReturnsCorrectPermissions()
+    {
+        var role = await _service.CreateRoleAsync("Full Mod", 
+            ModeratorPermissions.Kick | ModeratorPermissions.DenyEnter | ModeratorPermissions.RenameChannel);
+        await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 123, assignedBy: 1);
+
+        var perms = await _service.GetUserPermissionsForChannelAsync(123, 5);
+
+        Assert.AreEqual(ModeratorPermissions.Kick | ModeratorPermissions.DenyEnter | ModeratorPermissions.RenameChannel, perms);
+    }
+
+    [TestMethod]
+    public async Task GetUserPermissionsForChannel_NoAssignment_ReturnsNone()
+    {
+        var perms = await _service.GetUserPermissionsForChannelAsync(999, 5);
+
+        Assert.AreEqual(ModeratorPermissions.None, perms);
+    }
+
+    [TestMethod]
+    public async Task CleanupChannelAssignments_DeletesAllAssignments()
+    {
+        var role = await _service.CreateRoleAsync("Test Mod", ModeratorPermissions.Kick);
+        _mumbleSyncMock.Setup(x => x.SyncAssignmentAsync(
+            It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>()))
+            .ReturnsAsync(true);
+        
+        await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 1, assignedBy: 1);
+        await _service.AssignModeratorAsync(role.Id, channelId: 5, userId: 2, assignedBy: 1);
+        await _service.AssignModeratorAsync(role.Id, channelId: 6, userId: 1, assignedBy: 1);
+
+        await _service.CleanupChannelAssignmentsAsync(5);
+
+        var remaining = await _service.GetChannelModeratorsAsync(5);
+        Assert.AreEqual(0, remaining.Count);
+        
+        var otherChannel = await _service.GetChannelModeratorsAsync(6);
+        Assert.AreEqual(1, otherChannel.Count);
+    }
+}

--- a/tests/Brmble.Server.Tests/PermissionEnforcerTests.cs
+++ b/tests/Brmble.Server.Tests/PermissionEnforcerTests.cs
@@ -1,0 +1,62 @@
+using Brmble.Server.Moderator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Brmble.Server.Tests;
+
+[TestClass]
+public class PermissionEnforcerTests
+{
+    private Mock<IModeratorPermissionChecker> _checkerMock = null!;
+    private PermissionEnforcer _enforcer = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _checkerMock = new Mock<IModeratorPermissionChecker>();
+        _enforcer = new PermissionEnforcer(_checkerMock.Object);
+    }
+
+    [TestMethod]
+    public async Task HasModeratorPermission_ReturnsTrue_WhenUserHasPermission()
+    {
+        _checkerMock.Setup(x => x.GetModeratorPermissionsAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(ModeratorPermissions.Kick | ModeratorPermissions.DenyEnter);
+
+        var result = await _enforcer.HasModeratorPermissionAsync(userId: 123, channelId: 5, ModeratorPermissions.Kick);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public async Task HasModeratorPermission_ReturnsFalse_WhenUserLacksPermission()
+    {
+        _checkerMock.Setup(x => x.GetModeratorPermissionsAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(ModeratorPermissions.Kick);
+
+        var result = await _enforcer.HasModeratorPermissionAsync(userId: 123, channelId: 5, ModeratorPermissions.DenyEnter);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public async Task HasModeratorPermission_ReturnsFalse_WhenUserHasNoModeratorRole()
+    {
+        _checkerMock.Setup(x => x.GetModeratorPermissionsAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(ModeratorPermissions.None);
+
+        var result = await _enforcer.HasModeratorPermissionAsync(userId: 123, channelId: 5, ModeratorPermissions.Kick);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public async Task RequireModeratorPermission_Throws_WhenUserLacksPermission()
+    {
+        _checkerMock.Setup(x => x.GetModeratorPermissionsAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(ModeratorPermissions.None);
+
+        await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(
+            () => _enforcer.RequireModeratorPermissionAsync(userId: 123, channelId: 5, ModeratorPermissions.Kick));
+    }
+}


### PR DESCRIPTION
## Summary

- **UI Improvements**: ChannelEditModal tabs now match Settings modal styling with proper spacing and hover states
- **Role Creation Modal**: Improved styling with toggle switches for permission selection instead of checkboxes
- **User Info Display**: Admins can now see the User ID (Mumble registration ID) when viewing user info
- **Connected Users List**: Add Moderator modal shows connected registered users with their User ID and nickname

## Changes

### Frontend
- `ChannelEditModal.css`: Updated tab styling to match Settings modal, increased modal width to 600px
- `ManageModeratorsTab.tsx` & `.css`: Improved role modal styling, added toggle switches for permissions, simplified Add Moderator flow to show user list
- `UserInfoDialog.tsx` & `.css`: Added User ID display below username
- `ChannelTree.tsx` & `Sidebar.tsx`: Pass connected users and userId to components

### Client
- `MumbleAdapter.cs`: Now sends `RegisteredUserId` from Mumble to frontend

### Server
- `ModeratorEndpoints.cs`: Added logging for debugging role creation

## Known Issues

### 1. Registered Users List Not Working (#417)

**The "Add Moderator" feature to show a list of registered users is NOT fully working.**

- `getRegisteredUsers()` via Mumble's ICE interface returns an empty list
- Users exist in Mumble (verified with native Mumble client showing 17 registered accounts)
- ICE connection works for other operations (getChannels succeeds)

**Current Workaround**: The UI shows connected users who have a `userId` (registered Mumble users currently connected to the voice server).

### 2. Channel Password Setting Not Working (#417)

**Setting a channel password via the Edit Channel modal does nothing.**

**Root Cause**:
1. No handler exists for `voice.updateChannel` in the client
2. MumbleSharp's ChannelState protobuf is missing the password field (field 14)

**Files affected**: 
- `lib/MumbleSharp/MumbleSharp/Packets/Mumble.cs` - needs password field
- `lib/MumbleSharp/MumbleSharp/Model/Channel.cs` - needs Password property
- `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` - needs updateChannel handler

See issue #417 for detailed analysis and potential solutions.

## Testing

1. Open Edit Channel modal - tabs should be readable and properly spaced
2. Click "Create Role" - toggle switches should work for permissions
3. Right-click on a user as admin - User Info should show User ID
4. Click "Add Moderator" - should show list of connected registered users