### PR TITLE
feat: add screen share settings with viewer options

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,28 @@
+## Summary
+
+Adds a new "Screen Share" tab in the Settings modal for configuring screen capture and viewer options, plus a bug fix for re-watching.
+
+### Screen Share Settings Tab
+- **Capture Audio** - Toggle to capture microphone audio along with screen share
+- **Resolution** - Dropdown to select output resolution: 720p (HD), 1080p (Full HD), 1440p (QHD), 4K (Ultra HD)
+- **FPS** - Dropdown to select frame rate: 15, 30, or 60
+- **System Audio** - Toggle to include system audio (Windows/macOS only)
+- **Viewer Mode** - Choose where to display screen share when watching others:
+  - **In-app** - Shows in a split panel within the chat
+  - **Full window** - Opens in a full-screen overlay
+
+### Technical Implementation
+The UI settings are mapped to LiveKit's `ScreenShareCaptureOptions`:
+- Resolution/FPS → `resolution` object with width, height, frameRate
+- Bitrate → `videoEncoding.maxBitrate` (2-15 Mbps based on resolution)
+- Codec → `videoCodec: 'h264'` for cross-hardware efficiency
+
+### Bug Fix
+- **Re-watching** - Fixed a bug where viewers couldn't re-watch a screen share after closing the viewer. Previously, closing the viewer cleared `activeShare` to null, preventing re-watching. Now `activeShare` is only cleared when the sharer actually stops sharing (via the `screenShareStopped` event).
+
+## Testing
+1. Open Settings → Screen Share tab - verify all settings appear
+2. Toggle capture audio, change resolution/FPS, enable system audio - settings persist
+3. Share your screen with different settings - verify options are applied
+4. Watch someone else's screen share, close it, then re-watch - should now work
+5. Switch between In-app and Full window viewer modes - both work

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -19,7 +19,7 @@ import { ConnectModal } from './components/ConnectModal/ConnectModal';
 import { ServerList } from './components/ServerList/ServerList';
 import { ConnectionState } from './components/ConnectionState/ConnectionState';
 import type { ServerEntry } from './hooks/useServerlist';
-import { SettingsModal } from './components/SettingsModal/SettingsModal';
+import { SettingsModal, DEFAULT_SCREEN_SHARE } from './components/SettingsModal/SettingsModal';
 import { AvatarEditorModal } from './components/AvatarEditorModal/AvatarEditorModal';
 import { CloseDialog } from './components/CloseDialog/CloseDialog';
 import { CertWizard } from './components/CertWizard/CertWizard';
