### PR TITLE
fix: context menu flip positioning with viewport clamping

### DIFF
--- a/docs/superpowers/plans/2026-04-01-context-menu-flip-plan.md
+++ b/docs/superpowers/plans/2026-04-01-context-menu-flip-plan.md
@@ -1,0 +1,88 @@
+# Context Menu Flip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement context menu position flipping so menus flip above/to the left when there's no room below/to the right, matching Qt/Mumble behavior.
+
+**Architecture:** Modify the existing ContextMenu.tsx useEffect that handles positioning to implement flip logic instead of clamping.
+
+**Tech Stack:** React, TypeScript
+
+---
+
+### Task 1: Implement Position Flipping Logic
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx:126-134`
+
+- [ ] **Step 1: Read the existing ContextMenu.tsx to understand current implementation**
+
+Read: `src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx`
+Focus on lines 126-134 where positioning is handled.
+
+- [ ] **Step 2: Modify the positioning useEffect to implement flip logic**
+
+Replace the existing positioning code (lines 126-134) with:
+
+```typescript
+useEffect(() => {
+  if (menuRef.current) {
+    const rect = menuRef.current.getBoundingClientRect();
+    const menuWidth = rect.width;
+    const menuHeight = rect.height;
+    
+    const spaceBelow = window.innerHeight - y - 8;
+    const spaceRight = window.innerWidth - x - 8;
+    const spaceAbove = y - 8;
+    const spaceLeft = x - 8;
+    
+    let finalX = x;
+    let finalY = y;
+    
+    if (menuHeight > spaceBelow && menuHeight <= spaceAbove) {
+      finalY = y - menuHeight;
+    } else if (menuHeight > spaceBelow && menuHeight > spaceAbove) {
+      finalY = Math.max(8, spaceAbove);
+    }
+    
+    if (menuWidth > spaceRight && menuWidth <= spaceLeft) {
+      finalX = x - menuWidth;
+    } else if (menuWidth > spaceRight && menuWidth > spaceLeft) {
+      finalX = Math.max(8, spaceLeft);
+    }
+    
+    menuRef.current.style.left = `${finalX}px`;
+    menuRef.current.style.top = `${finalY}px`;
+  }
+}, [x, y]);
+```
+
+- [ ] **Step 3: Verify the change compiles**
+
+Run: `cd src/Brmble.Web && npm run build`
+Expected: Build completes without errors
+
+- [ ] **Step 4: Test the behavior manually**
+
+1. Build the frontend: `cd src/Brmble.Web && npm run build`
+2. Run the client: `dotnet run --project src/Brmble.Client`
+3. Right-click a channel at the bottom of the sidebar → menu should flip to appear above
+4. Right-click a channel at the far right edge → menu should flip to appear to the left
+5. Right-click in the middle → menu appears below/right as normal
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+git commit -m "feat: add context menu position flipping"
+```
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-01-context-menu-flip-plan.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-01-context-menu-flip-design.md
+++ b/docs/superpowers/specs/2026-04-01-context-menu-flip-design.md
@@ -1,0 +1,68 @@
+# Context Menu Position Flip Design
+
+## Context
+
+The context menu in the Brmble sidebar currently constrains itself to stay within the window bounds. When right-clicking a channel at the bottom of the list, the menu appears cut off because it cannot overflow outside the window.
+
+The original Mumble client uses Qt's `QMenu::exec()`, which automatically flips the menu to appear above the cursor when there isn't enough room below. This is the expected behavior users are familiar with.
+
+## Problem
+
+Current implementation in `src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx` (lines 126-134):
+
+```javascript
+const maxX = window.innerWidth - rect.width - 8;
+const maxY = window.innerHeight - rect.height - 8;
+if (x > maxX) menuRef.current.style.left = `${maxX}px`;
+if (y > maxY) menuRef.current.style.top = `${maxY}px`;
+```
+
+This clamps the position to fit within the viewport, preventing the natural flip behavior users expect.
+
+## Solution
+
+Implement position flipping similar to Qt's default behavior:
+
+1. **Calculate available space** in each direction from the cursor position
+2. **Flip vertically** if there's not enough room below (show above cursor)
+3. **Flip horizontally** if there's not enough room to the right (show to the left of cursor)
+4. **Only clamp as fallback** when flipping still doesn't provide enough space
+
+### Algorithm
+
+```
+spaceBelow = window.innerHeight - y - 8
+spaceRight = window.innerWidth - x - 8
+
+if (menuHeight > spaceBelow AND menuHeight <= y):
+    // Flip above if there's room
+    finalY = y - menuHeight
+else:
+    finalY = y  // Keep below
+
+if (menuWidth > spaceRight AND menuWidth <= x):
+    // Flip left if there's room
+    finalX = x - menuWidth
+else:
+    finalX = x  // Keep right
+```
+
+## Implementation
+
+Modify the `useEffect` in `ContextMenu.tsx` (lines 126-134) to:
+1. Calculate available space in all four directions
+2. Determine whether to flip vertically and/or horizontally
+3. Apply flip positioning before falling back to clamping
+
+No changes to the component interface or other files required.
+
+## Testing
+
+- Right-click channel at bottom of sidebar → menu should appear above
+- Right-click channel at far right edge → menu should appear to the left
+- Right-click channel in middle → menu appears below/right as normal
+- Menus with submenus continue to work correctly
+
+## Files Affected
+
+- `src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx`

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -126,10 +126,31 @@ export function ContextMenu({ x, y, items, onClose, mouseLeaveDelay = MOUSE_LEAV
   useEffect(() => {
     if (menuRef.current) {
       const rect = menuRef.current.getBoundingClientRect();
-      const maxX = window.innerWidth - rect.width - 8;
-      const maxY = window.innerHeight - rect.height - 8;
-      if (x > maxX) menuRef.current.style.left = `${maxX}px`;
-      if (y > maxY) menuRef.current.style.top = `${maxY}px`;
+      const menuWidth = rect.width;
+      const menuHeight = rect.height;
+      
+      const spaceBelow = window.innerHeight - y - 8;
+      const spaceRight = window.innerWidth - x - 8;
+      const spaceAbove = y - 8;
+      const spaceLeft = x - 8;
+      
+      let finalX = x;
+      let finalY = y;
+      
+      if (menuHeight > spaceBelow && menuHeight <= spaceAbove) {
+        finalY = y - menuHeight;
+      } else if (menuHeight > spaceBelow && menuHeight > spaceAbove) {
+        finalY = Math.max(8, spaceAbove);
+      }
+      
+      if (menuWidth > spaceRight && menuWidth <= spaceLeft) {
+        finalX = x - menuWidth;
+      } else if (menuWidth > spaceRight && menuWidth > spaceLeft) {
+        finalX = Math.max(8, spaceLeft);
+      }
+      
+      menuRef.current.style.left = `${finalX}px`;
+      menuRef.current.style.top = `${finalY}px`;
     }
   }, [x, y]);
 

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import './ContextMenu.css';
 
 const MOUSE_LEAVE_CLOSE_DELAY = 400;
@@ -33,8 +33,46 @@ function Submenu({ item, depth, onItemClick }: { item: { type: 'item'; children?
   useEffect(() => {
     if (submenuRef.current) {
       const rect = submenuRef.current.getBoundingClientRect();
+      
+      const x = parseInt(submenuRef.current.parentElement?.style.left || '0', 10);
+      const y = parseInt(submenuRef.current.parentElement?.style.top || '0', 10);
+      
+      const submenuWidth = rect.width;
+      const submenuHeight = rect.height;
+      
+      const spaceRight = window.innerWidth - x - 8;
+      const spaceLeft = x - 8;
+      const spaceBelow = window.innerHeight - y - 8;
+      const spaceAbove = y - 8;
+      
+      let newLeft: number | undefined;
+      let newTop: number | undefined;
+
+      if (submenuWidth > spaceRight && submenuWidth <= spaceLeft) {
+        newLeft = x - submenuWidth;
+      } else if (submenuWidth > spaceRight && submenuWidth > spaceLeft) {
+        newLeft = Math.max(8, window.innerWidth - submenuWidth - 8);
+      }
+      
+      if (submenuHeight > spaceBelow && submenuHeight <= spaceAbove) {
+        newTop = y - submenuHeight;
+      } else if (submenuHeight > spaceBelow && submenuHeight > spaceAbove) {
+        newTop = Math.max(8, spaceAbove);
+      }
+
+      if (newLeft !== undefined) {
+        submenuRef.current.style.left = `${newLeft}px`;
+      }
+      if (newTop !== undefined) {
+        submenuRef.current.style.top = `${newTop}px`;
+      }
+
       if (rect.right > window.innerWidth - 8) {
         submenuRef.current.classList.add('context-submenu--off-right');
+      }
+
+      if (rect.bottom > window.innerHeight - 8) {
+        submenuRef.current.classList.add('context-submenu--off-bottom');
       }
     }
   }, []);
@@ -123,36 +161,40 @@ export function ContextMenu({ x, y, items, onClose, mouseLeaveDelay = MOUSE_LEAV
     };
   }, []);
 
+  const spaceCalculations = useMemo(() => ({
+    x,
+    y,
+    spaceBelow: window.innerHeight - y - 8,
+    spaceRight: window.innerWidth - x - 8,
+    spaceAbove: y - 8,
+    spaceLeft: x - 8,
+  }), [x, y]);
+
   useEffect(() => {
-    if (menuRef.current) {
-      const rect = menuRef.current.getBoundingClientRect();
-      const menuWidth = rect.width;
-      const menuHeight = rect.height;
-      
-      const spaceBelow = window.innerHeight - y - 8;
-      const spaceRight = window.innerWidth - x - 8;
-      const spaceAbove = y - 8;
-      const spaceLeft = x - 8;
-      
-      let finalX = x;
-      let finalY = y;
-      
-      if (menuHeight > spaceBelow && menuHeight <= spaceAbove) {
-        finalY = y - menuHeight;
-      } else if (menuHeight > spaceBelow && menuHeight > spaceAbove) {
-        finalY = Math.max(8, spaceAbove);
-      }
-      
-      if (menuWidth > spaceRight && menuWidth <= spaceLeft) {
-        finalX = x - menuWidth;
-      } else if (menuWidth > spaceRight && menuWidth > spaceLeft) {
-        finalX = Math.max(8, spaceLeft);
-      }
-      
-      menuRef.current.style.left = `${finalX}px`;
-      menuRef.current.style.top = `${finalY}px`;
+    if (!menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    const menuWidth = rect.width;
+    const menuHeight = rect.height;
+    const { spaceBelow, spaceRight, spaceAbove, spaceLeft } = spaceCalculations;
+    
+    let finalX: number = x;
+    let finalY: number = y;
+    
+    if (menuHeight > spaceBelow && menuHeight <= spaceAbove) {
+      finalY = y - menuHeight;
+    } else if (menuHeight > spaceBelow && menuHeight > spaceAbove) {
+      finalY = Math.max(8, window.innerHeight - menuHeight - 8);
     }
-  }, [x, y]);
+    
+    if (menuWidth > spaceRight && menuWidth <= spaceLeft) {
+      finalX = x - menuWidth;
+    } else if (menuWidth > spaceRight && menuWidth > spaceLeft) {
+      finalX = Math.max(8, window.innerWidth - menuWidth - 8);
+    }
+    
+    menuRef.current.style.left = `${finalX}px`;
+    menuRef.current.style.top = `${finalY}px`;
+  }, [x, y, spaceCalculations]);
 
   const handleMouseEnter = (e: React.MouseEvent) => {
     const isTopLevel = (e.target as HTMLElement).closest('.context-menu') === menuRef.current;

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -32,10 +32,11 @@ function Submenu({ item, depth, onItemClick }: { item: { type: 'item'; children?
 
   useEffect(() => {
     if (submenuRef.current) {
+      const parentRect = submenuRef.current.parentElement?.getBoundingClientRect();
       const rect = submenuRef.current.getBoundingClientRect();
       
-      const x = parseInt(submenuRef.current.parentElement?.style.left || '0', 10);
-      const y = parseInt(submenuRef.current.parentElement?.style.top || '0', 10);
+      const x = parentRect?.left ?? 0;
+      const y = parentRect?.top ?? 0;
       
       const submenuWidth = rect.width;
       const submenuHeight = rect.height;
@@ -67,11 +68,12 @@ function Submenu({ item, depth, onItemClick }: { item: { type: 'item'; children?
         submenuRef.current.style.top = `${newTop}px`;
       }
 
-      if (rect.right > window.innerWidth - 8) {
+      const adjustedRect = submenuRef.current.getBoundingClientRect();
+      if (adjustedRect.right > window.innerWidth - 8) {
         submenuRef.current.classList.add('context-submenu--off-right');
       }
 
-      if (rect.bottom > window.innerHeight - 8) {
+      if (adjustedRect.bottom > window.innerHeight - 8) {
         submenuRef.current.classList.add('context-submenu--off-bottom');
       }
     }


### PR DESCRIPTION
## Summary

- Context menu now flips to opposite side when there's insufficient space in the original direction
- Added viewport boundary clamping to prevent menus from rendering outside the visible area
- Fixes edge case where menu would overflow viewport when too large for both directions

## Changes

### `src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx`

**Flip Logic (Commit 1 - `7c07105`)**
- Calculates available space in all 4 directions (below, above, right, left)
- Menu flips vertically when: `menuHeight > spaceBelow && menuHeight <= spaceAbove`
- Menu flips horizontally when: `menuWidth > spaceRight && menuWidth <= spaceLeft`

**Viewport Clamping (Commit 2 - `bd9a724`)**
- When menu is too large for ALL directions, clamps position to nearest viewport edge
- Applied to both main menu and submenus
- Ensures `8px` margin from viewport edges

## Before

Context menu would overflow viewport when:
- Right-clicking near right edge with a wide menu
- Right-clicking near bottom edge with a tall menu

## After

- Menu automatically flips to opposite side when space is insufficient
- Falls back to nearest viewport edge when menu is larger than available space in both directions
- Consistent behavior across main menu and submenus

## Testing

Test these scenarios:
1. Right-click at bottom-right of viewport → menu flips up and left
2. Right-click near any edge → menu stays within viewport bounds
3. Right-click with very large menu → menu clamped to nearest edge

## Notes

- No breaking changes
- Backwards compatible