### PR TITLE
fix(chat): properly display reply messages in chat

### DIFF
--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
@@ -182,3 +182,29 @@
   color: var(--text-primary);
   background: var(--bg-tertiary);
 }
+
+/* Reply preview in message bubble (Discord-style) */
+.message-reply-preview {
+  padding: var(--space-2xs) var(--space-xs);
+  margin-bottom: var(--space-2xs);
+  background: var(--bg-secondary);
+  border-left: 2px solid var(--accent-primary);
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.message-reply-preview .message-reply-sender {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--text-secondary);
+}
+
+.message-reply-preview .message-reply-content {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.tsx
@@ -30,6 +30,9 @@ interface MessageBubbleProps {
   messageId?: string;
   pending?: boolean;
   error?: boolean;
+  replyToEventId?: string;
+  replyToSender?: string;
+  replyToContent?: string;
   onDismiss?: (messageId: string) => void;
   onOpenContextMenu?: (x: number, y: number, sender: string, senderMatrixUserId?: string, content?: string, messageId?: string) => void;
 }
@@ -135,7 +138,7 @@ function processMessageContent(
   return mentionified;
 }
 
-export const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps & React.HTMLAttributes<HTMLDivElement>>(function MessageBubble({ sender, content, timestamp, isOwnMessage, isSystem, html, media, matrixClient, collapsed, searchQuery, isActiveMatch, messageIndex, senderAvatarUrl, senderMatrixUserId, currentUsername, knownUsernames, messageId, pending, error, onDismiss, onOpenContextMenu, className, ...rest }, ref) {
+export const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps & React.HTMLAttributes<HTMLDivElement>>(function MessageBubble({ sender, content, timestamp, isOwnMessage, isSystem, html, media, matrixClient, collapsed, searchQuery, isActiveMatch, messageIndex, senderAvatarUrl, senderMatrixUserId, currentUsername, knownUsernames, messageId, pending, error, replyToEventId, replyToSender, replyToContent, onDismiss, onOpenContextMenu, className, ...rest }, ref) {
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
 
   const formatTime = (date: Date) => {
@@ -174,6 +177,12 @@ export const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps & Rea
           <div className="message-header">
             <span className="message-sender">{sender}</span>
             <span className="message-time">{formatTime(timestamp)}</span>
+          </div>
+        )}
+        {replyToEventId && (replyToSender || replyToContent) && (
+          <div className="message-reply-preview">
+            <span className="message-reply-sender">{replyToSender}</span>
+            <span className="message-reply-content">{replyToContent}</span>
           </div>
         )}
         {content && (

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -97,6 +97,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
           msgtype?: string;
           url?: string;
           info?: { thumbnail_url?: string; w?: number; h?: number; mimetype?: string; size?: number };
+          'm.relates_to'?: { 'm.in_reply_to'?: { event_id: string } };
         };
 
         let media: MediaAttachment[] | undefined;
@@ -119,10 +120,17 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
         const isBridgeBotSender = /^@brmble[_-]?/.test(senderId);
         const bridgeMatch = isBridgeBotSender ? rawBody.match(/^\[(.+?)\]:\s*/) : null;
         const messageSender = bridgeMatch ? bridgeMatch[1] : displayName;
-        const messageContent = bridgeMatch ? rawBody.slice(bridgeMatch[0].length) : rawBody;
+        let messageContent = bridgeMatch ? rawBody.slice(bridgeMatch[0].length) : rawBody;
+
+        // Strip reply fallback from body (lines starting with > )
+        messageContent = messageContent.split('\n').filter(line => !/^> ?/.test(line)).join('\n').trim();
 
         // For image-only messages, body is just the filename — don't show it as text
         const displayContent = media ? '' : messageContent;
+
+        // Extract reply relation from Matrix event
+        const relatesTo = content['m.relates_to'] as { 'm.in_reply_to'?: { event_id: string } } | undefined;
+        const replyToEventId = relatesTo?.['m.in_reply_to']?.event_id;
 
         const message: ChatMessage = {
           id: event.getId() ?? crypto.randomUUID(),
@@ -132,6 +140,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
           content: displayContent,
           timestamp: new Date(event.getTs()),
           ...(media && { media }),
+          ...(replyToEventId && { replyToEventId }),
         };
 
         setMessages(prev => {
@@ -161,6 +170,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
         msgtype?: string;
         url?: string;
         info?: { thumbnail_url?: string; w?: number; h?: number; mimetype?: string; size?: number };
+        'm.relates_to'?: { 'm.in_reply_to'?: { event_id: string } };
       };
 
       let dmMedia: MediaAttachment[] | undefined;
@@ -183,10 +193,17 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       const isDmBridgeBotSender = /^@brmble[_-]?/.test(dmSenderId);
       const dmBridgeMatch = isDmBridgeBotSender ? dmRawBody.match(/^\[(.+?)\]:\s*/) : null;
       const dmSender = dmBridgeMatch ? dmBridgeMatch[1] : dmDisplayName;
-      const dmMessageContent = dmBridgeMatch ? dmRawBody.slice(dmBridgeMatch[0].length) : dmRawBody;
+      let dmMessageContent = dmBridgeMatch ? dmRawBody.slice(dmBridgeMatch[0].length) : dmRawBody;
+
+      // Strip reply fallback from body (lines starting with > )
+      dmMessageContent = dmMessageContent.split('\n').filter(line => !/^> ?/.test(line)).join('\n').trim();
 
       // For image-only messages, body is just the filename — don't show it as text
       const dmDisplayContent = dmMedia ? '' : dmMessageContent;
+
+      // Extract reply relation from Matrix event
+      const dmRelatesTo = dmContent['m.relates_to'] as { 'm.in_reply_to'?: { event_id: string } } | undefined;
+      const dmReplyToEventId = dmRelatesTo?.['m.in_reply_to']?.event_id;
 
       const dmMessage: ChatMessage = {
         id: event.getId() ?? crypto.randomUUID(),
@@ -196,6 +213,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
         content: dmDisplayContent,
         timestamp: new Date(event.getTs()),
         ...(dmMedia && { media: dmMedia }),
+        ...(dmReplyToEventId && { replyToEventId: dmReplyToEventId }),
       };
 
       setDmMessages(prev => {

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -53,6 +53,9 @@ export interface ChatMessage {
   media?: MediaAttachment[];
   pending?: boolean;
   error?: boolean;
+  replyToEventId?: string;
+  replyToSender?: string;
+  replyToContent?: string;
 }
 
 export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'failed' | 'disconnected';

--- a/src/Brmble.Web/src/utils/replyHelpers.ts
+++ b/src/Brmble.Web/src/utils/replyHelpers.ts
@@ -7,7 +7,10 @@ function escapeHtml(str: string): string {
 }
 
 export function stripReplyFallback(body: string): string {
-  return body.split('\n').filter(line => !/^> ?/.test(line)).join('\n').trim();
+  // Remove existing reply markers (> ) and any bridged sender prefixes ([Name]: )
+  const withoutReply = body.split('\n').filter(line => !/^> ?/.test(line)).join('\n').trim();
+  const withoutBridge = withoutReply.replace(/^\[.+?\]:\s*/, '');
+  return withoutBridge;
 }
 
 /**
@@ -16,9 +19,12 @@ export function stripReplyFallback(body: string): string {
  */
 export function makeReplyFallback(parent: { sender: string; body: string }, replyText: string): string {
   const cleanBody = stripReplyFallback(parent.body);
-  const lines = cleanBody.split('\n');
-  const firstLine = lines[0] || '(empty message)';
-  let fallback = `> <${parent.sender}> ${firstLine}`;
+  // Handle multiple lines - prefix each with >
+  const lines = cleanBody.split('\n').filter(l => l.trim());
+  if (lines.length === 0) {
+    return `> <${parent.sender}> (empty message)\n\n${replyText}`;
+  }
+  let fallback = `> <${parent.sender}> ${lines[0]}`;
   for (let i = 1; i < lines.length; ++i) {
     fallback += `\n> ${lines[i]}`;
   }
@@ -63,7 +69,7 @@ export function buildReplyContent(
   
   return {
     msgtype: MsgType.Text,
-    body: makeReplyFallback({ sender: senderId, body: parentBody }, replyText),
+    body: makeReplyFallback({ sender: parentSender, body: parentBody }, replyText),
     format: 'org.matrix.custom.html',
     formatted_body: makeReplyHtml(roomId, parentEventId, parentSender, senderId, parentBody) + escapedReplyText,
     'm.relates_to': {


### PR DESCRIPTION
## Summary
- Add replyToEventId, replyToSender, replyToContent fields to ChatMessage type
- Add reply preview rendering in MessageBubble with Discord-style CSS
- Strip reply fallback lines (starting with >) when storing incoming messages
- Fix display name usage in makeReplyFallback (was using Matrix ID)
- Strip bridged sender prefixes ([Name]: ) from reply content in fallback
- Parse m.in_reply_to from incoming Matrix events to show reply previews

## Problem
Reply messages were displaying incorrectly:
- Original message content included the reply fallback text
- Fallback was showing Matrix ID instead of display name
- Bridged sender prefixes were included in reply preview

## Solution
1. Added reply-related fields to ChatMessage type
2. Added reply preview rendering in MessageBubble
3. Strip reply fallback when storing messages in useMatrixClient
4. Fixed makeReplyFallback to use display name instead of Matrix ID
5. Strip bridged prefixes when generating reply fallback

## Testing
- Send a reply to another user - should show clean message without fallback text
- Receive a reply - should show reply preview in message bubble