### PR TITLE
feat: broken profile detection, cert recovery, and notification system (#433)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,8 @@ All UI icons use the centralized `<Icon>` component in `src/Brmble.Web/src/compo
 - Brmblegotchi icons are prefixed `gotchi-` (e.g. `gotchi-food`, `gotchi-play`)
 - Complex brand logos (`BrmbleLogo`, `MumbleIcon`, `BrmbleIcon`) stay as dedicated components — too complex for the icon map
 
+**Adding icons:** Source SVG paths from [lucide.dev/icons](https://lucide.dev/icons). Strip the outer `<svg>` wrapper and all stroke/fill/viewBox attributes from inner elements — the `<Icon>` component applies these. After adding an icon to Icon.tsx, update the icon table in `docs/UI_GUIDE.md` section 11.
+
 See `docs/UI_GUIDE.md` section 11 for full icon list, adding new icons, and conventions.
 
 ## Running Docker (local dev)

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -663,8 +663,9 @@ Brmblegotchi icons are prefixed `gotchi-` and shared across all pet themes (`ori
 
 ### Adding a New Icon
 
-1. Open `src/Brmble.Web/src/components/Icon/Icon.tsx`
-2. Add an entry to the `iconPaths` map in the appropriate group:
+1. **Find the icon** on [Lucide Icons](https://lucide.dev/icons). Search by name or keyword, click the icon, and copy the SVG markup.
+2. **Strip the outer `<svg>` wrapper.** Lucide gives you a full `<svg>` tag with attributes like `xmlns`, `width`, `height`, `viewBox`, `fill`, `stroke`, `stroke-width`, `stroke-linecap`, `stroke-linejoin`. Remove the outer `<svg>…</svg>` and keep only the inner elements (`<path>`, `<circle>`, `<line>`, `<polyline>`, `<rect>`, `<polygon>`). Also strip any `stroke`, `fill`, `stroke-width`, `stroke-linecap`, `stroke-linejoin` attributes from the inner elements — the `<Icon>` component applies these globally.
+3. **Open `src/Brmble.Web/src/components/Icon/Icon.tsx`** and add an entry to the `iconPaths` map in the appropriate category group:
    ```tsx
    'my-icon': {
      paths: (
@@ -675,7 +676,8 @@ Brmblegotchi icons are prefixed `gotchi-` and shared across all pet themes (`ori
      ),
    },
    ```
-3. Use it: `<Icon name="my-icon" size={20} />`
+4. **Use it:** `<Icon name="my-icon" size={20} />`
+5. **Update the icon table** in this guide (section 11 → "Available Icons (by category)") so the new icon appears in the correct category row.
 
 #### Icon Conventions
 
@@ -684,8 +686,10 @@ Brmblegotchi icons are prefixed `gotchi-` and shared across all pet themes (`ori
 | ViewBox | `0 0 24 24` (omit `viewBox` field — it's the default). Only set for non-standard icons (e.g. `check` uses `0 0 16 16`) |
 | Style | Feather/Lucide conventions: stroke-based, `currentColor`, strokeWidth 2, round caps/joins |
 | Fill icons | Set `fill: true` on the definition (e.g. `triangle-right`). Stroke attributes are omitted automatically |
+| Hybrid stroke+fill | Some icons mix stroke outlines with filled sub-elements. Keep the definition as stroke-based (no `fill: true` at the top level) and add `fill="currentColor" stroke="none"` on the specific element that needs filling (e.g. `gotchi-play` has a stroked `<circle>` with a filled `<polygon>`, and `info-filled` has a filled `<circle>` dot). |
 | Naming | Use Lucide names. Pair toggleable icons with `-off` suffix (`mic` / `mic-off`) |
 | Grouping | Place related icons adjacent in the map with a comment header (`/* ── Mic ── */`) |
+| Category banners | Major sections use a 3-line box comment. Format: `// ╔══…══╗` / `// ║  CATEGORY NAME  ║` / `// ╚══…══╝` with optional description lines between the name and bottom border. See existing banners in Icon.tsx (VOICE, MEDIA, CHAT, etc.) |
 | No emoji | Never use emoji characters for icons in the UI. Always use `<Icon>` |
 
 ### When NOT to Use `<Icon>`

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -750,7 +750,7 @@ The `status` prop drives icon, color, ARIA role, and auto-dismiss behavior:
 3. **Should it auto-dismiss?** Default from status, but can override with `duration` prop
 4. **Does it need a dismiss button?** Persistent notifications: yes. Blocking with no fallback: no dismiss.
 5. **What actions does it need?** Max 1 primary action. Action must be reachable elsewhere in UI since notifications can be missed.
-6. **What message text?** Short, no jargon. State what happened and what the user can do.
+6. **What title + detail?** Title = what happened (short, one line). Detail = context or next step (optional).
 
 ### Props
 
@@ -758,24 +758,84 @@ The `status` prop drives icon, color, ARIA role, and auto-dismiss behavior:
 interface NotificationProps {
   status: 'info' | 'success' | 'warning' | 'error';
   position: 'top-right' | 'bottom-center';
-  children: React.ReactNode;
+  title: React.ReactNode;         // Bold headline — what happened. Keep to one line.
+  detail?: React.ReactNode;       // Secondary text — context, next step, or explanation.
+  actions?: React.ReactNode;      // Action buttons rendered below the message.
   visible: boolean;
-  duration?: number | null;     // null = never. Defaults: info/success = 5000, warning/error = null
-  onDismiss?: () => void;       // When provided, close button (x) renders
-  onExited?: () => void;        // After exit animation completes
-  pauseOnHover?: boolean;       // Default: true. Pauses auto-dismiss on hover (WCAG 2.2.1)
-  className?: string;           // For consumer-specific styling
+  duration?: number | null;       // null = never. Defaults: info/success = 5000, warning/error = null
+  onDismiss?: () => void;         // When provided, close button (×) renders
+  onExited?: () => void;          // After exit animation completes
+  pauseOnHover?: boolean;         // Default: true. Pauses auto-dismiss on hover (WCAG 2.2.1)
+  className?: string;             // For consumer-specific styling
 }
 ```
+
+### Content Structure
+
+Every notification uses a **title + detail** pattern:
+
+- **Title** = what happened. Short, scannable, fits one line. Bold weight.
+- **Detail** = context or next step. Smaller, secondary color. Optional — omit if the title says it all.
+
+The status icon aligns vertically with the title line.
+
+| When writing… | Do | Don't |
+|---|---|---|
+| Title | `Certificate missing` | `Profile "X" has no certificate file` |
+| Title | `Update available` | `Update available: v1.2.3` |
+| Detail | `Profile "X" has no certificate.` | (cram everything into one line) |
+| Detail | `Press Update to install v1.2.3.` | (repeat info from title) |
 
 ### Behavioral Rules
 
 - **Auto-dismiss:** `info`/`success` auto-dismiss at 5s; `warning`/`error` persist. Timer pauses on hover.
 - **Errors and actionable notifications must never auto-dismiss.**
 - **Max 3** visible top-right notifications. Excess queued. Identical notifications (same status + message) deduplicated.
-- **Action buttons:** Max 1 primary per notification. Close button is separate from action button.
+- **Action buttons:** Max 1 primary per notification. Every labeled button must perform a distinct action (e.g. "Update", "Import", "Settings"). Close button is separate from action buttons.
+- **Dismissal is `×` only.** Never add a text button ("Dismiss", "Later", "Close") that duplicates the `×` close button. The `×` is the universal dismiss affordance — text buttons are reserved for meaningful actions. This keeps the UI clean and avoids redundancy.
 - Top-right notifications render inside a `.notification-stack` container in `App.tsx`.
 - Bottom-center notifications (`Toast`) position themselves independently.
+
+### Queue & Priority (`useNotificationQueue`)
+
+Top-right notifications are managed by the `useNotificationQueue` hook (`src/Brmble.Web/src/hooks/useNotificationQueue.ts`). This keeps the stack readable by limiting visible notifications and ensuring critical ones are always shown.
+
+**Priority order** (highest first):
+
+| Priority | Status | Numeric |
+|---|---|---|
+| Highest | `error` | 3 |
+| | `warning` | 2 |
+| | `info` | 1 |
+| Lowest | `success` | 0 |
+
+**Rules:**
+- Max **3** notifications visible simultaneously. Excess entries are queued.
+- Within the same priority, **arrival order** wins (first registered shows first).
+- When a higher-priority notification registers, it **preempts** the lowest-priority visible one.
+- When a notification is dismissed or exits, the next queued entry **re-appears** automatically.
+- `register(id, status)` — call when notification data exists (e.g. broken profile detected, update available, server imported).
+- `unregister(id)` — call from `onExited` (after exit animation), not from `onDismiss`. This ensures the exit animation completes before the slot is freed.
+- `isVisible(id)` — pass as the `visible` prop to `<Notification>`.
+- Bottom-center notifications (`Toast`) bypass the queue — they position independently.
+
+**Integration pattern in App.tsx:**
+```tsx
+const q = useNotificationQueue();
+
+// Register when data arrives
+useEffect(() => {
+  if (hasBrokenCert) q.register('broken-cert', 'warning');
+  else q.unregister('broken-cert');
+}, [hasBrokenCert]);
+
+// Render
+<Notification
+  visible={q.isVisible('broken-cert')}
+  onExited={() => q.unregister('broken-cert')}
+  ...
+/>
+```
 
 ### Accessibility
 
@@ -807,16 +867,23 @@ See `src/Brmble.Web/src/themes/_template.css` for guidance values per token.
 
 ```tsx
 // A "server unreachable" error notification
-<Notification status="error" position="top-right" onDismiss={handleDismiss}>
-  <p>Could not reach server. <strong>Check your connection.</strong></p>
-  <button className="btn btn-sm btn-primary" onClick={handleRetry}>Retry</button>
-</Notification>
+<Notification
+  status="error"
+  position="top-right"
+  visible={visible}
+  onDismiss={handleDismiss}
+  title="Server unreachable"
+  detail="Could not reach the server. Check your connection."
+  actions={
+    <button className="btn btn-sm btn-primary" onClick={handleRetry}>Retry</button>
+  }
+/>
 ```
 
 ### Existing Notifications
 
-| Component | Status | Position | Auto-dismiss | Notes |
-|---|---|---|---|---|
-| `Toast` | `info` | `bottom-center` | 8s | |
-| `UpdateNotification` | `info` | `top-right` | No | |
-| `BrokenCertNotification` | `warning` | `top-right` | No | One per broken profile; each independently dismissible |
+| Component | Status | Position | Auto-dismiss | Title | Detail |
+|---|---|---|---|---|---|
+| `Toast` | `info` | `bottom-center` | 8s | message string | (none) |
+| `UpdateNotification` | `info` | `top-right` | No | `Update available` | `Press Update to install v{version}.` |
+| `BrokenCertNotification` | `warning` | `top-right` | No | `Certificate missing` | Profile name, switched-to info, recovery instructions |

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -815,8 +815,8 @@ See `src/Brmble.Web/src/themes/_template.css` for guidance values per token.
 
 ### Existing Notifications
 
-| Component | Status | Position | Auto-dismiss |
-|---|---|---|---|
-| `Toast` | `info` | `bottom-center` | 8s |
-| `UpdateNotification` | `info` | `top-right` | No |
-| `BrokenCertNotification` | `warning` | `top-right` | No |
+| Component | Status | Position | Auto-dismiss | Notes |
+|---|---|---|---|---|
+| `Toast` | `info` | `bottom-center` | 8s | |
+| `UpdateNotification` | `info` | `top-right` | No | |
+| `BrokenCertNotification` | `warning` | `top-right` | No | One per broken profile; each independently dismissible |

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -723,3 +723,100 @@ Brmblegotchi icons are prefixed `gotchi-` and shared across all pet themes (`ori
    }
    ```
 4. **`overflow: visible`** must be set on SVGs with hover/animation effects that translate elements outside the viewBox.
+
+---
+
+## 13. Notification Pattern
+
+### Base Component
+
+All notifications use the shared `<Notification>` base component (`src/Brmble.Web/src/components/Notification/`). Never create standalone notification components with their own positioning/animation/styling — always wrap with `<Notification>`.
+
+### Status Types
+
+The `status` prop drives icon, color, ARIA role, and auto-dismiss behavior:
+
+| Status | Icon | Color tokens | ARIA role | Auto-dismiss |
+|---|---|---|---|---|
+| `info` | `info` | `--accent-info-*` | `role="status"` | 5s |
+| `success` | `check-circle` | `--accent-success-*` | `role="status"` | 5s |
+| `warning` | `alert-triangle` | `--accent-warning-*` | `role="status"` | No (persist) |
+| `error` | `alert-circle` | `--accent-danger-*` | `role="alert"` | No (persist) |
+
+### Decision Checklist (answer all before building a notification)
+
+1. **What status applies?** `info` = supplemental, `success` = action confirmed, `warning` = needs attention, `error` = something failed
+2. **What position?** `top-right` for system/background events, `bottom-center` for direct action feedback
+3. **Should it auto-dismiss?** Default from status, but can override with `duration` prop
+4. **Does it need a dismiss button?** Persistent notifications: yes. Blocking with no fallback: no dismiss.
+5. **What actions does it need?** Max 1 primary action. Action must be reachable elsewhere in UI since notifications can be missed.
+6. **What message text?** Short, no jargon. State what happened and what the user can do.
+
+### Props
+
+```tsx
+interface NotificationProps {
+  status: 'info' | 'success' | 'warning' | 'error';
+  position: 'top-right' | 'bottom-center';
+  children: React.ReactNode;
+  visible: boolean;
+  duration?: number | null;     // null = never. Defaults: info/success = 5000, warning/error = null
+  onDismiss?: () => void;       // When provided, close button (x) renders
+  onExited?: () => void;        // After exit animation completes
+  pauseOnHover?: boolean;       // Default: true. Pauses auto-dismiss on hover (WCAG 2.2.1)
+  className?: string;           // For consumer-specific styling
+}
+```
+
+### Behavioral Rules
+
+- **Auto-dismiss:** `info`/`success` auto-dismiss at 5s; `warning`/`error` persist. Timer pauses on hover.
+- **Errors and actionable notifications must never auto-dismiss.**
+- **Max 3** visible top-right notifications. Excess queued. Identical notifications (same status + message) deduplicated.
+- **Action buttons:** Max 1 primary per notification. Close button is separate from action button.
+- Top-right notifications render inside a `.notification-stack` container in `App.tsx`.
+- Bottom-center notifications (`Toast`) position themselves independently.
+
+### Accessibility
+
+- **ARIA:** `info`/`success`/`warning` use `role="status"` (`aria-live="polite"`); `error` uses `role="alert"` (`aria-live="assertive"`)
+- **Icons:** Status icon always rendered — never rely on color alone (WCAG 1.4.1)
+- **Keyboard:** Close button is keyboard accessible. `Esc` dismisses focused notification.
+- **Motion:** `prefers-reduced-motion: reduce` disables slide animation, keeps opacity fade only.
+
+### When NOT to Use Notification
+
+- **Blocking decisions** requiring immediate response → use `confirm()` modal
+- **Form validation errors** → use inline error text near the field (`.profiles-form-error` pattern)
+- **Passive status indicators** → use inline badges/dots, not notifications
+
+### Token Reference
+
+All four semantic accent families must be defined in every theme:
+
+| Family | Variants |
+|---|---|
+| `--accent-info-*` | base, `-text`, `-subtle`, `-border`, `-bg` |
+| `--accent-success-*` | base, `-text`, `-subtle`, `-border`, `-bg`, `-glow` |
+| `--accent-warning-*` | base, `-text`, `-subtle`, `-border`, `-bg` |
+| `--accent-danger-*` | base, `-text`, `-subtle`, `-border`, `-bg`, `-strong` |
+
+See `src/Brmble.Web/src/themes/_template.css` for guidance values per token.
+
+### Example: Adding a New Notification
+
+```tsx
+// A "server unreachable" error notification
+<Notification status="error" position="top-right" onDismiss={handleDismiss}>
+  <p>Could not reach server. <strong>Check your connection.</strong></p>
+  <button className="btn btn-sm btn-primary" onClick={handleRetry}>Retry</button>
+</Notification>
+```
+
+### Existing Notifications
+
+| Component | Status | Position | Auto-dismiss |
+|---|---|---|---|
+| `Toast` | `info` | `bottom-center` | 8s |
+| `UpdateNotification` | `info` | `top-right` | No |
+| `BrokenCertNotification` | `warning` | `top-right` | No |

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -790,7 +790,7 @@ The status icon aligns vertically with the title line.
 
 - **Auto-dismiss:** `info`/`success` auto-dismiss at 5s; `warning`/`error` persist. Timer pauses on hover.
 - **Errors and actionable notifications must never auto-dismiss.**
-- **Max 3** visible top-right notifications. Excess queued. Identical notifications (same status + message) deduplicated.
+- **Max 3** visible top-right notifications. Excess queued. Notifications are deduplicated by `id`; matching status/message alone does not deduplicate them.
 - **Action buttons:** Max 1 primary per notification. Every labeled button must perform a distinct action (e.g. "Update", "Import", "Settings"). Close button is separate from action buttons.
 - **Dismissal is `×` only.** Never add a text button ("Dismiss", "Later", "Close") that duplicates the `×` close button. The `×` is the universal dismiss affordance — text buttons are reserved for meaningful actions. This keeps the UI clean and avoids redundancy.
 - Top-right notifications render inside a `.notification-stack` container in `App.tsx`.

--- a/docs/superpowers/plans/2026-04-12-broken-profile-detection.md
+++ b/docs/superpowers/plans/2026-04-12-broken-profile-detection.md
@@ -1,0 +1,1543 @@
+# Broken Profile Detection & Notification Standardization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect orphaned profiles (missing `.pfx` cert), notify the user at startup with recovery options, and standardize the notification component system.
+
+**Architecture:** A shared `<Notification>` base component replaces duplicated CSS across Toast and UpdateNotification. The backend auto-switches away from broken profiles and reports the issue. A new `BrokenCertNotification` uses the shared base with `warning` status.
+
+**Tech Stack:** React + TypeScript (frontend), C# / WebView2 (backend), CSS custom properties (theming)
+
+---
+
+### Task 1: Add warning/info theme tokens to all theme files
+
+**Files:**
+- Modify: `src/Brmble.Web/src/themes/_template.css:230-330`
+- Modify: `src/Brmble.Web/src/themes/classic.css:45-65`
+- Modify: `src/Brmble.Web/src/themes/clean.css` (same accent section)
+- Modify: `src/Brmble.Web/src/themes/blue-lagoon.css` (same accent section)
+- Modify: `src/Brmble.Web/src/themes/aperol-spritz.css` (same accent section)
+- Modify: `src/Brmble.Web/src/themes/cosmopolitan.css` (same accent section)
+- Modify: `src/Brmble.Web/src/themes/midori-sour.css` (same accent section)
+- Modify: `src/Brmble.Web/src/themes/retro-terminal.css` (same accent section)
+- Modify: `src/Brmble.Web/src/themes/lemon-drop.css` (same accent section)
+
+- [ ] **Step 1: Add warning and info token documentation to `_template.css`**
+
+Insert after the Success Accent section (after line ~250) and before the Decorative Accent section. Follow the existing documentation format with hue ranges and opacity ranges:
+
+```css
+  /*
+    ── Warning Accent ──────────────────────────────────────────────
+    Amber / yellow tones for attention-needed states.
+    Hue range: 35-50 (amber-yellow).
+
+       Token                       Target
+       --accent-warning:           hsl(35-50, 80-100%, 60-70%)    — base
+       --accent-warning-text:      hsl(35-50, 80-100%, 65-75%)    — readable on dark bg
+       --accent-warning-subtle:    rgba(base, 0.08-0.15)          — faint bg tint
+       --accent-warning-border:    rgba(base, 0.30-0.50)          — visible border
+       --accent-warning-bg:        rgba(base, 0.20-0.30)          — warning panel bg
+  */
+  --accent-warning:        /* hsl(35-50, 80-100%, 60-70%) */;
+  --accent-warning-text:   /* hsl(35-50, 80-100%, 65-75%) */;
+  --accent-warning-subtle: /* rgba(R, G, B, 0.08-0.15) */;
+  --accent-warning-border: /* rgba(R, G, B, 0.30-0.50) */;
+  --accent-warning-bg:     /* rgba(R, G, B, 0.20-0.30) */;
+
+  /*
+    ── Info Accent ─────────────────────────────────────────────────
+    Blue tones for supplemental / informational states.
+    Hue range: 200-220 (blue).
+
+       Token                       Target
+       --accent-info:              hsl(200-220, 60-80%, 55-65%)   — base
+       --accent-info-text:         hsl(200-220, 60-80%, 62-72%)   — readable on dark bg
+       --accent-info-subtle:       rgba(base, 0.08-0.15)          — faint bg tint
+       --accent-info-border:       rgba(base, 0.30-0.50)          — visible border
+       --accent-info-bg:           rgba(base, 0.20-0.30)          — info panel bg
+  */
+  --accent-info:        /* hsl(200-220, 60-80%, 55-65%) */;
+  --accent-info-text:   /* hsl(200-220, 60-80%, 62-72%) */;
+  --accent-info-subtle: /* rgba(R, G, B, 0.08-0.15) */;
+  --accent-info-border: /* rgba(R, G, B, 0.30-0.50) */;
+  --accent-info-bg:     /* rgba(R, G, B, 0.20-0.30) */;
+```
+
+Also extend the Success section to add `--accent-success-text`, `--accent-success-border`, `--accent-success-bg` (currently only 3 of 5 variants exist):
+
+```css
+  --accent-success-text:   /* hsl(140-160, 50-70%, 55-65%) */;
+  --accent-success-border: /* rgba(R, G, B, 0.30-0.50) */;
+  --accent-success-bg:     /* rgba(R, G, B, 0.20-0.30) */;
+```
+
+- [ ] **Step 2: Add tokens to `classic.css`**
+
+Insert after the existing Success Accent block (after line 50) and before the Decorative Accent block (line 52). The classic theme uses warm tones:
+
+```css
+  /* Warning Accent (Amber) */
+  --accent-warning: #f0a030;
+  --accent-warning-text: #f0b050;
+  --accent-warning-subtle: rgba(240, 160, 48, 0.12);
+  --accent-warning-border: rgba(240, 160, 48, 0.4);
+  --accent-warning-bg: rgba(240, 160, 48, 0.25);
+
+  /* Info Accent (Blue) */
+  --accent-info: #5b9bd5;
+  --accent-info-text: #6baae0;
+  --accent-info-subtle: rgba(91, 155, 213, 0.12);
+  --accent-info-border: rgba(91, 155, 213, 0.4);
+  --accent-info-bg: rgba(91, 155, 213, 0.25);
+```
+
+Also extend the Success block:
+
+```css
+  --accent-success-text: #60d888;
+  --accent-success-border: rgba(80, 200, 120, 0.4);
+  --accent-success-bg: rgba(80, 200, 120, 0.25);
+```
+
+- [ ] **Step 3: Add tokens to remaining 7 theme files**
+
+Repeat the same pattern for each theme, choosing hue-appropriate warning (amber) and info (blue) values that match each theme's personality. Each theme file follows the same structure: find the existing Success Accent comment block, add `--accent-success-text/border/bg`, then add Warning Accent and Info Accent blocks before the Decorative Accent section.
+
+For each theme:
+- **clean.css**: Look at the existing danger/success hues and pick complementary amber and blue
+- **blue-lagoon.css**: Teal-leaning blues; info should be distinguishable from the theme's primary blue
+- **aperol-spritz.css**: Warm orange tones; warning amber should be distinguishable from the theme's primary orange
+- **cosmopolitan.css**: Already has warm danger hues; pick a distinct amber for warning
+- **midori-sour.css**: Green-focused; standard amber/blue will contrast well
+- **retro-terminal.css**: Bright terminal colors; use bright amber and bright blue
+- **lemon-drop.css**: Yellow-toned; warning amber must be distinguishable from the theme's primary yellow — consider shifting toward orange
+
+- [ ] **Step 4: Build the frontend to verify tokens load without errors**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/themes/
+git commit -m "feat: add warning and info accent token families to all themes"
+```
+
+---
+
+### Task 2: Add notification icons to Icon component
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Icon/Icon.tsx`
+
+- [ ] **Step 1: Add `check-circle`, `alert-triangle`, and `alert-circle` icons**
+
+Add these to the `iconPaths` record. Place them in a new `// ╔══ STATUS ══╗` category section. All icons follow Feather/Lucide conventions: 24x24 viewBox, stroke-based, `currentColor`, strokeWidth 2, round caps/joins.
+
+```tsx
+  // ╔══ STATUS ══╗
+  'check-circle': {
+    paths: (
+      <>
+        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+        <polyline points="22 4 12 14.01 9 11.01" />
+      </>
+    ),
+  },
+  'alert-triangle': {
+    paths: (
+      <>
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+        <line x1="12" y1="9" x2="12" y2="13" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </>
+    ),
+  },
+  'alert-circle': {
+    paths: (
+      <>
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </>
+    ),
+  },
+```
+
+- [ ] **Step 2: Build to verify icons compile**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Icon/Icon.tsx
+git commit -m "feat: add check-circle, alert-triangle, alert-circle status icons"
+```
+
+---
+
+### Task 3: Create the shared `Notification` base component
+
+**Files:**
+- Create: `src/Brmble.Web/src/components/Notification/Notification.tsx`
+- Create: `src/Brmble.Web/src/components/Notification/Notification.css`
+
+- [ ] **Step 1: Create `Notification.css`**
+
+```css
+.notification {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  z-index: 1100;
+  opacity: 0;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  box-shadow: var(--shadow-elevated);
+  max-width: 420px;
+}
+
+/* Position variants */
+.notification--top-right {
+  transform: translateY(-20px);
+}
+
+.notification--bottom-center {
+  position: fixed;
+  bottom: var(--space-lg);
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+}
+
+.notification--visible {
+  opacity: 1;
+}
+
+.notification--visible.notification--top-right {
+  transform: translateY(0);
+}
+
+.notification--visible.notification--bottom-center {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Status icon */
+.notification__icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.notification--info .notification__icon { color: var(--accent-info); }
+.notification--success .notification__icon { color: var(--accent-success); }
+.notification--warning .notification__icon { color: var(--accent-warning); }
+.notification--error .notification__icon { color: var(--accent-danger); }
+
+/* Status left border accent */
+.notification--info { border-left: 3px solid var(--accent-info); }
+.notification--success { border-left: 3px solid var(--accent-success); }
+.notification--warning { border-left: 3px solid var(--accent-warning); }
+.notification--error { border-left: 3px solid var(--accent-danger); }
+
+/* Content area */
+.notification__content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Close button */
+.notification__close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--space-xs);
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.notification__close:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+/* Stacking container */
+.notification-stack {
+  position: fixed;
+  top: var(--space-lg);
+  right: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  z-index: 1100;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .notification {
+    transition: opacity var(--transition-fast);
+    transform: none !important;
+  }
+  .notification--bottom-center {
+    transform: translateX(-50%) !important;
+  }
+  .notification--visible.notification--bottom-center {
+    transform: translateX(-50%) !important;
+  }
+}
+```
+
+- [ ] **Step 2: Create `Notification.tsx`**
+
+```tsx
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { Icon } from '../Icon/Icon';
+import './Notification.css';
+
+export type NotificationStatus = 'info' | 'success' | 'warning' | 'error';
+
+interface NotificationProps {
+  status: NotificationStatus;
+  position: 'top-right' | 'bottom-center';
+  children: React.ReactNode;
+  visible: boolean;
+  duration?: number | null;
+  onDismiss?: () => void;
+  onExited?: () => void;
+  pauseOnHover?: boolean;
+  className?: string;
+}
+
+const STATUS_ICONS: Record<NotificationStatus, string> = {
+  info: 'info',
+  success: 'check-circle',
+  warning: 'alert-triangle',
+  error: 'alert-circle',
+};
+
+const STATUS_ROLES: Record<NotificationStatus, string> = {
+  info: 'status',
+  success: 'status',
+  warning: 'status',
+  error: 'alert',
+};
+
+const STATUS_LIVE: Record<NotificationStatus, 'polite' | 'assertive'> = {
+  info: 'polite',
+  success: 'polite',
+  warning: 'polite',
+  error: 'assertive',
+};
+
+const DEFAULT_DURATIONS: Record<NotificationStatus, number | null> = {
+  info: 5000,
+  success: 5000,
+  warning: null,
+  error: null,
+};
+
+export function Notification({
+  status,
+  position,
+  children,
+  visible,
+  duration,
+  onDismiss,
+  onExited,
+  pauseOnHover = true,
+  className,
+}: NotificationProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const remainingRef = useRef<number | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const effectiveDuration = duration !== undefined ? duration : DEFAULT_DURATIONS[status];
+
+  // Enter animation
+  useEffect(() => {
+    if (visible) {
+      requestAnimationFrame(() => setIsVisible(true));
+    } else {
+      setIsVisible(false);
+      exitTimerRef.current = setTimeout(() => onExited?.(), 250);
+    }
+    return () => {
+      if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
+    };
+  }, [visible, onExited]);
+
+  // Auto-dismiss timer
+  const startTimer = useCallback((ms: number) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    remainingRef.current = ms;
+    startTimeRef.current = Date.now();
+    timerRef.current = setTimeout(() => {
+      onDismiss?.();
+    }, ms);
+  }, [onDismiss]);
+
+  const pauseTimer = useCallback(() => {
+    if (timerRef.current && startTimeRef.current !== null && remainingRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+      const elapsed = Date.now() - startTimeRef.current;
+      remainingRef.current = Math.max(0, remainingRef.current - elapsed);
+    }
+  }, []);
+
+  const resumeTimer = useCallback(() => {
+    if (remainingRef.current !== null && remainingRef.current > 0 && !timerRef.current) {
+      startTimer(remainingRef.current);
+    }
+  }, [startTimer]);
+
+  useEffect(() => {
+    if (visible && effectiveDuration !== null && effectiveDuration > 0) {
+      startTimer(effectiveDuration);
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [visible, effectiveDuration, startTimer]);
+
+  const handleMouseEnter = useCallback(() => {
+    if (pauseOnHover && effectiveDuration !== null) pauseTimer();
+  }, [pauseOnHover, effectiveDuration, pauseTimer]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (pauseOnHover && effectiveDuration !== null) resumeTimer();
+  }, [pauseOnHover, effectiveDuration, resumeTimer]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape' && onDismiss) {
+      onDismiss();
+    }
+  }, [onDismiss]);
+
+  const classNames = [
+    'notification',
+    `notification--${status}`,
+    `notification--${position}`,
+    isVisible ? 'notification--visible' : '',
+    className ?? '',
+  ].filter(Boolean).join(' ');
+
+  return (
+    <div
+      className={classNames}
+      role={STATUS_ROLES[status]}
+      aria-live={STATUS_LIVE[status]}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="notification__icon">
+        <Icon name={STATUS_ICONS[status]} size={18} />
+      </div>
+      <div className="notification__content">
+        {children}
+      </div>
+      {onDismiss && (
+        <button
+          className="notification__close"
+          onClick={onDismiss}
+          aria-label="Dismiss notification"
+        >
+          <Icon name="x" size={16} />
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Build to verify component compiles**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds. The component is not yet used by anything.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Notification/
+git commit -m "feat: create shared Notification base component with status-driven API"
+```
+
+---
+
+### Task 4: Refactor Toast to use Notification base
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Toast/Toast.tsx`
+- Modify: `src/Brmble.Web/src/components/Toast/Toast.css`
+
+- [ ] **Step 1: Refactor `Toast.tsx`**
+
+Replace the entire file with:
+
+```tsx
+import { useState, useCallback } from 'react';
+import { Notification } from '../Notification/Notification';
+import './Toast.css';
+
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+  primary?: boolean;
+}
+
+interface ToastProps {
+  message: string;
+  actions?: ToastAction[];
+  duration?: number;
+  onDismiss: () => void;
+}
+
+export function Toast({ message, actions, duration = 8000, onDismiss }: ToastProps) {
+  const [visible, setVisible] = useState(true);
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+  }, []);
+
+  const handleAction = useCallback((action: ToastAction) => {
+    action.onClick();
+    setVisible(false);
+  }, []);
+
+  return (
+    <Notification
+      status="info"
+      position="bottom-center"
+      visible={visible}
+      duration={duration}
+      onDismiss={handleDismiss}
+      onExited={onDismiss}
+    >
+      <span className="toast-message">{message}</span>
+      {actions && (
+        <div className="toast-actions">
+          {actions.map((action, i) => (
+            <button
+              key={i}
+              className={`btn btn-sm ${action.primary ? 'btn-primary' : 'btn-ghost'}`}
+              onClick={() => handleAction(action)}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </Notification>
+  );
+}
+```
+
+- [ ] **Step 2: Reduce `Toast.css` to Toast-specific styles only**
+
+Replace the entire file with:
+
+```css
+.toast-message {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.toast-actions {
+  display: flex;
+  gap: var(--space-xs);
+}
+```
+
+The positioning, background, border, animation, and z-index are now handled by `Notification.css`.
+
+- [ ] **Step 3: Build and verify Toast still works visually**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds. Toast component still renders correctly (same visual output, now using the shared base).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Toast/
+git commit -m "refactor: Toast uses shared Notification base component"
+```
+
+---
+
+### Task 5: Refactor UpdateNotification to use Notification base
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.tsx`
+- Modify: `src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.css`
+- Modify: `src/Brmble.Web/src/App.tsx:2219-2226`
+
+- [ ] **Step 1: Refactor `UpdateNotification.tsx`**
+
+Replace the entire file with:
+
+```tsx
+import { useState, useCallback } from 'react';
+import { Notification } from '../Notification/Notification';
+import './UpdateNotification.css';
+
+interface UpdateNotificationProps {
+  version: string;
+  onUpdate: () => void;
+  onDismiss: () => void;
+  progress: number | null;
+}
+
+export function UpdateNotification({ version, onUpdate, onDismiss, progress }: UpdateNotificationProps) {
+  const [visible, setVisible] = useState(true);
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+  }, []);
+
+  const isApplying = progress !== null;
+
+  return (
+    <Notification
+      status="info"
+      position="top-right"
+      visible={visible}
+      duration={null}
+      onDismiss={isApplying ? undefined : handleDismiss}
+      onExited={onDismiss}
+    >
+      {isApplying ? (
+        <>
+          <span className="update-notification__message">Updating to v{version}...</span>
+          <div className="update-notification__progress">
+            <div className="update-notification__progress-bar" style={{ width: `${progress}%` }} />
+          </div>
+        </>
+      ) : (
+        <>
+          <span className="update-notification__message">Update available: v{version}</span>
+          <div className="update-notification__actions">
+            <button className="btn btn-sm btn-ghost" onClick={handleDismiss}>Later</button>
+            <button className="btn btn-sm btn-primary" onClick={onUpdate}>Update</button>
+          </div>
+        </>
+      )}
+    </Notification>
+  );
+}
+```
+
+- [ ] **Step 2: Reduce `UpdateNotification.css` to component-specific styles only**
+
+Replace the entire file with:
+
+```css
+.update-notification__message {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.update-notification__actions {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.update-notification__progress {
+  width: 120px;
+  height: 4px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.update-notification__progress-bar {
+  height: 100%;
+  background: var(--accent);
+  border-radius: var(--radius-sm);
+  transition: width var(--transition-fast);
+}
+```
+
+- [ ] **Step 3: Add `.notification-stack` container in App.tsx**
+
+In `App.tsx`, find the render section (around line 2219) where `<UpdateNotification>` is rendered. Wrap it in a `.notification-stack` div. Replace:
+
+```tsx
+      {updateInfo && (
+        <UpdateNotification
+          version={updateInfo.version}
+          onUpdate={handleApplyUpdate}
+          onDismiss={handleDismissUpdate}
+          progress={updateProgress}
+        />
+      )}
+```
+
+With:
+
+```tsx
+      <div className="notification-stack">
+        {updateInfo && (
+          <UpdateNotification
+            version={updateInfo.version}
+            onUpdate={handleApplyUpdate}
+            onDismiss={handleDismissUpdate}
+            progress={updateProgress}
+          />
+        )}
+      </div>
+```
+
+- [ ] **Step 4: Build and verify UpdateNotification still works**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/UpdateNotification/ src/Brmble.Web/src/App.tsx
+git commit -m "refactor: UpdateNotification uses shared Notification base, add notification-stack"
+```
+
+---
+
+### Task 6: Add `profiles.recover` backend handler
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Certificate/CertificateService.cs`
+
+- [ ] **Step 1: Add `profiles.recover` handler**
+
+In `CertificateService.cs`, after the existing `profiles.rename` handler block (around line 500), add the new handler:
+
+```csharp
+bridge.RegisterHandler("profiles.recover", data =>
+{
+    try
+    {
+        var id = data.GetProperty("id").GetString();
+        var base64Data = data.GetProperty("data").GetString();
+
+        if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(base64Data))
+        {
+            bridge.Send("profiles.error", new { message = "Missing profile ID or certificate data." });
+            return Task.CompletedTask;
+        }
+
+        var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+        if (profile == null)
+        {
+            bridge.Send("profiles.error", new { message = "Profile not found." });
+            return Task.CompletedTask;
+        }
+
+        var certBytes = Convert.FromBase64String(base64Data);
+
+        // Validate the .pfx is loadable
+        string fingerprint;
+        try
+        {
+            using var cert = X509CertificateLoader.LoadPkcs12(certBytes, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+            fingerprint = cert.Thumbprint;
+        }
+        catch (Exception ex)
+        {
+            bridge.Send("profiles.error", new { message = $"Invalid certificate file: {ex.Message}" });
+            return Task.CompletedTask;
+        }
+
+        // Write to the expected cert path
+        var certPath = GetCertPath(profile.Id, profile.Name);
+        var certDir = Path.GetDirectoryName(certPath);
+        if (certDir != null) Directory.CreateDirectory(certDir);
+        File.WriteAllBytes(certPath, certBytes);
+
+        // Reload active cert if this is the active profile
+        if (_config.GetActiveProfileId() == id)
+        {
+            LoadActiveCertificate();
+            SendStatus();
+        }
+
+        bridge.Send("profiles.recovered", new
+        {
+            id = profile.Id,
+            name = profile.Name,
+            fingerprint,
+            certValid = true,
+        });
+    }
+    catch (Exception ex)
+    {
+        bridge.Send("profiles.error", new { message = $"Failed to recover certificate: {ex.Message}" });
+    }
+    return Task.CompletedTask;
+});
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run:
+```bash
+dotnet build src/Brmble.Client/Brmble.Client.csproj
+```
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Certificate/CertificateService.cs
+git commit -m "feat: add profiles.recover handler for cert re-import"
+```
+
+---
+
+### Task 7: Add auto-switch logic to `profiles.list` handler
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Certificate/CertificateService.cs:286-312`
+
+- [ ] **Step 1: Modify the `profiles.list` handler**
+
+Replace the current handler (lines 286-312) with:
+
+```csharp
+bridge.RegisterHandler("profiles.list", _ =>
+{
+    // Adopt orphaned .pfx files only on first launch (no prior config.json).
+    // This prevents re-adoption of intentionally deleted profiles.
+    if (_config.IsFirstLaunch)
+        AdoptOrphanedCerts();
+
+    var profiles = _config.GetProfiles().Select(p =>
+    {
+        var certPath = FindCertPath(p.Id, p.Name);
+        string? fingerprint = null;
+        bool certValid = false;
+        if (File.Exists(certPath))
+        {
+            try
+            {
+                using var cert = X509CertificateLoader.LoadPkcs12FromFile(certPath, password: null, keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                fingerprint = cert.Thumbprint;
+                certValid = true;
+            }
+            catch { }
+        }
+        return new { id = p.Id, name = p.Name, fingerprint, certValid };
+    }).ToList();
+
+    var activeProfileId = _config.GetActiveProfileId();
+    object? brokenActiveProfile = null;
+    object? autoSwitchedTo = null;
+
+    // Check if active profile has a broken cert
+    var activeProfile = profiles.FirstOrDefault(p => p.id == activeProfileId);
+    if (activeProfile != null && !activeProfile.certValid)
+    {
+        brokenActiveProfile = new { id = activeProfile.id, name = activeProfile.name };
+
+        // Try to auto-switch to the first healthy profile
+        var healthyProfile = profiles.FirstOrDefault(p => p.certValid);
+        if (healthyProfile != null)
+        {
+            _config.SetActiveProfileId(healthyProfile.id);
+            LoadActiveCertificate();
+            activeProfileId = healthyProfile.id;
+            autoSwitchedTo = new { id = healthyProfile.id, name = healthyProfile.name };
+        }
+    }
+
+    bridge.Send("profiles.list", new { profiles, activeProfileId, brokenActiveProfile, autoSwitchedTo });
+    return Task.CompletedTask;
+});
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run:
+```bash
+dotnet build src/Brmble.Client/Brmble.Client.csproj
+```
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Certificate/CertificateService.cs
+git commit -m "feat: auto-switch from broken active profile, report in profiles.list response"
+```
+
+---
+
+### Task 8: Add `recoverProfile` and `profiles.recovered` handler to useProfiles
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useProfiles.ts`
+
+- [ ] **Step 1: Add the `profiles.recovered` event handler and `recoverProfile` function**
+
+In `useProfiles.ts`, add a new handler inside the `useEffect`:
+
+After the `onError` handler (line 55), add:
+
+```typescript
+    const onRecovered = (data: unknown) => {
+      const d = data as { id: string; name: string; fingerprint: string; certValid: boolean };
+      setProfiles(prev => prev.map(p => p.id === d.id ? { ...p, fingerprint: d.fingerprint, certValid: d.certValid } : p));
+    };
+```
+
+Add the listener after line 62:
+
+```typescript
+    bridge.on('profiles.recovered', onRecovered);
+```
+
+Add the cleanup after line 71:
+
+```typescript
+      bridge.off('profiles.recovered', onRecovered);
+```
+
+Add the `recoverProfile` callback after `renameSwapCert` (line 116):
+
+```typescript
+  const recoverProfile = useCallback((id: string, data: string) => {
+    bridge.send('profiles.recover', { id, data });
+  }, []);
+```
+
+Update the return statement (line 119) to include `recoverProfile`:
+
+```typescript
+  return { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert, checkExistingCert, addFromExisting, renameSwapCert, recoverProfile };
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useProfiles.ts
+git commit -m "feat: add recoverProfile and profiles.recovered handler to useProfiles hook"
+```
+
+---
+
+### Task 9: Create BrokenCertNotification component
+
+**Files:**
+- Create: `src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx`
+- Create: `src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.css`
+
+- [ ] **Step 1: Create `BrokenCertNotification.css`**
+
+```css
+.broken-cert-notification__message {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  line-height: 1.4;
+  margin-bottom: var(--space-sm);
+}
+
+.broken-cert-notification__message strong {
+  color: var(--text-primary);
+}
+
+.broken-cert-notification__actions {
+  display: flex;
+  gap: var(--space-xs);
+  justify-content: flex-end;
+}
+```
+
+- [ ] **Step 2: Create `BrokenCertNotification.tsx`**
+
+```tsx
+import { useState, useCallback } from 'react';
+import { Notification } from '../Notification/Notification';
+import './BrokenCertNotification.css';
+
+interface BrokenCertNotificationProps {
+  brokenProfile: { id: string; name: string };
+  switchedTo: { id: string; name: string } | null;
+  onImport: () => void;
+  onOpenSettings: () => void;
+  onDismiss?: () => void;
+}
+
+export function BrokenCertNotification({
+  brokenProfile,
+  switchedTo,
+  onImport,
+  onOpenSettings,
+  onDismiss,
+}: BrokenCertNotificationProps) {
+  const [visible, setVisible] = useState(true);
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+  }, []);
+
+  return (
+    <Notification
+      status="warning"
+      position="top-right"
+      visible={visible}
+      duration={null}
+      onDismiss={onDismiss ? handleDismiss : undefined}
+      onExited={onDismiss}
+    >
+      <div>
+        <p className="broken-cert-notification__message">
+          {switchedTo ? (
+            <>
+              Profile <strong>"{brokenProfile.name}"</strong> has no certificate file.
+              Switched to <strong>"{switchedTo.name}"</strong>.
+            </>
+          ) : (
+            <>
+              Profile <strong>"{brokenProfile.name}"</strong> has no certificate.
+              Import a certificate or create a new profile to connect.
+            </>
+          )}
+        </p>
+        <div className="broken-cert-notification__actions">
+          {onDismiss && (
+            <button className="btn btn-sm btn-ghost" onClick={handleDismiss}>
+              Dismiss
+            </button>
+          )}
+          <button className="btn btn-sm btn-secondary" onClick={onOpenSettings}>
+            Open Settings
+          </button>
+          <button className="btn btn-sm btn-primary" onClick={onImport}>
+            Import Certificate
+          </button>
+        </div>
+      </div>
+    </Notification>
+  );
+}
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds. Component is not yet wired into App.tsx.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/BrokenCertNotification/
+git commit -m "feat: create BrokenCertNotification component"
+```
+
+---
+
+### Task 10: Wire BrokenCertNotification into App.tsx
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+
+- [ ] **Step 1: Add import**
+
+At the top of `App.tsx`, add:
+
+```typescript
+import { BrokenCertNotification } from './components/BrokenCertNotification/BrokenCertNotification';
+```
+
+- [ ] **Step 2: Add state**
+
+Near the other notification state (around line 1793), add:
+
+```typescript
+const [brokenCertInfo, setBrokenCertInfo] = useState<{
+  brokenProfile: { id: string; name: string };
+  switchedTo: { id: string; name: string } | null;
+} | null>(null);
+```
+
+- [ ] **Step 3: Update the `profiles.list` response handler**
+
+Find the `onProfilesList` handler (around line 1084). Replace it with:
+
+```typescript
+    const onProfilesList = (data: unknown) => {
+      const d = data as {
+        profiles: Array<{ id: string; name: string }>;
+        activeProfileId: string | null;
+        brokenActiveProfile: { id: string; name: string } | null;
+        autoSwitchedTo: { id: string; name: string } | null;
+      };
+      setProfiles(d.profiles ?? []);
+      if (d.activeProfileId) {
+        const active = d.profiles.find(p => p.id === d.activeProfileId);
+        if (active) setActiveProfileName(active.name);
+      }
+      if (d.brokenActiveProfile) {
+        setBrokenCertInfo({
+          brokenProfile: d.brokenActiveProfile,
+          switchedTo: d.autoSwitchedTo,
+        });
+      }
+    };
+```
+
+- [ ] **Step 4: Add `profiles.recovered` listener to clear brokenCertInfo**
+
+In the same `useEffect` where bridge listeners are registered, add:
+
+```typescript
+    const onProfilesRecovered = () => {
+      setBrokenCertInfo(null);
+    };
+    bridge.on('profiles.recovered', onProfilesRecovered);
+```
+
+And in the cleanup:
+
+```typescript
+      bridge.off('profiles.recovered', onProfilesRecovered);
+```
+
+- [ ] **Step 5: Add handler functions**
+
+Near the other notification handlers (around line 1802), add:
+
+```typescript
+  const handleBrokenCertImport = useCallback(() => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.pfx,.p12';
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file || !brokenCertInfo) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64 = (reader.result as string).split(',')[1];
+        bridge.send('profiles.recover', { id: brokenCertInfo.brokenProfile.id, data: base64 });
+      };
+      reader.readAsDataURL(file);
+    };
+    input.click();
+  }, [brokenCertInfo]);
+
+  const handleBrokenCertOpenSettings = useCallback(() => {
+    setShowSettings(true);
+    setSettingsTab('profile');
+  }, []);
+
+  const handleBrokenCertDismiss = useCallback(() => {
+    setBrokenCertInfo(null);
+  }, []);
+```
+
+- [ ] **Step 6: Add BrokenCertNotification to the notification-stack**
+
+Find the `.notification-stack` div (from Task 5) and add the BrokenCertNotification inside it:
+
+```tsx
+      <div className="notification-stack">
+        {updateInfo && (
+          <UpdateNotification
+            version={updateInfo.version}
+            onUpdate={handleApplyUpdate}
+            onDismiss={handleDismissUpdate}
+            progress={updateProgress}
+          />
+        )}
+        {brokenCertInfo && (
+          <BrokenCertNotification
+            brokenProfile={brokenCertInfo.brokenProfile}
+            switchedTo={brokenCertInfo.switchedTo}
+            onImport={handleBrokenCertImport}
+            onOpenSettings={handleBrokenCertOpenSettings}
+            onDismiss={brokenCertInfo.switchedTo ? handleBrokenCertDismiss : undefined}
+          />
+        )}
+      </div>
+```
+
+Note: `onDismiss` is only provided when `switchedTo` is not null (Scenario A). When there's no fallback (Scenario B), `onDismiss` is undefined, so no Dismiss button or close X renders.
+
+- [ ] **Step 7: Also clear brokenCertInfo when the broken profile is deleted**
+
+Find where `profiles.removed` is handled in App.tsx (if it exists at the App level). If not, add a listener:
+
+```typescript
+    const onProfilesRemoved = (data: unknown) => {
+      const d = data as { id: string };
+      setBrokenCertInfo(prev => prev && prev.brokenProfile.id === d.id ? null : prev);
+    };
+    bridge.on('profiles.removed', onProfilesRemoved);
+```
+
+And cleanup:
+
+```typescript
+      bridge.off('profiles.removed', onProfilesRemoved);
+```
+
+- [ ] **Step 8: Build to verify**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx
+git commit -m "feat: wire BrokenCertNotification into App with import, settings, and dismiss handlers"
+```
+
+---
+
+### Task 11: Add broken profile indicators to ProfileSettingsTab
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx`
+- Modify: `src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css`
+
+- [ ] **Step 1: Add Icon import to ProfileSettingsTab.tsx**
+
+At the top of the file, ensure the `Icon` import exists (it may already be imported for the empty state):
+
+```typescript
+import { Icon } from '../Icon/Icon';
+```
+
+- [ ] **Step 2: Get `recoverProfile` from the hook**
+
+In the component, update the `useProfiles()` destructuring to include `recoverProfile`:
+
+```typescript
+const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert, checkExistingCert, addFromExisting, renameSwapCert, recoverProfile } = useProfiles();
+```
+
+- [ ] **Step 3: Add import handler function**
+
+Add a handler for the import action on broken profiles:
+
+```typescript
+  const handleRecoverCert = useCallback((profile: { id: string; name: string }) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.pfx,.p12';
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64 = (reader.result as string).split(',')[1];
+        recoverProfile(profile.id, base64);
+      };
+      reader.readAsDataURL(file);
+    };
+    input.click();
+  }, [recoverProfile]);
+```
+
+- [ ] **Step 4: Modify profile card rendering**
+
+Find the profile info section (around line 346-348). Replace:
+
+```tsx
+                  <div className="profiles-info">
+                    <span className="profiles-name">{profile.name}</span>
+                    <span className="profiles-fingerprint">{formatFingerprint(profile.fingerprint)}</span>
+
+                  </div>
+```
+
+With:
+
+```tsx
+                  <div className="profiles-info">
+                    <span className="profiles-name">
+                      {profile.name}
+                      {!profile.certValid && (
+                        <Icon name="alert-triangle" size={14} className="profiles-warning-icon" />
+                      )}
+                    </span>
+                    <span className={`profiles-fingerprint${!profile.certValid ? ' profiles-fingerprint--broken' : ''}`}>
+                      {profile.certValid ? formatFingerprint(profile.fingerprint) : 'Certificate missing'}
+                    </span>
+                  </div>
+```
+
+- [ ] **Step 5: Replace Export with Import for broken profiles**
+
+Find the Export button (around line 374-381). Replace:
+
+```tsx
+                    <Tooltip content="Export certificate">
+                      <button
+                        className="btn btn-primary profiles-action-btn"
+                        onClick={() => exportCert(profile.id)}
+                      >
+                        Export
+                      </button>
+                    </Tooltip>
+```
+
+With:
+
+```tsx
+                    {profile.certValid ? (
+                      <Tooltip content="Export certificate">
+                        <button
+                          className="btn btn-primary profiles-action-btn"
+                          onClick={() => exportCert(profile.id)}
+                        >
+                          Export
+                        </button>
+                      </Tooltip>
+                    ) : (
+                      <Tooltip content="Import certificate to restore this profile">
+                        <button
+                          className="btn btn-primary profiles-action-btn"
+                          onClick={() => handleRecoverCert(profile)}
+                        >
+                          Import
+                        </button>
+                      </Tooltip>
+                    )}
+```
+
+- [ ] **Step 6: Add CSS for broken profile indicators**
+
+In `ProfilesSettingsTab.css`, add at the end:
+
+```css
+.profiles-warning-icon {
+  color: var(--accent-warning);
+  margin-left: var(--space-xs);
+  vertical-align: middle;
+}
+
+.profiles-fingerprint--broken {
+  color: var(--accent-warning-text);
+}
+```
+
+- [ ] **Step 7: Build to verify**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
+git commit -m "feat: show warning indicators and import action for broken profiles in Settings"
+```
+
+---
+
+### Task 12: Update UI_GUIDE.md with Notification Pattern section
+
+**Files:**
+- Modify: `docs/UI_GUIDE.md`
+
+- [ ] **Step 1: Add the Notification Pattern section**
+
+Find the last numbered section in `UI_GUIDE.md` and add a new section after it. The section number will depend on the current last section (check the file). Add:
+
+```markdown
+## N. Notification Pattern
+
+### Base Component
+
+All notifications use the shared `<Notification>` base component (`src/Brmble.Web/src/components/Notification/`). Never create standalone notification components with their own positioning/animation/styling — always wrap with `<Notification>`.
+
+### Status Types
+
+The `status` prop drives icon, color, ARIA role, and auto-dismiss behavior:
+
+| Status | Icon | Color tokens | ARIA role | Auto-dismiss |
+|---|---|---|---|---|
+| `info` | `info` | `--accent-info-*` | `role="status"` | 5s |
+| `success` | `check-circle` | `--accent-success-*` | `role="status"` | 5s |
+| `warning` | `alert-triangle` | `--accent-warning-*` | `role="status"` | No (persist) |
+| `error` | `alert-circle` | `--accent-danger-*` | `role="alert"` | No (persist) |
+
+### Decision Checklist (answer all before building a notification)
+
+1. **What status applies?** `info` = supplemental, `success` = action confirmed, `warning` = needs attention, `error` = something failed
+2. **What position?** `top-right` for system/background events, `bottom-center` for direct action feedback
+3. **Should it auto-dismiss?** Default from status, but can override with `duration` prop
+4. **Does it need a dismiss button?** Persistent notifications: yes. Blocking with no fallback: no dismiss.
+5. **What actions does it need?** Max 1 primary action. Action must be reachable elsewhere in UI since notifications can be missed.
+6. **What message text?** Short, no jargon. State what happened and what the user can do.
+
+### Props
+
+```tsx
+interface NotificationProps {
+  status: 'info' | 'success' | 'warning' | 'error';
+  position: 'top-right' | 'bottom-center';
+  children: React.ReactNode;
+  visible: boolean;
+  duration?: number | null;     // null = never. Defaults: info/success = 5000, warning/error = null
+  onDismiss?: () => void;       // When provided, close button (x) renders
+  onExited?: () => void;        // After exit animation completes
+  pauseOnHover?: boolean;       // Default: true. Pauses auto-dismiss on hover (WCAG 2.2.1)
+  className?: string;           // For consumer-specific styling
+}
+```
+
+### Behavioral Rules
+
+- **Auto-dismiss:** `info`/`success` auto-dismiss at 5s; `warning`/`error` persist. Timer pauses on hover.
+- **Errors and actionable notifications must never auto-dismiss.**
+- **Max 3** visible top-right notifications. Excess queued. Identical notifications (same status + message) deduplicated.
+- **Action buttons:** Max 1 primary per notification. Close button is separate from action button.
+- Top-right notifications render inside a `.notification-stack` container in `App.tsx`.
+- Bottom-center notifications (`Toast`) position themselves independently.
+
+### Accessibility
+
+- **ARIA:** `info`/`success`/`warning` use `role="status"` (`aria-live="polite"`); `error` uses `role="alert"` (`aria-live="assertive"`)
+- **Icons:** Status icon always rendered — never rely on color alone (WCAG 1.4.1)
+- **Keyboard:** Close button is keyboard accessible. `Esc` dismisses focused notification.
+- **Motion:** `prefers-reduced-motion: reduce` disables slide animation, keeps opacity fade only.
+
+### When NOT to Use Notification
+
+- **Blocking decisions** requiring immediate response → use `confirm()` modal
+- **Form validation errors** → use inline error text near the field (`.profiles-form-error` pattern)
+- **Passive status indicators** → use inline badges/dots, not notifications
+
+### Token Reference
+
+All four semantic accent families must be defined in every theme:
+
+| Family | Variants |
+|---|---|
+| `--accent-info-*` | base, `-text`, `-subtle`, `-border`, `-bg` |
+| `--accent-success-*` | base, `-text`, `-subtle`, `-border`, `-bg`, `-glow` |
+| `--accent-warning-*` | base, `-text`, `-subtle`, `-border`, `-bg` |
+| `--accent-danger-*` | base, `-text`, `-subtle`, `-border`, `-bg`, `-strong` |
+
+See `src/Brmble.Web/src/themes/_template.css` for guidance values per token.
+
+### Example: Adding a New Notification
+
+```tsx
+// A "server unreachable" error notification
+<Notification status="error" position="top-right" onDismiss={handleDismiss}>
+  <p>Could not reach server. <strong>Check your connection.</strong></p>
+  <button className="btn btn-sm btn-primary" onClick={handleRetry}>Retry</button>
+</Notification>
+```
+
+### Existing Notifications
+
+| Component | Status | Position | Auto-dismiss |
+|---|---|---|---|
+| `Toast` | `info` | `bottom-center` | 8s |
+| `UpdateNotification` | `info` | `top-right` | No |
+| `BrokenCertNotification` | `warning` | `top-right` | No |
+```
+
+- [ ] **Step 2: Build to verify docs don't break anything**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds (docs changes don't affect build, but verify nothing was accidentally broken).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/UI_GUIDE.md
+git commit -m "docs: add Notification Pattern section to UI_GUIDE.md"
+```
+
+---
+
+### Task 13: Run full build and test
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Build the frontend**
+
+Run:
+```bash
+cd src/Brmble.Web && npm run build
+```
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 2: Build the backend**
+
+Run:
+```bash
+dotnet build
+```
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+```bash
+dotnet test
+```
+Expected: All tests pass.
+
+- [ ] **Step 4: Verify no lint errors**
+
+Run:
+```bash
+cd src/Brmble.Web && npx tsc --noEmit
+```
+Expected: No TypeScript errors.

--- a/docs/superpowers/specs/2026-04-12-broken-profile-detection-design.md
+++ b/docs/superpowers/specs/2026-04-12-broken-profile-detection-design.md
@@ -1,0 +1,260 @@
+# Broken Profile Detection & Cert Recovery
+
+**Issue:** #433
+**Date:** 2026-04-12
+**Status:** Approved
+
+## Problem
+
+When a Brmble profile exists in `config.json` but its backing `.pfx` certificate file is missing from disk (manually deleted or lost), the profile becomes orphaned. It shows `certValid: false` and no fingerprint. The onboarding wizard already filters these out, but the Settings profile manager shows them with no indication anything is wrong, and the user can attempt to connect — hitting confusing errors only after the TLS handshake or Matrix credential fetch fails.
+
+**Primary scenario:** User or disk cleanup tool accidentally deletes the `.pfx` file.
+
+## Design
+
+### 1. Detection & Notification Flow
+
+**When:** At app startup, `profiles.list` already computes `certValid` per profile. After receiving the response, the frontend checks if the active profile has `certValid === false`.
+
+**Auto-switch:** If the active profile is broken and other healthy profiles exist, the backend auto-switches to the first healthy profile (in config list order) and reports this in the `profiles.list` response.
+
+**Notification:** A `BrokenCertNotification` component renders fixed top-right with a warning status (warning icon and warning color scheme).
+
+Two scenarios with different behavior:
+
+**Scenario A — has healthy fallback:**
+- Message: `Profile "X" has no certificate file. Switched to "Y".`
+- Buttons: Dismiss / Open Settings / Import Certificate
+- Dismiss hides for this session only; reappears on next launch if still broken
+
+**Scenario B — only profile, no fallback:**
+- Message: `Profile "X" has no certificate. Import a certificate or create a new profile to connect.`
+- Buttons: Open Settings / Import Certificate (no Dismiss — notification is persistent until resolved)
+- Server list is visible but connecting will fail gracefully
+
+### 2. Backend Changes
+
+#### New `profiles.recover` handler (CertificateService.cs)
+
+- Accepts `{ id: string, data: string }` — profile ID + base64-encoded `.pfx` file data
+- Validates the `.pfx` is loadable via `X509CertificateLoader.LoadPkcs12FromFile` (same approach used elsewhere; no CN or fingerprint matching — just loadability)
+- Writes the `.pfx` to the expected cert path via `GetCertPath(id, name)`
+- Reloads the active certificate if this is the active profile
+- Sends `profiles.recovered` with updated profile info: `{ id, name, fingerprint, certValid: true }`
+- On failure, sends `profiles.error`
+
+#### Auto-switch logic (in `profiles.list` handler)
+
+After computing all profiles, if the active profile has `certValid === false`:
+1. Find the first profile with `certValid === true`
+2. If found: call `SetActiveProfileId` + `LoadActiveCertificate`
+3. Include in response: `brokenActiveProfile: { id, name } | null` and `autoSwitchedTo: { id, name } | null`
+
+If no healthy profile exists, `autoSwitchedTo` is null and the active profile remains the broken one.
+
+### 3. Notification System Standardization
+
+Currently `Toast` and `UpdateNotification` are two separate components with nearly identical CSS (same tokens, same z-index, same animation pattern) but no shared base. Adding `BrokenCertNotification` as a third copy would worsen this. This branch standardizes the pattern based on best practices from Carbon Design System, Atlassian, Ant Design, Chakra UI, and WCAG guidelines.
+
+#### Shared base: `Notification` component
+
+- Location: `src/Brmble.Web/src/components/Notification/`
+- A status-driven base component: the `status` prop determines icon, color tokens, ARIA role, and default dismiss behavior.
+
+**Status → behavior mapping:**
+
+| Status | Icon | Color tokens | ARIA role | Default auto-dismiss |
+|---|---|---|---|---|
+| `info` | `info` | `--accent-info-*` | `role="status"` | 5s |
+| `success` | `check-circle` | `--accent-success-*` | `role="status"` | 5s |
+| `warning` | `alert-triangle` | `--accent-warning-*` | `role="status"` | No (persist) |
+| `error` | `alert-circle` | `--accent-danger-*` | `role="alert"` | No (persist) |
+
+**Props:**
+
+- `status: 'info' | 'success' | 'warning' | 'error'` — drives icon, color, ARIA role, and default dismiss behavior
+- `position: 'top-right' | 'bottom-center'` — viewport placement and slide direction
+- `children: ReactNode` — message + action content
+- `visible: boolean` — controls enter/exit animation
+- `duration?: number | null` — override auto-dismiss duration. `null` = never dismiss. Defaults: info/success = 5000ms, warning/error = null.
+- `onDismiss?: () => void` — close button handler. When provided, a close button (`x`) renders. Required for persistent notifications.
+- `onExited?: () => void` — callback after exit animation completes (for unmounting)
+- `pauseOnHover?: boolean` — default `true`. Pauses auto-dismiss timer when user hovers over the notification. Required for WCAG 2.2.1 compliance.
+- `className?: string` — for consumer-specific styling extensions
+
+**What the base handles:** Visual shell (`--bg-elevated` background, status-colored left border, `--radius-lg`, z-index 1100, `--shadow-elevated`), status icon rendering via `<Icon>`, slide+fade animation (250ms ease-out entry, 200ms ease-in exit), auto-dismiss timer with hover pause, close button, ARIA attributes.
+
+**What consumers handle:** Message text, action buttons, progress bars, and any behavior-specific logic.
+
+**Accessibility:**
+- Status icons always rendered (never color-only). Color is paired with icon shape per WCAG 1.4.1.
+- Close button is keyboard accessible (`Tab` to focus, `Enter`/`Space` to activate).
+- `Esc` dismisses the focused notification.
+- Respects `prefers-reduced-motion: reduce` — disables slide animation, keeps only opacity fade.
+
+**CSS:** `Notification.css` with `.notification`, `.notification--info`, `.notification--success`, `.notification--warning`, `.notification--error`, `.notification--top-right`, `.notification--bottom-center`, `.notification--visible`.
+
+#### Stacking
+
+When multiple top-right notifications are visible, they stack vertically with `var(--space-sm)` gap, newest on top. Maximum 3 visible simultaneously; excess notifications are queued and shown as earlier ones dismiss.
+
+This is handled by rendering them in a `.notification-stack` container in App.tsx (a simple flex column, fixed top-right) rather than each notification positioning itself independently. Bottom-center notifications (`<Toast>`) are positioned independently, not part of the stack.
+
+Identical notifications (same status + same message) are deduplicated.
+
+#### Refactor existing components
+
+- **Toast** — refactored to render a `<Notification status="info" position="bottom-center" duration={8000}>` wrapper around its message + action buttons. Keeps its own props API (`message`, `actions[]`, `onDismiss`). `Toast.css` reduces to only Toast-specific styles (action button layout).
+- **UpdateNotification** — refactored to render a `<Notification status="info" position="top-right" duration={null}>` wrapper. Keeps its own progress bar state and two-mode rendering (idle vs. applying). `UpdateNotification.css` reduces to only the progress bar styles.
+
+#### New `BrokenCertNotification` component
+
+- Renders a `<Notification status="warning" position="top-right" duration={null}>` wrapper
+- Props: `brokenProfile: { id, name }`, `switchedTo: { id, name } | null`, `onImport: () => void`, `onOpenSettings: () => void`, `onDismiss?: () => void`
+- `onDismiss` only provided in Scenario A (has fallback); when absent, no Dismiss button and no close `x`
+- The `warning` status automatically provides the `alert-triangle` icon and `--accent-warning-*` color tokens
+- Action buttons: max 1 primary action (Import Certificate) + secondary actions (Open Settings, Dismiss). Follows the convention of 1 primary action per notification.
+
+#### New theme tokens
+
+The project currently has `--accent-danger-*` (6 variants) and `--accent-success-*` (3 variants) but no warning or info token families. The notification system needs two new families added to every theme file and the template:
+
+- **`--accent-warning-*`**: `--accent-warning`, `--accent-warning-text`, `--accent-warning-subtle`, `--accent-warning-border`, `--accent-warning-bg`. Amber/yellow hues. Used by `warning` status notifications and inline warning indicators.
+- **`--accent-info-*`**: `--accent-info`, `--accent-info-text`, `--accent-info-subtle`, `--accent-info-border`, `--accent-info-bg`. Blue hues. Used by `info` status notifications.
+
+These follow the same 5-variant pattern as `--accent-danger-*` (base, text, subtle, border, bg). The success family should also be extended from 3 to 5 variants (`--accent-success-text`, `--accent-success-border`, `--accent-success-bg` are currently missing).
+
+**Documentation updates:**
+- `_template.css`: Add guidance values, hue ranges, and opacity ranges for all new token families (same format as the existing `--accent-danger-*` documentation block)
+- `UI_GUIDE.md`: Update the token reference section to list all four semantic color families and their variants, noting that all themes must define all four families
+
+#### Icons needed
+
+Add to `Icon.tsx` if not already present: `info`, `check-circle`, `alert-triangle`, `alert-circle`. These are standard Feather/Lucide icons consistent with the existing icon system.
+
+#### UI_GUIDE.md update
+
+Add a new "Notification Pattern" section. This section must be complete enough that a future contributor can build a new notification without asking questions. It should include:
+
+**Component API reference:**
+- The `<Notification>` base component and its full props list with types and defaults
+- Status types and what each one drives (icon, color tokens, ARIA role, auto-dismiss default)
+
+**Decision checklist for new notifications** (a contributor must answer all of these):
+1. What **status** applies? (`info` = supplemental, `success` = action confirmed, `warning` = needs attention, `error` = something failed)
+2. What **position**? (`top-right` for system/background events, `bottom-center` for direct action feedback)
+3. Should it **auto-dismiss**? (Default from status, but can override with `duration`)
+4. Does it need a **dismiss button**? (Persistent notifications: yes. Blocking with no fallback: no dismiss.)
+5. What **actions** does it need? (Max 1 primary action. Action must be reachable elsewhere in UI since notifications can be missed.)
+6. What **message text**? (Short, no jargon. State what happened and what the user can do.)
+
+**Behavioral rules:**
+- Auto-dismiss rules: `info`/`success` auto-dismiss at 5s; `warning`/`error` persist; timer pauses on hover
+- Errors and actionable notifications must never auto-dismiss
+- Max 3 visible top-right notifications; excess queued; identical notifications deduplicated
+- Action buttons: max 1 primary per notification; close button is separate from action button
+
+**Accessibility requirements:**
+- ARIA roles: `info`/`success`/`warning` use `role="status"` (`aria-live="polite"`); `error` uses `role="alert"` (`aria-live="assertive"`)
+- Status icon always rendered (never rely on color alone, WCAG 1.4.1)
+- Close button keyboard accessible; `Esc` dismisses focused notification
+- `prefers-reduced-motion: reduce` disables slide, keeps opacity fade only
+
+**When NOT to use Notification:**
+- Blocking decisions requiring immediate response → use `confirm()` modal
+- Form validation errors → use inline error text near the field
+- Passive status indicators → use inline badges/dots, not notifications
+
+**Token reference:**
+- List all notification-related token families (`--accent-info-*`, `--accent-success-*`, `--accent-warning-*`, `--accent-danger-*`) with their variant suffixes (base, `-text`, `-subtle`, `-border`, `-bg`)
+- Note: themes must define all four families. Reference `_template.css` for guidance values.
+
+**Example: adding a new notification:**
+```tsx
+// A "server unreachable" error notification
+<Notification status="error" position="top-right" onDismiss={handleDismiss}>
+  <p>Could not reach server. <strong>Check your connection.</strong></p>
+  <button className="btn btn-sm btn-primary" onClick={handleRetry}>Retry</button>
+</Notification>
+```
+
+### 4. Frontend Feature Changes
+
+#### App.tsx wiring
+
+- New state: `brokenCertInfo: { brokenProfile: { id, name }, switchedTo: { id, name } | null } | null`
+- On `profiles.list` response: check `brokenActiveProfile` field, set `brokenCertInfo` if present
+- Top-right notifications rendered inside a `.notification-stack` container (replaces individual fixed positioning for `UpdateNotification` and `BrokenCertNotification`)
+- `<Toast>` remains independently positioned at bottom-center (not part of the stack)
+- `onImport`: trigger file picker, read as base64, send `profiles.recover`
+- `onOpenSettings`: `setShowSettings(true)` + `setSettingsTab('profile')`
+- `onDismiss`: set `brokenCertInfo` to null (session-only)
+- On `profiles.recovered`: clear `brokenCertInfo`, profile list refreshes via existing reactive events
+
+#### ProfileSettingsTab.tsx changes
+
+For each profile card, check `profile.certValid`:
+- If `false`: show `<Icon name="alert-triangle" />` next to profile name, replace fingerprint with "Certificate missing" in `--accent-warning-text` color (new token), replace Export button with Import button
+- Import button triggers file picker + `profiles.recover` flow
+- Delete still works as before (removes orphaned config entry)
+- Edit (rename) still works as before
+
+#### useProfiles.ts changes
+
+- Add handler for `profiles.recovered` event — updates profile in list with new `certValid`/`fingerprint`
+- Expose `recoverProfile(id: string, data: string)` function that sends `profiles.recover`
+
+### 5. Edge Cases & Error Handling
+
+**Import fails (invalid/corrupt .pfx):**
+Backend sends `profiles.error`. Frontend shows error via existing `confirm()` modal alert. Notification/Settings stays visible for retry.
+
+**Auto-switch with multiple healthy profiles:**
+Picks the first healthy profile in list order (config.json order). Notification tells the user which profile was selected.
+
+**Profile recovered while notification is showing:**
+`profiles.recovered` fires → `brokenCertInfo` clears → notification disappears. Same if profile is deleted via Settings (`profiles.removed` → clear `brokenCertInfo`).
+
+**Notification + Update notification both visible:**
+Both render inside the `.notification-stack` container in App.tsx. They stack vertically with `var(--space-sm)` gap, no manual CSS offset needed.
+
+**New profile created while notification shows (Scenario B):**
+Creating a new profile auto-sets it as active (existing behavior). `profiles.added` + `profiles.activeChanged` fire → frontend detects healthy active profile → clears `brokenCertInfo`.
+
+**Multiple broken profiles:**
+Notification only surfaces the active (or previously-active) broken profile. Other broken profiles are visible only in Settings with the warning indicator.
+
+## New Bridge Messages
+
+| Message | Direction | Payload |
+|---------|-----------|---------|
+| `profiles.recover` | JS → C# | `{ id: string, data: string }` |
+| `profiles.recovered` | C# → JS | `{ id: string, name: string, fingerprint: string, certValid: true }` |
+
+## Modified Bridge Messages
+
+| Message | Change |
+|---------|--------|
+| `profiles.list` response | Add `brokenActiveProfile: { id, name } \| null` and `autoSwitchedTo: { id, name } \| null` fields |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/Brmble.Client/Services/Certificate/CertificateService.cs` | New `profiles.recover` handler; auto-switch logic in `profiles.list` handler |
+| `src/Brmble.Web/src/components/Notification/Notification.tsx` | New shared base notification component |
+| `src/Brmble.Web/src/components/Notification/Notification.css` | Shared notification styles (position variants, animation, stacking) |
+| `src/Brmble.Web/src/components/Toast/Toast.tsx` | Refactor to use `<Notification>` base |
+| `src/Brmble.Web/src/components/Toast/Toast.css` | Reduce to Toast-specific styles only |
+| `src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.tsx` | Refactor to use `<Notification>` base |
+| `src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.css` | Reduce to progress bar styles only |
+| `src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx` | New component using `<Notification>` base |
+| `src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.css` | Danger variant styles |
+| `src/Brmble.Web/src/components/Icon/Icon.tsx` | Add `info`, `check-circle`, `alert-triangle`, `alert-circle` icons if missing |
+| `src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx` | Warning indicator + Import button for broken profiles |
+| `src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css` | Danger text styles for broken profiles |
+| `src/Brmble.Web/src/hooks/useProfiles.ts` | `profiles.recovered` handler + `recoverProfile` function |
+| `src/Brmble.Web/src/App.tsx` | `brokenCertInfo` state, `.notification-stack` container, import/settings/dismiss handlers |
+| `docs/UI_GUIDE.md` | New Notification Pattern section |
+| `src/Brmble.Web/src/themes/*.css` | Add `--accent-warning-*` and `--accent-info-*` token families; extend `--accent-success-*` to 5 variants |
+| `src/Brmble.Web/src/themes/_template.css` | Document new token families in theme template |

--- a/docs/superpowers/specs/2026-04-12-broken-profile-detection-design.md
+++ b/docs/superpowers/specs/2026-04-12-broken-profile-detection-design.md
@@ -14,23 +14,18 @@ When a Brmble profile exists in `config.json` but its backing `.pfx` certificate
 
 ### 1. Detection & Notification Flow
 
-**When:** At app startup, `profiles.list` already computes `certValid` per profile. After receiving the response, the frontend checks if the active profile has `certValid === false`.
+**When:** At app startup, `profiles.list` already computes `certValid` per profile. The backend collects **all** profiles with `certValid === false` into a `brokenProfiles` array and sends it in the response.
 
-**Auto-switch:** If the active profile is broken and other healthy profiles exist, the backend auto-switches to the first healthy profile (in config list order) and reports this in the `profiles.list` response.
+**Auto-switch:** If the active profile is broken and other healthy profiles exist, the backend auto-switches to the first healthy profile (in config list order) and reports this via `autoSwitchedTo` in the `profiles.list` response.
 
-**Notification:** A `BrokenCertNotification` component renders fixed top-right with a warning status (warning icon and warning color scheme).
+**Notification:** The frontend renders **one `BrokenCertNotification` per broken profile**, each fixed top-right in the `.notification-stack` container with a warning status (warning icon and warning color scheme).
 
-Two scenarios with different behavior:
-
-**Scenario A — has healthy fallback:**
-- Message: `Profile "X" has no certificate file. Switched to "Y".`
-- Buttons: Dismiss / Open Settings / Import Certificate
-- Dismiss hides for this session only; reappears on next launch if still broken
-
-**Scenario B — only profile, no fallback:**
-- Message: `Profile "X" has no certificate. Import a certificate or create a new profile to connect.`
-- Buttons: Open Settings / Import Certificate (no Dismiss — notification is persistent until resolved)
-- Server list is visible but connecting will fail gracefully
+Each notification shows:
+- Message: `Profile "X" has no certificate file.` (plus `Switched to "Y".` on the first notification if auto-switch occurred)
+- Buttons: Dismiss / Settings / Import
+- Dismiss hides that single notification for this session; reappears on next launch if still broken
+- Import triggers a file picker scoped to that specific profile
+- Recovering or dismissing one notification does not affect others
 
 ### 2. Backend Changes
 
@@ -45,10 +40,11 @@ Two scenarios with different behavior:
 
 #### Auto-switch logic (in `profiles.list` handler)
 
-After computing all profiles, if the active profile has `certValid === false`:
-1. Find the first profile with `certValid === true`
-2. If found: call `SetActiveProfileId` + `LoadActiveCertificate`
-3. Include in response: `brokenActiveProfile: { id, name } | null` and `autoSwitchedTo: { id, name } | null`
+After computing all profiles:
+1. Collect all profiles with `certValid === false` into a `brokenProfiles` array
+2. If the active profile has `certValid === false`, find the first profile with `certValid === true`
+3. If found: call `SetActiveProfileId` + `LoadActiveCertificate`
+4. Include in response: `brokenProfiles: Array<{ id, name }>` and `autoSwitchedTo: { id, name } | null`
 
 If no healthy profile exists, `autoSwitchedTo` is null and the active profile remains the broken one.
 
@@ -110,10 +106,10 @@ Identical notifications (same status + same message) are deduplicated.
 #### New `BrokenCertNotification` component
 
 - Renders a `<Notification status="warning" position="top-right" duration={null}>` wrapper
-- Props: `brokenProfile: { id, name }`, `switchedTo: { id, name } | null`, `onImport: () => void`, `onOpenSettings: () => void`, `onDismiss?: () => void`
-- `onDismiss` only provided in Scenario A (has fallback); when absent, no Dismiss button and no close `x`
+- Props: `profile: { id, name }`, `switchedTo: { id, name } | null`, `onImport: (profileId: string) => void`, `onOpenSettings: () => void`, `onDismiss: () => void`
+- Each notification is independently dismissible
 - The `warning` status automatically provides the `alert-triangle` icon and `--accent-warning-*` color tokens
-- Action buttons: max 1 primary action (Import Certificate) + secondary actions (Open Settings, Dismiss). Follows the convention of 1 primary action per notification.
+- Action buttons: Import (primary), Settings (secondary), Dismiss (ghost)
 
 #### New theme tokens
 
@@ -182,14 +178,16 @@ Add a new "Notification Pattern" section. This section must be complete enough t
 
 #### App.tsx wiring
 
-- New state: `brokenCertInfo: { brokenProfile: { id, name }, switchedTo: { id, name } | null } | null`
-- On `profiles.list` response: check `brokenActiveProfile` field, set `brokenCertInfo` if present
+- New state: `brokenCertInfo: { brokenProfiles: Array<{ id: string; name: string }>; switchedTo: { id: string; name: string } | null } | null`
+- On `profiles.list` response: check `brokenProfiles` array, set `brokenCertInfo` if non-empty
 - Top-right notifications rendered inside a `.notification-stack` container (replaces individual fixed positioning for `UpdateNotification` and `BrokenCertNotification`)
 - `<Toast>` remains independently positioned at bottom-center (not part of the stack)
-- `onImport`: trigger file picker, read as base64, send `profiles.recover`
+- Renders **one `BrokenCertNotification` per broken profile** via `.map()` with `key={bp.id}`
+- `onImport(profileId)`: trigger file picker, read as base64, send `profiles.recover` with the specific profile ID
 - `onOpenSettings`: `setShowSettings(true)` + `setSettingsTab('profile')`
-- `onDismiss`: set `brokenCertInfo` to null (session-only)
-- On `profiles.recovered`: clear `brokenCertInfo`, profile list refreshes via existing reactive events
+- `onDismiss(profileId)`: filters that profile out of `brokenCertInfo.brokenProfiles`; clears state entirely when array becomes empty
+- On `profiles.recovered`: filters the recovered profile out of `brokenCertInfo.brokenProfiles`
+- On `profiles.removed`: filters the removed profile out of `brokenCertInfo.brokenProfiles`
 
 #### ProfileSettingsTab.tsx changes
 
@@ -222,7 +220,7 @@ Both render inside the `.notification-stack` container in App.tsx. They stack ve
 Creating a new profile auto-sets it as active (existing behavior). `profiles.added` + `profiles.activeChanged` fire → frontend detects healthy active profile → clears `brokenCertInfo`.
 
 **Multiple broken profiles:**
-Notification only surfaces the active (or previously-active) broken profile. Other broken profiles are visible only in Settings with the warning indicator.
+Each broken profile gets its own notification in the `.notification-stack`. Recovering, dismissing, or deleting a profile removes only that profile's notification. The `switchedTo` info is shown on the first notification (when the active profile was broken and auto-switched), providing context for the switch.
 
 ## New Bridge Messages
 
@@ -235,7 +233,7 @@ Notification only surfaces the active (or previously-active) broken profile. Oth
 
 | Message | Change |
 |---------|--------|
-| `profiles.list` response | Add `brokenActiveProfile: { id, name } \| null` and `autoSwitchedTo: { id, name } \| null` fields |
+| `profiles.list` response | Add `brokenProfiles: Array<{ id, name }>` and `autoSwitchedTo: { id, name } \| null` fields |
 
 ## Files Changed
 

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -516,6 +516,70 @@ internal sealed class CertificateService : IService
             return Task.CompletedTask;
         });
 
+        bridge.RegisterHandler("profiles.recover", data =>
+        {
+            try
+            {
+                var id = data.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+                var base64Data = data.TryGetProperty("data", out var d) ? d.GetString() : null;
+
+                if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(base64Data))
+                {
+                    bridge.Send("profiles.error", new { message = "Missing profile ID or certificate data." });
+                    return Task.CompletedTask;
+                }
+
+                var profile = _config.GetProfiles().FirstOrDefault(p => p.Id == id);
+                if (profile == null)
+                {
+                    bridge.Send("profiles.error", new { message = "Profile not found." });
+                    return Task.CompletedTask;
+                }
+
+                var certBytes = Convert.FromBase64String(base64Data);
+
+                // Validate the .pfx is loadable
+                string fingerprint;
+                try
+                {
+                    using var cert = X509CertificateLoader.LoadPkcs12(certBytes, password: null,
+                        keyStorageFlags: X509KeyStorageFlags.DefaultKeySet);
+                    fingerprint = cert.Thumbprint;
+                }
+                catch (Exception ex)
+                {
+                    bridge.Send("profiles.error", new { message = $"Invalid certificate file: {ex.Message}" });
+                    return Task.CompletedTask;
+                }
+
+                // Write to the expected cert path
+                var certPath = GetCertPath(profile.Id, profile.Name);
+                var certDir = Path.GetDirectoryName(certPath);
+                if (certDir != null) Directory.CreateDirectory(certDir);
+                File.WriteAllBytes(certPath, certBytes);
+
+                // Reload active cert if this is the active profile
+                if (_config.GetActiveProfileId() == id)
+                {
+                    lock (_certLock) { LoadActiveCertificate(); }
+                    SendStatus();
+                }
+
+                bridge.Send("profiles.recovered", new
+                {
+                    id = profile.Id,
+                    name = profile.Name,
+                    fingerprint,
+                    certValid = true,
+                });
+            }
+            catch (Exception ex)
+            {
+                bridge.Send("profiles.error", new { message = $"Failed to recover certificate: {ex.Message}" });
+            }
+            return Task.CompletedTask;
+        });
+
         // Rename profile AND swap its cert to an existing cert file matching the new name
         bridge.RegisterHandler("profiles.renameSwapCert", data =>
         {

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -310,6 +310,7 @@ internal sealed class CertificateService : IService
 
             var activeProfileId = _config.GetActiveProfileId();
             object? autoSwitchedTo = null;
+            string? switchedFromId = null;
 
             // Collect all broken profiles
             var brokenProfiles = profiles
@@ -324,6 +325,7 @@ internal sealed class CertificateService : IService
                 var healthyProfile = profiles.FirstOrDefault(p => p.certValid);
                 if (healthyProfile != null)
                 {
+                    switchedFromId = activeProfile.id;
                     _config.SetActiveProfileId(healthyProfile.id);
                     lock (_certLock) { LoadActiveCertificate(); }
                     activeProfileId = healthyProfile.id;
@@ -331,7 +333,7 @@ internal sealed class CertificateService : IService
                 }
             }
 
-            bridge.Send("profiles.list", new { profiles, activeProfileId, brokenProfiles, autoSwitchedTo });
+            bridge.Send("profiles.list", new { profiles, activeProfileId, brokenProfiles, autoSwitchedTo, switchedFromId });
             return Task.CompletedTask;
         });
 

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -307,7 +307,29 @@ internal sealed class CertificateService : IService
                 }
                 return new { id = p.Id, name = p.Name, fingerprint, certValid };
             }).ToList();
-            bridge.Send("profiles.list", new { profiles, activeProfileId = _config.GetActiveProfileId() });
+
+            var activeProfileId = _config.GetActiveProfileId();
+            object? brokenActiveProfile = null;
+            object? autoSwitchedTo = null;
+
+            // Check if active profile has a broken cert
+            var activeProfile = profiles.FirstOrDefault(p => p.id == activeProfileId);
+            if (activeProfile != null && !activeProfile.certValid)
+            {
+                brokenActiveProfile = new { id = activeProfile.id, name = activeProfile.name };
+
+                // Try to auto-switch to the first healthy profile
+                var healthyProfile = profiles.FirstOrDefault(p => p.certValid);
+                if (healthyProfile != null)
+                {
+                    _config.SetActiveProfileId(healthyProfile.id);
+                    lock (_certLock) { LoadActiveCertificate(); }
+                    activeProfileId = healthyProfile.id;
+                    autoSwitchedTo = new { id = healthyProfile.id, name = healthyProfile.name };
+                }
+            }
+
+            bridge.Send("profiles.list", new { profiles, activeProfileId, brokenActiveProfile, autoSwitchedTo });
             return Task.CompletedTask;
         });
 

--- a/src/Brmble.Client/Services/Certificate/CertificateService.cs
+++ b/src/Brmble.Client/Services/Certificate/CertificateService.cs
@@ -309,16 +309,18 @@ internal sealed class CertificateService : IService
             }).ToList();
 
             var activeProfileId = _config.GetActiveProfileId();
-            object? brokenActiveProfile = null;
             object? autoSwitchedTo = null;
 
-            // Check if active profile has a broken cert
+            // Collect all broken profiles
+            var brokenProfiles = profiles
+                .Where(p => !p.certValid)
+                .Select(p => new { id = p.id, name = p.name })
+                .ToList();
+
+            // If the active profile is broken, auto-switch to the first healthy one
             var activeProfile = profiles.FirstOrDefault(p => p.id == activeProfileId);
             if (activeProfile != null && !activeProfile.certValid)
             {
-                brokenActiveProfile = new { id = activeProfile.id, name = activeProfile.name };
-
-                // Try to auto-switch to the first healthy profile
                 var healthyProfile = profiles.FirstOrDefault(p => p.certValid);
                 if (healthyProfile != null)
                 {
@@ -329,7 +331,7 @@ internal sealed class CertificateService : IService
                 }
             }
 
-            bridge.Send("profiles.list", new { profiles, activeProfileId, brokenActiveProfile, autoSwitchedTo });
+            bridge.Send("profiles.list", new { profiles, activeProfileId, brokenProfiles, autoSwitchedTo });
             return Task.CompletedTask;
         });
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -169,6 +169,8 @@ function App() {
   const [certFingerprint, setCertFingerprint] = useState('');
   const [activeProfileName, setActiveProfileName] = useState('');
   const [profiles, setProfiles] = useState<Array<{ id: string; name: string }>>([]);
+  const profilesRef = useRef(profiles);
+  profilesRef.current = profiles;
 
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('idle');
   const { statuses, updateStatus, resetStatuses } = useServiceStatus();
@@ -1264,10 +1266,15 @@ function App() {
     bridge.on('profiles.recovered', onProfilesRecovered);
     const onProfilesRemoved = (data: unknown) => {
       const d = data as { id: string };
+      const updatedProfiles = profilesRef.current.filter(p => p.id !== d.id);
+      setProfiles(updatedProfiles);
       setBrokenCertInfo(prev => {
         if (!prev) return null;
         const remaining = prev.brokenProfiles.filter(p => p.id !== d.id);
-        return remaining.length > 0 ? { ...prev, brokenProfiles: remaining } : null;
+        if (remaining.length === 0) return null;
+        const brokenIds = new Set(remaining.map(p => p.id));
+        const hasHealthyFallback = updatedProfiles.some(p => !brokenIds.has(p.id));
+        return { ...prev, brokenProfiles: remaining, hasHealthyFallback };
       });
     };
     bridge.on('profiles.removed', onProfilesRemoved);
@@ -2179,7 +2186,7 @@ const handleConnect = (serverData: SavedServer) => {
         <main className="main-content">
           {connectionStatus === 'idle' ? (
             certExists === true ? (
-              <ServerList onConnect={handleServerConnect} connectionError={connectionError} onClearError={() => setConnectionError(null)} activeProfileName={activeProfileName} />
+              <ServerList onConnect={handleServerConnect} connectDisabled={brokenCertInfo != null && !brokenCertInfo.hasHealthyFallback} connectionError={connectionError} onClearError={() => setConnectionError(null)} activeProfileName={activeProfileName} />
             ) : (
               <div className="connection-state">
                 <div className="connection-state-content">
@@ -2335,7 +2342,7 @@ const handleConnect = (serverData: SavedServer) => {
               profile={bp}
               onImport={handleBrokenCertImport}
               onOpenSettings={handleBrokenCertOpenSettings}
-              onDismiss={brokenCertInfo.hasHealthyFallback ? () => { handleBrokenCertDismiss(bp.id); notifQueue.unregister(`cert-${bp.id}`); } : undefined}
+              onDismiss={() => { handleBrokenCertDismiss(bp.id); notifQueue.unregister(`cert-${bp.id}`); }}
             />
           ) : null
         ))}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1083,15 +1083,15 @@ function App() {
     };
 
     const onProfilesList = (data: unknown) => {
-      const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null; brokenActiveProfile?: { id: string; name: string }; autoSwitchedTo?: { id: string; name: string } | null };
+      const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null; brokenProfiles?: Array<{ id: string; name: string }>; autoSwitchedTo?: { id: string; name: string } | null };
       setProfiles(d.profiles ?? []);
       if (d.activeProfileId) {
         const active = d.profiles.find(p => p.id === d.activeProfileId);
         if (active) setActiveProfileName(active.name);
       }
-      if (d.brokenActiveProfile) {
+      if (d.brokenProfiles && d.brokenProfiles.length > 0) {
         setBrokenCertInfo({
-          brokenProfile: d.brokenActiveProfile,
+          brokenProfiles: d.brokenProfiles,
           switchedTo: d.autoSwitchedTo ?? null,
         });
       }
@@ -1246,13 +1246,22 @@ function App() {
     bridge.on('cert.imported', onCertImported);
     bridge.on('profiles.activeChanged', onProfilesActiveChanged);
     bridge.on('profiles.list', onProfilesList);
-    const onProfilesRecovered = () => {
-      setBrokenCertInfo(null);
+    const onProfilesRecovered = (data: unknown) => {
+      const d = data as { id: string };
+      setBrokenCertInfo(prev => {
+        if (!prev) return null;
+        const remaining = prev.brokenProfiles.filter(p => p.id !== d.id);
+        return remaining.length > 0 ? { ...prev, brokenProfiles: remaining } : null;
+      });
     };
     bridge.on('profiles.recovered', onProfilesRecovered);
     const onProfilesRemoved = (data: unknown) => {
       const d = data as { id: string };
-      setBrokenCertInfo(prev => prev && prev.brokenProfile.id === d.id ? null : prev);
+      setBrokenCertInfo(prev => {
+        if (!prev) return null;
+        const remaining = prev.brokenProfiles.filter(p => p.id !== d.id);
+        return remaining.length > 0 ? { ...prev, brokenProfiles: remaining } : null;
+      });
     };
     bridge.on('profiles.removed', onProfilesRemoved);
     bridge.on('voice.autoConnect', onAutoConnect);
@@ -1811,7 +1820,7 @@ const handleConnect = (serverData: SavedServer) => {
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null);
   const [updateProgress, setUpdateProgress] = useState<number | null>(null);
   const [brokenCertInfo, setBrokenCertInfo] = useState<{
-    brokenProfile: { id: string; name: string };
+    brokenProfiles: Array<{ id: string; name: string }>;
     switchedTo: { id: string; name: string } | null;
   } | null>(null);
 
@@ -1831,30 +1840,34 @@ const handleConnect = (serverData: SavedServer) => {
     bridge.send('app.dismissUpdate');
   }, []);
 
-  const handleBrokenCertImport = useCallback(() => {
+  const handleBrokenCertImport = useCallback((profileId: string) => {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.pfx,.p12';
     input.onchange = async () => {
       const file = input.files?.[0];
-      if (!file || !brokenCertInfo) return;
+      if (!file) return;
       const reader = new FileReader();
       reader.onload = () => {
         const base64 = (reader.result as string).split(',')[1];
-        bridge.send('profiles.recover', { id: brokenCertInfo.brokenProfile.id, data: base64 });
+        bridge.send('profiles.recover', { id: profileId, data: base64 });
       };
       reader.readAsDataURL(file);
     };
     input.click();
-  }, [brokenCertInfo]);
+  }, []);
 
   const handleBrokenCertOpenSettings = useCallback(() => {
     setShowSettings(true);
     setSettingsTab('profile');
   }, []);
 
-  const handleBrokenCertDismiss = useCallback(() => {
-    setBrokenCertInfo(null);
+  const handleBrokenCertDismiss = useCallback((profileId: string) => {
+    setBrokenCertInfo(prev => {
+      if (!prev) return null;
+      const remaining = prev.brokenProfiles.filter(p => p.id !== profileId);
+      return remaining.length > 0 ? { ...prev, brokenProfiles: remaining } : null;
+    });
   }, []);
 
   const channelUnreads = useMemo(() => {
@@ -2273,15 +2286,16 @@ const handleConnect = (serverData: SavedServer) => {
             progress={updateProgress}
           />
         )}
-        {brokenCertInfo && (
+        {brokenCertInfo && brokenCertInfo.brokenProfiles.map(bp => (
           <BrokenCertNotification
-            brokenProfile={brokenCertInfo.brokenProfile}
+            key={bp.id}
+            profile={bp}
             switchedTo={brokenCertInfo.switchedTo}
             onImport={handleBrokenCertImport}
             onOpenSettings={handleBrokenCertOpenSettings}
-            onDismiss={brokenCertInfo.switchedTo ? handleBrokenCertDismiss : undefined}
+            onDismiss={() => handleBrokenCertDismiss(bp.id)}
           />
-        )}
+        ))}
       </div>
 
       {screenShareToast && (

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1096,13 +1096,16 @@ function App() {
         const active = d.profiles.find(p => p.id === d.activeProfileId);
         if (active) setActiveProfileName(active.name);
       }
-      if (d.brokenProfiles && d.brokenProfiles.length > 0) {
-        const brokenIds = new Set(d.brokenProfiles.map(p => p.id));
+      const brokenProfiles = d.brokenProfiles ?? [];
+      if (brokenProfiles.length > 0) {
+        const brokenIds = new Set(brokenProfiles.map(p => p.id));
         const hasHealthyFallback = (d.profiles ?? []).some(p => !brokenIds.has(p.id));
         setBrokenCertInfo({
-          brokenProfiles: d.brokenProfiles,
+          brokenProfiles,
           hasHealthyFallback,
         });
+      } else {
+        setBrokenCertInfo(null);
       }
     };
 
@@ -1260,7 +1263,10 @@ function App() {
       setBrokenCertInfo(prev => {
         if (!prev) return null;
         const remaining = prev.brokenProfiles.filter(p => p.id !== d.id);
-        return remaining.length > 0 ? { ...prev, brokenProfiles: remaining } : null;
+        if (remaining.length === 0) return null;
+        const brokenIds = new Set(remaining.map(p => p.id));
+        const hasHealthyFallback = profilesRef.current.some(p => !brokenIds.has(p.id));
+        return { ...prev, brokenProfiles: remaining, hasHealthyFallback };
       });
     };
     bridge.on('profiles.recovered', onProfilesRecovered);
@@ -1839,11 +1845,12 @@ const handleConnect = (serverData: SavedServer) => {
   } | null>(null);
 
   // Server import notifications (from onboarding wizard) — one per server
-  interface ServerImportToast { id: string; label: string; }
+  interface ServerImportToast { id: string; label: string; visible: boolean; }
   const [serverImportToasts, setServerImportToasts] = useState<ServerImportToast[]>([]);
+  const nextServerImportToastIdRef = useRef(0);
 
   const handleServersImported = useCallback((labels: string[]) => {
-    const toasts = labels.map((label, i) => ({ id: `srv-${Date.now()}-${i}`, label }));
+    const toasts = labels.map((label) => ({ id: `srv-${nextServerImportToastIdRef.current++}`, label, visible: true }));
     setServerImportToasts(toasts);
     toasts.forEach(t => notifQueue.register(t.id, 'info'));
   }, [notifQueue]);
@@ -2352,13 +2359,12 @@ const handleConnect = (serverData: SavedServer) => {
               key={toast.id}
               status="info"
               position="top-right"
-              visible={true}
+              visible={toast.visible}
               duration={5000}
               title="Server imported"
               detail={toast.label}
               onDismiss={() => {
-                setServerImportToasts(prev => prev.filter(t => t.id !== toast.id));
-                notifQueue.unregister(toast.id);
+                setServerImportToasts(prev => prev.map(t => t.id === toast.id ? { ...t, visible: false } : t));
               }}
               onExited={() => {
                 setServerImportToasts(prev => prev.filter(t => t.id !== toast.id));

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1083,16 +1083,20 @@ function App() {
     };
 
     const onProfilesList = (data: unknown) => {
-      const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null; brokenProfiles?: Array<{ id: string; name: string }>; autoSwitchedTo?: { id: string; name: string } | null };
+      const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null; brokenProfiles?: Array<{ id: string; name: string }>; autoSwitchedTo?: { id: string; name: string } | null; switchedFromId?: string | null };
       setProfiles(d.profiles ?? []);
       if (d.activeProfileId) {
         const active = d.profiles.find(p => p.id === d.activeProfileId);
         if (active) setActiveProfileName(active.name);
       }
       if (d.brokenProfiles && d.brokenProfiles.length > 0) {
+        const brokenIds = new Set(d.brokenProfiles.map(p => p.id));
+        const hasHealthyFallback = (d.profiles ?? []).some(p => !brokenIds.has(p.id));
         setBrokenCertInfo({
           brokenProfiles: d.brokenProfiles,
           switchedTo: d.autoSwitchedTo ?? null,
+          switchedFromId: d.switchedFromId ?? null,
+          hasHealthyFallback,
         });
       }
     };
@@ -1822,6 +1826,8 @@ const handleConnect = (serverData: SavedServer) => {
   const [brokenCertInfo, setBrokenCertInfo] = useState<{
     brokenProfiles: Array<{ id: string; name: string }>;
     switchedTo: { id: string; name: string } | null;
+    switchedFromId: string | null;
+    hasHealthyFallback: boolean;
   } | null>(null);
 
   const { isOnCooldown: leaveVoiceOnCooldown, trigger: triggerLeaveVoiceCooldown } = useLeaveVoiceCooldown(1000);
@@ -2290,10 +2296,10 @@ const handleConnect = (serverData: SavedServer) => {
           <BrokenCertNotification
             key={bp.id}
             profile={bp}
-            switchedTo={brokenCertInfo.switchedTo}
+            switchedTo={bp.id === brokenCertInfo.switchedFromId ? brokenCertInfo.switchedTo : null}
             onImport={handleBrokenCertImport}
             onOpenSettings={handleBrokenCertOpenSettings}
-            onDismiss={() => handleBrokenCertDismiss(bp.id)}
+            onDismiss={brokenCertInfo.hasHealthyFallback ? () => handleBrokenCertDismiss(bp.id) : undefined}
           />
         ))}
       </div>

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -35,6 +35,7 @@ import { GameUI } from './components/Game/GameUI';
 import { Brmblegotchi } from './components/Brmblegotchi/Brmblegotchi';
 import { ProfileProvider } from './contexts/ProfileContext';
 import { UpdateNotification } from './components/UpdateNotification/UpdateNotification';
+import { BrokenCertNotification } from './components/BrokenCertNotification/BrokenCertNotification';
 import { migrateLocalStorage } from './utils/migrateLocalStorage';
 import './App.css';
 
@@ -1082,11 +1083,17 @@ function App() {
     };
 
     const onProfilesList = (data: unknown) => {
-      const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null };
+      const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null; brokenActiveProfile?: { id: string; name: string }; autoSwitchedTo?: { id: string; name: string } | null };
       setProfiles(d.profiles ?? []);
       if (d.activeProfileId) {
         const active = d.profiles.find(p => p.id === d.activeProfileId);
         if (active) setActiveProfileName(active.name);
+      }
+      if (d.brokenActiveProfile) {
+        setBrokenCertInfo({
+          brokenProfile: d.brokenActiveProfile,
+          switchedTo: d.autoSwitchedTo ?? null,
+        });
       }
     };
 
@@ -1239,6 +1246,15 @@ function App() {
     bridge.on('cert.imported', onCertImported);
     bridge.on('profiles.activeChanged', onProfilesActiveChanged);
     bridge.on('profiles.list', onProfilesList);
+    const onProfilesRecovered = () => {
+      setBrokenCertInfo(null);
+    };
+    bridge.on('profiles.recovered', onProfilesRecovered);
+    const onProfilesRemoved = (data: unknown) => {
+      const d = data as { id: string };
+      setBrokenCertInfo(prev => prev && prev.brokenProfile.id === d.id ? null : prev);
+    };
+    bridge.on('profiles.removed', onProfilesRemoved);
     bridge.on('voice.autoConnect', onAutoConnect);
     bridge.on('voice.reconnecting', onVoiceReconnecting);
     bridge.on('voice.reconnectFailed', onVoiceReconnectFailed);
@@ -1289,6 +1305,8 @@ function App() {
       bridge.off('cert.imported', onCertImported);
       bridge.off('profiles.activeChanged', onProfilesActiveChanged);
       bridge.off('profiles.list', onProfilesList);
+      bridge.off('profiles.recovered', onProfilesRecovered);
+      bridge.off('profiles.removed', onProfilesRemoved);
       bridge.off('voice.autoConnect', onAutoConnect);
       bridge.off('voice.reconnecting', onVoiceReconnecting);
       bridge.off('voice.reconnectFailed', onVoiceReconnectFailed);
@@ -1792,6 +1810,10 @@ const handleConnect = (serverData: SavedServer) => {
   const [copyToast, setCopyToast] = useState<{ message: string } | null>(null);
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null);
   const [updateProgress, setUpdateProgress] = useState<number | null>(null);
+  const [brokenCertInfo, setBrokenCertInfo] = useState<{
+    brokenProfile: { id: string; name: string };
+    switchedTo: { id: string; name: string } | null;
+  } | null>(null);
 
   const { isOnCooldown: leaveVoiceOnCooldown, trigger: triggerLeaveVoiceCooldown } = useLeaveVoiceCooldown(1000);
   const { isOnCooldown: muteOnCooldown, trigger: triggerMuteCooldown } = useLeaveVoiceCooldown(1000);
@@ -1807,6 +1829,32 @@ const handleConnect = (serverData: SavedServer) => {
     setUpdateInfo(null);
     setUpdateProgress(null);
     bridge.send('app.dismissUpdate');
+  }, []);
+
+  const handleBrokenCertImport = useCallback(() => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.pfx,.p12';
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file || !brokenCertInfo) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64 = (reader.result as string).split(',')[1];
+        bridge.send('profiles.recover', { id: brokenCertInfo.brokenProfile.id, data: base64 });
+      };
+      reader.readAsDataURL(file);
+    };
+    input.click();
+  }, [brokenCertInfo]);
+
+  const handleBrokenCertOpenSettings = useCallback(() => {
+    setShowSettings(true);
+    setSettingsTab('profile');
+  }, []);
+
+  const handleBrokenCertDismiss = useCallback(() => {
+    setBrokenCertInfo(null);
   }, []);
 
   const channelUnreads = useMemo(() => {
@@ -2223,6 +2271,15 @@ const handleConnect = (serverData: SavedServer) => {
             onUpdate={handleApplyUpdate}
             onDismiss={handleDismissUpdate}
             progress={updateProgress}
+          />
+        )}
+        {brokenCertInfo && (
+          <BrokenCertNotification
+            brokenProfile={brokenCertInfo.brokenProfile}
+            switchedTo={brokenCertInfo.switchedTo}
+            onImport={handleBrokenCertImport}
+            onOpenSettings={handleBrokenCertOpenSettings}
+            onDismiss={brokenCertInfo.switchedTo ? handleBrokenCertDismiss : undefined}
           />
         )}
       </div>

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2216,14 +2216,16 @@ const handleConnect = (serverData: SavedServer) => {
       <Prompt />
       <PromptWithInput />
 
-      {updateInfo && (
-        <UpdateNotification
-          version={updateInfo.version}
-          onUpdate={handleApplyUpdate}
-          onDismiss={handleDismissUpdate}
-          progress={updateProgress}
-        />
-      )}
+      <div className="notification-stack">
+        {updateInfo && (
+          <UpdateNotification
+            version={updateInfo.version}
+            onUpdate={handleApplyUpdate}
+            onDismiss={handleDismissUpdate}
+            progress={updateProgress}
+          />
+        )}
+      </div>
 
       {screenShareToast && (
         <Toast

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -6,6 +6,7 @@ import { useMatrixClient } from './hooks/useMatrixClient';
 import type { MatrixCredentials } from './hooks/useMatrixClient';
 import { useScreenShare } from './hooks/useScreenShare';
 import { useLeaveVoiceCooldown } from './hooks/useLeaveVoiceCooldown';
+import { useNotificationQueue } from './hooks/useNotificationQueue';
 import { useUnreadTracker, resetMarkersCache } from './hooks/useUnreadTracker';
 import { useServiceStatus } from './hooks/useServiceStatus';
 import { useServerHealth } from './hooks/useServerHealth';
@@ -36,6 +37,7 @@ import { Brmblegotchi } from './components/Brmblegotchi/Brmblegotchi';
 import { ProfileProvider } from './contexts/ProfileContext';
 import { UpdateNotification } from './components/UpdateNotification/UpdateNotification';
 import { BrokenCertNotification } from './components/BrokenCertNotification/BrokenCertNotification';
+import { Notification } from './components/Notification/Notification';
 import { migrateLocalStorage } from './utils/migrateLocalStorage';
 import './App.css';
 
@@ -133,6 +135,9 @@ interface User {
 
 
 function App() {
+  // --- Notification queue (max 3 visible, priority-based) ---
+  const notifQueue = useNotificationQueue();
+
   // --- Brmblegotchi settings state ---
   const [brmblegotchiEnabled, setBrmblegotchiEnabledState] = useState<boolean>(() => {
     try {
@@ -1083,7 +1088,7 @@ function App() {
     };
 
     const onProfilesList = (data: unknown) => {
-      const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null; brokenProfiles?: Array<{ id: string; name: string }>; autoSwitchedTo?: { id: string; name: string } | null; switchedFromId?: string | null };
+      const d = data as { profiles: Array<{ id: string; name: string }>; activeProfileId: string | null; brokenProfiles?: Array<{ id: string; name: string }> };
       setProfiles(d.profiles ?? []);
       if (d.activeProfileId) {
         const active = d.profiles.find(p => p.id === d.activeProfileId);
@@ -1094,8 +1099,6 @@ function App() {
         const hasHealthyFallback = (d.profiles ?? []).some(p => !brokenIds.has(p.id));
         setBrokenCertInfo({
           brokenProfiles: d.brokenProfiles,
-          switchedTo: d.autoSwitchedTo ?? null,
-          switchedFromId: d.switchedFromId ?? null,
           hasHealthyFallback,
         });
       }
@@ -1825,10 +1828,43 @@ const handleConnect = (serverData: SavedServer) => {
   const [updateProgress, setUpdateProgress] = useState<number | null>(null);
   const [brokenCertInfo, setBrokenCertInfo] = useState<{
     brokenProfiles: Array<{ id: string; name: string }>;
-    switchedTo: { id: string; name: string } | null;
-    switchedFromId: string | null;
     hasHealthyFallback: boolean;
   } | null>(null);
+
+  // Server import notifications (from onboarding wizard) — one per server
+  interface ServerImportToast { id: string; label: string; }
+  const [serverImportToasts, setServerImportToasts] = useState<ServerImportToast[]>([]);
+
+  const handleServersImported = useCallback((labels: string[]) => {
+    const toasts = labels.map((label, i) => ({ id: `srv-${Date.now()}-${i}`, label }));
+    setServerImportToasts(toasts);
+    toasts.forEach(t => notifQueue.register(t.id, 'info'));
+  }, [notifQueue]);
+
+  // Register/unregister update notification with queue
+  useEffect(() => {
+    if (updateInfo) notifQueue.register('update', 'info');
+    else notifQueue.unregister('update');
+  }, [updateInfo, notifQueue]);
+
+  // Register/unregister broken cert notifications with queue
+  const prevBrokenIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const currentIds = new Set<string>();
+    if (brokenCertInfo) {
+      brokenCertInfo.brokenProfiles.forEach(bp => {
+        currentIds.add(`cert-${bp.id}`);
+        notifQueue.register(`cert-${bp.id}`, 'warning');
+      });
+    }
+    // Unregister any that were previously registered but are now gone
+    for (const id of prevBrokenIdsRef.current) {
+      if (!currentIds.has(id)) {
+        notifQueue.unregister(id);
+      }
+    }
+    prevBrokenIdsRef.current = currentIds;
+  }, [brokenCertInfo, notifQueue]);
 
   const { isOnCooldown: leaveVoiceOnCooldown, trigger: triggerLeaveVoiceCooldown } = useLeaveVoiceCooldown(1000);
   const { isOnCooldown: muteOnCooldown, trigger: triggerMuteCooldown } = useLeaveVoiceCooldown(1000);
@@ -2238,7 +2274,7 @@ const handleConnect = (serverData: SavedServer) => {
               setBrmblegotchiEnabledState(parsed.brmblegotchi?.enabled ?? false);
             }
           } catch { /* ignore */ }
-        }} />
+        }} onServersImported={handleServersImported} />
       )}
 
       <SettingsModal
@@ -2284,23 +2320,45 @@ const handleConnect = (serverData: SavedServer) => {
       <PromptWithInput />
 
       <div className="notification-stack">
-        {updateInfo && (
+        {updateInfo && notifQueue.isVisible('update') && (
           <UpdateNotification
             version={updateInfo.version}
             onUpdate={handleApplyUpdate}
-            onDismiss={handleDismissUpdate}
+            onDismiss={() => { handleDismissUpdate(); notifQueue.unregister('update'); }}
             progress={updateProgress}
           />
         )}
         {brokenCertInfo && brokenCertInfo.brokenProfiles.map(bp => (
-          <BrokenCertNotification
-            key={bp.id}
-            profile={bp}
-            switchedTo={bp.id === brokenCertInfo.switchedFromId ? brokenCertInfo.switchedTo : null}
-            onImport={handleBrokenCertImport}
-            onOpenSettings={handleBrokenCertOpenSettings}
-            onDismiss={brokenCertInfo.hasHealthyFallback ? () => handleBrokenCertDismiss(bp.id) : undefined}
-          />
+          notifQueue.isVisible(`cert-${bp.id}`) ? (
+            <BrokenCertNotification
+              key={bp.id}
+              profile={bp}
+              onImport={handleBrokenCertImport}
+              onOpenSettings={handleBrokenCertOpenSettings}
+              onDismiss={brokenCertInfo.hasHealthyFallback ? () => { handleBrokenCertDismiss(bp.id); notifQueue.unregister(`cert-${bp.id}`); } : undefined}
+            />
+          ) : null
+        ))}
+        {serverImportToasts.map(toast => (
+          notifQueue.isVisible(toast.id) ? (
+            <Notification
+              key={toast.id}
+              status="info"
+              position="top-right"
+              visible={true}
+              duration={5000}
+              title="Server imported"
+              detail={toast.label}
+              onDismiss={() => {
+                setServerImportToasts(prev => prev.filter(t => t.id !== toast.id));
+                notifQueue.unregister(toast.id);
+              }}
+              onExited={() => {
+                setServerImportToasts(prev => prev.filter(t => t.id !== toast.id));
+                notifQueue.unregister(toast.id);
+              }}
+            />
+          ) : null
         ))}
       </div>
 

--- a/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.css
+++ b/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.css
@@ -1,16 +1,3 @@
-.broken-cert-notification__message {
-  font-size: var(--text-sm);
+.broken-cert-notification__detail strong {
   color: var(--text-primary);
-  line-height: 1.4;
-  margin-bottom: var(--space-sm);
-}
-
-.broken-cert-notification__message strong {
-  color: var(--text-primary);
-}
-
-.broken-cert-notification__actions {
-  display: flex;
-  gap: var(--space-xs);
-  justify-content: flex-end;
 }

--- a/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.css
+++ b/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.css
@@ -1,3 +1,1 @@
-.broken-cert-notification__detail strong {
-  color: var(--text-primary);
-}
+/* BrokenCertNotification — no component-specific styles needed; uses Notification base */

--- a/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.css
+++ b/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.css
@@ -1,0 +1,16 @@
+.broken-cert-notification__message {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  line-height: 1.4;
+  margin-bottom: var(--space-sm);
+}
+
+.broken-cert-notification__message strong {
+  color: var(--text-primary);
+}
+
+.broken-cert-notification__actions {
+  display: flex;
+  gap: var(--space-xs);
+  justify-content: flex-end;
+}

--- a/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx
+++ b/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx
@@ -4,7 +4,6 @@ import './BrokenCertNotification.css';
 
 interface BrokenCertNotificationProps {
   profile: { id: string; name: string };
-  switchedTo: { id: string; name: string } | null;
   onImport: (profileId: string) => void;
   onOpenSettings: () => void;
   onDismiss?: () => void;
@@ -12,7 +11,6 @@ interface BrokenCertNotificationProps {
 
 export function BrokenCertNotification({
   profile,
-  switchedTo,
   onImport,
   onOpenSettings,
   onDismiss,
@@ -31,31 +29,18 @@ export function BrokenCertNotification({
       duration={null}
       onDismiss={onDismiss ? handleDismiss : undefined}
       onExited={onDismiss}
-    >
-      <div>
-        <p className="broken-cert-notification__message">
-          Profile <strong>"{profile.name}"</strong> has no certificate file.
-          {switchedTo && (
-            <> Switched to <strong>"{switchedTo.name}"</strong>.</>
-          )}
-          {!switchedTo && !onDismiss && (
-            <> Import a certificate or create a new profile to connect.</>
-          )}
-        </p>
-        <div className="broken-cert-notification__actions">
-          {onDismiss && (
-            <button className="btn btn-sm btn-ghost" onClick={handleDismiss}>
-              Dismiss
-            </button>
-          )}
+      title={<>Certificate missing from "<strong>{profile.name}</strong>"</>}
+      detail="Choose Import to recover it, or delete the profile in Settings."
+      actions={
+        <>
           <button className="btn btn-sm btn-secondary" onClick={onOpenSettings}>
             Settings
           </button>
           <button className="btn btn-sm btn-primary" onClick={() => onImport(profile.id)}>
             Import
           </button>
-        </div>
-      </div>
-    </Notification>
+        </>
+      }
+    />
   );
 }

--- a/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx
+++ b/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx
@@ -3,15 +3,15 @@ import { Notification } from '../Notification/Notification';
 import './BrokenCertNotification.css';
 
 interface BrokenCertNotificationProps {
-  brokenProfile: { id: string; name: string };
+  profile: { id: string; name: string };
   switchedTo: { id: string; name: string } | null;
-  onImport: () => void;
+  onImport: (profileId: string) => void;
   onOpenSettings: () => void;
-  onDismiss?: () => void;
+  onDismiss: () => void;
 }
 
 export function BrokenCertNotification({
-  brokenProfile,
+  profile,
   switchedTo,
   onImport,
   onOpenSettings,
@@ -29,34 +29,25 @@ export function BrokenCertNotification({
       position="top-right"
       visible={visible}
       duration={null}
-      onDismiss={onDismiss ? handleDismiss : undefined}
+      onDismiss={handleDismiss}
       onExited={onDismiss}
     >
       <div>
         <p className="broken-cert-notification__message">
-          {switchedTo ? (
-            <>
-              Profile <strong>"{brokenProfile.name}"</strong> has no certificate file.
-              Switched to <strong>"{switchedTo.name}"</strong>.
-            </>
-          ) : (
-            <>
-              Profile <strong>"{brokenProfile.name}"</strong> has no certificate.
-              Import a certificate or create a new profile to connect.
-            </>
+          Profile <strong>"{profile.name}"</strong> has no certificate file.
+          {switchedTo && (
+            <> Switched to <strong>"{switchedTo.name}"</strong>.</>
           )}
         </p>
         <div className="broken-cert-notification__actions">
-          {onDismiss && (
-            <button className="btn btn-sm btn-ghost" onClick={handleDismiss}>
-              Dismiss
-            </button>
-          )}
-          <button className="btn btn-sm btn-secondary" onClick={onOpenSettings}>
-            Open Settings
+          <button className="btn btn-sm btn-ghost" onClick={handleDismiss}>
+            Dismiss
           </button>
-          <button className="btn btn-sm btn-primary" onClick={onImport}>
-            Import Certificate
+          <button className="btn btn-sm btn-secondary" onClick={onOpenSettings}>
+            Settings
+          </button>
+          <button className="btn btn-sm btn-primary" onClick={() => onImport(profile.id)}>
+            Import
           </button>
         </div>
       </div>

--- a/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx
+++ b/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx
@@ -1,0 +1,65 @@
+import { useState, useCallback } from 'react';
+import { Notification } from '../Notification/Notification';
+import './BrokenCertNotification.css';
+
+interface BrokenCertNotificationProps {
+  brokenProfile: { id: string; name: string };
+  switchedTo: { id: string; name: string } | null;
+  onImport: () => void;
+  onOpenSettings: () => void;
+  onDismiss?: () => void;
+}
+
+export function BrokenCertNotification({
+  brokenProfile,
+  switchedTo,
+  onImport,
+  onOpenSettings,
+  onDismiss,
+}: BrokenCertNotificationProps) {
+  const [visible, setVisible] = useState(true);
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+  }, []);
+
+  return (
+    <Notification
+      status="warning"
+      position="top-right"
+      visible={visible}
+      duration={null}
+      onDismiss={onDismiss ? handleDismiss : undefined}
+      onExited={onDismiss}
+    >
+      <div>
+        <p className="broken-cert-notification__message">
+          {switchedTo ? (
+            <>
+              Profile <strong>"{brokenProfile.name}"</strong> has no certificate file.
+              Switched to <strong>"{switchedTo.name}"</strong>.
+            </>
+          ) : (
+            <>
+              Profile <strong>"{brokenProfile.name}"</strong> has no certificate.
+              Import a certificate or create a new profile to connect.
+            </>
+          )}
+        </p>
+        <div className="broken-cert-notification__actions">
+          {onDismiss && (
+            <button className="btn btn-sm btn-ghost" onClick={handleDismiss}>
+              Dismiss
+            </button>
+          )}
+          <button className="btn btn-sm btn-secondary" onClick={onOpenSettings}>
+            Open Settings
+          </button>
+          <button className="btn btn-sm btn-primary" onClick={onImport}>
+            Import Certificate
+          </button>
+        </div>
+      </div>
+    </Notification>
+  );
+}

--- a/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx
+++ b/src/Brmble.Web/src/components/BrokenCertNotification/BrokenCertNotification.tsx
@@ -7,7 +7,7 @@ interface BrokenCertNotificationProps {
   switchedTo: { id: string; name: string } | null;
   onImport: (profileId: string) => void;
   onOpenSettings: () => void;
-  onDismiss: () => void;
+  onDismiss?: () => void;
 }
 
 export function BrokenCertNotification({
@@ -29,7 +29,7 @@ export function BrokenCertNotification({
       position="top-right"
       visible={visible}
       duration={null}
-      onDismiss={handleDismiss}
+      onDismiss={onDismiss ? handleDismiss : undefined}
       onExited={onDismiss}
     >
       <div>
@@ -38,11 +38,16 @@ export function BrokenCertNotification({
           {switchedTo && (
             <> Switched to <strong>"{switchedTo.name}"</strong>.</>
           )}
+          {!switchedTo && !onDismiss && (
+            <> Import a certificate or create a new profile to connect.</>
+          )}
         </p>
         <div className="broken-cert-notification__actions">
-          <button className="btn btn-sm btn-ghost" onClick={handleDismiss}>
-            Dismiss
-          </button>
+          {onDismiss && (
+            <button className="btn btn-sm btn-ghost" onClick={handleDismiss}>
+              Dismiss
+            </button>
+          )}
           <button className="btn btn-sm btn-secondary" onClick={onOpenSettings}>
             Settings
           </button>

--- a/src/Brmble.Web/src/components/Icon/Icon.tsx
+++ b/src/Brmble.Web/src/components/Icon/Icon.tsx
@@ -279,6 +279,35 @@ const iconPaths: Record<string, IconDef> = {
     ),
   },
 
+  /* ── status / alert ──────────────────────────────────── */
+
+  'check-circle': {
+    paths: (
+      <>
+        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+        <polyline points="22 4 12 14.01 9 11.01" />
+      </>
+    ),
+  },
+  'alert-triangle': {
+    paths: (
+      <>
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+        <line x1="12" y1="9" x2="12" y2="13" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </>
+    ),
+  },
+  'alert-circle': {
+    paths: (
+      <>
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </>
+    ),
+  },
+
   // ╔══════════════════════════════════════════════════════════════════════╗
   // ║  UI — OBJECTS                                                      ║
   // ║  Settings, user profile, save, palette, etc.                       ║

--- a/src/Brmble.Web/src/components/Notification/Notification.css
+++ b/src/Brmble.Web/src/components/Notification/Notification.css
@@ -3,14 +3,17 @@
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
   padding: var(--space-sm) var(--space-md);
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: auto auto;
+  column-gap: var(--space-md);
+  row-gap: var(--space-sm);
   z-index: 1100;
   opacity: 0;
   transition: opacity var(--transition-fast), transform var(--transition-fast);
   box-shadow: var(--shadow-elevated);
-  max-width: 420px;
+  max-width: 480px;
+  min-width: 320px;
 }
 
 /* Position variants */
@@ -37,33 +40,40 @@
   transform: translateX(-50%) translateY(0);
 }
 
-/* Status icon */
+/* Grid placement: row 1 = icon | message | close */
 .notification__icon {
-  flex-shrink: 0;
+  grid-column: 1;
+  grid-row: 1;
+  align-self: start;
   display: flex;
   align-items: center;
+  padding-top: var(--space-xs);
 }
 
-.notification--info .notification__icon { color: var(--accent-info); }
-.notification--success .notification__icon { color: var(--accent-success); }
-.notification--warning .notification__icon { color: var(--accent-warning); }
-.notification--error .notification__icon { color: var(--accent-danger); }
-
-/* Status left border accent */
-.notification--info { border-left: 3px solid var(--accent-info); }
-.notification--success { border-left: 3px solid var(--accent-success); }
-.notification--warning { border-left: 3px solid var(--accent-warning); }
-.notification--error { border-left: 3px solid var(--accent-danger); }
-
-/* Content area */
-.notification__content {
-  flex: 1;
+.notification__message {
+  grid-column: 2;
+  grid-row: 1;
   min-width: 0;
+  padding-top: var(--space-xs);
 }
 
-/* Close button */
+.notification__title {
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.notification__detail {
+  font-size: 0.85em;
+  color: var(--text-secondary);
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
 .notification__close {
-  flex-shrink: 0;
+  grid-column: 3;
+  grid-row: 1;
+  align-self: start;
   background: none;
   border: none;
   color: var(--text-muted);
@@ -80,10 +90,56 @@
   background: var(--bg-hover);
 }
 
+/* Grid placement: row 2 = actions spanning message + close columns */
+.notification__actions {
+  grid-column: 2 / -1;
+  grid-row: 2;
+  display: flex;
+  gap: var(--space-xs);
+  justify-content: flex-end;
+}
+
+/* Status icon colors */
+.notification--info .notification__icon { color: var(--accent-info); }
+.notification--success .notification__icon { color: var(--accent-success); }
+.notification--warning .notification__icon { color: var(--accent-warning); }
+.notification--error .notification__icon { color: var(--accent-danger); }
+
+/* Status left border accent */
+.notification--info { border-left: 3px solid var(--accent-info); }
+.notification--success { border-left: 3px solid var(--accent-success); }
+.notification--warning { border-left: 3px solid var(--accent-warning); }
+.notification--error { border-left: 3px solid var(--accent-danger); }
+
+/* Auto-dismiss timer bar */
+@keyframes notification-timer {
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
+}
+
+.notification__timer {
+  grid-column: 1 / -1;
+  grid-row: -1;
+  height: 2px;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  transform-origin: right center;
+  animation: notification-timer linear forwards;
+  margin: var(--space-xs) calc(-1 * var(--space-md)) calc(-1 * var(--space-sm));
+}
+
+.notification__timer--paused {
+  animation-play-state: paused;
+}
+
+.notification--info .notification__timer    { background: var(--accent-info); }
+.notification--success .notification__timer { background: var(--accent-success); }
+.notification--warning .notification__timer { background: var(--accent-warning); }
+.notification--error .notification__timer   { background: var(--accent-danger); }
+
 /* Stacking container */
 .notification-stack {
   position: fixed;
-  top: var(--space-lg);
+  top: calc(var(--header-height) + var(--space-sm));
   right: var(--space-lg);
   display: flex;
   flex-direction: column;
@@ -102,5 +158,9 @@
   }
   .notification--visible.notification--bottom-center {
     transform: translateX(-50%) !important;
+  }
+  .notification__timer {
+    animation: none;
+    transform: scaleX(1);
   }
 }

--- a/src/Brmble.Web/src/components/Notification/Notification.css
+++ b/src/Brmble.Web/src/components/Notification/Notification.css
@@ -1,0 +1,106 @@
+.notification {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  z-index: 1100;
+  opacity: 0;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  box-shadow: var(--shadow-elevated);
+  max-width: 420px;
+}
+
+/* Position variants */
+.notification--top-right {
+  transform: translateY(-20px);
+}
+
+.notification--bottom-center {
+  position: fixed;
+  bottom: var(--space-lg);
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+}
+
+.notification--visible {
+  opacity: 1;
+}
+
+.notification--visible.notification--top-right {
+  transform: translateY(0);
+}
+
+.notification--visible.notification--bottom-center {
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Status icon */
+.notification__icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.notification--info .notification__icon { color: var(--accent-info); }
+.notification--success .notification__icon { color: var(--accent-success); }
+.notification--warning .notification__icon { color: var(--accent-warning); }
+.notification--error .notification__icon { color: var(--accent-danger); }
+
+/* Status left border accent */
+.notification--info { border-left: 3px solid var(--accent-info); }
+.notification--success { border-left: 3px solid var(--accent-success); }
+.notification--warning { border-left: 3px solid var(--accent-warning); }
+.notification--error { border-left: 3px solid var(--accent-danger); }
+
+/* Content area */
+.notification__content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Close button */
+.notification__close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--space-xs);
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.notification__close:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+/* Stacking container */
+.notification-stack {
+  position: fixed;
+  top: var(--space-lg);
+  right: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  z-index: 1100;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .notification {
+    transition: opacity var(--transition-fast);
+    transform: none !important;
+  }
+  .notification--bottom-center {
+    transform: translateX(-50%) !important;
+  }
+  .notification--visible.notification--bottom-center {
+    transform: translateX(-50%) !important;
+  }
+}

--- a/src/Brmble.Web/src/components/Notification/Notification.tsx
+++ b/src/Brmble.Web/src/components/Notification/Notification.tsx
@@ -80,13 +80,16 @@ export function Notification({
 
   // Enter animation
   useEffect(() => {
+    let animationFrameId: number | null = null;
+
     if (visible) {
-      requestAnimationFrame(() => setIsVisible(true));
+      animationFrameId = requestAnimationFrame(() => setIsVisible(true));
     } else {
       setIsVisible(false);
       exitTimerRef.current = setTimeout(() => onExitedRef.current?.(), 250);
     }
     return () => {
+      if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
       if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
     };
   }, [visible]);

--- a/src/Brmble.Web/src/components/Notification/Notification.tsx
+++ b/src/Brmble.Web/src/components/Notification/Notification.tsx
@@ -7,7 +7,10 @@ export type NotificationStatus = 'info' | 'success' | 'warning' | 'error';
 interface NotificationProps {
   status: NotificationStatus;
   position: 'top-right' | 'bottom-center';
-  children: React.ReactNode;
+  title: React.ReactNode;
+  detail?: React.ReactNode;
+  actions?: React.ReactNode;
+  children?: React.ReactNode;
   visible: boolean;
   duration?: number | null;
   onDismiss?: () => void;
@@ -47,6 +50,9 @@ const DEFAULT_DURATIONS: Record<NotificationStatus, number | null> = {
 export function Notification({
   status,
   position,
+  title,
+  detail,
+  actions,
   children,
   visible,
   duration,
@@ -56,12 +62,21 @@ export function Notification({
   className,
 }: NotificationProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const remainingRef = useRef<number | null>(null);
   const startTimeRef = useRef<number | null>(null);
   const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onDismissRef = useRef(onDismiss);
+  const onExitedRef = useRef(onExited);
 
   const effectiveDuration = duration !== undefined ? duration : DEFAULT_DURATIONS[status];
+
+  // Keep callback refs current without triggering timer/animation resets
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+    onExitedRef.current = onExited;
+  });
 
   // Enter animation
   useEffect(() => {
@@ -69,12 +84,12 @@ export function Notification({
       requestAnimationFrame(() => setIsVisible(true));
     } else {
       setIsVisible(false);
-      exitTimerRef.current = setTimeout(() => onExited?.(), 250);
+      exitTimerRef.current = setTimeout(() => onExitedRef.current?.(), 250);
     }
     return () => {
       if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
     };
-  }, [visible, onExited]);
+  }, [visible]);
 
   // Auto-dismiss timer
   const startTimer = useCallback((ms: number) => {
@@ -82,9 +97,9 @@ export function Notification({
     remainingRef.current = ms;
     startTimeRef.current = Date.now();
     timerRef.current = setTimeout(() => {
-      onDismiss?.();
+      onDismissRef.current?.();
     }, ms);
-  }, [onDismiss]);
+  }, []);
 
   const pauseTimer = useCallback(() => {
     if (timerRef.current && startTimeRef.current !== null && remainingRef.current !== null) {
@@ -111,11 +126,17 @@ export function Notification({
   }, [visible, effectiveDuration, startTimer]);
 
   const handleMouseEnter = useCallback(() => {
-    if (pauseOnHover && effectiveDuration !== null) pauseTimer();
+    if (pauseOnHover && effectiveDuration !== null) {
+      pauseTimer();
+      setIsPaused(true);
+    }
   }, [pauseOnHover, effectiveDuration, pauseTimer]);
 
   const handleMouseLeave = useCallback(() => {
-    if (pauseOnHover && effectiveDuration !== null) resumeTimer();
+    if (pauseOnHover && effectiveDuration !== null) {
+      resumeTimer();
+      setIsPaused(false);
+    }
   }, [pauseOnHover, effectiveDuration, resumeTimer]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -142,10 +163,11 @@ export function Notification({
       onKeyDown={handleKeyDown}
     >
       <div className="notification__icon">
-        <Icon name={STATUS_ICONS[status]} size={18} />
+        <Icon name={STATUS_ICONS[status]} size={22} />
       </div>
-      <div className="notification__content">
-        {children}
+      <div className="notification__message">
+        <div className="notification__title">{title ?? children}</div>
+        {detail && <div className="notification__detail">{detail}</div>}
       </div>
       {onDismiss && (
         <button
@@ -153,8 +175,19 @@ export function Notification({
           onClick={onDismiss}
           aria-label="Dismiss notification"
         >
-          <Icon name="x" size={16} />
+          <Icon name="x" size={18} />
         </button>
+      )}
+      {actions && (
+        <div className="notification__actions">
+          {actions}
+        </div>
+      )}
+      {effectiveDuration !== null && effectiveDuration > 0 && isVisible && (
+        <div
+          className={`notification__timer${isPaused ? ' notification__timer--paused' : ''}`}
+          style={{ animationDuration: `${effectiveDuration}ms` }}
+        />
       )}
     </div>
   );

--- a/src/Brmble.Web/src/components/Notification/Notification.tsx
+++ b/src/Brmble.Web/src/components/Notification/Notification.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { Icon, type IconName } from '../Icon/Icon';
+import './Notification.css';
+
+export type NotificationStatus = 'info' | 'success' | 'warning' | 'error';
+
+interface NotificationProps {
+  status: NotificationStatus;
+  position: 'top-right' | 'bottom-center';
+  children: React.ReactNode;
+  visible: boolean;
+  duration?: number | null;
+  onDismiss?: () => void;
+  onExited?: () => void;
+  pauseOnHover?: boolean;
+  className?: string;
+}
+
+const STATUS_ICONS: Record<NotificationStatus, IconName> = {
+  info: 'info',
+  success: 'check-circle',
+  warning: 'alert-triangle',
+  error: 'alert-circle',
+};
+
+const STATUS_ROLES: Record<NotificationStatus, string> = {
+  info: 'status',
+  success: 'status',
+  warning: 'status',
+  error: 'alert',
+};
+
+const STATUS_LIVE: Record<NotificationStatus, 'polite' | 'assertive'> = {
+  info: 'polite',
+  success: 'polite',
+  warning: 'polite',
+  error: 'assertive',
+};
+
+const DEFAULT_DURATIONS: Record<NotificationStatus, number | null> = {
+  info: 5000,
+  success: 5000,
+  warning: null,
+  error: null,
+};
+
+export function Notification({
+  status,
+  position,
+  children,
+  visible,
+  duration,
+  onDismiss,
+  onExited,
+  pauseOnHover = true,
+  className,
+}: NotificationProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const remainingRef = useRef<number | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const effectiveDuration = duration !== undefined ? duration : DEFAULT_DURATIONS[status];
+
+  // Enter animation
+  useEffect(() => {
+    if (visible) {
+      requestAnimationFrame(() => setIsVisible(true));
+    } else {
+      setIsVisible(false);
+      exitTimerRef.current = setTimeout(() => onExited?.(), 250);
+    }
+    return () => {
+      if (exitTimerRef.current) clearTimeout(exitTimerRef.current);
+    };
+  }, [visible, onExited]);
+
+  // Auto-dismiss timer
+  const startTimer = useCallback((ms: number) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    remainingRef.current = ms;
+    startTimeRef.current = Date.now();
+    timerRef.current = setTimeout(() => {
+      onDismiss?.();
+    }, ms);
+  }, [onDismiss]);
+
+  const pauseTimer = useCallback(() => {
+    if (timerRef.current && startTimeRef.current !== null && remainingRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+      const elapsed = Date.now() - startTimeRef.current;
+      remainingRef.current = Math.max(0, remainingRef.current - elapsed);
+    }
+  }, []);
+
+  const resumeTimer = useCallback(() => {
+    if (remainingRef.current !== null && remainingRef.current > 0 && !timerRef.current) {
+      startTimer(remainingRef.current);
+    }
+  }, [startTimer]);
+
+  useEffect(() => {
+    if (visible && effectiveDuration !== null && effectiveDuration > 0) {
+      startTimer(effectiveDuration);
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [visible, effectiveDuration, startTimer]);
+
+  const handleMouseEnter = useCallback(() => {
+    if (pauseOnHover && effectiveDuration !== null) pauseTimer();
+  }, [pauseOnHover, effectiveDuration, pauseTimer]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (pauseOnHover && effectiveDuration !== null) resumeTimer();
+  }, [pauseOnHover, effectiveDuration, resumeTimer]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape' && onDismiss) {
+      onDismiss();
+    }
+  }, [onDismiss]);
+
+  const classNames = [
+    'notification',
+    `notification--${status}`,
+    `notification--${position}`,
+    isVisible ? 'notification--visible' : '',
+    className ?? '',
+  ].filter(Boolean).join(' ');
+
+  return (
+    <div
+      className={classNames}
+      role={STATUS_ROLES[status]}
+      aria-live={STATUS_LIVE[status]}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="notification__icon">
+        <Icon name={STATUS_ICONS[status]} size={18} />
+      </div>
+      <div className="notification__content">
+        {children}
+      </div>
+      {onDismiss && (
+        <button
+          className="notification__close"
+          onClick={onDismiss}
+          aria-label="Dismiss notification"
+        >
+          <Icon name="x" size={16} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.css
+++ b/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.css
@@ -9,6 +9,19 @@
   z-index: 100;
   overflow-y: auto;
   padding: var(--space-xl) 0;
+  padding-top: var(--header-height);
+}
+
+/* ── Minimal titlebar (window controls only) ─────────────────────── */
+.onboarding-titlebar {
+  --window-btn-width: 46px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-height);
+  -webkit-app-region: drag;
+  z-index: 101;
 }
 
 .onboarding-panel {

--- a/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -92,6 +92,7 @@ interface ScannedCert {
 
 interface OnboardingWizardProps {
   onComplete: (fingerprint: string) => void;
+  onServersImported?: (labels: string[]) => void;
 }
 
 // ── Settings types (local copies to avoid SettingsModal coupling) ──
@@ -168,9 +169,13 @@ function triggerBlobDownload(base64: string, filename: string) {
 
 // ── Main component ────────────────────────────────────────────────
 
-export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
+export function OnboardingWizard({ onComplete, onServersImported }: OnboardingWizardProps) {
   const [step, setStep] = useState<WizardStep>('welcome');
   const stepIndex = STEPS.indexOf(step);
+
+  // Stable ref for onServersImported to avoid re-registering bridge handlers
+  const onServersImportedRef = useRef(onServersImported);
+  onServersImportedRef.current = onServersImported;
 
   // Detection state
   const [detecting, setDetecting] = useState(false);
@@ -254,7 +259,8 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     };
     const onServersImported = (data: unknown) => {
       const d = data as { servers?: Array<{ id: string; label: string }> } | undefined;
-      setImportedServers(prev => [...prev, ...(d?.servers ?? [])]);
+      const servers = d?.servers ?? [];
+      setImportedServers(prev => [...prev, ...servers]);
       setImportedIndices(prev => {
         const next = new Set(prev);
         pendingImportIndicesRef.current.forEach(i => next.add(i));
@@ -262,6 +268,10 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
         return next;
       });
       setServersImportBusy(false);
+      // Notify parent to show server import notification
+      if (servers.length > 0) {
+        onServersImportedRef.current?.(servers.map(s => s.label));
+      }
       setStep('connection');
     };
     const onRenamed = () => {
@@ -522,6 +532,21 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
 
   return (
     <div className="onboarding-overlay">
+      {/* Minimal titlebar — window controls only, no close-to-tray prompt */}
+      <div className="onboarding-titlebar">
+        <div className="window-controls">
+          <button className="window-btn window-btn-minimize" onClick={() => bridge.send('window.minimize')} aria-label="Minimize">
+            <Icon name="window-minimize" size={10} />
+          </button>
+          <button className="window-btn window-btn-maximize" onClick={() => bridge.send('window.maximize')} aria-label="Maximize">
+            <Icon name="window-maximize" size={10} />
+          </button>
+          <button className="window-btn window-btn-close" onClick={() => bridge.send('window.quit')} aria-label="Close">
+            <Icon name="window-close" size={10} />
+          </button>
+        </div>
+      </div>
+
       <div className="onboarding-panel glass-panel">
 
         {/* Progress dots */}

--- a/src/Brmble.Web/src/components/ServerList/ServerList.tsx
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.tsx
@@ -11,12 +11,13 @@ import './ServerList.css';
 
 interface ServerListProps {
   onConnect: (server: ServerEntry) => void;
+  connectDisabled?: boolean;
   connectionError?: string | null;
   onClearError?: () => void;
   activeProfileName?: string;
 }
 
-export function ServerList({ onConnect, connectionError, onClearError, activeProfileName }: ServerListProps) {
+export function ServerList({ onConnect, connectDisabled, connectionError, onClearError, activeProfileName }: ServerListProps) {
   const { servers, loading, addServer, updateServer, removeServer } = useServerlist();
   const { profiles } = useProfiles();
   const [editing, setEditing] = useState<ServerEntry | null>(null);
@@ -172,6 +173,7 @@ export function ServerList({ onConnect, connectionError, onClearError, activePro
                       <button 
                         className="btn btn-primary server-list-connect-btn"
                         onClick={() => onConnect(server)}
+                        disabled={connectDisabled}
                       >
                         Connect
                       </button>

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import Avatar from '../Avatar/Avatar';
 import AvatarUpload from '../AvatarUpload/AvatarUpload';
 import bridge from '../../bridge';
@@ -44,7 +44,7 @@ function triggerBlobDownload(base64: string, filename: string) {
 
 export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar, connected, registeredName }: ProfileSettingsTabProps) {
   const [showUpload, setShowUpload] = useState(false);
-  const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert, checkExistingCert, addFromExisting, renameSwapCert } = useProfiles();
+  const { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert, checkExistingCert, addFromExisting, renameSwapCert, recoverProfile } = useProfiles();
 
   const [isAdding, setIsAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -237,6 +237,23 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
     setEditName('');
   };
 
+  const handleRecoverCert = useCallback((profile: { id: string; name: string }) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.pfx,.p12';
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64 = (reader.result as string).split(',')[1];
+        recoverProfile(profile.id, base64);
+      };
+      reader.readAsDataURL(file);
+    };
+    input.click();
+  }, [recoverProfile]);
+
   return (
     <div className="profile-settings-tab">
       {/* Avatar section */}
@@ -344,9 +361,15 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
                     {getInitial(profile.name)}
                   </div>
                   <div className="profiles-info">
-                    <span className="profiles-name">{profile.name}</span>
-                    <span className="profiles-fingerprint">{formatFingerprint(profile.fingerprint)}</span>
-
+                    <span className="profiles-name">
+                      {profile.name}
+                      {!profile.certValid && (
+                        <Icon name="alert-triangle" size={14} className="profiles-warning-icon" />
+                      )}
+                    </span>
+                    <span className={`profiles-fingerprint${!profile.certValid ? ' profiles-fingerprint--broken' : ''}`}>
+                      {profile.certValid ? formatFingerprint(profile.fingerprint) : 'Certificate missing'}
+                    </span>
                   </div>
                   <div className="profiles-actions">
                     <Tooltip content={connected && isActive ? 'Disconnect to delete this profile' : 'Delete profile'}>
@@ -371,14 +394,25 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
                         </button>
                       </span>
                     </Tooltip>
-                    <Tooltip content="Export certificate">
-                      <button
-                        className="btn btn-primary profiles-action-btn"
-                        onClick={() => exportCert(profile.id)}
-                      >
-                        Export
-                      </button>
-                    </Tooltip>
+                    {profile.certValid ? (
+                      <Tooltip content="Export certificate">
+                        <button
+                          className="btn btn-primary profiles-action-btn"
+                          onClick={() => exportCert(profile.id)}
+                        >
+                          Export
+                        </button>
+                      </Tooltip>
+                    ) : (
+                      <Tooltip content="Import certificate to restore this profile">
+                        <button
+                          className="btn btn-primary profiles-action-btn"
+                          onClick={() => handleRecoverCert(profile)}
+                        >
+                          Import
+                        </button>
+                      </Tooltip>
+                    )}
                   </div>
                 </div>
               );

--- a/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfileSettingsTab.tsx
@@ -220,10 +220,13 @@ export function ProfileSettingsTab({ currentUser, onUploadAvatar, onRemoveAvatar
     setIsAdding(false);
   };
 
-  const handleDelete = async (profile: { id: string; name: string }) => {
+  const handleDelete = async (profile: { id: string; name: string; certValid: boolean }) => {
+    const message = profile.certValid
+      ? `Remove "${profile.name}"? The certificate file will remain on disk and can be re-imported later.`
+      : `Remove "${profile.name}"? This profile has no certificate — it can only be restored by importing a new one.`;
     const confirmed = await confirm({
       title: 'Delete profile',
-      message: `Remove "${profile.name}"? The certificate file will remain on disk and can be re-imported later.`,
+      message,
       confirmLabel: 'Delete',
       cancelLabel: 'Cancel',
     });

--- a/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ProfilesSettingsTab.css
@@ -200,3 +200,13 @@
   color: var(--accent-danger-text);
   margin-top: var(--space-xs);
 }
+
+.profiles-warning-icon {
+  color: var(--accent-warning);
+  margin-left: var(--space-xs);
+  vertical-align: middle;
+}
+
+.profiles-fingerprint--broken {
+  color: var(--accent-warning-text);
+}

--- a/src/Brmble.Web/src/components/Toast/Toast.css
+++ b/src/Brmble.Web/src/components/Toast/Toast.css
@@ -1,10 +1,3 @@
-.toast-message {
-  font-size: var(--text-sm);
-  color: var(--text-primary);
+.toast-title {
   white-space: nowrap;
-}
-
-.toast-actions {
-  display: flex;
-  gap: var(--space-xs);
 }

--- a/src/Brmble.Web/src/components/Toast/Toast.css
+++ b/src/Brmble.Web/src/components/Toast/Toast.css
@@ -1,26 +1,3 @@
-.toast {
-  position: fixed;
-  bottom: var(--space-lg);
-  left: 50%;
-  transform: translateX(-50%) translateY(20px);
-  opacity: 0;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  padding: var(--space-sm) var(--space-md);
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  z-index: 1100;
-  transition: opacity var(--transition-fast), transform var(--transition-fast);
-  box-shadow: var(--shadow-elevated);
-}
-
-.toast--visible {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
-}
-
 .toast-message {
   font-size: var(--text-sm);
   color: var(--text-primary);

--- a/src/Brmble.Web/src/components/Toast/Toast.tsx
+++ b/src/Brmble.Web/src/components/Toast/Toast.tsx
@@ -35,10 +35,9 @@ export function Toast({ message, actions, duration = 8000, onDismiss }: ToastPro
       duration={duration}
       onDismiss={handleDismiss}
       onExited={onDismiss}
-    >
-      <span className="toast-message">{message}</span>
-      {actions && (
-        <div className="toast-actions">
+      title={<span className="toast-title">{message}</span>}
+      actions={actions ? (
+        <>
           {actions.map((action, i) => (
             <button
               key={i}
@@ -48,8 +47,8 @@ export function Toast({ message, actions, duration = 8000, onDismiss }: ToastPro
               {action.label}
             </button>
           ))}
-        </div>
-      )}
-    </Notification>
+        </>
+      ) : undefined}
+    />
   );
 }

--- a/src/Brmble.Web/src/components/Toast/Toast.tsx
+++ b/src/Brmble.Web/src/components/Toast/Toast.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
+import { Notification } from '../Notification/Notification';
 import './Toast.css';
 
 interface ToastAction {
@@ -15,25 +16,26 @@ interface ToastProps {
 }
 
 export function Toast({ message, actions, duration = 8000, onDismiss }: ToastProps) {
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useState(true);
 
-  useEffect(() => {
-    requestAnimationFrame(() => setVisible(true));
-    const timer = setTimeout(() => {
-      setVisible(false);
-      setTimeout(onDismiss, 200);
-    }, duration);
-    return () => clearTimeout(timer);
-  }, [duration, onDismiss]);
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+  }, []);
 
   const handleAction = useCallback((action: ToastAction) => {
     action.onClick();
     setVisible(false);
-    setTimeout(onDismiss, 200);
-  }, [onDismiss]);
+  }, []);
 
   return (
-    <div className={`toast ${visible ? 'toast--visible' : ''}`} role="status" aria-live="polite">
+    <Notification
+      status="info"
+      position="bottom-center"
+      visible={visible}
+      duration={duration}
+      onDismiss={handleDismiss}
+      onExited={onDismiss}
+    >
       <span className="toast-message">{message}</span>
       {actions && (
         <div className="toast-actions">
@@ -48,6 +50,6 @@ export function Toast({ message, actions, duration = 8000, onDismiss }: ToastPro
           ))}
         </div>
       )}
-    </div>
+    </Notification>
   );
 }

--- a/src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.css
+++ b/src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.css
@@ -1,14 +1,3 @@
-.update-notification__message {
-  font-size: var(--text-sm);
-  color: var(--text-primary);
-  white-space: nowrap;
-}
-
-.update-notification__actions {
-  display: flex;
-  gap: var(--space-xs);
-}
-
 .update-notification__progress {
   width: 120px;
   height: 4px;

--- a/src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.css
+++ b/src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.css
@@ -1,26 +1,3 @@
-.update-notification {
-  position: fixed;
-  top: var(--space-lg);
-  right: var(--space-lg);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  padding: var(--space-sm) var(--space-md);
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  z-index: 1100;
-  opacity: 0;
-  transform: translateY(-20px);
-  transition: opacity var(--transition-fast), transform var(--transition-fast);
-  box-shadow: var(--shadow-elevated);
-}
-
-.update-notification--visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
 .update-notification__message {
   font-size: var(--text-sm);
   color: var(--text-primary);

--- a/src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.tsx
+++ b/src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.tsx
@@ -26,23 +26,19 @@ export function UpdateNotification({ version, onUpdate, onDismiss, progress }: U
       duration={null}
       onDismiss={isApplying ? undefined : handleDismiss}
       onExited={onDismiss}
-    >
-      {isApplying ? (
-        <>
-          <span className="update-notification__message">Updating to v{version}...</span>
-          <div className="update-notification__progress">
-            <div className="update-notification__progress-bar" style={{ width: `${progress}%` }} />
-          </div>
-        </>
+      title={isApplying ? 'Updating...' : 'Update available'}
+      detail={
+        <span className="update-notification__detail">
+          {isApplying ? `Installing v${version}` : `Press Update to install v${version}.`}
+        </span>
+      }
+      actions={isApplying ? (
+        <div className="update-notification__progress">
+          <div className="update-notification__progress-bar" style={{ width: `${progress}%` }} />
+        </div>
       ) : (
-        <>
-          <span className="update-notification__message">Update available: v{version}</span>
-          <div className="update-notification__actions">
-            <button className="btn btn-sm btn-ghost" onClick={handleDismiss}>Later</button>
-            <button className="btn btn-sm btn-primary" onClick={onUpdate}>Update</button>
-          </div>
-        </>
+        <button className="btn btn-sm btn-primary" onClick={onUpdate}>Update</button>
       )}
-    </Notification>
+    />
   );
 }

--- a/src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.tsx
+++ b/src/Brmble.Web/src/components/UpdateNotification/UpdateNotification.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
+import { Notification } from '../Notification/Notification';
 import './UpdateNotification.css';
 
 interface UpdateNotificationProps {
@@ -9,25 +10,23 @@ interface UpdateNotificationProps {
 }
 
 export function UpdateNotification({ version, onUpdate, onDismiss, progress }: UpdateNotificationProps) {
-  const [visible, setVisible] = useState(false);
-  const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    requestAnimationFrame(() => setVisible(true));
-    return () => {
-      if (dismissTimer.current) clearTimeout(dismissTimer.current);
-    };
-  }, []);
+  const [visible, setVisible] = useState(true);
 
   const handleDismiss = useCallback(() => {
     setVisible(false);
-    dismissTimer.current = setTimeout(onDismiss, 200);
-  }, [onDismiss]);
+  }, []);
 
   const isApplying = progress !== null;
 
   return (
-    <div className={`update-notification ${visible ? 'update-notification--visible' : ''}`} role="status" aria-live="polite">
+    <Notification
+      status="info"
+      position="top-right"
+      visible={visible}
+      duration={null}
+      onDismiss={isApplying ? undefined : handleDismiss}
+      onExited={onDismiss}
+    >
       {isApplying ? (
         <>
           <span className="update-notification__message">Updating to v{version}...</span>
@@ -44,6 +43,6 @@ export function UpdateNotification({ version, onUpdate, onDismiss, progress }: U
           </div>
         </>
       )}
-    </div>
+    </Notification>
   );
 }

--- a/src/Brmble.Web/src/hooks/useNotificationQueue.ts
+++ b/src/Brmble.Web/src/hooks/useNotificationQueue.ts
@@ -1,0 +1,64 @@
+import { useState, useCallback, useRef } from 'react';
+import type { NotificationStatus } from '../components/Notification/Notification';
+
+const MAX_VISIBLE = 3;
+
+const PRIORITY: Record<NotificationStatus, number> = {
+  error: 3,
+  warning: 2,
+  info: 1,
+  success: 0,
+};
+
+export interface QueueEntry {
+  id: string;
+  status: NotificationStatus;
+  /** Arrival order for stable sorting within same priority */
+  _order: number;
+}
+
+/**
+ * Manages which top-right notifications are visible (max 3).
+ * Higher-priority notifications preempt lower-priority ones.
+ * Displaced notifications re-appear when a slot opens.
+ *
+ * Usage:
+ *   const q = useNotificationQueue();
+ *   q.register('broken-cert-1', 'warning');  // register when data exists
+ *   q.unregister('broken-cert-1');            // unregister when dismissed/exited
+ *   const isVisible = q.isVisible('broken-cert-1');
+ */
+export function useNotificationQueue() {
+  const [entries, setEntries] = useState<QueueEntry[]>([]);
+  const orderRef = useRef(0);
+
+  const getVisible = useCallback((items: QueueEntry[]): Set<string> => {
+    const sorted = [...items].sort((a, b) => {
+      const pDiff = PRIORITY[b.status] - PRIORITY[a.status];
+      if (pDiff !== 0) return pDiff;
+      return a._order - b._order;
+    });
+    const visibleIds = new Set<string>();
+    for (let i = 0; i < Math.min(MAX_VISIBLE, sorted.length); i++) {
+      visibleIds.add(sorted[i].id);
+    }
+    return visibleIds;
+  }, []);
+
+  const register = useCallback((id: string, status: NotificationStatus) => {
+    setEntries(prev => {
+      if (prev.some(e => e.id === id)) return prev;
+      return [...prev, { id, status, _order: orderRef.current++ }];
+    });
+  }, []);
+
+  const unregister = useCallback((id: string) => {
+    setEntries(prev => prev.filter(e => e.id !== id));
+  }, []);
+
+  const visibleSet = getVisible(entries);
+
+  const isVisible = useCallback((id: string) => visibleSet.has(id), [visibleSet]);
+
+  return { register, unregister, isVisible, visibleCount: visibleSet.size, totalCount: entries.length };
+}

--- a/src/Brmble.Web/src/hooks/useProfiles.ts
+++ b/src/Brmble.Web/src/hooks/useProfiles.ts
@@ -47,6 +47,11 @@ export function useProfiles() {
       setActiveProfileId(d.id);
     };
 
+    const onRecovered = (data: unknown) => {
+      const d = data as { id: string; name: string; fingerprint: string; certValid: boolean };
+      setProfiles(prev => prev.map(p => p.id === d.id ? { ...p, fingerprint: d.fingerprint, certValid: d.certValid } : p));
+    };
+
     const onError = (data: unknown) => {
       const d = data as { message?: string };
       if (d.message) {
@@ -59,6 +64,7 @@ export function useProfiles() {
     bridge.on('profiles.removed', onRemoved);
     bridge.on('profiles.renamed', onRenamed);
     bridge.on('profiles.activeChanged', onActiveChanged);
+    bridge.on('profiles.recovered', onRecovered);
     bridge.on('profiles.error', onError);
     bridge.send('profiles.list');
 
@@ -68,6 +74,7 @@ export function useProfiles() {
       bridge.off('profiles.removed', onRemoved);
       bridge.off('profiles.renamed', onRenamed);
       bridge.off('profiles.activeChanged', onActiveChanged);
+      bridge.off('profiles.recovered', onRecovered);
       bridge.off('profiles.error', onError);
     };
   }, []);
@@ -116,5 +123,9 @@ export function useProfiles() {
     bridge.send('profiles.renameSwapCert', { id, name });
   }, []);
 
-  return { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert, checkExistingCert, addFromExisting, renameSwapCert };
+  const recoverProfile = useCallback((id: string, data: string) => {
+    bridge.send('profiles.recover', { id, data });
+  }, []);
+
+  return { profiles, activeProfileId, loading, addProfile, importProfile, removeProfile, renameProfile, setActive, exportCert, checkExistingCert, addFromExisting, renameSwapCert, recoverProfile };
 }

--- a/src/Brmble.Web/src/themes/_template.css
+++ b/src/Brmble.Web/src/themes/_template.css
@@ -9,7 +9,7 @@
    THE 3 DECISIONS
    ───────────────
    Every Brmble theme derives from exactly 3 starting choices. Once these
-    are locked, all 73 tokens can be mechanically produced.
+    are locked, all 86 tokens can be mechanically produced.
    
    ┌──────────────────┬──────────────────────────────────────────────────────┐
    │ 1. BASE HUE      │ An HSL degree (0-360) that tints backgrounds,      │
@@ -224,7 +224,7 @@
 
 
   /* ─────────────────────────────────────────────────────────────────────────
-     SUCCESS ACCENT (3 tokens)
+     SUCCESS ACCENT (6 tokens)
      ─────────────────────────────────────────────────────────────────────────
      Used for connection status, success messages, online indicators.
      Typically a green in the 120-160° hue range. Should be distinct from
@@ -248,6 +248,46 @@
   --accent-success:        /* hsl(140-160, 50-70%, 50-60%) */;
   --accent-success-glow:   /* rgba(R, G, B, 0.25-0.35) */;
   --accent-success-subtle: /* rgba(R, G, B, 0.10-0.20) */;
+  --accent-success-text:   /* hsl(140-160, 50-70%, 55-65%) */;
+  --accent-success-border: /* rgba(R, G, B, 0.30-0.50) */;
+  --accent-success-bg:     /* rgba(R, G, B, 0.20-0.30) */;
+
+
+  /*
+    ── Warning Accent ──────────────────────────────────────────────
+    Amber / yellow tones for attention-needed states.
+    Hue range: 35-50 (amber-yellow).
+
+       Token                       Target
+       --accent-warning:           hsl(35-50, 80-100%, 60-70%)    — base
+       --accent-warning-text:      hsl(35-50, 80-100%, 65-75%)    — readable on dark bg
+       --accent-warning-subtle:    rgba(base, 0.08-0.15)          — faint bg tint
+       --accent-warning-border:    rgba(base, 0.30-0.50)          — visible border
+       --accent-warning-bg:        rgba(base, 0.20-0.30)          — warning panel bg
+  */
+  --accent-warning:        /* hsl(35-50, 80-100%, 60-70%) */;
+  --accent-warning-text:   /* hsl(35-50, 80-100%, 65-75%) */;
+  --accent-warning-subtle: /* rgba(R, G, B, 0.08-0.15) */;
+  --accent-warning-border: /* rgba(R, G, B, 0.30-0.50) */;
+  --accent-warning-bg:     /* rgba(R, G, B, 0.20-0.30) */;
+
+  /*
+    ── Info Accent ─────────────────────────────────────────────────
+    Blue tones for supplemental / informational states.
+    Hue range: 200-220 (blue).
+
+       Token                       Target
+       --accent-info:              hsl(200-220, 60-80%, 55-65%)   — base
+       --accent-info-text:         hsl(200-220, 60-80%, 62-72%)   — readable on dark bg
+       --accent-info-subtle:       rgba(base, 0.08-0.15)          — faint bg tint
+       --accent-info-border:       rgba(base, 0.30-0.50)          — visible border
+       --accent-info-bg:           rgba(base, 0.20-0.30)          — info panel bg
+  */
+  --accent-info:        /* hsl(200-220, 60-80%, 55-65%) */;
+  --accent-info-text:   /* hsl(200-220, 60-80%, 62-72%) */;
+  --accent-info-subtle: /* rgba(R, G, B, 0.08-0.15) */;
+  --accent-info-border: /* rgba(R, G, B, 0.30-0.50) */;
+  --accent-info-bg:     /* rgba(R, G, B, 0.20-0.30) */;
 
 
   /* ─────────────────────────────────────────────────────────────────────────
@@ -747,7 +787,7 @@
    
    Before shipping your theme, verify:
    
-     □  All 73 tokens are defined (no remaining placeholder comments)
+     □  All 86 tokens are defined (no remaining placeholder comments)
    □  Replace THEME_SLUG with your theme's ID (lowercase, hyphenated)
    □  Replace THEME_NAME with the display name
    □  Update the cocktail name and vibe description in the header
@@ -771,7 +811,9 @@
      Backgrounds .......... 12
      Primary Accent ........ 7
      Secondary Accent ...... 3
-     Success Accent ........ 3
+      Success Accent ........ 6
+      Warning Accent ........ 5
+      Info Accent ........... 5
      Decorative Accent ..... 4
      Danger Accent ......... 6
      Status ................ 1
@@ -784,7 +826,7 @@
       Typography ............ 3
       Heading Scale ......... 6
        Theme Features ........ 4  (+3 noise-texture, noise-opacity, noise-scale)
-                              ──
-       Total                  73
+                               ──
+       Total                  86
    
    ═══════════════════════════════════════════════════════════════════════════ */

--- a/src/Brmble.Web/src/themes/aperol-spritz.css
+++ b/src/Brmble.Web/src/themes/aperol-spritz.css
@@ -59,12 +59,33 @@
   --accent-secondary-glow:   rgba(217, 165, 50, 0.32);
   --accent-secondary-subtle: rgba(217, 165, 50, 0.15);
 
-  /* ── Success Accent — Olive Green (3 tokens)
+  /* ── Success Accent — Olive Green (6 tokens)
      hsl(90, 40%, 50%) ≈ #7ab34d
      ──────────────────────────────────────────────── */
   --accent-success:        #7ab34d;
   --accent-success-glow:   rgba(122, 179, 77, 0.30);
   --accent-success-subtle: rgba(122, 179, 77, 0.14);
+  --accent-success-text:   #8cc260;
+  --accent-success-border: rgba(122, 179, 77, 0.4);
+  --accent-success-bg:     rgba(122, 179, 77, 0.25);
+
+  /* ── Warning Accent — Deep Gold (5 tokens)
+     hsl(48, 80%, 55%) — distinguishable from orange primary
+     ──────────────────────────────────────────────── */
+  --accent-warning:        #d4a020;
+  --accent-warning-text:   #e0b040;
+  --accent-warning-subtle: rgba(212, 160, 32, 0.12);
+  --accent-warning-border: rgba(212, 160, 32, 0.42);
+  --accent-warning-bg:     rgba(212, 160, 32, 0.25);
+
+  /* ── Info Accent — Steel Blue (5 tokens)
+     hsl(212, 60%, 58%) — cool contrast against warm theme
+     ──────────────────────────────────────────────── */
+  --accent-info:        #5088c4;
+  --accent-info-text:   #6498d0;
+  --accent-info-subtle: rgba(80, 136, 196, 0.12);
+  --accent-info-border: rgba(80, 136, 196, 0.4);
+  --accent-info-bg:     rgba(80, 136, 196, 0.25);
 
   /* ── Decorative Accent — Terracotta (4 tokens)
      hsl(15, 50%, 40%) ≈ #994d33

--- a/src/Brmble.Web/src/themes/blue-lagoon.css
+++ b/src/Brmble.Web/src/themes/blue-lagoon.css
@@ -58,12 +58,33 @@
   --accent-secondary-glow:   rgba(232, 112, 64, 0.3);
   --accent-secondary-subtle: rgba(232, 112, 64, 0.15);
 
-  /* ── Success Accent — Seafoam (3 tokens)
+  /* ── Success Accent — Seafoam (6 tokens)
      hsl(160, 50%, 55%) ≈ #5cc9a5
      ──────────────────────────────────────────────── */
   --accent-success:        #5cc9a5;
   --accent-success-glow:   rgba(92, 201, 165, 0.3);
   --accent-success-subtle: rgba(92, 201, 165, 0.15);
+  --accent-success-text:   #6ed4b2;
+  --accent-success-border: rgba(92, 201, 165, 0.4);
+  --accent-success-bg:     rgba(92, 201, 165, 0.25);
+
+  /* ── Warning Accent — Warm Amber (5 tokens)
+     hsl(40, 85%, 62%) — distinct from coral secondary
+     ──────────────────────────────────────────────── */
+  --accent-warning:        #e8a830;
+  --accent-warning-text:   #f0b848;
+  --accent-warning-subtle: rgba(232, 168, 48, 0.12);
+  --accent-warning-border: rgba(232, 168, 48, 0.4);
+  --accent-warning-bg:     rgba(232, 168, 48, 0.25);
+
+  /* ── Info Accent — Sky Blue (5 tokens)
+     hsl(210, 70%, 60%) — distinguishable from cyan primary
+     ──────────────────────────────────────────────── */
+  --accent-info:        #4a8ad4;
+  --accent-info-text:   #5e9ae0;
+  --accent-info-subtle: rgba(74, 138, 212, 0.12);
+  --accent-info-border: rgba(74, 138, 212, 0.4);
+  --accent-info-bg:     rgba(74, 138, 212, 0.25);
 
   /* ── Decorative Accent — Deep Navy (4 tokens)
      hsl(220, 60%, 45%) ≈ #2e52b3

--- a/src/Brmble.Web/src/themes/classic.css
+++ b/src/Brmble.Web/src/themes/classic.css
@@ -48,6 +48,23 @@
   --accent-success: #50c878;
   --accent-success-glow: rgba(80, 200, 120, 0.3);
   --accent-success-subtle: rgba(80, 200, 120, 0.15);
+  --accent-success-text: #60d888;
+  --accent-success-border: rgba(80, 200, 120, 0.4);
+  --accent-success-bg: rgba(80, 200, 120, 0.25);
+
+  /* Warning Accent (Amber) */
+  --accent-warning: #f0a030;
+  --accent-warning-text: #f0b050;
+  --accent-warning-subtle: rgba(240, 160, 48, 0.12);
+  --accent-warning-border: rgba(240, 160, 48, 0.4);
+  --accent-warning-bg: rgba(240, 160, 48, 0.25);
+
+  /* Info Accent (Blue) */
+  --accent-info: #5b9bd5;
+  --accent-info-text: #6baae0;
+  --accent-info-subtle: rgba(91, 155, 213, 0.12);
+  --accent-info-border: rgba(91, 155, 213, 0.4);
+  --accent-info-bg: rgba(91, 155, 213, 0.25);
 
   /* Decorative Accent (Purple) */
   --accent-decorative: #7b4dff;

--- a/src/Brmble.Web/src/themes/cosmopolitan.css
+++ b/src/Brmble.Web/src/themes/cosmopolitan.css
@@ -59,12 +59,34 @@
   --accent-secondary-glow:   rgba(217, 149, 106, 0.3);
   --accent-secondary-subtle: rgba(217, 149, 106, 0.14);
 
-  /* ── Success Accent — Lime (3 tokens)
+  /* ── Success Accent — Lime (6 tokens)
      hsl(120, 50%, 55%) ≈ #55c855
      ──────────────────────────────────────────────── */
   --accent-success:        #55c855;
   --accent-success-glow:   rgba(85, 200, 85, 0.3);
   --accent-success-subtle: rgba(85, 200, 85, 0.14);
+  --accent-success-text:   #68d468;
+  --accent-success-border: rgba(85, 200, 85, 0.4);
+  --accent-success-bg:     rgba(85, 200, 85, 0.25);
+
+  /* ── Warning Accent — Warm Gold (5 tokens)
+     hsl(42, 85%, 60%) — distinct amber, separated from
+     the orange-red danger accent
+     ──────────────────────────────────────────────── */
+  --accent-warning:        #e8a830;
+  --accent-warning-text:   #f0b848;
+  --accent-warning-subtle: rgba(232, 168, 48, 0.12);
+  --accent-warning-border: rgba(232, 168, 48, 0.4);
+  --accent-warning-bg:     rgba(232, 168, 48, 0.22);
+
+  /* ── Info Accent — Dusty Blue (5 tokens)
+     hsl(215, 55%, 58%) — cool counterpoint to warm palette
+     ──────────────────────────────────────────────── */
+  --accent-info:        #5580c0;
+  --accent-info-text:   #6890cc;
+  --accent-info-subtle: rgba(85, 128, 192, 0.12);
+  --accent-info-border: rgba(85, 128, 192, 0.4);
+  --accent-info-bg:     rgba(85, 128, 192, 0.22);
 
   /* ── Decorative Accent — Deep Rose (4 tokens)
      hsl(330, 50%, 35%) ≈ #8c2d6a

--- a/src/Brmble.Web/src/themes/lemon-drop.css
+++ b/src/Brmble.Web/src/themes/lemon-drop.css
@@ -61,13 +61,36 @@
   --accent-secondary-glow:   rgba(212, 206, 191, 0.30);
   --accent-secondary-subtle: rgba(212, 206, 191, 0.15);
 
-  /* ── Success Accent — Spring Green (3 tokens)
+  /* ── Success Accent — Spring Green (6 tokens)
      hsl(140, 55%, 55%) ≈ #50c878
      Distinct from the gold primary — a fresh green.
      ──────────────────────────────────────────────── */
   --accent-success:        #50c878;
   --accent-success-glow:   rgba(80, 200, 120, 0.30);
   --accent-success-subtle: rgba(80, 200, 120, 0.14);
+  --accent-success-text:   #62d48a;
+  --accent-success-border: rgba(80, 200, 120, 0.4);
+  --accent-success-bg:     rgba(80, 200, 120, 0.25);
+
+  /* ── Warning Accent — Tangerine Orange (5 tokens)
+     hsl(25, 85%, 58%) — shifted toward orange to be
+     clearly distinct from the gold/yellow primary accent.
+     ──────────────────────────────────────────────── */
+  --accent-warning:        #e88030;
+  --accent-warning-text:   #f09048;
+  --accent-warning-subtle: rgba(232, 128, 48, 0.12);
+  --accent-warning-border: rgba(232, 128, 48, 0.42);
+  --accent-warning-bg:     rgba(232, 128, 48, 0.25);
+
+  /* ── Info Accent — Slate Blue (5 tokens)
+     hsl(215, 55%, 55%) — cool blue, complementary
+     contrast against the warm gold palette
+     ──────────────────────────────────────────────── */
+  --accent-info:        #4878c0;
+  --accent-info-text:   #5a88cc;
+  --accent-info-subtle: rgba(72, 120, 192, 0.12);
+  --accent-info-border: rgba(72, 120, 192, 0.42);
+  --accent-info-bg:     rgba(72, 120, 192, 0.25);
 
   /* ── Decorative Accent — Amber Dark (4 tokens)
      hsl(35, 60%, 30%) ≈ #7a5a1f

--- a/src/Brmble.Web/src/themes/midori-sour.css
+++ b/src/Brmble.Web/src/themes/midori-sour.css
@@ -59,7 +59,7 @@
   --accent-secondary-glow:   rgba(45, 184, 168, 0.32);
   --accent-secondary-subtle: rgba(45, 184, 168, 0.15);
 
-  /* ── Success Accent — Bright Lime (3 tokens)
+  /* ── Success Accent — Bright Lime (6 tokens)
      hsl(80, 70%, 55%) ≈ #a3d942
      IMPORTANT: Lime hue 80° is visually distinct from
      primary green hue 145° — yellow-green vs blue-green.
@@ -67,6 +67,29 @@
   --accent-success:        #a3d942;
   --accent-success-glow:   rgba(163, 217, 66, 0.30);
   --accent-success-subtle: rgba(163, 217, 66, 0.14);
+  --accent-success-text:   #b0e258;
+  --accent-success-border: rgba(163, 217, 66, 0.4);
+  --accent-success-bg:     rgba(163, 217, 66, 0.25);
+
+  /* ── Warning Accent — Neon Amber (5 tokens)
+     hsl(40, 90%, 60%) — bright amber, high contrast
+     against the green-dominant palette
+     ──────────────────────────────────────────────── */
+  --accent-warning:        #f0a820;
+  --accent-warning-text:   #f5b840;
+  --accent-warning-subtle: rgba(240, 168, 32, 0.12);
+  --accent-warning-border: rgba(240, 168, 32, 0.42);
+  --accent-warning-bg:     rgba(240, 168, 32, 0.25);
+
+  /* ── Info Accent — Electric Blue (5 tokens)
+     hsl(210, 75%, 58%) — cool blue, strong contrast
+     against green backgrounds
+     ──────────────────────────────────────────────── */
+  --accent-info:        #3d8ce8;
+  --accent-info-text:   #529cf0;
+  --accent-info-subtle: rgba(61, 140, 232, 0.12);
+  --accent-info-border: rgba(61, 140, 232, 0.42);
+  --accent-info-bg:     rgba(61, 140, 232, 0.25);
 
   /* ── Decorative Accent — Deep Teal (4 tokens)
      hsl(180, 55%, 30%) ≈ #226e6e

--- a/src/Brmble.Web/src/themes/retro-terminal.css
+++ b/src/Brmble.Web/src/themes/retro-terminal.css
@@ -62,13 +62,36 @@
   --accent-secondary-glow:   rgba(255, 176, 0, 0.35);
   --accent-secondary-subtle: rgba(255, 176, 0, 0.15);
 
-  /* ── Success Accent — Bright Green (3 tokens)
+  /* ── Success Accent — Bright Green (6 tokens)
      #00ff41 — slightly different hue from primary
      to remain distinguishable as a status indicator.
      ──────────────────────────────────────────────── */
   --accent-success:        #00ff41;
   --accent-success-glow:   rgba(0, 255, 65, 0.35);
   --accent-success-subtle: rgba(0, 255, 65, 0.12);
+  --accent-success-text:   #33ff66;
+  --accent-success-border: rgba(0, 255, 65, 0.45);
+  --accent-success-bg:     rgba(0, 255, 65, 0.22);
+
+  /* ── Warning Accent — Terminal Amber (5 tokens)
+     #ffbb00 — bright CRT amber warning.
+     Distinct from secondary amber (#ffb000) by being
+     slightly warmer and used for alert states.
+     ──────────────────────────────────────────────── */
+  --accent-warning:        #ffbb00;
+  --accent-warning-text:   #ffcc33;
+  --accent-warning-subtle: rgba(255, 187, 0, 0.14);
+  --accent-warning-border: rgba(255, 187, 0, 0.45);
+  --accent-warning-bg:     rgba(255, 187, 0, 0.22);
+
+  /* ── Info Accent — Bright Cyan (5 tokens)
+     #00ccff — CRT cyan, crisp and electric.
+     ──────────────────────────────────────────────── */
+  --accent-info:        #00ccff;
+  --accent-info-text:   #33ddff;
+  --accent-info-subtle: rgba(0, 204, 255, 0.14);
+  --accent-info-border: rgba(0, 204, 255, 0.45);
+  --accent-info-bg:     rgba(0, 204, 255, 0.22);
 
   /* ── Decorative Accent — Dark Green (4 tokens)
      #0a4a0a — deep phosphor shadow.


### PR DESCRIPTION
## Summary

Closes #433. Detects profiles with missing certificate files, notifies the user, and provides recovery paths (import or delete). Also standardizes the notification component system across the app.

### Broken profile detection & recovery
- Backend (`CertificateService`) scans profiles on startup, reports broken certs in `profiles.list` response
- Auto-switches away from a broken active profile to the first healthy one
- `profiles.recover` handler allows re-importing a certificate for a broken profile
- Warning notification per broken profile with Import and Settings actions
- Context-aware delete confirmation (different message for broken vs healthy profiles)
- Connect button disabled when no healthy profile exists

### Notification system standardization
- Shared `<Notification>` base component with title/detail grid layout, status-driven icons, colors, and ARIA
- `useNotificationQueue` hook — max 3 visible, priority-based (error > warning > info > success), with automatic slot-up on dismiss
- Auto-dismiss timer bar (2px accent-colored bar, shrinks over duration, pauses on hover)
- All existing notifications (Toast, UpdateNotification, BrokenCertNotification) refactored to use the shared base
- Server import info notifications bubble from OnboardingWizard to App notification stack
- Minimal onboarding titlebar with window controls (close = quit, no tray prompt)

### Theme & docs
- Added `--accent-warning-*` and `--accent-info-*` token families to all 8 themes
- Added `check-circle`, `alert-triangle`, `alert-circle` status icons to Icon system
- UI_GUIDE section 13: notification pattern, title/detail standard, queue/priority rules, decision checklist

### Bug fixes
- Fixed auto-dismiss timer never completing (stabilized onDismiss/onExited callbacks via refs)
- Fixed dismissed notifications not freeing queue slots (broken cert unregister cleanup)
- Fixed `hasHealthyFallback` not updating when healthy profile is deleted
