### PR TITLE
feat: add voice controls context menu to mute, deafen, and screen share buttons

### DIFF
--- a/docs/superpowers/plans/2026-04-05-voice-context-menu-plan.md
+++ b/docs/superpowers/plans/2026-04-05-voice-context-menu-plan.md
@@ -1,0 +1,473 @@
+# Voice Controls Context Menu Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a context menu to the mute button with quick access to Push-to-Talk toggle, Input Volume slider, and Voice Settings shortcut.
+
+**Architecture:** Extend the existing ContextMenu component with new item types (checkbox, slider). UserPanel manages context menu state and reads/writes audio settings via bridge + localStorage, matching SettingsModal patterns.
+
+**Tech Stack:** React (UserPanel, ContextMenu), TypeScript, CSS
+
+---
+
+## File Structure
+
+- Modify: `src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx` — Add checkbox/slider item types
+- Modify: `src/Brmble.Web/src/components/ContextMenu/ContextMenu.css` — Add styles for new item types
+- Modify: `src/Brmble.Web/src/components/UserPanel/UserPanel.tsx` — Add context menu state and right-click handler
+- Modify: `src/Brmble.Web/src/App.tsx` — Pass audio settings handlers to UserPanel
+
+---
+
+## Tasks
+
+### Task 1: Extend ContextMenu Item Types
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx`
+
+- [ ] **Step 1: Add new item type definitions**
+
+Find the `ContextMenuItem` type definition (around line 6) and update it:
+
+```typescript
+type ContextMenuItem =
+  | { type: 'divider' }
+  | { type: 'item'; label: string; onClick?: () => void; icon?: React.ReactNode; disabled?: boolean; children?: ContextMenuItem[] }
+  | { type: 'checkbox'; label: string; checked: boolean; onChange: (checked: boolean) => void; disabled?: boolean }
+  | { type: 'slider'; label: string; value: number; min: number; max: number; onChange: (value: number) => void; disabled?: boolean };
+```
+
+- [ ] **Step 2: Add CheckboxMenuItem component**
+
+Add this new component after the `MenuItem` function (before the closing of the file, around line 95):
+
+```typescript
+function CheckboxMenuItem({ item, onItemClick }: { item: { type: 'checkbox'; label: string; checked: boolean; onChange: (checked: boolean) => void; disabled?: boolean }; onItemClick: () => void }) {
+  const isDisabled = item.disabled;
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <div className="context-menu-item-wrapper">
+      <button
+        className={`context-menu-item context-menu-checkbox${isDisabled ? ' context-menu-item--disabled' : ''}`}
+        onClick={() => {
+          if (isDisabled) return;
+          item.onChange(!item.checked);
+          onItemClick();
+        }}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        disabled={isDisabled}
+      >
+        <span className="context-menu-label">{item.label}</span>
+        <input
+          type="checkbox"
+          checked={item.checked}
+          onChange={() => {}} // Controlled by parent
+          onClick={(e) => e.stopPropagation()} // Prevent double-toggle
+          tabIndex={-1}
+        />
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add SliderMenuItem component**
+
+Add this new component after `CheckboxMenuItem`:
+
+```typescript
+function SliderMenuItem({ item }: { item: { type: 'slider'; label: string; value: number; min: number; max: number; onChange: (value: number) => void; disabled?: boolean } }) {
+  const isDisabled = item.disabled;
+
+  return (
+    <div className={`context-menu-item-wrapper context-menu-slider${isDisabled ? ' context-menu-item--disabled' : ''}`}>
+      <div className="context-menu-slider-label">
+        <span className="context-menu-label">{item.label}</span>
+      </div>
+      <input
+        type="range"
+        className="context-menu-slider-input"
+        min={item.min}
+        max={item.max}
+        value={item.value}
+        onChange={(e) => item.onChange(parseInt(e.target.value, 10))}
+        disabled={isDisabled}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Update MenuItem to render new types**
+
+Find the `MenuItem` function and update its render logic. The function currently checks for divider. Add checks for checkbox and slider:
+
+```typescript
+function MenuItem({ item, depth, onItemClick }: MenuItemProps) {
+  if (isDivider(item)) {
+    return (
+      <div className="context-menu-divider" role="separator" aria-orientation="horizontal" />
+    );
+  }
+
+  if (item.type === 'checkbox') {
+    return <CheckboxMenuItem item={item} onItemClick={onItemClick} />;
+  }
+
+  if (item.type === 'slider') {
+    return <SliderMenuItem item={item} />;
+  }
+
+  if (!isMenuItem(item)) {
+    return null;
+  }
+
+  // ... existing item rendering code
+}
+```
+
+- [ ] **Step 5: Update handleItemClick to not close on slider changes**
+
+Find the `handleItemClick` function and update it to keep the menu open when interacting with sliders:
+
+```typescript
+const handleItemClick = (item: ContextMenuItem) => {
+  if (isMenuItem(item) && item.onClick) {
+    item.onClick();
+  }
+  // Don't close on checkbox or slider interactions — let user continue adjusting
+  if (item.type === 'item' || item.type === 'divider') {
+    onClose();
+  }
+};
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+git commit -m "feat: add checkbox and slider item types to ContextMenu"
+```
+
+---
+
+### Task 2: Add ContextMenu CSS Styles
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/ContextMenu/ContextMenu.css`
+
+- [ ] **Step 1: Add checkbox and slider styles**
+
+Add these styles at the end of the file (after line 149):
+
+```css
+.context-menu-checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.context-menu-checkbox:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.context-menu-checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent-primary);
+  pointer-events: none;
+  flex-shrink: 0;
+}
+
+.context-menu-slider {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  cursor: default;
+}
+
+.context-menu-slider-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.context-menu-slider-input {
+  width: 100%;
+  height: 4px;
+  accent-color: var(--accent-primary);
+  cursor: pointer;
+  padding: 0;
+}
+
+.context-menu-slider-input:hover {
+  accent-color: var(--accent-hover);
+}
+
+.context-menu-slider-input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/ContextMenu/ContextMenu.css
+git commit -m "feat: add checkbox and slider styles to ContextMenu"
+```
+
+---
+
+### Task 3: Add Voice Context Menu to UserPanel
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/UserPanel/UserPanel.tsx`
+
+- [ ] **Step 1: Add imports for ContextMenu**
+
+Find the imports at the top (around line 1) and add:
+
+```typescript
+import { useState } from 'react';
+import { Tooltip } from '../Tooltip/Tooltip';
+import Avatar from '../Avatar/Avatar';
+import { ContextMenu } from '../ContextMenu/ContextMenu';
+import type { ContextMenuItem } from '../ContextMenu/ContextMenu';
+import './UserPanel.css';
+```
+
+- [ ] **Step 2: Update interface to add audio settings props**
+
+Find the `UserPanelProps` interface (around line 6) and add:
+
+```typescript
+interface UserPanelProps {
+  // ... existing props
+  onOpenAudioSettings?: () => void;
+}
+```
+
+- [ ] **Step 3: Update component signature and add state**
+
+Find the component function signature and add the new prop, plus state for the context menu:
+
+```typescript
+export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown, onOpenAudioSettings }: UserPanelProps) {
+  const [pressedBtn, setPressedBtn] = useState<string | null>(null);
+  const [voiceContextMenu, setVoiceContextMenu] = useState<{ x: number; y: number } | null>(null);
+  // ... rest of existing state
+```
+
+- [ ] **Step 4: Add helper functions for settings**
+
+Add these functions after the existing helper functions (after `handleKeyUp`):
+
+```typescript
+const getAudioSettings = (): { transmissionMode: string; inputVolume: number } => {
+  try {
+    const stored = localStorage.getItem('brmble-settings');
+    if (stored) {
+      const settings = JSON.parse(stored);
+      return {
+        transmissionMode: settings?.audio?.transmissionMode || 'pushToTalk',
+        inputVolume: settings?.audio?.inputVolume ?? 250,
+      };
+    }
+  } catch {}
+  return { transmissionMode: 'pushToTalk', inputVolume: 250 };
+};
+
+const saveAudioSettings = (transmissionMode: string, inputVolume: number) => {
+  try {
+    const stored = localStorage.getItem('brmble-settings');
+    const settings = stored ? JSON.parse(stored) : {};
+    settings.audio = {
+      ...settings.audio,
+      transmissionMode,
+      inputVolume,
+    };
+    localStorage.setItem('brmble-settings', JSON.stringify(settings));
+    // Notify backend via bridge
+    import('../../bridge').then(({ default: bridge }) => {
+      bridge.send('settings.update', { settings });
+    });
+  } catch (e) {
+    console.error('Failed to save audio settings:', e);
+  }
+};
+```
+
+- [ ] **Step 5: Add context menu items function**
+
+Add this function before the return statement:
+
+```typescript
+const voiceContextMenuItems: ContextMenuItem[] = [
+  {
+    type: 'checkbox',
+    label: 'Push to Talk',
+    checked: getAudioSettings().transmissionMode === 'pushToTalk',
+    onChange: (checked) => {
+      const mode = checked ? 'pushToTalk' : 'voiceActivity';
+      const { inputVolume } = getAudioSettings();
+      saveAudioSettings(mode, inputVolume);
+    },
+  },
+  { type: 'divider' },
+  {
+    type: 'slider',
+    label: `Input Volume: ${getAudioSettings().inputVolume}%`,
+    value: getAudioSettings().inputVolume,
+    min: 0,
+    max: 250,
+    onChange: (value) => {
+      const { transmissionMode } = getAudioSettings();
+      saveAudioSettings(transmissionMode, value);
+    },
+  },
+  { type: 'divider' },
+  {
+    type: 'item',
+    label: 'Voice Settings',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+        <circle cx="12" cy="12" r="3" />
+      </svg>
+    ),
+    onClick: () => {
+      setVoiceContextMenu(null);
+      onOpenAudioSettings?.();
+    },
+  },
+];
+```
+
+- [ ] **Step 6: Add onContextMenu to mute button**
+
+Find the mute button (around line 129) and add the onContextMenu handler:
+
+```tsx
+<button 
+  className={`btn btn-ghost btn-icon user-panel-btn mute-btn ${(muted || leftVoice || deafened) ? 'active' : ''} ${activeBtn === 'mute' ? 'pressed' : ''} ${(leftVoice || deafened || muteOnCooldown) ? 'disabled' : ''}`}
+  onMouseDown={handleMouseDown('mute')}
+  onMouseUp={handleMouseUp('mute', onToggleMute)}
+  onMouseLeave={handleMouseLeave}
+  onKeyDown={handleKeyDown('mute')}
+  onKeyUp={handleKeyUp('mute', onToggleMute)}
+  onContextMenu={(e) => {
+    e.preventDefault();
+    setVoiceContextMenu({ x: e.clientX, y: e.clientY });
+  }}
+  disabled={leftVoice || deafened || muteOnCooldown}
+>
+```
+
+- [ ] **Step 7: Add ContextMenu render at end of component**
+
+Find the end of the return statement (before the closing `);` of the component) and add:
+
+```tsx
+{voiceContextMenu && (
+  <ContextMenu
+    x={voiceContextMenu.x}
+    y={voiceContextMenu.y}
+    items={voiceContextMenuItems}
+    onClose={() => setVoiceContextMenu(null)}
+  />
+)}
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
+git commit -m "feat: add voice context menu to mute button"
+```
+
+---
+
+### Task 4: Update App.tsx to Pass Handler to UserPanel
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+
+- [ ] **Step 1: Find UserPanel in App.tsx and add onOpenAudioSettings prop**
+
+Find the UserPanel component render (around line 1890) and add the new prop:
+
+```tsx
+<UserPanel
+  username={username}
+  // ... existing props
+  onOpenAudioSettings={() => {
+    setSettingsTab('audio');
+    setShowSettings(true);
+  }}
+/>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx
+git commit -m "feat: wire up onOpenAudioSettings handler to UserPanel"
+```
+
+---
+
+### Task 5: Test the Implementation
+
+- [ ] **Step 1: Build and check for errors**
+
+```bash
+cd src/Brmble.Web && npm run build
+```
+
+Expected: Build completes without errors
+
+- [ ] **Step 2: Verify context menu appears**
+
+1. Run the dev server: `npm run dev`
+2. Run the client: `dotnet run --project src/Brmble.Client`
+3. Connect to a server
+4. Right-click the mute button
+5. Verify the context menu appears with:
+   - "Push to Talk" checkbox
+   - "Input Volume" slider
+   - "Voice Settings" item with cog icon
+
+- [ ] **Step 3: Test checkbox interaction**
+
+1. Check the "Push to Talk" checkbox
+2. Open Settings → Audio tab
+3. Verify transmission mode is set to "Push to Talk"
+
+- [ ] **Step 4: Test slider interaction**
+
+1. Adjust the Input Volume slider
+2. Open Settings → Audio tab
+3. Verify input volume matches the slider value
+
+- [ ] **Step 5: Test Voice Settings navigation**
+
+1. Click "Voice Settings" in the context menu
+2. Verify Settings modal opens on the Audio tab
+
+---
+
+## Self-Review Checklist
+
+- [ ] All ContextMenu item types implemented (checkbox, slider)
+- [ ] Checkbox: entire row clickable with hover highlight
+- [ ] Slider: no hover highlight on container, only thumb shows hover
+- [ ] Settings persist via localStorage + bridge
+- [ ] Voice Settings opens Audio tab in Settings modal
+- [ ] No TypeScript errors
+- [ ] Build succeeds

--- a/docs/superpowers/plans/2026-04-05-voice-context-menu-plan.md
+++ b/docs/superpowers/plans/2026-04-05-voice-context-menu-plan.md
@@ -295,7 +295,7 @@ const saveAudioSettings = (transmissionMode: string, inputVolume: number) => {
     localStorage.setItem('brmble-settings', JSON.stringify(settings));
     // Notify backend via bridge
     import('../../bridge').then(({ default: bridge }) => {
-      bridge.send('settings.update', { settings });
+      bridge.send('settings.set', { settings });
     });
   } catch (e) {
     console.error('Failed to save audio settings:', e);

--- a/docs/superpowers/specs/2026-04-05-voice-context-menu-design.md
+++ b/docs/superpowers/specs/2026-04-05-voice-context-menu-design.md
@@ -132,14 +132,14 @@ Need to expose audio settings state from SettingsModal context, or read from loc
 - Label: "Push to Talk"
 - Checked: `transmissionMode === 'pushToTalk'`
 - On change: Update `transmissionMode` to `'pushToTalk'` or `'voiceActivity'`
-- Saves to localStorage and sends `settings.update` via bridge
+- Saves to localStorage and sends `settings.set` via bridge
 
 ### Input Volume (slider)
 - Label: "Input Volume: {value}%"
 - Value: `inputVolume` (0-250)
 - Min: 0, Max: 250
 - On change: Update `inputVolume`
-- Saves to localStorage and sends `settings.update` via bridge
+- Saves to localStorage and sends `settings.set` via bridge
 
 ### Voice Settings (item)
 - Label: "Voice Settings"
@@ -205,4 +205,4 @@ Add styles for new item types in `ContextMenu.css`:
 
 - If localStorage read fails, use default values
 - If bridge send fails, show toast notification
-- Menu closes on any item interaction (matches existing behavior)
+- Menu closes for standard action items, but remains open for checkbox and slider interactions so users can adjust settings in place

--- a/docs/superpowers/specs/2026-04-05-voice-context-menu-design.md
+++ b/docs/superpowers/specs/2026-04-05-voice-context-menu-design.md
@@ -37,7 +37,9 @@ type ContextMenuItem =
 
 ### Checkbox Item
 - Displays label with a checkbox indicator on the right
+- **Entire row is clickable** — not just the tiny checkbox box
 - Click toggles the checked state and calls `onChange`
+- Hover state highlights the entire row
 - Supports `disabled` state
 
 ### Slider Item
@@ -45,6 +47,7 @@ type ContextMenuItem =
 - Dragging updates the value in real-time and calls `onChange`
 - Value is displayed as percentage: `${value}%`
 - Min: 0, Max: 250 (matches AudioSettings inputVolume range)
+- **No hover highlight on the slider container** — only the thumb shows hover state to avoid visual confusion with clickable items
 
 ## UserPanel Changes
 
@@ -153,16 +156,25 @@ Add styles for new item types in `ContextMenu.css`:
   align-items: center;
   justify-content: space-between;
   padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+/* Entire row is clickable - use the button's hover styles */
+.context-menu-checkbox:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .context-menu-checkbox input[type="checkbox"] {
   width: 16px;
   height: 16px;
   accent-color: var(--accent-primary);
+  pointer-events: none; /* Click handled by parent */
 }
 
 .context-menu-slider {
   padding: var(--space-xs) var(--space-sm);
+  /* No hover highlight - avoids visual confusion with clickable items */
 }
 
 .context-menu-slider label {
@@ -174,6 +186,12 @@ Add styles for new item types in `ContextMenu.css`:
   width: 100%;
   height: 4px;
   accent-color: var(--accent-primary);
+  cursor: pointer;
+}
+
+/* Only the slider thumb shows hover state */
+.context-menu-slider input[type="range"]:hover {
+  accent-color: var(--accent-hover);
 }
 ```
 

