### PR TITLE
fix: style reply header with Brmble UI design tokens

### DIFF
--- a/src/Brmble.Web/src/components/ChatPanel/ReplyHeader.css
+++ b/src/Brmble.Web/src/components/ChatPanel/ReplyHeader.css
@@ -8,7 +8,7 @@
   border-left: 2px solid var(--accent-primary);
   border-radius: var(--radius-md, 8px);
   margin-bottom: var(--space-sm, 12px);
-  box-shadow: var(--shadow-sm, 0 1px 3px rgba(0,0,0,0.1));
+  box-shadow: var(--shadow-drop-subtle);
 }
 
 .reply-header-label {

--- a/src/Brmble.Web/src/components/ChatPanel/ReplyHeader.css
+++ b/src/Brmble.Web/src/components/ChatPanel/ReplyHeader.css
@@ -1,40 +1,46 @@
 .reply-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  background: var(--surface-hover, #f5f5f5);
-  border: 1px solid var(--border-color, #e0e0e0);
-  border-radius: 4px;
-  margin-bottom: 8px;
+  gap: var(--space-sm, 12px);
+  padding: var(--space-sm, 12px);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-left: 2px solid var(--accent-primary);
+  border-radius: var(--radius-md, 8px);
+  margin-bottom: var(--space-sm, 12px);
+  box-shadow: var(--shadow-sm, 0 1px 3px rgba(0,0,0,0.1));
 }
 
 .reply-header-label {
-  font-size: 11px;
+  font-family: var(--font-body);
+  font-size: var(--text-2xs, 10px);
   font-weight: 600;
-  color: var(--text-muted, #666);
+  color: var(--text-muted);
   text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .reply-header-content {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-xs, 8px);
   flex: 1;
   min-width: 0;
   overflow: hidden;
 }
 
 .reply-header-sender {
+  font-family: var(--font-body);
   font-weight: 600;
-  font-size: 13px;
-  color: var(--text-primary, #333);
+  font-size: var(--text-xs, 12px);
+  color: var(--text-primary);
   white-space: nowrap;
 }
 
 .reply-header-preview {
-  font-size: 13px;
-  color: var(--text-secondary, #666);
+  font-family: var(--font-body);
+  font-size: var(--text-xs, 12px);
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -42,18 +48,19 @@
 }
 
 .reply-header-cancel {
-  padding: 4px;
+  padding: var(--space-2xs, 4px);
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-muted, #666);
-  border-radius: 4px;
+  color: var(--text-muted);
+  border-radius: var(--radius-xs, 4px);
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .reply-header-cancel:hover {
-  background: var(--surface-active, #e0e0e0);
-  color: var(--text-primary, #333);
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }


### PR DESCRIPTION
## Summary

- Updates ReplyHeader CSS to use Brmble design tokens instead of hardcoded values
- Adds accent border on left side to match message bubble styling
- Adds subtle shadow and proper border radius
- Uses `--font-body`, `--text-*` tokens for typography
- Uses `--space-*` tokens for consistent spacing
- Adds smooth transitions on hover states

## Changes

- `ReplyHeader.css`: Full refactor to use Brmble token system

## Testing

Built and ran client locally to verify the styled reply header displays correctly in the chat panel.

## Review Notes

- This is a small UI polish PR - the main change is CSS-only
- All tokens are theme-compatible (works across all 8 themes)
- Retro Terminal theme will have near-zero border radius as expected per UI_GUIDE.md
- 
<img width="894" height="111" alt="image" src="https://github.com/user-attachments/assets/2b1b4450-07a3-4b47-a2fb-356c10e1efe9" />