@@ -1678,9 +1678,22 @@ const handleConnect = (serverData: SavedServer) => {
 
   const { Prompt, PromptWithInput } = usePrompt();
 
+  const screenShareSettings = (() => {
+    try {
+      const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+      if (stored) {
+        const settings = JSON.parse(stored);
+        if (settings.screenShare) {
+          return settings.screenShare;
+        }
+      }
+    } catch {}
+    return DEFAULT_SCREEN_SHARE;
+  })();
+
   const { isSharing, startSharing, stopSharing, error: screenShareError, activeShare, remoteVideoEl, disconnectViewer, connectAsViewer } = useScreenShare(() => {
     setSharingChannelId(undefined);
-  });
+  }, screenShareSettings);
   disconnectViewerRef.current = disconnectViewer;
   const [sharingChannelId, setSharingChannelId] = useState<string | undefined>();
   const [screenShareToast, setScreenShareToast] = useState<{

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -19,7 +19,7 @@ import { ConnectModal } from './components/ConnectModal/ConnectModal';
 import { ServerList } from './components/ServerList/ServerList';
 import { ConnectionState } from './components/ConnectionState/ConnectionState';
 import type { ServerEntry } from './hooks/useServerlist';
-import { SettingsModal, DEFAULT_SCREEN_SHARE } from './components/SettingsModal/SettingsModal';
+import { SettingsModal, DEFAULT_SCREEN_SHARE, type ScreenShareSettings } from './components/SettingsModal/SettingsModal';
 import { AvatarEditorModal } from './components/AvatarEditorModal/AvatarEditorModal';
 import { CloseDialog } from './components/CloseDialog/CloseDialog';
 import { CertWizard } from './components/CertWizard/CertWizard';
@@ -1678,18 +1678,25 @@ const handleConnect = (serverData: SavedServer) => {
 
   const { Prompt, PromptWithInput } = usePrompt();
 
-  const screenShareSettings = (() => {
-    try {
-      const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
-      if (stored) {
-        const settings = JSON.parse(stored);
-        if (settings.screenShare) {
-          return settings.screenShare;
+  const [screenShareSettings, setScreenShareSettings] = useState<ScreenShareSettings>(DEFAULT_SCREEN_SHARE);
+
+  useEffect(() => {
+    const loadSettings = () => {
+      try {
+        const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+        if (stored) {
+          const settings = JSON.parse(stored);
+          if (settings.screenShare) {
+            setScreenShareSettings(settings.screenShare);
+          }
         }
-      }
-    } catch {}
-    return DEFAULT_SCREEN_SHARE;
-  })();
+      } catch {}
+    };
+    loadSettings();
+    const handleStorage = () => loadSettings();
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
 
   const { isSharing, startSharing, stopSharing, error: screenShareError, activeShare, remoteVideoEl, disconnectViewer, connectAsViewer } = useScreenShare(() => {
     setSharingChannelId(undefined);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2016,6 +2016,7 @@ const handleConnect = (serverData: SavedServer) => {
                     readMarkerTs={channelDividerTs}
                     screenShareVideoEl={remoteVideoEl}
                     screenSharerName={activeShare?.userName}
+                    screenShareViewerMode={screenShareSettings.viewerMode}
                     onCloseScreenShare={disconnectViewer}
                     users={users}
                   />

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -191,6 +191,19 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
       
       const overlay = document.createElement('div');
       overlay.id = 'screenshare-new-window-overlay';
+      
+      const closeOverlay = () => {
+        overlay.remove();
+        onCloseScreenShare?.();
+      };
+      
+      const handleEsc = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          closeOverlay();
+        }
+      };
+      document.addEventListener('keydown', handleEsc);
+      
       overlay.innerHTML = `
         <style>
           #screenshare-new-window-overlay {
@@ -199,58 +212,80 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
             left: 0;
             width: 100vw;
             height: 100vh;
-            background: rgba(0, 0, 0, 0.95);
+            background: #000;
             z-index: 99999;
             display: flex;
             flex-direction: column;
+          }
+          #screenshare-new-window-overlay .header {
+            display: flex;
             align-items: center;
-            justify-content: center;
-          }
-          #screenshare-new-window-overlay video {
-            max-width: 90%;
-            max-height: 85%;
-          }
-          #screenshare-new-window-overlay .close-btn {
-            position: absolute;
-            top: 20px;
-            right: 20px;
-            background: var(--bg-surface, #333);
-            border: 1px solid var(--border-subtle, #555);
-            color: var(--text-primary, #fff);
-            padding: 8px 16px;
-            cursor: pointer;
-            border-radius: 4px;
+            justify-content: space-between;
+            padding: 12px 20px;
+            background: #1a1a1a;
+            -webkit-app-region: drag;
           }
           #screenshare-new-window-overlay .title {
-            position: absolute;
-            top: 20px;
-            left: 20px;
-            color: var(--text-primary, #fff);
-            font-size: 16px;
+            color: #fff;
+            font-size: 15px;
+            font-weight: 500;
+          }
+          #screenshare-new-window-overlay .buttons {
+            display: flex;
+            gap: 8px;
+            -webkit-app-region: no-drag;
+          }
+          #screenshare-new-window-overlay .btn {
+            background: #333;
+            border: none;
+            color: #fff;
+            padding: 6px 14px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 12px;
+          }
+          #screenshare-new-window-overlay .btn-close {
+            background: #d32f2f;
+          }
+          #screenshare-new-window-overlay .btn-close:hover {
+            background: #b71c1c;
+          }
+          #screenshare-new-window-overlay .video-container {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #000;
+          }
+          #screenshare-new-window-overlay video {
+            max-width: 100%;
+            max-height: 100%;
+            object-fit: contain;
           }
         </style>
-        <span class="title">Screen Share - ${screenSharerName}</span>
-        <button class="close-btn" id="screenshare-close-btn">Close</button>
+        <div class="header">
+          <span class="title">Screen Share - ${screenSharerName}</span>
+          <div class="buttons">
+            <button class="btn btn-close" id="screenshare-close-btn">Close</button>
+          </div>
+        </div>
+        <div class="video-container">
+          <video autoplay playsinline></video>
+        </div>
       `;
       
       document.body.appendChild(overlay);
       
-      const newVideo = document.createElement('video');
-      newVideo.autoplay = true;
-      newVideo.playsInline = true;
-      if (screenShareVideoEl.srcObject) {
+      const newVideo = overlay.querySelector('video') as HTMLVideoElement;
+      if (newVideo && screenShareVideoEl.srcObject) {
         newVideo.srcObject = screenShareVideoEl.srcObject;
       }
-      overlay.insertBefore(newVideo, overlay.querySelector('.close-btn'));
       
-      const closeBtn = document.getElementById('screenshare-close-btn');
-      closeBtn?.addEventListener('click', () => {
-        overlay.remove();
-        onCloseScreenShare?.();
-      });
+      document.getElementById('screenshare-close-btn')?.addEventListener('click', closeOverlay);
       
       return () => {
         overlay.remove();
+        document.removeEventListener('keydown', handleEsc);
       };
     }
   }, [hasNewWindowScreenShare, screenShareVideoEl, screenSharerName, onCloseScreenShare]);

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -183,33 +183,77 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
   const hasNewWindowScreenShare = screenShareViewerMode === 'new-window' && !!screenShareVideoEl && !!screenSharerName && !!onCloseScreenShare;
 
   useEffect(() => {
-    if (hasNewWindowScreenShare && screenShareVideoEl) {
-      const width = 800;
-      const height = 600;
-      const newWindow = window.open('about:blank', '_blank', `width=${width},height=${height},noopener,noreferrer`);
-      if (newWindow && screenShareVideoEl.srcObject) {
-        newWindow.document.write(`
-          <html>
-            <head>
-              <title>Screen Share - ${screenSharerName}</title>
-              <style>
-                body { margin: 0; background: #000; display: flex; justify-content: center; align-items: center; height: 100vh; }
-                video { max-width: 100%; max-height: 100%; }
-              </style>
-            </head>
-            <body>
-              <video autoplay playsinline></video>
-            </body>
-          </html>
-        `);
-        const newVideo = newWindow.document.querySelector('video') as HTMLVideoElement;
-        if (newVideo && screenShareVideoEl.srcObject) {
-          newVideo.srcObject = screenShareVideoEl.srcObject;
-        }
-        newWindow.document.close();
+    if (hasNewWindowScreenShare && screenShareVideoEl && screenSharerName) {
+      const existingOverlay = document.getElementById('screenshare-new-window-overlay');
+      if (existingOverlay) {
+        existingOverlay.remove();
       }
+      
+      const overlay = document.createElement('div');
+      overlay.id = 'screenshare-new-window-overlay';
+      overlay.innerHTML = `
+        <style>
+          #screenshare-new-window-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            background: rgba(0, 0, 0, 0.95);
+            z-index: 99999;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+          }
+          #screenshare-new-window-overlay video {
+            max-width: 90%;
+            max-height: 85%;
+          }
+          #screenshare-new-window-overlay .close-btn {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            background: var(--bg-surface, #333);
+            border: 1px solid var(--border-subtle, #555);
+            color: var(--text-primary, #fff);
+            padding: 8px 16px;
+            cursor: pointer;
+            border-radius: 4px;
+          }
+          #screenshare-new-window-overlay .title {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            color: var(--text-primary, #fff);
+            font-size: 16px;
+          }
+        </style>
+        <span class="title">Screen Share - ${screenSharerName}</span>
+        <button class="close-btn" id="screenshare-close-btn">Close</button>
+      `;
+      
+      document.body.appendChild(overlay);
+      
+      const newVideo = document.createElement('video');
+      newVideo.autoplay = true;
+      newVideo.playsInline = true;
+      if (screenShareVideoEl.srcObject) {
+        newVideo.srcObject = screenShareVideoEl.srcObject;
+      }
+      overlay.insertBefore(newVideo, overlay.querySelector('.close-btn'));
+      
+      const closeBtn = document.getElementById('screenshare-close-btn');
+      closeBtn?.addEventListener('click', () => {
+        overlay.remove();
+        onCloseScreenShare?.();
+      });
+      
+      return () => {
+        overlay.remove();
+      };
     }
-  }, [hasNewWindowScreenShare, screenShareVideoEl, screenSharerName]);
+  }, [hasNewWindowScreenShare, screenShareVideoEl, screenSharerName, onCloseScreenShare]);
 
   const handleScroll = useCallback(() => {
     const container = messagesContainerRef.current;

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -24,6 +24,7 @@ interface ChatPanelProps {
   readMarkerTs?: number | null;
   screenShareVideoEl?: HTMLVideoElement | null;
   screenSharerName?: string;
+  screenShareViewerMode?: 'in-app' | 'new-window';
   onCloseScreenShare?: () => void;
   /** Connected users for avatar lookup by sender name */
   users?: { name: string; matrixUserId?: string; avatarUrl?: string }[];
@@ -36,7 +37,7 @@ const SCROLL_THRESHOLD = 150;
 const SPLIT_STORAGE_KEY = 'brmble-screenshare-split';
 const DEFAULT_SPLIT = 50;
 
-export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, screenShareVideoEl, screenSharerName, onCloseScreenShare, users, disabled, topNotice }: ChatPanelProps) {
+export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, screenShareVideoEl, screenSharerName, screenShareViewerMode, onCloseScreenShare, users, disabled, topNotice }: ChatPanelProps) {
   // Build lookup maps from sender name and matrixUserId → avatar data for MessageBubble.
   // Name-based lookup works when Mumble name matches message sender.
   // MatrixUserId-based lookup handles cases where the user connected with a different
@@ -178,7 +179,37 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
     document.addEventListener('mouseup', onMouseUp);
   }, []);
 
-  const hasScreenShare = !!screenShareVideoEl && !!screenSharerName && !!onCloseScreenShare;
+  const hasScreenShare = screenShareViewerMode === 'in-app' && !!screenShareVideoEl && !!screenSharerName && !!onCloseScreenShare;
+  const hasNewWindowScreenShare = screenShareViewerMode === 'new-window' && !!screenShareVideoEl && !!screenSharerName && !!onCloseScreenShare;
+
+  useEffect(() => {
+    if (hasNewWindowScreenShare && screenShareVideoEl) {
+      const width = 800;
+      const height = 600;
+      const newWindow = window.open('', 'Screen Share', `width=${width},height=${height}`);
+      if (newWindow && screenShareVideoEl.srcObject) {
+        newWindow.document.write(`
+          <html>
+            <head>
+              <title>Screen Share - ${screenSharerName}</title>
+              <style>
+                body { margin: 0; background: #000; display: flex; justify-content: center; align-items: center; height: 100vh; }
+                video { max-width: 100%; max-height: 100%; }
+              </style>
+            </head>
+            <body>
+              <video autoplay playsinline></video>
+            </body>
+          </html>
+        `);
+        const newVideo = newWindow.document.querySelector('video') as HTMLVideoElement;
+        if (newVideo && screenShareVideoEl.srcObject) {
+          newVideo.srcObject = screenShareVideoEl.srcObject;
+        }
+        newWindow.document.close();
+      }
+    }
+  }, [hasNewWindowScreenShare, screenShareVideoEl, screenSharerName]);
 
   const handleScroll = useCallback(() => {
     const container = messagesContainerRef.current;

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -186,7 +186,7 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
     if (hasNewWindowScreenShare && screenShareVideoEl) {
       const width = 800;
       const height = 600;
-      const newWindow = window.open('', 'Screen Share', `width=${width},height=${height}`);
+      const newWindow = window.open('about:blank', '_blank', `width=${width},height=${height},noopener,noreferrer`);
       if (newWindow && screenShareVideoEl.srcObject) {
         newWindow.document.write(`
           <html>

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
@@ -9,9 +9,30 @@
   padding: var(--space-sm) 0;
 }
 
+.screen-share-settings-tab .settings-label-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
 .screen-share-settings-tab .settings-label {
   font-size: var(--text-sm);
   color: var(--text-secondary);
+}
+
+.screen-share-settings-tab .settings-info-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: help;
+  border: 1px solid var(--border-subtle);
 }
 
 .screen-share-settings-tab .brmble-toggle {

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
@@ -1,0 +1,9 @@
+.screen-share-settings-tab {
+  padding: 16px;
+}
+
+.settings-note {
+  font-size: var(--font-size-small);
+  color: var(--text-secondary);
+  margin-top: 16px;
+}

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
@@ -2,6 +2,11 @@
   padding: 16px;
 }
 
+.settings-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
 .settings-note {
   font-size: var(--font-size-small);
   color: var(--text-secondary);

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
@@ -2,9 +2,39 @@
   padding: 16px;
 }
 
-.settings-label {
+.screen-share-settings-tab .settings-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) 0;
+}
+
+.screen-share-settings-tab .settings-label {
   font-size: var(--text-sm);
   color: var(--text-secondary);
+}
+
+.screen-share-settings-tab .brmble-toggle {
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.screen-share-settings-tab .brmble-toggle input {
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.screen-share-settings-tab .brmble-toggle-slider {
+  pointer-events: none;
+}
+
+.screen-share-settings-tab .brmble-select {
+  pointer-events: auto;
+}
+
+.screen-share-settings-tab .brmble-select-trigger {
+  pointer-events: auto;
+  cursor: pointer;
 }
 
 .settings-note {

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.css
@@ -2,13 +2,6 @@
   padding: 16px;
 }
 
-.screen-share-settings-tab .settings-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-sm) 0;
-}
-
 .screen-share-settings-tab .settings-label-group {
   display: flex;
   align-items: center;
@@ -58,7 +51,7 @@
   cursor: pointer;
 }
 
-.settings-note {
+.screen-share-settings-tab .settings-note {
   font-size: var(--font-size-small);
   color: var(--text-secondary);
   margin-top: 16px;

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -35,14 +35,14 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         
         <div className="settings-item settings-toggle">
           <label>Capture Audio</label>
-          <button
-            className={`toggle-switch ${localSettings.captureAudio ? 'active' : ''}`}
-            onClick={() => handleChange('captureAudio', !localSettings.captureAudio)}
-            role="switch"
-            aria-checked={localSettings.captureAudio}
-          >
-            <span className="toggle-slider" />
-          </button>
+          <label className="brmble-toggle">
+            <input
+              type="checkbox"
+              checked={localSettings.captureAudio}
+              onChange={(e) => handleChange('captureAudio', e.target.checked)}
+            />
+            <span className="brmble-toggle-slider"></span>
+          </label>
         </div>
 
         <div className="settings-item">
@@ -56,14 +56,14 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
 
         <div className="settings-item settings-toggle">
           <label>System Audio</label>
-          <button
-            className={`toggle-switch ${localSettings.systemAudio ? 'active' : ''}`}
-            onClick={() => handleChange('systemAudio', !localSettings.systemAudio)}
-            role="switch"
-            aria-checked={localSettings.systemAudio}
-          >
-            <span className="toggle-slider" />
-          </button>
+          <label className="brmble-toggle">
+            <input
+              type="checkbox"
+              checked={localSettings.systemAudio}
+              onChange={(e) => handleChange('systemAudio', e.target.checked)}
+            />
+            <span className="brmble-toggle-slider"></span>
+          </label>
         </div>
       </div>
 

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -15,6 +15,12 @@ const RESOLUTION_OPTIONS = [
   { value: '4k', label: '4K (Ultra HD)' },
 ];
 
+const FPS_OPTIONS = [
+  { value: '15', label: '15 FPS' },
+  { value: '30', label: '30 FPS' },
+  { value: '60', label: '60 FPS' },
+];
+
 export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettingsTabProps) {
   const [localSettings, setLocalSettings] = useState<ScreenShareSettings>(settings);
 
@@ -51,6 +57,15 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
             value={localSettings.resolution}
             onChange={(value) => handleChange('resolution', value as ScreenShareSettings['resolution'])}
             options={RESOLUTION_OPTIONS}
+          />
+        </div>
+
+        <div className="settings-item">
+          <span className="settings-label">Frame Rate</span>
+          <Select
+            value={String(localSettings.fps)}
+            onChange={(value) => handleChange('fps', Number(value) as ScreenShareSettings['fps'])}
+            options={FPS_OPTIONS}
           />
         </div>
 

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -24,7 +24,7 @@ const FPS_OPTIONS = [
 
 const VIEWER_MODE_OPTIONS = [
   { value: 'in-app', label: 'In app (chat area)' },
-  { value: 'new-window', label: 'New window' },
+  { value: 'new-window', label: 'Full window' },
 ];
 
 export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettingsTabProps) {

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+import { Select } from '../Select';
+import type { ScreenShareSettings } from './SettingsModal';
+import './ScreenShareSettingsTab.css';
+
+interface ScreenShareSettingsTabProps {
+  settings: ScreenShareSettings;
+  onChange: (settings: ScreenShareSettings) => void;
+}
+
+const RESOLUTION_OPTIONS = [
+  { value: '720p', label: '720p (HD)' },
+  { value: '1080p', label: '1080p (Full HD)' },
+  { value: '1440p', label: '1440p (QHD)' },
+  { value: '4k', label: '4K (Ultra HD)' },
+];
+
+export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettingsTabProps) {
+  const [localSettings, setLocalSettings] = useState<ScreenShareSettings>(settings);
+
+  useEffect(() => {
+    setLocalSettings(settings);
+  }, [settings]);
+
+  const handleChange = <K extends keyof ScreenShareSettings>(key: K, value: ScreenShareSettings[K]) => {
+    const newSettings = { ...localSettings, [key]: value };
+    setLocalSettings(newSettings);
+    onChange(newSettings);
+  };
+
+  return (
+    <div className="screen-share-settings-tab">
+      <div className="settings-section">
+        <h3 className="heading-section settings-section-title">Screen Capture</h3>
+        
+        <div className="settings-item settings-toggle">
+          <label>Capture Audio</label>
+          <button
+            className={`toggle-switch ${localSettings.captureAudio ? 'active' : ''}`}
+            onClick={() => handleChange('captureAudio', !localSettings.captureAudio)}
+            role="switch"
+            aria-checked={localSettings.captureAudio}
+          >
+            <span className="toggle-slider" />
+          </button>
+        </div>
+
+        <div className="settings-item">
+          <label>Resolution</label>
+          <Select
+            value={localSettings.resolution}
+            onChange={(value) => handleChange('resolution', value as ScreenShareSettings['resolution'])}
+            options={RESOLUTION_OPTIONS}
+          />
+        </div>
+
+        <div className="settings-item settings-toggle">
+          <label>System Audio</label>
+          <button
+            className={`toggle-switch ${localSettings.systemAudio ? 'active' : ''}`}
+            onClick={() => handleChange('systemAudio', !localSettings.systemAudio)}
+            role="switch"
+            aria-checked={localSettings.systemAudio}
+          >
+            <span className="toggle-slider" />
+          </button>
+        </div>
+      </div>
+
+      <p className="settings-note">
+        System audio is available on Windows and macOS. Audio capture requires browser support.
+      </p>
+    </div>
+  );
+}

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Select } from '../Select';
+import { Tooltip } from '../Tooltip/Tooltip';
 import type { ScreenShareSettings } from './SettingsModal';
 import './ScreenShareSettingsTab.css';
 
@@ -40,7 +41,9 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         <h3 className="heading-section settings-section-title">Screen Capture</h3>
         
         <div className="settings-item settings-toggle">
-          <span className="settings-label">Capture Audio</span>
+          <Tooltip content="Capture microphone audio along with screen share" position="right" align="start">
+            <span className="settings-label">Capture Audio</span>
+          </Tooltip>
           <label className="brmble-toggle">
             <input
               type="checkbox"
@@ -52,7 +55,9 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         </div>
 
         <div className="settings-item">
-          <span className="settings-label">Resolution</span>
+          <Tooltip content="Higher resolution uses more bandwidth" position="right" align="start">
+            <span className="settings-label">Resolution</span>
+          </Tooltip>
           <Select
             value={localSettings.resolution}
             onChange={(value) => handleChange('resolution', value as ScreenShareSettings['resolution'])}
@@ -61,7 +66,9 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         </div>
 
         <div className="settings-item">
-          <span className="settings-label">Frame Rate</span>
+          <Tooltip content="Higher frame rate uses more bandwidth" position="right" align="start">
+            <span className="settings-label">Frame Rate</span>
+          </Tooltip>
           <Select
             value={String(localSettings.fps)}
             onChange={(value) => handleChange('fps', Number(value) as ScreenShareSettings['fps'])}
@@ -70,7 +77,9 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         </div>
 
         <div className="settings-item settings-toggle">
-          <span className="settings-label">System Audio</span>
+          <Tooltip content="Capture system audio (Windows/macOS only)" position="right" align="start">
+            <span className="settings-label">System Audio</span>
+          </Tooltip>
           <label className="brmble-toggle">
             <input
               type="checkbox"

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -41,9 +41,12 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         <h3 className="heading-section settings-section-title">Screen Capture</h3>
         
         <div className="settings-item settings-toggle">
-          <Tooltip content="Capture microphone audio along with screen share" position="right" align="start">
+          <div className="settings-label-group">
             <span className="settings-label">Capture Audio</span>
-          </Tooltip>
+            <Tooltip content="Capture microphone audio along with screen share" position="right" align="start">
+              <span className="settings-info-btn">?</span>
+            </Tooltip>
+          </div>
           <label className="brmble-toggle">
             <input
               type="checkbox"
@@ -55,9 +58,12 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         </div>
 
         <div className="settings-item">
-          <Tooltip content="Higher resolution uses more bandwidth" position="right" align="start">
+          <div className="settings-label-group">
             <span className="settings-label">Resolution</span>
-          </Tooltip>
+            <Tooltip content="Higher resolution uses more bandwidth" position="right" align="start">
+              <span className="settings-info-btn">?</span>
+            </Tooltip>
+          </div>
           <Select
             value={localSettings.resolution}
             onChange={(value) => handleChange('resolution', value as ScreenShareSettings['resolution'])}
@@ -66,9 +72,12 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         </div>
 
         <div className="settings-item">
-          <Tooltip content="Higher frame rate uses more bandwidth" position="right" align="start">
+          <div className="settings-label-group">
             <span className="settings-label">Frame Rate</span>
-          </Tooltip>
+            <Tooltip content="Higher frame rate uses more bandwidth" position="right" align="start">
+              <span className="settings-info-btn">?</span>
+            </Tooltip>
+          </div>
           <Select
             value={String(localSettings.fps)}
             onChange={(value) => handleChange('fps', Number(value) as ScreenShareSettings['fps'])}
@@ -77,9 +86,12 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         </div>
 
         <div className="settings-item settings-toggle">
-          <Tooltip content="Capture system audio (Windows/macOS only)" position="right" align="start">
+          <div className="settings-label-group">
             <span className="settings-label">System Audio</span>
-          </Tooltip>
+            <Tooltip content="Capture system audio (Windows/macOS only)" position="right" align="start">
+              <span className="settings-info-btn">?</span>
+            </Tooltip>
+          </div>
           <label className="brmble-toggle">
             <input
               type="checkbox"

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -34,7 +34,7 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         <h3 className="heading-section settings-section-title">Screen Capture</h3>
         
         <div className="settings-item settings-toggle">
-          <label>Capture Audio</label>
+          <span className="settings-label">Capture Audio</span>
           <label className="brmble-toggle">
             <input
               type="checkbox"
@@ -46,7 +46,7 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         </div>
 
         <div className="settings-item">
-          <label>Resolution</label>
+          <span className="settings-label">Resolution</span>
           <Select
             value={localSettings.resolution}
             onChange={(value) => handleChange('resolution', value as ScreenShareSettings['resolution'])}
@@ -55,7 +55,7 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         </div>
 
         <div className="settings-item settings-toggle">
-          <label>System Audio</label>
+          <span className="settings-label">System Audio</span>
           <label className="brmble-toggle">
             <input
               type="checkbox"

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -22,6 +22,11 @@ const FPS_OPTIONS = [
   { value: '60', label: '60 FPS' },
 ];
 
+const VIEWER_MODE_OPTIONS = [
+  { value: 'in-app', label: 'In app (chat area)' },
+  { value: 'new-window', label: 'New window' },
+];
+
 export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettingsTabProps) {
   const [localSettings, setLocalSettings] = useState<ScreenShareSettings>(settings);
 
@@ -100,6 +105,20 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
             />
             <span className="brmble-toggle-slider"></span>
           </label>
+        </div>
+
+        <div className="settings-item">
+          <div className="settings-label-group">
+            <span className="settings-label">Viewer Location</span>
+            <Tooltip content="Where to show screen share when viewing others" position="right" align="start">
+              <span className="settings-info-btn">?</span>
+            </Tooltip>
+          </div>
+          <Select
+            value={localSettings.viewerMode}
+            onChange={(value) => handleChange('viewerMode', value as ScreenShareSettings['viewerMode'])}
+            options={VIEWER_MODE_OPTIONS}
+          />
         </div>
       </div>
 

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -50,12 +50,14 @@ interface SettingsModalProps {
 export interface ScreenShareSettings {
   captureAudio: boolean;
   resolution: '720p' | '1080p' | '1440p' | '4k';
+  fps: 15 | 30 | 60;
   systemAudio: boolean;
 }
 
 export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
   captureAudio: false,
   resolution: '1080p',
+  fps: 30,
   systemAudio: false,
 };
 

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -10,6 +10,7 @@ import { type AppearanceSettings, type OverlaySettings, type BrmblegotchiSetting
 import { ConnectionSettingsTab, type ConnectionSettings } from './ConnectionSettingsTab';
 import { ProfileSettingsTab } from './ProfileSettingsTab';
 import { AdminSettingsTab } from './AdminSettingsTab';
+import { ScreenShareSettingsTab } from './ScreenShareSettingsTab';
 import { useServerlist } from '../../hooks/useServerlist';
 import { usePermissions, Permission } from '../../hooks/usePermissions';
 
@@ -46,6 +47,18 @@ interface SettingsModalProps {
   setBrmblegotchiEnabled?: (enabled: boolean) => void;
 }
 
+export interface ScreenShareSettings {
+  captureAudio: boolean;
+  resolution: '720p' | '1080p' | '1440p' | '4k';
+  systemAudio: boolean;
+}
+
+export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
+  captureAudio: false,
+  resolution: '1080p',
+  systemAudio: false,
+};
+
 interface AppSettings {
   audio: AudioSettings;
   shortcuts: ShortcutsSettings;
@@ -54,6 +67,7 @@ interface AppSettings {
   overlay: OverlaySettings;
   brmblegotchi: BrmblegotchiSettings;
   speechDenoise: SpeechDenoiseSettings;
+  screenShare: ScreenShareSettings;
   reconnectEnabled: boolean;
   rememberLastChannel: boolean;
   autoConnectEnabled: boolean;
@@ -68,6 +82,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   overlay: DEFAULT_OVERLAY,
   brmblegotchi: DEFAULT_BRMBLEGOTCHI,
   speechDenoise: DEFAULT_SPEECH_DENOISE,
+  screenShare: DEFAULT_SCREEN_SHARE,
   reconnectEnabled: true,
   rememberLastChannel: true,
   autoConnectEnabled: false,
@@ -76,7 +91,7 @@ const DEFAULT_SETTINGS: AppSettings = {
 
 export function SettingsModal(props: SettingsModalProps) {
   const { isOpen, onClose, initialTab } = props;
-  const [activeTab, setActiveTab] = useState<'profile' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection' | 'admin'>(initialTab ?? 'profile');
+  const [activeTab, setActiveTab] = useState<'profile' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection' | 'admin' | 'screenShare'>(initialTab ?? 'profile');
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const { servers } = useServerlist();
   const { hasPermission } = usePermissions();
@@ -319,6 +334,13 @@ export function SettingsModal(props: SettingsModalProps) {
     localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(newSettings));
   };
 
+  const handleScreenShareChange = (screenShare: ScreenShareSettings) => {
+    const newSettings = { ...settings, screenShare };
+    setSettings(newSettings);
+    bridge.send('settings.set', { settings: newSettings });
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(newSettings));
+  };
+
   const handleConnectionChange = (connection: ConnectionSettings) => {
     const newSettings = {
       ...settings,
@@ -379,6 +401,12 @@ export function SettingsModal(props: SettingsModalProps) {
           >
             Connection
           </button>
+          <button 
+            className={`settings-tab ${activeTab === 'screenShare' ? 'active' : ''}`}
+            onClick={() => setActiveTab('screenShare')}
+          >
+            Screen Share
+          </button>
           {hasAdminPermission && (
             <button
               className={`settings-tab ${activeTab === 'admin' ? 'active' : ''}`}
@@ -425,6 +453,12 @@ export function SettingsModal(props: SettingsModalProps) {
               }}
               onChange={handleConnectionChange}
               servers={servers.map(s => ({ id: s.id, label: s.label }))}
+            />
+          )}
+          {activeTab === 'screenShare' && (
+            <ScreenShareSettingsTab
+              settings={settings.screenShare}
+              onChange={handleScreenShareChange}
             />
           )}
           {activeTab === 'admin' && hasAdminPermission && <AdminSettingsTab />}

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -158,6 +158,7 @@ export function SettingsModal(props: SettingsModalProps) {
             ...DEFAULT_SETTINGS,
             ...d.settings!,
             brmblegotchi: d.settings!.brmblegotchi ?? prev.brmblegotchi ?? DEFAULT_BRMBLEGOTCHI,
+            screenShare: d.settings!.screenShare ?? prev.screenShare ?? DEFAULT_SCREEN_SHARE,
             speechDenoise: normalizedDenoise,
           };
           if (d.settings!.appearance?.theme) {

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -52,6 +52,7 @@ export interface ScreenShareSettings {
   resolution: '720p' | '1080p' | '1440p' | '4k';
   fps: 15 | 30 | 60;
   systemAudio: boolean;
+  viewerMode: 'in-app' | 'new-window';
 }
 
 export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
@@ -59,6 +60,7 @@ export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
   resolution: '1080p',
   fps: 30,
   systemAudio: false,
+  viewerMode: 'in-app',
 };
 
 interface AppSettings {

--- a/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
+++ b/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
@@ -52,7 +52,6 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
   useEffect(() => {
     if (!isAnyMenuOpen) return;
 
-    let active = true;
     const handleSettingsUpdated = (data: unknown) => {
       type AudioSettings = { transmissionMode?: string; inputVolume?: number; outputVolume?: number };
       type SettingsData = { settings?: { audio?: AudioSettings } };

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -202,7 +202,8 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
       viewerRoomRef.current = null;
     }
     setRemoteVideoEl(null);
-    setActiveShare(null);
+    // Don't clear activeShare here - it will be cleared by screenShareStopped event
+    // when the sharer actually stops sharing. This allows re-watching.
   }, []);
 
   // Listen for screen share events from bridge

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -85,12 +85,11 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
           captureOptions.systemAudio = 'include';
         }
 
-        if (screenShareSettings.resolution) {
-          captureOptions.resolution = resolutionMap[screenShareSettings.resolution];
-        }
-
-        if (screenShareSettings.fps) {
-          captureOptions.fps = screenShareSettings.fps;
+        if (screenShareSettings.resolution || screenShareSettings.fps) {
+          captureOptions.resolution = {
+            ...resolutionMap[screenShareSettings.resolution],
+            frameRate: screenShareSettings.fps,
+          };
         }
 
         // Remove empty options

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -8,7 +8,13 @@ export interface ActiveShare {
   sessionId?: number;
 }
 
-export function useScreenShare(onDisconnected?: () => void) {
+export interface ScreenShareSettings {
+  captureAudio: boolean;
+  resolution: '720p' | '1080p' | '1440p' | '4k';
+  systemAudio: boolean;
+}
+
+export function useScreenShare(onDisconnected?: () => void, screenShareSettings?: ScreenShareSettings) {
   const [isSharing, setIsSharing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeShare, setActiveShare] = useState<ActiveShare | null>(null);
@@ -58,7 +64,37 @@ export function useScreenShare(onDisconnected?: () => void) {
       });
 
       await room.connect(url, token);
-      await room.localParticipant.setScreenShareEnabled(true);
+
+      let captureOptions: Record<string, unknown> | undefined;
+      if (screenShareSettings) {
+        const resolutionMap: Record<string, { width: number; height: number }> = {
+          '720p': { width: 1280, height: 720 },
+          '1080p': { width: 1920, height: 1080 },
+          '1440p': { width: 2560, height: 1440 },
+          '4k': { width: 3840, height: 2160 },
+        };
+
+        captureOptions = {};
+
+        if (screenShareSettings.captureAudio) {
+          captureOptions.audio = true;
+        }
+
+        if (screenShareSettings.systemAudio) {
+          captureOptions.systemAudio = 'include';
+        }
+
+        if (screenShareSettings.resolution) {
+          captureOptions.resolution = resolutionMap[screenShareSettings.resolution];
+        }
+
+        // Remove empty options
+        if (Object.keys(captureOptions).length === 0) {
+          captureOptions = undefined;
+        }
+      }
+
+      await room.localParticipant.setScreenShareEnabled(true, captureOptions);
 
       publishRoomRef.current = room;
       setIsSharing(true);

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -11,6 +11,7 @@ export interface ActiveShare {
 export interface ScreenShareSettings {
   captureAudio: boolean;
   resolution: '720p' | '1080p' | '1440p' | '4k';
+  fps: 15 | 30 | 60;
   systemAudio: boolean;
 }
 
@@ -86,6 +87,10 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
 
         if (screenShareSettings.resolution) {
           captureOptions.resolution = resolutionMap[screenShareSettings.resolution];
+        }
+
+        if (screenShareSettings.fps) {
+          captureOptions.fps = screenShareSettings.fps;
         }
 
         // Remove empty options

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -110,7 +110,7 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
       setError(err instanceof Error ? err.message : 'Screen share failed');
       setIsSharing(false);
     }
-  }, []);
+  }, [screenShareSettings]);
 
   const stopSharing = useCallback(async () => {
     const room = publishRoomRef.current;

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -75,6 +75,13 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
           '4k': { width: 3840, height: 2160 },
         };
 
+        const bitrateMap: Record<string, number> = {
+          '720p': 2_000_000,
+          '1080p': 4_000_000,
+          '1440p': 8_000_000,
+          '4k': 15_000_000,
+        };
+
         captureOptions = {};
 
         if (screenShareSettings.captureAudio) {
@@ -86,13 +93,18 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
         }
 
         if (screenShareSettings.resolution || screenShareSettings.fps) {
+          const res = resolutionMap[screenShareSettings.resolution];
           captureOptions.resolution = {
-            ...resolutionMap[screenShareSettings.resolution],
+            ...res,
             frameRate: screenShareSettings.fps,
           };
+          captureOptions.videoEncoding = {
+            maxBitrate: bitrateMap[screenShareSettings.resolution],
+            maxFramerate: screenShareSettings.fps,
+          };
+          captureOptions.videoCodec = 'h264';
         }
 
-        // Remove empty options
         if (Object.keys(captureOptions).length === 0) {
           captureOptions = undefined;
         }


### PR DESCRIPTION
## Summary

Adds a new "Screen Share" tab in the Settings modal for configuring screen capture and viewer options, plus a bug fix for re-watching.

### Screen Share Settings Tab
- **Capture Audio** - Toggle to capture microphone audio along with screen share
- **Resolution** - Dropdown to select output resolution: 720p (HD), 1080p (Full HD), 1440p (QHD), 4K (Ultra HD)
- **FPS** - Dropdown to select frame rate: 15, 30, or 60
- **System Audio** - Toggle to include system audio (Windows/macOS only)
- **Viewer Mode** - Choose where to display screen share when watching others:
  - **In-app** - Shows in a split panel within the chat
  - **Full window** - Opens in a full-screen overlay

### Technical Implementation
The UI settings are mapped to LiveKit's `ScreenShareCaptureOptions`:
- Resolution/FPS → `resolution` object with width, height, frameRate
- Bitrate → `videoEncoding.maxBitrate` (2-15 Mbps based on resolution)
- Codec → `videoCodec: 'h264'` for cross-hardware efficiency

### Bug Fix
- **Re-watching** - Fixed a bug where viewers couldn't re-watch a screen share after closing the viewer. Previously, closing the viewer cleared `activeShare` to null, preventing re-watching. Now `activeShare` is only cleared when the sharer actually stops sharing (via the `screenShareStopped` event).

## Testing
1. Open Settings → Screen Share tab - verify all settings appear
2. Toggle capture audio, change resolution/FPS, enable system audio - settings persist
3. Share your screen with different settings - verify options are applied
4. Watch someone else's screen share, close it, then re-watch - should now work
5. Switch between In-app and Full window viewer modes - both work