--- a/docs/superpowers/specs/2026-04-05-voice-context-menu-design.md
+++ b/docs/superpowers/specs/2026-04-05-voice-context-menu-design.md
@@ -1,0 +1,190 @@
+# Voice Controls Context Menu Design
+
+## Overview
+
+Add a context menu to the mute button in the user panel that provides quick access to voice controls. The menu displays the current transmission mode setting, input volume slider, and a shortcut to open full voice settings.
+
+## Architecture
+
+### Component Changes
+
+1. **Extend `ContextMenu.tsx`** — Add support for `checkbox` and `slider` item types alongside existing `item` and `divider`
+2. **Extend `UserPanel.tsx`** — Add context menu state and right-click handler to the mute button
+3. **New CSS** — Add styling for checkbox and slider items within context menu
+4. **Update `App.tsx`** — Pass audio settings and handlers to UserPanel
+
+### Data Flow
+
+```
+UserPanel (mute button right-click)
+  └── Opens VoiceContextMenu at (x, y)
+  ├── Reads settings from localStorage on open
+  ├── Checkbox/slider changes → update localStorage + send bridge event
+  └── Voice Settings click → App.tsx: setSettingsTab('audio'); setShowSettings(true)
+```
+
+Settings persistence uses the same bridge + localStorage approach as SettingsModal.
+
+## New ContextMenu Item Types
+
+```typescript
+type ContextMenuItem =
+  | { type: 'divider' }
+  | { type: 'item'; label: string; onClick?: () => void; icon?: React.ReactNode; disabled?: boolean; children?: ContextMenuItem[] }
+  | { type: 'checkbox'; label: string; checked: boolean; onChange: (checked: boolean) => void; disabled?: boolean }
+  | { type: 'slider'; label: string; value: number; min: number; max: number; onChange: (value: number) => void; disabled?: boolean };
+```
+
+### Checkbox Item
+- Displays label with a checkbox indicator on the right
+- Click toggles the checked state and calls `onChange`
+- Supports `disabled` state
+
+### Slider Item
+- Displays label with current value and a range input below
+- Dragging updates the value in real-time and calls `onChange`
+- Value is displayed as percentage: `${value}%`
+- Min: 0, Max: 250 (matches AudioSettings inputVolume range)
+
+## UserPanel Changes
+
+### New Props
+
+```typescript
+interface UserPanelProps {
+  // ... existing props
+  audioSettings?: AudioSettings;        // For reading current values
+  onAudioSettingsChange?: (settings: AudioSettings) => void;  // For writing changes
+  onOpenAudioSettings?: () => void;      // For opening settings modal
+}
+```
+
+### New State
+
+```typescript
+const [voiceContextMenu, setVoiceContextMenu] = useState<{ x: number; y: number } | null>(null);
+```
+
+### Mute Button Change
+
+Add `onContextMenu` handler to the mute button:
+
+```tsx
+<button
+  onContextMenu={(e) => {
+    e.preventDefault();
+    setVoiceContextMenu({ x: e.clientX, y: e.clientY });
+  }}
+  // ... existing handlers
+>
+```
+
+### Context Menu Items
+
+```
+┌─────────────────────────────┐
+│ ◉ Push to Talk         ☐   │  ← checkbox
+│ ─────────────────────────  │
+│ Input Volume         50%  ──│  ← slider
+│ ─────────────────────────  │
+│ ⚙ Voice Settings          │  ← opens settings on audio tab
+└─────────────────────────────┘
+```
+
+- **Push to Talk checkbox**: Checked = 'pushToTalk', Unchecked = 'voiceActivity'
+- **Input Volume slider**: 0-250 range, displays percentage
+- **Voice Settings**: Opens SettingsModal on the Audio tab
+
+## App.tsx Changes
+
+### New State
+
+Need to expose audio settings state from SettingsModal context, or read from localStorage directly in UserPanel.
+
+**Option A** (recommended): Read settings directly in UserPanel from localStorage:
+- Avoids lifting state to App.tsx
+- Consistent with how SettingsModal already works
+- UserPanel reads `localStorage.getItem('brmble-settings')` on menu open
+
+**Option B**: Lift settings state to App.tsx:
+- More complex refactoring
+- Better for future features that need shared state
+- Defer to future if needed
+
+### Pass to UserPanel
+
+```tsx
+<UserPanel
+  // ... existing props
+  onOpenAudioSettings={() => {
+    setSettingsTab('audio');
+    setShowSettings(true);
+  }}
+/>
+```
+
+## Context Menu Items Detail
+
+### Push to Talk (checkbox)
+- Label: "Push to Talk"
+- Checked: `transmissionMode === 'pushToTalk'`
+- On change: Update `transmissionMode` to `'pushToTalk'` or `'voiceActivity'`
+- Saves to localStorage and sends `settings.update` via bridge
+
+### Input Volume (slider)
+- Label: "Input Volume: {value}%"
+- Value: `inputVolume` (0-250)
+- Min: 0, Max: 250
+- On change: Update `inputVolume`
+- Saves to localStorage and sends `settings.update` via bridge
+
+### Voice Settings (item)
+- Label: "Voice Settings"
+- Icon: Cog wheel SVG
+- On click: Call `onOpenAudioSettings()`
+
+## CSS Changes
+
+Add styles for new item types in `ContextMenu.css`:
+
+```css
+.context-menu-checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-xs) var(--space-sm);
+}
+
+.context-menu-checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent-primary);
+}
+
+.context-menu-slider {
+  padding: var(--space-xs) var(--space-sm);
+}
+
+.context-menu-slider label {
+  display: block;
+  margin-bottom: var(--space-xs);
+}
+
+.context-menu-slider input[type="range"] {
+  width: 100%;
+  height: 4px;
+  accent-color: var(--accent-primary);
+}
+```
+
+## Backward Compatibility
+
+- `ContextMenu` remains backward compatible — existing `item` and `divider` types work unchanged
+- `UserPanel` new props are all optional — existing usage continues to work
+- Settings read/write uses existing bridge API
+
+## Error Handling
+
+- If localStorage read fails, use default values
+- If bridge send fails, show toast notification
+- Menu closes on any item interaction (matches existing behavior)

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1893,6 +1893,7 @@ const handleConnect = (serverData: SavedServer) => {
         dmActive={dmStore.appMode === 'dm'}
         unreadDMCount={totalDmUnreadCount}
         onOpenSettings={() => { setSettingsTab('profile'); setShowSettings(true); }}
+        onOpenAudioSettings={() => { setSettingsTab('audio'); setShowSettings(true); }}
         onAvatarClick={connected ? () => setShowAvatarEditor(true) : undefined}
         avatarUrl={currentUserAvatarUrl}
         matrixUserId={matrixCredentials?.userId}

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.css
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.css
@@ -172,6 +172,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
+  padding: var(--space-xs) var(--space-sm);
   cursor: default;
 }
 
