### PR TITLE
fix: disable Brmblegotchi by default

### DIFF
--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -137,10 +137,10 @@ function App() {
       const stored = localStorage.getItem('brmble-settings');
       if (stored) {
         const parsed = JSON.parse(stored);
-        return parsed.brmblegotchi?.enabled ?? true;
+        return parsed.brmblegotchi?.enabled ?? false;
       }
     } catch { /* ignore */ }
-    return true;
+    return false;
   });
   const setBrmblegotchiEnabled = useCallback((enabled: boolean) => {
     setBrmblegotchiEnabledState(enabled);


### PR DESCRIPTION
## Summary

- Disable Brmblegotchi feature by default for new users
- Users can still enable it manually via Settings > Appearance

## Problem

The Brmblegotchi companion pet was enabled by default for all users. Since this is an optional/fun feature that some users may not want, it should be disabled by default and require explicit opt-in.

## Solution

Changed the default value of `brmblegotchi.enabled` from `true` to `false` in `App.tsx`. Existing users who have already enabled Brmblegotchi will retain their preference (stored in localStorage).

## Testing

- Verified the change compiles without errors
- Existing localStorage settings are preserved for users who previously enabled Brmblegotchi

## Notes

- This is a purely opt-out feature change
- No migration or data cleanup required