### PR TITLE
feat: Add right-click context menu for channel creation

### DIFF
--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1977,6 +1977,15 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             }
 
             var description = data.TryGetProperty("description", out var d) ? d.GetString() : null;
+            if (!string.IsNullOrEmpty(description))
+            {
+                var utf8Length = System.Text.Encoding.UTF8.GetByteCount(description);
+                if (utf8Length >= 128)
+                {
+                    _bridge?.Send("voice.error", new { message = "Channel description exceeds 127 bytes (UTF-8)", type = "invalidRequest" });
+                    return Task.CompletedTask;
+                }
+            }
             var parent = data.TryGetProperty("parent", out var p) ? p.GetUInt32() : 0u;
 
             Connection.SendControl(PacketType.ChannelState, new MumbleProto.ChannelState

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1961,6 +1961,34 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             return Task.CompletedTask;
         });
 
+        bridge.RegisterHandler("voice.addChannel", data =>
+        {
+            if (Connection is not { State: ConnectionStates.Connected })
+            {
+                _bridge?.Send("voice.error", new { message = "Not connected to server", type = "notConnected" });
+                return Task.CompletedTask;
+            }
+
+            var name = data.TryGetProperty("name", out var n) ? n.GetString() : null;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                _bridge?.Send("voice.error", new { message = "Channel name is required", type = "invalidRequest" });
+                return Task.CompletedTask;
+            }
+
+            var description = data.TryGetProperty("description", out var d) ? d.GetString() : null;
+            var parent = data.TryGetProperty("parent", out var p) ? p.GetUInt32() : 0u;
+
+            Connection.SendControl(PacketType.ChannelState, new MumbleProto.ChannelState
+            {
+                Parent = parent,
+                Name = name,
+                Description = description,
+            });
+
+            return Task.CompletedTask;
+        });
+
         bridge.RegisterHandler("voice.getBans", data =>
         {
             if (Connection is not { State: ConnectionStates.Connected })

--- a/src/Brmble.Web/src/components/Prompt/Prompt.css
+++ b/src/Brmble.Web/src/components/Prompt/Prompt.css
@@ -35,3 +35,10 @@
   flex: 1;
   max-width: 140px;
 }
+
+.char-counter {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  align-self: center;
+  min-width: 40px;
+}

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -588,8 +588,8 @@ export function Sidebar({
               <button className="btn btn-secondary" onClick={() => { setAddChannelDialog(false); setNewChannelName(''); setNewChannelDescription(''); }}>
                 Cancel
               </button>
-              <button className="btn btn-primary" disabled>
-                Send (coming soon)
+              <button className="btn btn-primary" onClick={() => { bridge.send('voice.addChannel', { name: newChannelName, description: newChannelDescription, parent: 0 }); setAddChannelDialog(false); setNewChannelName(''); setNewChannelDescription(''); }}>
+                Send
               </button>
             </div>
           </div>

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -302,6 +302,9 @@ export function Sidebar({
       )}
 
       <div className="sidebar-channels" onContextMenu={(e) => {
+        if (e.target !== e.currentTarget) {
+          return;
+        }
         e.preventDefault();
         setSidebarContextMenu({ x: e.clientX, y: e.clientY });
       }}>
@@ -577,18 +580,19 @@ export function Sidebar({
             <div className="prompt-input-container">
               <textarea
                 className="brmble-input"
-                placeholder="Description (optional)"
+                placeholder="Description (optional, max 127 chars)"
                 value={newChannelDescription}
-                onChange={(e) => setNewChannelDescription(e.target.value)}
+                onChange={(e) => setNewChannelDescription(e.target.value.slice(0, 127))}
                 rows={3}
                 style={{ resize: 'vertical', minHeight: '60px' }}
               />
             </div>
             <div className="prompt-footer">
+              <span className="char-counter">{newChannelDescription.length}/127</span>
               <button className="btn btn-secondary" onClick={() => { setAddChannelDialog(false); setNewChannelName(''); setNewChannelDescription(''); }}>
                 Cancel
               </button>
-              <button className="btn btn-primary" onClick={() => { bridge.send('voice.addChannel', { name: newChannelName, description: newChannelDescription, parent: 0 }); setAddChannelDialog(false); setNewChannelName(''); setNewChannelDescription(''); }}>
+              <button className="btn btn-primary" disabled={newChannelName.trim().length === 0} onClick={() => { const trimmedName = newChannelName.trim(); if (!trimmedName) { return; } bridge.send('voice.addChannel', { name: trimmedName, description: newChannelDescription, parent: 0 }); setAddChannelDialog(false); setNewChannelName(''); setNewChannelDescription(''); }}>
                 Send
               </button>
             </div>

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -553,6 +553,68 @@ export function Sidebar({
           />
         );
       })()}
+      {addChannelDialog && (
+        <div className="modal-overlay" onClick={() => { setAddChannelDialog(false); setNewChannelName(''); setNewChannelDescription(''); }}>
+          <div
+            className="prompt glass-panel animate-slide-up"
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="modal-header">
+              <h2 className="heading-title modal-title">Add Channel</h2>
+            </div>
+            <div className="prompt-input-container">
+              <input
+                type="text"
+                className="brmble-input"
+                placeholder="Channel name"
+                value={newChannelName}
+                onChange={(e) => setNewChannelName(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <div className="prompt-input-container">
+              <textarea
+                className="brmble-input"
+                placeholder="Description (optional)"
+                value={newChannelDescription}
+                onChange={(e) => setNewChannelDescription(e.target.value)}
+                rows={3}
+                style={{ resize: 'vertical', minHeight: '60px' }}
+              />
+            </div>
+            <div className="prompt-footer">
+              <button className="btn btn-secondary" onClick={() => { setAddChannelDialog(false); setNewChannelName(''); setNewChannelDescription(''); }}>
+                Cancel
+              </button>
+              <button className="btn btn-primary" disabled>
+                Send (coming soon)
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {requestChannelDialog && (
+        <div className="modal-overlay" onClick={() => setRequestChannelDialog(false)}>
+          <div
+            className="prompt glass-panel animate-slide-up"
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="modal-header">
+              <h2 className="heading-title modal-title">Request Channel</h2>
+              <p className="modal-subtitle">Channel request feature coming soon</p>
+            </div>
+            <div className="prompt-footer">
+              <button className="btn btn-primary" onClick={() => setRequestChannelDialog(false)}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <div
         className={`sidebar-resize-handle${isDragging ? ' sidebar-resize-handle--active' : ''}`}
         ref={handleProps.ref}

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -113,6 +113,12 @@ export function Sidebar({
 
   const [infoDialogUser, setInfoDialogUser] = useState<{ userId: string; userName: string; isSelf: boolean } | null>(null);
 
+  const [sidebarContextMenu, setSidebarContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [addChannelDialog, setAddChannelDialog] = useState(false);
+  const [requestChannelDialog, setRequestChannelDialog] = useState(false);
+  const [newChannelName, setNewChannelName] = useState('');
+  const [newChannelDescription, setNewChannelDescription] = useState('');
+
   const { hasPermission, Permission, requestPermissions } = usePermissions();
 
   useEffect(() => {
@@ -295,7 +301,10 @@ export function Sidebar({
         </div>
       )}
 
-      <div className="sidebar-channels">
+      <div className="sidebar-channels" onContextMenu={(e) => {
+        e.preventDefault();
+        setSidebarContextMenu({ x: e.clientX, y: e.clientY });
+      }}>
         {connected && (
           <div className="channels-section-header">
             <h4 className="heading-label">Channels</h4>
@@ -491,6 +500,41 @@ export function Sidebar({
             })(),
           ]}
           onClose={() => setContextMenu(null)}
+        />
+      )}
+      {sidebarContextMenu && (
+        <ContextMenu
+          x={sidebarContextMenu.x}
+          y={sidebarContextMenu.y}
+          items={[
+            ...(hasPermission(0, Permission.MakeChannel) ? [{
+              type: 'item' as const,
+              label: 'Add Channel',
+              icon: (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M12 5v14M5 12h14"/>
+                </svg>
+              ),
+              onClick: () => {
+                setAddChannelDialog(true);
+                setSidebarContextMenu(null);
+              },
+            }] : []),
+            {
+              type: 'item' as const,
+              label: 'Request Channel',
+              icon: (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+                </svg>
+              ),
+              onClick: () => {
+                setRequestChannelDialog(true);
+                setSidebarContextMenu(null);
+              },
+            },
+          ]}
+          onClose={() => setSidebarContextMenu(null)}
         />
       )}
       {infoDialogUser && (() => {


### PR DESCRIPTION
## Summary

- Add right-click context menu on sidebar-channels container with:
  - "Add Channel" option (visible for admins with MakeChannel permission on root)
  - "Request Channel" option (visible for all users, placeholder feature)
- Add Add Channel dialog with channel name and optional description fields
- Add `voice.addChannel` backend handler in MumbleAdapter that creates channels via Mumble protocol (ChannelState packet)
- Request Channel dialog shows placeholder "coming soon" message

## Changes

- `Sidebar.tsx`: Context menu, dialogs, state management
- `MumbleAdapter.cs`: `voice.addChannel` handler using Mumble protocol

## Test Plan

- [ ] Right-click on sidebar-channels area (empty space)
- [ ] Verify "Add Channel" appears for admin users
- [ ] Verify "Request Channel" appears for all users
- [ ] Test creating a channel with name and description
- [ ] Verify channel appears in channel list after creation