@@ -183,10 +184,11 @@
 
 .context-menu-slider-input {
   width: 100%;
-  height: 4px;
+  height: 20px;
   accent-color: var(--accent-primary);
   cursor: pointer;
   padding: 0;
+  margin: var(--space-xs) 0;
 }
 
 .context-menu-slider-input:hover {

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.css
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.css
@@ -110,6 +110,18 @@
   margin-right: var(--space-2xs);
 }
 
+.context-submenu--off-bottom {
+  top: auto;
+  bottom: 0;
+}
+
+.context-submenu--off-right.context-submenu--off-bottom {
+  right: 100%;
+  bottom: 0;
+  margin-left: 0;
+  margin-right: var(--space-2xs);
+}
+
 .context-submenu .context-menu-item {
   white-space: nowrap;
 }
@@ -134,4 +146,54 @@
   height: 1px;
   background: var(--border-default);
   margin: var(--space-2xs) var(--space-xs);
+}
+
+.context-menu-checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.context-menu-checkbox:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.context-menu-checkbox input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent-primary);
+  pointer-events: none;
+  flex-shrink: 0;
+}
+
+.context-menu-slider {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  cursor: default;
+}
+
+.context-menu-slider-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.context-menu-slider-input {
+  width: 100%;
+  height: 4px;
+  accent-color: var(--accent-primary);
+  cursor: pointer;
+  padding: 0;
+}
+
+.context-menu-slider-input:hover {
+  accent-color: var(--accent-hover);
+}
+
+.context-menu-slider-input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -99,23 +99,27 @@ function CheckboxMenuItem({ item }: { item: { type: 'checkbox'; label: string; c
 
   return (
     <div className="context-menu-item-wrapper">
-      <button
+      <div
         className={`context-menu-item context-menu-checkbox${isDisabled ? ' context-menu-item--disabled' : ''}`}
+        role="menuitemcheckbox"
+        aria-checked={item.checked}
+        aria-disabled={isDisabled}
+        tabIndex={isDisabled ? -1 : 0}
         onClick={() => {
           if (isDisabled) return;
           item.onChange(!item.checked);
         }}
-        disabled={isDisabled}
+        onKeyDown={(e) => {
+          if (isDisabled) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            item.onChange(!item.checked);
+          }
+        }}
       >
         <span className="context-menu-label">{item.label}</span>
-        <input
-          type="checkbox"
-          checked={item.checked}
-          readOnly
-          onClick={(e) => e.stopPropagation()}
-          tabIndex={-1}
-        />
-      </button>
+        <span aria-hidden="true">{item.checked ? '☑' : '☐'}</span>
+      </div>
     </div>
   );
 }

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -5,7 +5,9 @@ const MOUSE_LEAVE_CLOSE_DELAY = 400;
 
 type ContextMenuItem =
   | { type: 'divider' }
-  | { type: 'item'; label: string; onClick?: () => void; icon?: React.ReactNode; disabled?: boolean; children?: ContextMenuItem[] };
+  | { type: 'item'; label: string; onClick?: () => void; icon?: React.ReactNode; disabled?: boolean; children?: ContextMenuItem[] }
+  | { type: 'checkbox'; label: string; checked: boolean; onChange: (checked: boolean) => void; disabled?: boolean }
+  | { type: 'slider'; label: string; value: number; min: number; max: number; onChange: (value: number) => void; disabled?: boolean };
 
 function isDivider(item: ContextMenuItem): item is { type: 'divider' } {
   return item.type === 'divider';
@@ -92,11 +94,70 @@ function isMenuItem(item: ContextMenuItem): item is { type: 'item'; label: strin
   return item.type === 'item';
 }
 
+function CheckboxMenuItem({ item, onItemClick }: { item: { type: 'checkbox'; label: string; checked: boolean; onChange: (checked: boolean) => void; disabled?: boolean }; onItemClick: () => void }) {
+  const isDisabled = item.disabled;
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <div className="context-menu-item-wrapper">
+      <button
+        className={`context-menu-item context-menu-checkbox${isDisabled ? ' context-menu-item--disabled' : ''}`}
+        onClick={() => {
+          if (isDisabled) return;
+          item.onChange(!item.checked);
+          onItemClick();
+        }}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        disabled={isDisabled}
+      >
+        <span className="context-menu-label">{item.label}</span>
+        <input
+          type="checkbox"
+          checked={item.checked}
+          onChange={() => {}} // Controlled by parent
+          onClick={(e) => e.stopPropagation()} // Prevent double-toggle
+          tabIndex={-1}
+        />
+      </button>
+    </div>
+  );
+}
+
+function SliderMenuItem({ item }: { item: { type: 'slider'; label: string; value: number; min: number; max: number; onChange: (value: number) => void; disabled?: boolean } }) {
+  const isDisabled = item.disabled;
+
+  return (
+    <div className={`context-menu-item-wrapper context-menu-slider${isDisabled ? ' context-menu-item--disabled' : ''}`}>
+      <div className="context-menu-slider-label">
+        <span className="context-menu-label">{item.label}</span>
+      </div>
+      <input
+        type="range"
+        className="context-menu-slider-input"
+        min={item.min}
+        max={item.max}
+        value={item.value}
+        onChange={(e) => item.onChange(parseInt(e.target.value, 10))}
+        disabled={isDisabled}
+      />
+    </div>
+  );
+}
+
 function MenuItem({ item, depth, onItemClick }: MenuItemProps) {
   if (isDivider(item)) {
     return (
       <div className="context-menu-divider" role="separator" aria-orientation="horizontal" />
     );
+  }
+
+  if (item.type === 'checkbox') {
+    return <CheckboxMenuItem item={item} onItemClick={onItemClick} />;
+  }
+
+  if (item.type === 'slider') {
+    return <SliderMenuItem item={item} />;
   }
 
   if (!isMenuItem(item)) {
@@ -220,7 +281,10 @@ export function ContextMenu({ x, y, items, onClose, mouseLeaveDelay = MOUSE_LEAV
     if (isMenuItem(item) && item.onClick) {
       item.onClick();
     }
-    onClose();
+    // Don't close on checkbox or slider interactions — let user continue adjusting
+    if (item.type === 'item' || item.type === 'divider') {
+      onClose();
+    }
   };
 
   return (

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -94,7 +94,7 @@ function isMenuItem(item: ContextMenuItem): item is { type: 'item'; label: strin
   return item.type === 'item';
 }
 
-function CheckboxMenuItem({ item, onItemClick }: { item: { type: 'checkbox'; label: string; checked: boolean; onChange: (checked: boolean) => void; disabled?: boolean }; onItemClick: () => void }) {
+function CheckboxMenuItem({ item }: { item: { type: 'checkbox'; label: string; checked: boolean; onChange: (checked: boolean) => void; disabled?: boolean } }) {
   const isDisabled = item.disabled;
 
   return (
@@ -104,7 +104,6 @@ function CheckboxMenuItem({ item, onItemClick }: { item: { type: 'checkbox'; lab
         onClick={() => {
           if (isDisabled) return;
           item.onChange(!item.checked);
-          onItemClick();
         }}
         disabled={isDisabled}
       >
@@ -150,7 +149,7 @@ function MenuItem({ item, depth, onItemClick }: MenuItemProps) {
   }
 
   if (item.type === 'checkbox') {
-    return <CheckboxMenuItem item={item} onItemClick={onItemClick} />;
+    return <CheckboxMenuItem item={item} />;
   }
 
   if (item.type === 'slider') {

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -136,6 +136,7 @@ function SliderMenuItem({ item }: { item: { type: 'slider'; label: string; value
         value={item.value}
         onChange={(e) => item.onChange(parseInt(e.target.value, 10))}
         disabled={isDisabled}
+        aria-label={item.label}
       />
     </div>
   );

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -96,7 +96,6 @@ function isMenuItem(item: ContextMenuItem): item is { type: 'item'; label: strin
 
 function CheckboxMenuItem({ item, onItemClick }: { item: { type: 'checkbox'; label: string; checked: boolean; onChange: (checked: boolean) => void; disabled?: boolean }; onItemClick: () => void }) {
   const isDisabled = item.disabled;
-  const [isFocused, setIsFocused] = useState(false);
 
   return (
     <div className="context-menu-item-wrapper">
@@ -107,16 +106,14 @@ function CheckboxMenuItem({ item, onItemClick }: { item: { type: 'checkbox'; lab
           item.onChange(!item.checked);
           onItemClick();
         }}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
         disabled={isDisabled}
       >
         <span className="context-menu-label">{item.label}</span>
         <input
           type="checkbox"
           checked={item.checked}
-          onChange={() => {}} // Controlled by parent
-          onClick={(e) => e.stopPropagation()} // Prevent double-toggle
+          readOnly
+          onClick={(e) => e.stopPropagation()}
           tabIndex={-1}
         />
       </button>

--- a/src/Brmble.Web/src/components/Header/Header.tsx
+++ b/src/Brmble.Web/src/components/Header/Header.tsx
@@ -9,6 +9,7 @@ interface HeaderProps {
   dmActive?: boolean;
   unreadDMCount?: number;
   onOpenSettings: () => void;
+  onOpenAudioSettings?: () => void;
   onAvatarClick?: () => void;
   avatarUrl?: string;
   matrixUserId?: string;
@@ -32,7 +33,7 @@ interface HeaderProps {
   deafOnCooldown?: boolean;
 }
 
-export function Header({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, onToggleGame, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown }: HeaderProps) {
+export function Header({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onOpenAudioSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, onToggleGame, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown }: HeaderProps) {
   return (
     <header className="header">
       <div className="header-left">
@@ -47,6 +48,7 @@ export function Header({ username, onToggleDM, dmActive, unreadDMCount, onOpenSe
           dmActive={dmActive}
           unreadDMCount={unreadDMCount}
           onOpenSettings={onOpenSettings}
+          onOpenAudioSettings={onOpenAudioSettings}
           onAvatarClick={onAvatarClick}
           avatarUrl={avatarUrl}
           matrixUserId={matrixUserId}

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -149,10 +149,12 @@ export function SettingsModal(props: SettingsModalProps) {
     };
 
     bridge.on('settings.current', handleCurrent);
+    bridge.on('settings.updated', handleCurrent);
     bridge.send('settings.get');
 
     return () => {
       bridge.off('settings.current', handleCurrent);
+      bridge.off('settings.updated', handleCurrent);
     };
   }, []);
 

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -125,36 +125,43 @@ export function SettingsModal(props: SettingsModalProps) {
   }), [settings.audio.pushToTalkKey, settings.shortcuts]);
 
   useEffect(() => {
+    let bridgeModule: { default: typeof import('../../bridge').default } | null = null;
+
     const handleCurrent = (data: unknown) => {
       const d = data as { settings?: AppSettings } | undefined;
       if (d?.settings) {
-        // Normalize speechDenoise mode to valid values
-        const normalizedDenoise = { ...DEFAULT_SPEECH_DENOISE, ...d.settings.speechDenoise };
-        const validModes = ['disabled', 'rnnoise', 'gtcrn'];
-        if (!validModes.includes(normalizedDenoise.mode)) {
-          normalizedDenoise.mode = 'rnnoise';
-        }
-        // Backend doesn't have brmblegotchi, so preserve existing/local value if missing
-        const mergedSettings = {
-          ...DEFAULT_SETTINGS,
-          ...d.settings,
-          brmblegotchi: d.settings.brmblegotchi ?? settings.brmblegotchi ?? DEFAULT_BRMBLEGOTCHI,
-          speechDenoise: normalizedDenoise,
-        };
-        setSettings(mergedSettings);
-        if (d.settings.appearance?.theme) {
-          applyTheme(d.settings.appearance.theme);
-        }
+        setSettings(prev => {
+          const normalizedDenoise = { ...DEFAULT_SPEECH_DENOISE, ...d.settings!.speechDenoise };
+          const validModes = ['disabled', 'rnnoise', 'gtcrn'];
+          if (!validModes.includes(normalizedDenoise.mode)) {
+            normalizedDenoise.mode = 'rnnoise';
+          }
+          const mergedSettings = {
+            ...DEFAULT_SETTINGS,
+            ...d.settings!,
+            brmblegotchi: d.settings!.brmblegotchi ?? prev.brmblegotchi ?? DEFAULT_BRMBLEGOTCHI,
+            speechDenoise: normalizedDenoise,
+          };
+          if (d.settings!.appearance?.theme) {
+            applyTheme(d.settings!.appearance.theme);
+          }
+          return mergedSettings;
+        });
       }
     };
 
-    bridge.on('settings.current', handleCurrent);
-    bridge.on('settings.updated', handleCurrent);
-    bridge.send('settings.get');
+    import('../../bridge').then(module => {
+      bridgeModule = module;
+      module.default.on('settings.current', handleCurrent);
+      module.default.on('settings.updated', handleCurrent);
+      module.default.send('settings.get');
+    });
 
     return () => {
-      bridge.off('settings.current', handleCurrent);
-      bridge.off('settings.updated', handleCurrent);
+      if (bridgeModule) {
+        bridgeModule.default.off('settings.current', handleCurrent);
+        bridgeModule.default.off('settings.updated', handleCurrent);
+      }
     };
   }, []);
 

--- a/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
+++ b/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
@@ -37,19 +37,11 @@ interface UserPanelProps {
 export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown, onOpenAudioSettings }: UserPanelProps) {
   const [pressedBtn, setPressedBtn] = useState<string | null>(null);
   const [voiceContextMenu, setVoiceContextMenu] = useState<{ x: number; y: number } | null>(null);
-  const [audioSettings, setAudioSettings] = useState<{ transmissionMode: string; inputVolume: number }>(() => {
-    try {
-      const stored = localStorage.getItem('brmble-settings');
-      if (stored) {
-        const settings = JSON.parse(stored);
-        return {
-          transmissionMode: settings?.audio?.transmissionMode || 'pushToTalk',
-          inputVolume: settings?.audio?.inputVolume ?? 250,
-        };
-      }
-    } catch {}
-    return { transmissionMode: 'pushToTalk', inputVolume: 250 };
-  });
+  const [deafenContextMenu, setDeafenContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [screenShareContextMenu, setScreenShareContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [contextMenuPushToTalk, setContextMenuPushToTalk] = useState<boolean>(true);
+  const [contextMenuInputVolume, setContextMenuInputVolume] = useState<number>(250);
+  const [contextMenuOutputVolume, setContextMenuOutputVolume] = useState<number>(250);
   const activeBtn = hotkeyPressedBtn || pressedBtn;
 
   const handleMouseDown = (btn: string) => (e: React.MouseEvent) => {
@@ -86,17 +78,51 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
     }
   };
 
-  const saveAudioSettings = (transmissionMode: string, inputVolume: number) => {
+  const getAudioSettings = (): { transmissionMode: string; inputVolume: number; outputVolume: number } => {
     try {
       const stored = localStorage.getItem('brmble-settings');
-      const settings = stored ? JSON.parse(stored) : {};
-      settings.audio = {
-        ...settings.audio,
-        transmissionMode,
-        inputVolume,
+      if (stored) {
+        const settings = JSON.parse(stored);
+        return {
+          transmissionMode: settings?.audio?.transmissionMode || 'pushToTalk',
+          inputVolume: settings?.audio?.inputVolume ?? 250,
+          outputVolume: settings?.audio?.outputVolume ?? 250,
+        };
+      }
+    } catch {}
+    return { transmissionMode: 'pushToTalk', inputVolume: 250, outputVolume: 250 };
+  };
+
+  const saveAudioSettings = (transmissionMode?: string, inputVolume?: number, outputVolume?: number) => {
+    try {
+      const stored = localStorage.getItem('brmble-settings');
+      const partialSettings = stored ? JSON.parse(stored) : {};
+      const audioSettings = {
+        inputDevice: (partialSettings.audio as any)?.inputDevice || 'default',
+        outputDevice: (partialSettings.audio as any)?.outputDevice || 'default',
+        inputVolume: inputVolume ?? (partialSettings.audio as any)?.inputVolume ?? 250,
+        outputVolume: outputVolume ?? (partialSettings.audio as any)?.outputVolume ?? 250,
+        maxAmplification: (partialSettings.audio as any)?.maxAmplification || 100,
+        transmissionMode: transmissionMode ?? ((partialSettings.audio as any)?.transmissionMode || 'pushToTalk'),
+        pushToTalkKey: (partialSettings.audio as any)?.pushToTalkKey || null,
+        opusBitrate: (partialSettings.audio as any)?.opusBitrate || 72000,
+        opusFrameSize: (partialSettings.audio as any)?.opusFrameSize || 20,
+        captureApi: ((partialSettings.audio as any)?.captureApi || 'wasapi') as 'waveIn' | 'wasapi',
+      };
+      const settings = {
+        audio: audioSettings,
+        shortcuts: partialSettings.shortcuts || { toggleLeaveVoiceKey: null, toggleMuteDeafenKey: null, toggleMuteKey: null, toggleDMScreenKey: null, toggleScreenShareKey: null, toggleGameKey: null },
+        messages: partialSettings.messages || { showTimestamps: true, compactMode: false, wordWrap: true },
+        appearance: partialSettings.appearance || { theme: 'dark' },
+        overlay: partialSettings.overlay || { enabled: false, x: 100, y: 100 },
+        brmblegotchi: partialSettings.brmblegotchi || { enabled: false, petType: 'cat' },
+        speechDenoise: partialSettings.speechDenoise || { mode: 'rnnoise' },
+        reconnectEnabled: partialSettings.reconnectEnabled ?? true,
+        rememberLastChannel: partialSettings.rememberLastChannel ?? true,
+        autoConnectEnabled: partialSettings.autoConnectEnabled ?? false,
+        autoConnectServerId: partialSettings.autoConnectServerId ?? null,
       };
       localStorage.setItem('brmble-settings', JSON.stringify(settings));
-      setAudioSettings({ transmissionMode, inputVolume });
       import('../../bridge').then(({ default: bridge }) => {
         bridge.send('settings.set', { settings });
       }).catch((e) => console.error('Failed to save audio settings:', e));
@@ -105,25 +131,38 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
     }
   };
 
+  const audioSettings = getAudioSettings();
+
   const voiceContextMenuItems: ContextMenuItem[] = [
     {
       type: 'checkbox',
+      label: 'Mute',
+      checked: muted || false,
+      onChange: () => {
+        onToggleMute?.();
+      },
+    },
+    { type: 'divider' },
+    {
+      type: 'checkbox',
       label: 'Push to Talk',
-      checked: audioSettings.transmissionMode === 'pushToTalk',
+      checked: contextMenuPushToTalk,
       onChange: (checked) => {
         const mode = checked ? 'pushToTalk' : 'voiceActivity';
         const { inputVolume } = audioSettings;
+        setContextMenuPushToTalk(checked);
         saveAudioSettings(mode, inputVolume);
       },
     },
     { type: 'divider' },
     {
       type: 'slider',
-      label: `Input Volume: ${audioSettings.inputVolume}%`,
-      value: audioSettings.inputVolume,
+      label: `Input Volume: ${contextMenuInputVolume}%`,
+      value: contextMenuInputVolume,
       min: 0,
       max: 250,
       onChange: (value) => {
+        setContextMenuInputVolume(value);
         const { transmissionMode } = audioSettings;
         saveAudioSettings(transmissionMode, value);
       },
@@ -140,6 +179,70 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
       ),
       onClick: () => {
         setVoiceContextMenu(null);
+        onOpenAudioSettings?.();
+      },
+    },
+  ];
+
+  const deafenContextMenuItems: ContextMenuItem[] = [
+    {
+      type: 'checkbox',
+      label: 'Deafen',
+      checked: deafened || false,
+      onChange: () => {
+        onToggleDeaf?.();
+      },
+    },
+    { type: 'divider' },
+    {
+      type: 'slider',
+      label: `Output Volume: ${contextMenuOutputVolume}%`,
+      value: contextMenuOutputVolume,
+      min: 0,
+      max: 250,
+      onChange: (value) => {
+        setContextMenuOutputVolume(value);
+        saveAudioSettings(undefined, undefined, value);
+      },
+    },
+    { type: 'divider' },
+    {
+      type: 'item',
+      label: 'Voice Settings',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+      ),
+      onClick: () => {
+        setDeafenContextMenu(null);
+        onOpenAudioSettings?.();
+      },
+    },
+  ];
+
+  const screenShareContextMenuItems: ContextMenuItem[] = [
+    {
+      type: 'item',
+      label: screenSharing ? 'Stop Screen Share' : 'Start Screen Share',
+      onClick: () => {
+        setScreenShareContextMenu(null);
+        onToggleScreenShare?.();
+      },
+    },
+    { type: 'divider' },
+    {
+      type: 'item',
+      label: 'Voice Settings',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+      ),
+      onClick: () => {
+        setScreenShareContextMenu(null);
         onOpenAudioSettings?.();
       },
     },
@@ -178,6 +281,12 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
           onMouseLeave={handleMouseLeave}
           onKeyDown={handleKeyDown('deaf')}
           onKeyUp={handleKeyUp('deaf', onToggleDeaf)}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            const settings = getAudioSettings();
+            setContextMenuOutputVolume(settings.outputVolume);
+            setDeafenContextMenu({ x: e.clientX, y: e.clientY });
+          }}
           disabled={leftVoice || deafOnCooldown}
         >
           {(deafened || leftVoice) ? (
@@ -205,6 +314,9 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
           className="tooltip-wrapper"
           onContextMenu={(e) => {
             e.preventDefault();
+            const settings = getAudioSettings();
+            setContextMenuPushToTalk(settings.transmissionMode === 'pushToTalk');
+            setContextMenuInputVolume(settings.inputVolume);
             setVoiceContextMenu({ x: e.clientX, y: e.clientY });
           }}
         >
@@ -241,10 +353,19 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
         <button
           className={`btn btn-ghost btn-icon user-panel-btn screen-share-btn ${(screenSharing || (!screenSharing && !canScreenShare)) ? 'active' : ''} ${activeBtn === 'screen' ? 'pressed' : ''} ${(!screenSharing && !canScreenShare) ? 'disabled' : ''}`}
           onMouseDown={handleMouseDown('screen')}
-          onMouseUp={handleMouseUp('screen', onToggleScreenShare)}
+          onMouseUp={handleMouseUp('screen')}
           onMouseLeave={handleMouseLeave}
           onKeyDown={handleKeyDown('screen')}
           onKeyUp={handleKeyUp('screen', onToggleScreenShare)}
+          onClick={(e) => {
+            e.preventDefault();
+            const rect = e.currentTarget.getBoundingClientRect();
+            setScreenShareContextMenu({ x: rect.left, y: rect.bottom + 4 });
+          }}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setScreenShareContextMenu({ x: e.clientX, y: e.clientY });
+          }}
           disabled={!screenSharing && !canScreenShare}
         >
           {(!screenSharing && !canScreenShare) ? (
@@ -321,6 +442,22 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
           y={voiceContextMenu.y}
           items={voiceContextMenuItems}
           onClose={() => setVoiceContextMenu(null)}
+        />
+      )}
+      {deafenContextMenu && (
+        <ContextMenu
+          x={deafenContextMenu.x}
+          y={deafenContextMenu.y}
+          items={deafenContextMenuItems}
+          onClose={() => setDeafenContextMenu(null)}
+        />
+      )}
+      {screenShareContextMenu && (
+        <ContextMenu
+          x={screenShareContextMenu.x}
+          y={screenShareContextMenu.y}
+          items={screenShareContextMenuItems}
+          onClose={() => setScreenShareContextMenu(null)}
         />
       )}
     </div>

--- a/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
+++ b/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Tooltip } from '../Tooltip/Tooltip';
 import Avatar from '../Avatar/Avatar';
 import { ContextMenu } from '../ContextMenu/ContextMenu';
@@ -43,6 +43,41 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
   const [contextMenuInputVolume, setContextMenuInputVolume] = useState<number>(250);
   const [contextMenuOutputVolume, setContextMenuOutputVolume] = useState<number>(250);
   const activeBtn = hotkeyPressedBtn || pressedBtn;
+
+  const isAnyMenuOpen = voiceContextMenu !== null || deafenContextMenu !== null || screenShareContextMenu !== null;
+
+  useEffect(() => {
+    if (!isAnyMenuOpen) return;
+
+    const handleSettingsUpdated = (data: unknown) => {
+      const d = data as { settings?: { audio?: { transmissionMode?: string; inputVolume?: number; outputVolume?: number } } } } | undefined;
+      if (d?.settings?.audio) {
+        const audio = d.settings.audio;
+        if (audio.transmissionMode !== undefined) {
+          setContextMenuPushToTalk(audio.transmissionMode === 'pushToTalk');
+        }
+        if (audio.inputVolume !== undefined) {
+          setContextMenuInputVolume(audio.inputVolume);
+        }
+        if (audio.outputVolume !== undefined) {
+          setContextMenuOutputVolume(audio.outputVolume);
+        }
+      }
+    };
+
+    import('../../bridge').then(({ default: bridge }) => {
+      bridge.on('settings.updated', handleSettingsUpdated);
+      return () => {
+        bridge.off('settings.updated', handleSettingsUpdated);
+      };
+    }).catch((e) => console.error('Failed to load bridge:', e));
+
+    return () => {
+      import('../../bridge').then(({ default: bridge }) => {
+        bridge.off('settings.updated', handleSettingsUpdated);
+      }).catch(() => {});
+    };
+  }, [isAnyMenuOpen]);
 
   const handleMouseDown = (btn: string) => (e: React.MouseEvent) => {
     if (e.button !== 0) return;
@@ -96,31 +131,23 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
   const saveAudioSettings = (transmissionMode?: string, inputVolume?: number, outputVolume?: number) => {
     try {
       const stored = localStorage.getItem('brmble-settings');
-      const partialSettings = stored ? JSON.parse(stored) : {};
+      const existingSettings = stored ? JSON.parse(stored) : {};
+      const existingAudio = (existingSettings.audio as any) || {};
       const audioSettings = {
-        inputDevice: (partialSettings.audio as any)?.inputDevice || 'default',
-        outputDevice: (partialSettings.audio as any)?.outputDevice || 'default',
-        inputVolume: inputVolume ?? (partialSettings.audio as any)?.inputVolume ?? 250,
-        outputVolume: outputVolume ?? (partialSettings.audio as any)?.outputVolume ?? 250,
-        maxAmplification: (partialSettings.audio as any)?.maxAmplification || 100,
-        transmissionMode: transmissionMode ?? ((partialSettings.audio as any)?.transmissionMode || 'pushToTalk'),
-        pushToTalkKey: (partialSettings.audio as any)?.pushToTalkKey || null,
-        opusBitrate: (partialSettings.audio as any)?.opusBitrate || 72000,
-        opusFrameSize: (partialSettings.audio as any)?.opusFrameSize || 20,
-        captureApi: ((partialSettings.audio as any)?.captureApi || 'wasapi') as 'waveIn' | 'wasapi',
+        inputDevice: existingAudio.inputDevice || 'default',
+        outputDevice: existingAudio.outputDevice || 'default',
+        inputVolume: inputVolume ?? existingAudio.inputVolume ?? 250,
+        outputVolume: outputVolume ?? existingAudio.outputVolume ?? 250,
+        maxAmplification: existingAudio.maxAmplification || 100,
+        transmissionMode: transmissionMode ?? existingAudio.transmissionMode ?? 'pushToTalk',
+        pushToTalkKey: existingAudio.pushToTalkKey ?? null,
+        opusBitrate: existingAudio.opusBitrate || 72000,
+        opusFrameSize: existingAudio.opusFrameSize || 20,
+        captureApi: (existingAudio.captureApi || 'wasapi') as 'waveIn' | 'wasapi',
       };
       const settings = {
+        ...existingSettings,
         audio: audioSettings,
-        shortcuts: partialSettings.shortcuts || { toggleLeaveVoiceKey: null, toggleMuteDeafenKey: null, toggleMuteKey: null, toggleDMScreenKey: null, toggleScreenShareKey: null, toggleGameKey: null },
-        messages: partialSettings.messages || { showTimestamps: true, compactMode: false, wordWrap: true },
-        appearance: partialSettings.appearance || { theme: 'dark' },
-        overlay: partialSettings.overlay || { enabled: false, x: 100, y: 100 },
-        brmblegotchi: partialSettings.brmblegotchi || { enabled: false, petType: 'cat' },
-        speechDenoise: partialSettings.speechDenoise || { mode: 'rnnoise' },
-        reconnectEnabled: partialSettings.reconnectEnabled ?? true,
-        rememberLastChannel: partialSettings.rememberLastChannel ?? true,
-        autoConnectEnabled: partialSettings.autoConnectEnabled ?? false,
-        autoConnectServerId: partialSettings.autoConnectServerId ?? null,
       };
       localStorage.setItem('brmble-settings', JSON.stringify(settings));
       import('../../bridge').then(({ default: bridge }) => {
@@ -149,9 +176,9 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
       checked: contextMenuPushToTalk,
       onChange: (checked) => {
         const mode = checked ? 'pushToTalk' : 'voiceActivity';
-        const { inputVolume } = audioSettings;
+        const freshSettings = getAudioSettings();
         setContextMenuPushToTalk(checked);
-        saveAudioSettings(mode, inputVolume);
+        saveAudioSettings(mode, freshSettings.inputVolume);
       },
     },
     { type: 'divider' },
@@ -163,8 +190,8 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
       max: 250,
       onChange: (value) => {
         setContextMenuInputVolume(value);
-        const { transmissionMode } = audioSettings;
-        saveAudioSettings(transmissionMode, value);
+        const freshSettings = getAudioSettings();
+        saveAudioSettings(freshSettings.transmissionMode, value);
       },
     },
     { type: 'divider' },
@@ -273,7 +300,17 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
 
       {onToggleDeaf && (
         <Tooltip content={deafened ? 'Undeafen' : 'Deafen'} position="bottom" align="start">
-        <span className="tooltip-wrapper">
+        <span 
+          className="tooltip-wrapper"
+          onContextMenu={(e) => {
+            e.preventDefault();
+            const settings = getAudioSettings();
+            setContextMenuOutputVolume(settings.outputVolume);
+            setVoiceContextMenu(null);
+            setScreenShareContextMenu(null);
+            setDeafenContextMenu({ x: e.clientX, y: e.clientY });
+          }}
+        >
         <button 
           className={`btn btn-ghost btn-icon user-panel-btn deaf-btn ${(deafened || leftVoice) ? 'active' : ''} ${activeBtn === 'deaf' ? 'pressed' : ''} ${leftVoice || deafOnCooldown ? 'disabled' : ''}`}
           onMouseDown={handleMouseDown('deaf')}
@@ -281,12 +318,6 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
           onMouseLeave={handleMouseLeave}
           onKeyDown={handleKeyDown('deaf')}
           onKeyUp={handleKeyUp('deaf', onToggleDeaf)}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            const settings = getAudioSettings();
-            setContextMenuOutputVolume(settings.outputVolume);
-            setDeafenContextMenu({ x: e.clientX, y: e.clientY });
-          }}
           disabled={leftVoice || deafOnCooldown}
         >
           {(deafened || leftVoice) ? (
@@ -317,6 +348,8 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
             const settings = getAudioSettings();
             setContextMenuPushToTalk(settings.transmissionMode === 'pushToTalk');
             setContextMenuInputVolume(settings.inputVolume);
+            setDeafenContextMenu(null);
+            setScreenShareContextMenu(null);
             setVoiceContextMenu({ x: e.clientX, y: e.clientY });
           }}
         >
@@ -349,7 +382,22 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
 
       {onToggleScreenShare && (
         <Tooltip content={screenShareError ? `Screen share error: ${screenShareError}` : screenSharing ? 'Stop Sharing' : !canScreenShare ? 'Join a channel to share screen' : 'Share Screen'} position="bottom" align="start">
-        <span className="tooltip-wrapper">
+        <span 
+          className="tooltip-wrapper"
+          onClick={(e) => {
+            e.preventDefault();
+            const rect = e.currentTarget.getBoundingClientRect();
+            setVoiceContextMenu(null);
+            setDeafenContextMenu(null);
+            setScreenShareContextMenu({ x: rect.left, y: rect.bottom + 4 });
+          }}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setVoiceContextMenu(null);
+            setDeafenContextMenu(null);
+            setScreenShareContextMenu({ x: e.clientX, y: e.clientY });
+          }}
+        >
         <button
           className={`btn btn-ghost btn-icon user-panel-btn screen-share-btn ${(screenSharing || (!screenSharing && !canScreenShare)) ? 'active' : ''} ${activeBtn === 'screen' ? 'pressed' : ''} ${(!screenSharing && !canScreenShare) ? 'disabled' : ''}`}
           onMouseDown={handleMouseDown('screen')}
@@ -357,15 +405,6 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
           onMouseLeave={handleMouseLeave}
           onKeyDown={handleKeyDown('screen')}
           onKeyUp={handleKeyUp('screen', onToggleScreenShare)}
-          onClick={(e) => {
-            e.preventDefault();
-            const rect = e.currentTarget.getBoundingClientRect();
-            setScreenShareContextMenu({ x: rect.left, y: rect.bottom + 4 });
-          }}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            setScreenShareContextMenu({ x: e.clientX, y: e.clientY });
-          }}
           disabled={!screenSharing && !canScreenShare}
         >
           {(!screenSharing && !canScreenShare) ? (

--- a/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
+++ b/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Tooltip } from '../Tooltip/Tooltip';
 import Avatar from '../Avatar/Avatar';
+import { ContextMenu } from '../ContextMenu/ContextMenu';
+import type { ContextMenuItem } from '../ContextMenu/ContextMenu';
 import './UserPanel.css';
 
 interface UserPanelProps {
@@ -29,10 +31,12 @@ interface UserPanelProps {
   leaveVoiceOnCooldown?: boolean;
   muteOnCooldown?: boolean;
   deafOnCooldown?: boolean;
+  onOpenAudioSettings?: () => void;
 }
 
-export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown }: UserPanelProps) {
+export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown, onOpenAudioSettings }: UserPanelProps) {
   const [pressedBtn, setPressedBtn] = useState<string | null>(null);
+  const [voiceContextMenu, setVoiceContextMenu] = useState<{ x: number; y: number } | null>(null);
   const activeBtn = hotkeyPressedBtn || pressedBtn;
 
   const handleMouseDown = (btn: string) => (e: React.MouseEvent) => {
@@ -68,6 +72,78 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
       setPressedBtn(null);
     }
   };
+
+  const getAudioSettings = (): { transmissionMode: string; inputVolume: number } => {
+    try {
+      const stored = localStorage.getItem('brmble-settings');
+      if (stored) {
+        const settings = JSON.parse(stored);
+        return {
+          transmissionMode: settings?.audio?.transmissionMode || 'pushToTalk',
+          inputVolume: settings?.audio?.inputVolume ?? 250,
+        };
+      }
+    } catch {}
+    return { transmissionMode: 'pushToTalk', inputVolume: 250 };
+  };
+
+  const saveAudioSettings = (transmissionMode: string, inputVolume: number) => {
+    try {
+      const stored = localStorage.getItem('brmble-settings');
+      const settings = stored ? JSON.parse(stored) : {};
+      settings.audio = {
+        ...settings.audio,
+        transmissionMode,
+        inputVolume,
+      };
+      localStorage.setItem('brmble-settings', JSON.stringify(settings));
+      import('../../bridge').then(({ default: bridge }) => {
+        bridge.send('settings.update', { settings });
+      });
+    } catch (e) {
+      console.error('Failed to save audio settings:', e);
+    }
+  };
+
+  const voiceContextMenuItems: ContextMenuItem[] = [
+    {
+      type: 'checkbox',
+      label: 'Push to Talk',
+      checked: getAudioSettings().transmissionMode === 'pushToTalk',
+      onChange: (checked) => {
+        const mode = checked ? 'pushToTalk' : 'voiceActivity';
+        const { inputVolume } = getAudioSettings();
+        saveAudioSettings(mode, inputVolume);
+      },
+    },
+    { type: 'divider' },
+    {
+      type: 'slider',
+      label: `Input Volume: ${getAudioSettings().inputVolume}%`,
+      value: getAudioSettings().inputVolume,
+      min: 0,
+      max: 250,
+      onChange: (value) => {
+        const { transmissionMode } = getAudioSettings();
+        saveAudioSettings(transmissionMode, value);
+      },
+    },
+    { type: 'divider' },
+    {
+      type: 'item',
+      label: 'Voice Settings',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+      ),
+      onClick: () => {
+        setVoiceContextMenu(null);
+        onOpenAudioSettings?.();
+      },
+    },
+  ];
 
   return (
     <div className="user-panel">
@@ -133,6 +209,10 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
           onMouseLeave={handleMouseLeave}
           onKeyDown={handleKeyDown('mute')}
           onKeyUp={handleKeyUp('mute', onToggleMute)}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setVoiceContextMenu({ x: e.clientX, y: e.clientY });
+          }}
           disabled={leftVoice || deafened || muteOnCooldown}
         >
           {(muted || leftVoice || deafened) ? (
@@ -233,6 +313,14 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
         <Avatar user={{ name: username || '', matrixUserId: matrixUserId, avatarUrl: avatarUrl }} size={20} speaking={speaking} />
       </button>
       </Tooltip>
+      {voiceContextMenu && (
+        <ContextMenu
+          x={voiceContextMenu.x}
+          y={voiceContextMenu.y}
+          items={voiceContextMenuItems}
+          onClose={() => setVoiceContextMenu(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
+++ b/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
@@ -37,6 +37,19 @@ interface UserPanelProps {
 export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown, onOpenAudioSettings }: UserPanelProps) {
   const [pressedBtn, setPressedBtn] = useState<string | null>(null);
   const [voiceContextMenu, setVoiceContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [audioSettings, setAudioSettings] = useState<{ transmissionMode: string; inputVolume: number }>(() => {
+    try {
+      const stored = localStorage.getItem('brmble-settings');
+      if (stored) {
+        const settings = JSON.parse(stored);
+        return {
+          transmissionMode: settings?.audio?.transmissionMode || 'pushToTalk',
+          inputVolume: settings?.audio?.inputVolume ?? 250,
+        };
+      }
+    } catch {}
+    return { transmissionMode: 'pushToTalk', inputVolume: 250 };
+  });
   const activeBtn = hotkeyPressedBtn || pressedBtn;
 
   const handleMouseDown = (btn: string) => (e: React.MouseEvent) => {
@@ -73,20 +86,6 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
     }
   };
 
-  const getAudioSettings = (): { transmissionMode: string; inputVolume: number } => {
-    try {
-      const stored = localStorage.getItem('brmble-settings');
-      if (stored) {
-        const settings = JSON.parse(stored);
-        return {
-          transmissionMode: settings?.audio?.transmissionMode || 'pushToTalk',
-          inputVolume: settings?.audio?.inputVolume ?? 250,
-        };
-      }
-    } catch {}
-    return { transmissionMode: 'pushToTalk', inputVolume: 250 };
-  };
-
   const saveAudioSettings = (transmissionMode: string, inputVolume: number) => {
     try {
       const stored = localStorage.getItem('brmble-settings');
@@ -97,15 +96,14 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
         inputVolume,
       };
       localStorage.setItem('brmble-settings', JSON.stringify(settings));
+      setAudioSettings({ transmissionMode, inputVolume });
       import('../../bridge').then(({ default: bridge }) => {
-        bridge.send('settings.update', { settings });
+        bridge.send('settings.set', { settings });
       }).catch((e) => console.error('Failed to save audio settings:', e));
     } catch (e) {
       console.error('Failed to save audio settings:', e);
     }
   };
-
-  const audioSettings = getAudioSettings();
 
   const voiceContextMenuItems: ContextMenuItem[] = [
     {
@@ -203,7 +201,13 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
 
       {onToggleMute && (
         <Tooltip content={muted ? 'Unmute' : deafened ? 'Muted (deafened)' : 'Mute'} position="bottom" align="start">
-        <span className="tooltip-wrapper">
+        <span 
+          className="tooltip-wrapper"
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setVoiceContextMenu({ x: e.clientX, y: e.clientY });
+          }}
+        >
         <button 
           className={`btn btn-ghost btn-icon user-panel-btn mute-btn ${(muted || leftVoice || deafened) ? 'active' : ''} ${activeBtn === 'mute' ? 'pressed' : ''} ${(leftVoice || deafened || muteOnCooldown) ? 'disabled' : ''}`}
           onMouseDown={handleMouseDown('mute')}
@@ -211,10 +215,6 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
           onMouseLeave={handleMouseLeave}
           onKeyDown={handleKeyDown('mute')}
           onKeyUp={handleKeyUp('mute', onToggleMute)}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            setVoiceContextMenu({ x: e.clientX, y: e.clientY });
-          }}
           disabled={leftVoice || deafened || muteOnCooldown}
         >
           {(muted || leftVoice || deafened) ? (

--- a/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
+++ b/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
@@ -99,32 +99,34 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
       localStorage.setItem('brmble-settings', JSON.stringify(settings));
       import('../../bridge').then(({ default: bridge }) => {
         bridge.send('settings.update', { settings });
-      });
+      }).catch((e) => console.error('Failed to save audio settings:', e));
     } catch (e) {
       console.error('Failed to save audio settings:', e);
     }
   };
 
+  const audioSettings = getAudioSettings();
+
   const voiceContextMenuItems: ContextMenuItem[] = [
     {
       type: 'checkbox',
       label: 'Push to Talk',
-      checked: getAudioSettings().transmissionMode === 'pushToTalk',
+      checked: audioSettings.transmissionMode === 'pushToTalk',
       onChange: (checked) => {
         const mode = checked ? 'pushToTalk' : 'voiceActivity';
-        const { inputVolume } = getAudioSettings();
+        const { inputVolume } = audioSettings;
         saveAudioSettings(mode, inputVolume);
       },
     },
     { type: 'divider' },
     {
       type: 'slider',
-      label: `Input Volume: ${getAudioSettings().inputVolume}%`,
-      value: getAudioSettings().inputVolume,
+      label: `Input Volume: ${audioSettings.inputVolume}%`,
+      value: audioSettings.inputVolume,
       min: 0,
       max: 250,
       onChange: (value) => {
-        const { transmissionMode } = getAudioSettings();
+        const { transmissionMode } = audioSettings;
         saveAudioSettings(transmissionMode, value);
       },
     },


### PR DESCRIPTION
## Summary

Add context menus to the mute, deafen, and screen share buttons in the user panel for quick access to voice controls without opening Settings.

### Mute Button Context Menu (right-click)
- **Mute** checkbox - toggle mute state
- **Push to Talk** checkbox - switch between push-to-talk and voice activity modes
- **Input Volume** slider - adjust input volume (0-250%)
- **Voice Settings** - opens Settings modal on Audio tab

### Deafen Button Context Menu (right-click)
- **Deafen** checkbox - toggle deafen state
- **Output Volume** slider - adjust output volume (0-250%)
- **Voice Settings** - opens Settings modal on Audio tab

### Screen Share Button Context Menu (left-click or right-click)
- **Start/Stop Screen Share** item - toggle screen sharing
- **Voice Settings** - opens Settings modal on Audio tab

## Changes

### New Features
- Extended `ContextMenu` component with `checkbox` and `slider` item types
- Added context menus to mute, deafen, and screen share buttons
- Settings changes sync bidirectionally with the Settings modal
- Screen share button now shows context menu on left-click

### Technical Details
- Checkbox/slider state is read from `localStorage` when menu opens
- Changes are saved via `bridge.send('settings.set')` for backend persistence
- SettingsModal now listens for both `settings.current` and `settings.updated` events
- Menu stays open while adjusting sliders for better UX

## Files Changed

| File | Change |
|------|--------|
| `ContextMenu.tsx` | Added checkbox and slider item types |
| `ContextMenu.css` | Added styles for new item types |
| `UserPanel.tsx` | Added 3 context menus with voice controls |
| `SettingsModal.tsx` | Listen for settings.updated events |

## Testing

1. Right-click mute button - verify Push to Talk checkbox syncs with Settings
2. Right-click deafen button - verify Output Volume slider works
3. Left-click or right-click screen share button - verify context menu appears
4. Change settings in modal while context menu is open - verify sync