### PR TITLE
fix: unified resize handles, window borders, and settings modal (#381, #409)

### DIFF
--- a/docs/superpowers/plans/2026-04-15-unified-resize-borders.md
+++ b/docs/superpowers/plans/2026-04-15-unified-resize-borders.md
@@ -1,0 +1,504 @@
+# Unified Resize Handles and Window Borders — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix four visual inconsistencies: sidebar resize handle invisible at rest, sidebar scrollbar in onboarding, hardcoded native border color, missing spacing when maximized.
+
+**Architecture:** CSS-only fixes for the sidebar handle and onboarding scrollbar. Bridge message plumbing for window state and dynamic brush update on the C# side. CSS class toggle on the frontend for maximized padding.
+
+**Tech Stack:** CSS (theme tokens), C# (Win32 P/Invoke, GDI brushes), TypeScript/React (bridge messages, state)
+
+**Spec:** `docs/superpowers/specs/2026-04-15-unified-resize-borders-design.md`
+
+---
+
+### Task 1: Unify Sidebar Resize Handle Styling
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Sidebar/Sidebar.css:297-313`
+
+- [ ] **Step 1: Change resting state from transparent to visible**
+
+In `src/Brmble.Web/src/components/Sidebar/Sidebar.css`, change the `::after` pseudo-element's default background from `transparent` to `var(--border-subtle)`, and change the hover state to `var(--accent-primary)`.
+
+Find this block (lines 297-313):
+```css
+.sidebar-resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 2px;
+  background: transparent;
+  transition: background var(--transition-fast);
+}
+
+.sidebar-resize-handle:hover::after {
+  background: var(--border-subtle);
+}
+
+.sidebar-resize-handle--active::after {
+  background: var(--accent-primary);
+  transition: none;
+}
+```
+
+Replace with:
+```css
+.sidebar-resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--border-subtle);
+  transition: background var(--transition-fast);
+}
+
+.sidebar-resize-handle:hover::after {
+  background: var(--accent-primary);
+}
+
+.sidebar-resize-handle--active::after {
+  background: var(--accent-primary);
+  transition: none;
+}
+```
+
+Changes: resting `transparent` → `var(--border-subtle)`, hover `var(--border-subtle)` → `var(--accent-primary)`. Active stays the same.
+
+- [ ] **Step 2: Visual verification**
+
+Run: `cd src/Brmble.Web && npm run dev`
+
+Verify in the app:
+- The sidebar resize handle shows a subtle 2px line at rest (not invisible)
+- On hover, it turns accent color
+- While dragging, it stays accent color
+- Compare with the chat split divider — they should follow the same pattern
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Sidebar/Sidebar.css
+git commit -m "fix: make sidebar resize handle visible at rest (#409)
+
+Match the chat split divider pattern: --border-subtle at rest,
+--accent-primary on hover/active."
+```
+
+---
+
+### Task 2: Hide Sidebar Scrollbar During Onboarding
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx:2132`
+- Modify: `src/Brmble.Web/src/App.css` (add rule after line 30)
+
+- [ ] **Step 1: Add `.app--onboarding` class to root element**
+
+In `src/Brmble.Web/src/App.tsx`, find the root div at line 2132:
+```tsx
+<div className="app">
+```
+
+Replace with:
+```tsx
+<div className={`app${showOnboarding ? ' app--onboarding' : ''}`}>
+```
+
+- [ ] **Step 2: Add CSS rule to hide sidebar overflow during onboarding**
+
+In `src/Brmble.Web/src/App.css`, after the `.sidebar--disconnected` rule (around line 34), add:
+
+```css
+.app--onboarding .sidebar {
+  overflow: hidden;
+}
+```
+
+- [ ] **Step 3: Visual verification**
+
+Clear app data to trigger the onboarding wizard (or temporarily set `showOnboarding` to `true`). Verify no sidebar scrollbar is visible during any wizard step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx src/Brmble.Web/src/App.css
+git commit -m "fix: hide sidebar scrollbar during onboarding wizard (#409)"
+```
+
+---
+
+### Task 3: Add P/Invoke Declarations for Dynamic Brush Update
+
+**Files:**
+- Modify: `src/Brmble.Client/Win32Window.cs` (add P/Invoke declarations near existing ones around line 243)
+
+- [ ] **Step 1: Add GDI and window class P/Invoke declarations**
+
+In `src/Brmble.Client/Win32Window.cs`, find the existing `CreateSolidBrush` declaration (line 243-244):
+```csharp
+[DllImport("gdi32.dll")]
+private static extern IntPtr CreateSolidBrush(uint crColor);
+```
+
+After it, add the following declarations:
+
+```csharp
+[DllImport("gdi32.dll")]
+public static extern bool DeleteObject(IntPtr hObject);
+
+[DllImport("user32.dll")]
+public static extern bool InvalidateRect(IntPtr hWnd, IntPtr lpRect, bool bErase);
+
+[DllImport("user32.dll", EntryPoint = "SetClassLongPtrW")]
+private static extern IntPtr SetClassLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+[DllImport("user32.dll", EntryPoint = "SetClassLongW")]
+private static extern IntPtr SetClassLongPtr32(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+public static IntPtr SetClassLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+{
+    return IntPtr.Size == 8
+        ? SetClassLongPtr64(hWnd, nIndex, dwNewLong)
+        : SetClassLongPtr32(hWnd, nIndex, dwNewLong);
+}
+
+public const int GCL_HBRBACKGROUND = -10;
+```
+
+Note: `SetClassLongPtr` needs a 32/64-bit wrapper because the entry point differs between architectures. `CreateSolidBrush` is already `private`, but the new methods are `public` since they will be called from `Program.cs`.
+
+Also add a public helper to create brushes (since `CreateSolidBrush` is currently private):
+
+```csharp
+public static IntPtr CreateBackgroundBrush(uint colorRef)
+{
+    return CreateSolidBrush(colorRef);
+}
+```
+
+- [ ] **Step 2: Build and verify no compilation errors**
+
+Run: `dotnet build src/Brmble.Client/Brmble.Client.csproj`
+Expected: Build succeeded, no errors from the new declarations.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Brmble.Client/Win32Window.cs
+git commit -m "refactor: add P/Invoke declarations for dynamic window brush updates"
+```
+
+---
+
+### Task 4: Dynamic Border Brush Per Theme
+
+**Files:**
+- Modify: `src/Brmble.Client/Program.cs:383-393` (notification.theme handler)
+
+- [ ] **Step 1: Add a static field to track the current brush handle**
+
+In `src/Brmble.Client/Program.cs`, near the existing static fields at the top of the class (near `_hwnd`, `_bridge`, `_controller`), add:
+
+```csharp
+private static IntPtr _currentBgBrush;
+```
+
+- [ ] **Step 2: Extend the notification.theme handler to update the window brush**
+
+Find the existing handler (lines 383-393):
+```csharp
+_bridge.RegisterHandler("notification.theme", data =>
+{
+    var theme = data.TryGetProperty("theme", out var t) ? t.GetString() : null;
+    if (!string.IsNullOrEmpty(theme))
+    {
+        TrayIcon.SetTheme(theme);
+        TaskbarBadge.SetTheme(theme);
+        Win32Window.SetWindowIcon(_hwnd, theme);
+    }
+    return Task.CompletedTask;
+});
+```
+
+Replace with:
+```csharp
+_bridge.RegisterHandler("notification.theme", data =>
+{
+    var theme = data.TryGetProperty("theme", out var t) ? t.GetString() : null;
+    if (!string.IsNullOrEmpty(theme))
+    {
+        TrayIcon.SetTheme(theme);
+        TaskbarBadge.SetTheme(theme);
+        Win32Window.SetWindowIcon(_hwnd, theme);
+
+        // Update the native resize border brush to match the theme
+        var (r, g, b) = ThemeColors.GetBgDeep(theme);
+        uint colorRef = (uint)(b << 16 | g << 8 | r);
+        var newBrush = Win32Window.CreateBackgroundBrush(colorRef);
+        var oldBrush = Win32Window.SetClassLongPtr(
+            _hwnd, Win32Window.GCL_HBRBACKGROUND, newBrush);
+        if (oldBrush != IntPtr.Zero && oldBrush != _currentBgBrush)
+            Win32Window.DeleteObject(oldBrush);
+        if (_currentBgBrush != IntPtr.Zero && _currentBgBrush != oldBrush)
+            Win32Window.DeleteObject(_currentBgBrush);
+        _currentBgBrush = newBrush;
+        Win32Window.InvalidateRect(_hwnd, IntPtr.Zero, true);
+    }
+    return Task.CompletedTask;
+});
+```
+
+The brush cleanup logic: `SetClassLongPtr` returns the previous brush. We delete the old one to avoid GDI handle leaks. We also track `_currentBgBrush` in case the old brush returned differs from what we expect (defensive).
+
+- [ ] **Step 3: Build and verify**
+
+Run: `dotnet build src/Brmble.Client/Brmble.Client.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Manual test**
+
+Launch the app. Switch between themes in Settings. The 6px border strip (visible in normal/restored window mode) should change color to match each theme's `--bg-deep` value. There should be no visible seam between the border strip and the WebView2 content background.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Client/Program.cs
+git commit -m "fix: update native border brush color on theme change (#381)
+
+Extend notification.theme handler to swap the window class background
+brush via SetClassLongPtr, matching the active theme's --bg-deep."
+```
+
+---
+
+### Task 5: Bridge Message for Window State Changes
+
+**Files:**
+- Modify: `src/Brmble.Client/Program.cs:466-471` (WM_SIZE handler)
+
+- [ ] **Step 1: Add SIZE constants if not already defined**
+
+In `src/Brmble.Client/Win32Window.cs`, check if `SIZE_MAXIMIZED` and `SIZE_RESTORED` constants exist. If not, add them near other WM_ constants:
+
+```csharp
+public const int SIZE_RESTORED = 0;
+public const int SIZE_MAXIMIZED = 2;
+```
+
+- [ ] **Step 2: Extend WM_SIZE handler to send window.stateChanged**
+
+In `src/Brmble.Client/Program.cs`, find the `WM_SIZE` handler (lines 466-471):
+```csharp
+case Win32Window.WM_SIZE:
+    if (_controller != null)
+    {
+        _controller.Bounds = GetWebViewBounds(hwnd);
+    }
+    return IntPtr.Zero;
+```
+
+Replace with:
+```csharp
+case Win32Window.WM_SIZE:
+    if (_controller != null)
+    {
+        _controller.Bounds = GetWebViewBounds(hwnd);
+    }
+    var sizeType = (int)(wParam.ToInt64() & 0xFFFF);
+    if (sizeType == Win32Window.SIZE_MAXIMIZED || sizeType == Win32Window.SIZE_RESTORED)
+    {
+        _bridge?.Send("window.stateChanged", new { maximized = Win32Window.IsZoomed(hwnd) });
+        _bridge?.NotifyUiThread();
+    }
+    return IntPtr.Zero;
+```
+
+This sends `window.stateChanged` with `{ maximized: true }` or `{ maximized: false }` whenever the window is maximized or restored. The `NotifyUiThread()` call posts `WM_USER` to flush the bridge message queue.
+
+- [ ] **Step 3: Build and verify**
+
+Run: `dotnet build src/Brmble.Client/Brmble.Client.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Client/Program.cs src/Brmble.Client/Win32Window.cs
+git commit -m "feat: send window.stateChanged bridge message on maximize/restore (#381)"
+```
+
+---
+
+### Task 6: Frontend Maximized State and CSS Compensation
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx:2132` (root div className)
+- Modify: `src/Brmble.Web/src/App.css` (add `.app--maximized` rule)
+
+- [ ] **Step 1: Add isMaximized state and bridge listener in App.tsx**
+
+In `src/Brmble.Web/src/App.tsx`, near the other state declarations (around line 168 where `showOnboarding` is), add:
+
+```tsx
+const [isMaximized, setIsMaximized] = useState(false);
+```
+
+Then add a `useEffect` to listen for the bridge message. Place it near other bridge-related effects:
+
+```tsx
+useEffect(() => {
+  const handleWindowState = (data: { maximized?: boolean }) => {
+    setIsMaximized(data.maximized === true);
+  };
+  bridge.on('window.stateChanged', handleWindowState);
+  return () => bridge.off('window.stateChanged', handleWindowState);
+}, []);
+```
+
+- [ ] **Step 2: Add isMaximized to the root div className**
+
+Find the root div (line 2132, already modified in Task 2):
+```tsx
+<div className={`app${showOnboarding ? ' app--onboarding' : ''}`}>
+```
+
+Replace with:
+```tsx
+<div className={`app${showOnboarding ? ' app--onboarding' : ''}${isMaximized ? ' app--maximized' : ''}`}>
+```
+
+- [ ] **Step 3: Add CSS rule for maximized padding**
+
+In `src/Brmble.Web/src/App.css`, after the `.app--onboarding` rule (added in Task 2), add:
+
+```css
+.app--maximized {
+  padding: 6px;
+}
+```
+
+- [ ] **Step 4: Visual verification**
+
+Launch the app. Maximize the window — content should have 6px of `--bg-deep` colored padding on all sides, matching the visual spacing of the normal/restored mode. Restore the window — padding should disappear (the native 6px border inset takes over). Toggle back and forth several times to confirm no flicker or layout jump.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx src/Brmble.Web/src/App.css
+git commit -m "fix: add 6px padding when maximized to match normal mode spacing (#381)
+
+Listen for window.stateChanged bridge message and toggle .app--maximized
+class. CSS adds 6px padding to compensate for the missing native border
+inset when maximized."
+```
+
+---
+
+### Task 7: Maximize Button Icon Toggle
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Icon/Icon.tsx:363-366` (add window-restore icon)
+- Modify: `src/Brmble.Web/src/components/Header/Header.tsx:80-82` (toggle icon)
+
+- [ ] **Step 1: Add window-restore icon to Icon.tsx**
+
+In `src/Brmble.Web/src/components/Icon/Icon.tsx`, find the `window-maximize` entry (lines 363-366):
+```tsx
+'window-maximize': {
+    viewBox: '0 0 10 10',
+    paths: <rect x="0.5" y="0.5" width="9" height="9" fill="none" stroke="currentColor" strokeWidth="1" />,
+  },
+```
+
+After it, add the `window-restore` icon (two overlapping rectangles, standard Windows restore icon):
+```tsx
+  'window-restore': {
+    viewBox: '0 0 10 10',
+    paths: (
+      <>
+        <rect x="2.5" y="0.5" width="7" height="7" fill="none" stroke="currentColor" strokeWidth="1" />
+        <rect x="0.5" y="2.5" width="7" height="7" fill="var(--bg-deep, #0f0a14)" stroke="currentColor" strokeWidth="1" />
+      </>
+    ),
+  },
+```
+
+The restore icon has a back rectangle (top-right) and a front rectangle (bottom-left), with the front filled with the background color to create the overlapping effect.
+
+- [ ] **Step 2: Pass isMaximized prop to Header**
+
+In `src/Brmble.Web/src/App.tsx`, find where `<Header` is rendered. Add the `isMaximized` prop:
+
+```tsx
+<Header isMaximized={isMaximized} ... />
+```
+
+(Keep all existing props intact, just add `isMaximized`.)
+
+- [ ] **Step 3: Update Header to accept and use isMaximized**
+
+In `src/Brmble.Web/src/components/Header/Header.tsx`, add `isMaximized` to the component's props interface/destructuring.
+
+Then find the maximize button (lines 80-82):
+```tsx
+<button className="window-btn window-btn-maximize" onClick={() => bridge.send('window.maximize')} aria-label="Maximize">
+  <Icon name="window-maximize" size={10} />
+</button>
+```
+
+Replace with:
+```tsx
+<button className="window-btn window-btn-maximize" onClick={() => bridge.send('window.maximize')} aria-label={isMaximized ? 'Restore' : 'Maximize'}>
+  <Icon name={isMaximized ? 'window-restore' : 'window-maximize'} size={10} />
+</button>
+```
+
+- [ ] **Step 4: Visual verification**
+
+Launch the app. The maximize button should show a single rectangle (maximize icon) in normal mode. When maximized, it should switch to the overlapping rectangles (restore icon). Clicking it should toggle the window state and the icon should update accordingly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Icon/Icon.tsx src/Brmble.Web/src/components/Header/Header.tsx src/Brmble.Web/src/App.tsx
+git commit -m "feat: toggle maximize/restore icon based on window state (#381)
+
+Add window-restore icon and pass isMaximized prop to Header so the
+button shows the correct icon for the current window state."
+```
+
+---
+
+### Task 8: Final Integration Test
+
+- [ ] **Step 1: Build everything**
+
+```bash
+dotnet build
+cd src/Brmble.Web && npm run build
+```
+
+Expected: Both builds succeed with no errors.
+
+- [ ] **Step 2: Full manual test pass**
+
+Launch the app and verify all four fixes:
+
+1. **Sidebar resize handle**: Visible subtle line at rest. Accent color on hover. Accent color while dragging. Matches chat split divider pattern.
+2. **Onboarding scrollbar**: If testable, confirm no sidebar scrollbar during wizard.
+3. **Border theme color**: Switch between multiple themes (Classic, Blue Lagoon, Retro Terminal at minimum). The 6px border strip should seamlessly match the app background.
+4. **Maximized spacing**: Maximize window — 6px padding visible on all edges. Restore — padding gone, native border strip visible. No layout jump or flicker.
+5. **Maximize button icon**: Shows maximize icon when restored, restore icon when maximized.
+
+- [ ] **Step 3: Run existing tests**
+
+```bash
+dotnet test
+```
+
+Expected: All existing tests pass (no regressions).

--- a/docs/superpowers/specs/2026-04-15-unified-resize-borders-design.md
+++ b/docs/superpowers/specs/2026-04-15-unified-resize-borders-design.md
@@ -1,0 +1,101 @@
+# Unified Resize Handles and Window Borders
+
+Fixes #409 (sidebar resize handle style + onboarding scrollbar) and #381 (window border theme color + maximized spacing).
+
+## Problem
+
+Four related visual inconsistencies in resize/border behavior:
+
+1. **Sidebar resize handle is invisible at rest**, while the chat split divider is always visible. Users don't know the sidebar is resizable until they accidentally hover it.
+2. **Sidebar scrollbar leaks through during onboarding wizard**, where it shouldn't appear.
+3. **Native window border color is hardcoded** to Classic theme's `--bg-deep` (`#0f0a14`). Other themes show a mismatched border strip.
+4. **Content is flush against edges when maximized.** The 6px native resize border inset disappears when the window is maximized, leaving 0px spacing on the left and top edges.
+
+## What Stays
+
+- **`useResizable` hook** (`hooks/useResizable.ts`) -- solid implementation using Pointer Events API with pointer capture, proper cleanup, min/max clamping, profile-scoped localStorage persistence, and double-click-to-reset. No changes needed.
+- **Native hit-test architecture** (`HitTestHelper.cs`, `WM_NCHITTEST` in `Program.cs`) -- correct approach for custom-chrome WebView2 apps. Clean and unit-tested.
+- **Chat split divider styling** (`ChatPanel.css:452-462`) -- this is the reference pattern that the sidebar handle should match.
+
+## Fix 1: Unified Sidebar Resize Handle
+
+**Files:** `src/Brmble.Web/src/components/Sidebar/Sidebar.css` (lines 280-313)
+
+Change the `::after` pseudo-element on `.sidebar-resize-handle` from invisible at rest to always-visible, matching the chat split divider pattern:
+
+| State | Current | New |
+|-------|---------|-----|
+| Resting | `background: transparent` | `background: var(--border-subtle)` |
+| Hover | `background: var(--border-subtle)` | `background: var(--accent-primary)` |
+| Active/dragging | `background: var(--accent-primary)` | `background: var(--accent-primary)` (unchanged) |
+
+The hit area (8px wide), line width (2px), cursor (`col-resize`), z-index (200), and ARIA attributes all stay the same.
+
+## Fix 2: Hide Sidebar Scrollbar During Onboarding
+
+**Files:** `src/Brmble.Web/src/App.tsx`, `src/Brmble.Web/src/App.css`
+
+The `showOnboarding` state already exists in `App.tsx`. When true, add class `.app--onboarding` to the root `.app` element. Then in CSS:
+
+```css
+.app--onboarding .sidebar {
+  overflow: hidden;
+}
+```
+
+The sidebar isn't interactive during onboarding, so hiding overflow has no side effects.
+
+## Fix 3: Dynamic Native Border Brush Per Theme
+
+**Files:** `src/Brmble.Client/Program.cs`, `src/Brmble.Client/Win32Window.cs`
+
+The frontend already sends `notification.theme` with `{ theme }` on every theme change (via MutationObserver in `App.tsx`). The C# handler already receives this and updates tray icon, taskbar badge, and window icon.
+
+Extend the existing `notification.theme` handler to also update the window background brush:
+
+1. Call `ThemeColors.GetBgDeep(theme)` to get the correct COLORREF value.
+2. Create a new brush with `CreateSolidBrush(colorRef)`.
+3. Swap the window class brush via `SetClassLongPtr(hwnd, GCL_HBRBACKGROUND, newBrush)`.
+4. Delete the old brush with `DeleteObject(oldBrush)` to avoid GDI handle leaks.
+5. Call `InvalidateRect(hwnd, IntPtr.Zero, true)` to repaint the border strip.
+
+Add P/Invoke declarations for `SetClassLongPtr`, `InvalidateRect`, and `DeleteObject` to `Win32Window.cs` if not already present. Store the current brush handle in a `static IntPtr _currentBgBrush` field in `Program.cs` so the old brush can be cleaned up on swap.
+
+## Fix 4: Consistent Spacing When Maximized
+
+**Files:** `src/Brmble.Client/Program.cs`, `src/Brmble.Web/src/App.tsx`, `src/Brmble.Web/src/App.css`, `src/Brmble.Web/src/components/Header/Header.tsx`
+
+### Bridge message: `window.stateChanged`
+
+In the `WM_SIZE` handler in `Program.cs` (which already handles WebView2 bounds updates), detect maximize/restore transitions. When `wParam` is `SIZE_MAXIMIZED` or `SIZE_RESTORED`, send:
+
+```csharp
+bridge.Send("window.stateChanged", new { maximized = IsZoomed(hwnd) });
+bridge.NotifyUiThread();
+```
+
+### Frontend state
+
+In `App.tsx`, listen for `window.stateChanged` and store `isMaximized` in state. Add class `.app--maximized` to the root `.app` element when true.
+
+### CSS compensation
+
+```css
+.app--maximized {
+  padding: 6px;
+}
+```
+
+Since `.app` is `height: 100vh` with `display: flex; flex-direction: column` and `background: var(--bg-deep)`, the 6px padding fills the same role as the native border inset. The `--bg-deep` background shows through the padding, visually matching the border strip in normal mode.
+
+### Maximize button icon toggle (polish)
+
+Pass `isMaximized` as a prop to `Header.tsx`. The window control button currently always shows the maximize icon. When `isMaximized` is true, show a restore icon instead.
+
+## Testing
+
+- **Sidebar handle:** Hover and drag the sidebar resize handle. It should show a subtle `--border-subtle` line at rest, and highlight to `--accent-primary` on hover and drag. Compare visually with the chat split divider -- they should look the same.
+- **Onboarding scrollbar:** Run through the onboarding wizard. No sidebar scrollbar should be visible at any step.
+- **Border theme color:** Switch between all 8 themes while the window is in normal (restored) mode. The 6px border strip should match the theme's background color without a visible seam.
+- **Maximized spacing:** Maximize the window. Content should not be flush with screen edges -- 6px of `--bg-deep` padding should be visible on all sides. Restore the window and verify the double-padding issue does not occur (native 6px inset + no extra CSS padding).
+- **Maximize button:** The header button should show a restore icon when maximized, and a maximize icon when restored.

--- a/docs/superpowers/specs/2026-04-15-unified-resize-borders-design.md
+++ b/docs/superpowers/specs/2026-04-15-unified-resize-borders-design.md
@@ -63,30 +63,32 @@ Add P/Invoke declarations for `SetClassLongPtr`, `InvalidateRect`, and `DeleteOb
 
 ## Fix 4: Consistent Spacing When Maximized
 
-**Files:** `src/Brmble.Client/Program.cs`, `src/Brmble.Web/src/App.tsx`, `src/Brmble.Web/src/App.css`, `src/Brmble.Web/src/components/Header/Header.tsx`
+**Files:** `src/Brmble.Client/Program.cs`, `src/Brmble.Web/src/App.tsx`, `src/Brmble.Web/src/components/Header/Header.tsx`
+
+### Native inset
+
+Keep the native 6px inset in `Program.cs` consistent across restored and maximized states instead of compensating in the web layer. The goal is for the same chrome-owned spacing to remain visible when the window is maximized, so content never sits flush against the screen edges.
+
+### Frontend state
+
+No frontend maximize-state plumbing is required for this behavior. `App.tsx` does not need to listen for a window-state event or toggle an `.app--maximized` class.
+
+### CSS compensation
+
+No maximized-only CSS padding is needed. Spacing is provided by the native window inset rather than by adding padding in the app root.
+
+This keeps the responsibility for edge spacing in the native chrome layer, avoids web/native duplication, and ensures maximized and restored windows use the same 6px inset behavior.
 
 ### Bridge message: `window.stateChanged`
 
-In the `WM_SIZE` handler in `Program.cs` (which already handles WebView2 bounds updates), detect maximize/restore transitions. When `wParam` is `SIZE_MAXIMIZED` or `SIZE_RESTORED`, send:
+In the `WM_SIZE` handler in `Program.cs`, detect maximize/restore transitions. When `wParam` is `SIZE_MAXIMIZED` or `SIZE_RESTORED`, send:
 
 ```csharp
 bridge.Send("window.stateChanged", new { maximized = IsZoomed(hwnd) });
 bridge.NotifyUiThread();
 ```
 
-### Frontend state
-
-In `App.tsx`, listen for `window.stateChanged` and store `isMaximized` in state. Add class `.app--maximized` to the root `.app` element when true.
-
-### CSS compensation
-
-```css
-.app--maximized {
-  padding: 6px;
-}
-```
-
-Since `.app` is `height: 100vh` with `display: flex; flex-direction: column` and `background: var(--bg-deep)`, the 6px padding fills the same role as the native border inset. The `--bg-deep` background shows through the padding, visually matching the border strip in normal mode.
+This message is used by the frontend to toggle the maximize/restore icon in the Header, not for spacing.
 
 ### Maximize button icon toggle (polish)
 
@@ -97,5 +99,5 @@ Pass `isMaximized` as a prop to `Header.tsx`. The window control button currentl
 - **Sidebar handle:** Hover and drag the sidebar resize handle. It should show a subtle `--border-subtle` line at rest, and highlight to `--accent-primary` on hover and drag. Compare visually with the chat split divider -- they should look the same.
 - **Onboarding scrollbar:** Run through the onboarding wizard. No sidebar scrollbar should be visible at any step.
 - **Border theme color:** Switch between all 8 themes while the window is in normal (restored) mode. The 6px border strip should match the theme's background color without a visible seam.
-- **Maximized spacing:** Maximize the window. Content should not be flush with screen edges -- 6px of `--bg-deep` padding should be visible on all sides. Restore the window and verify the double-padding issue does not occur (native 6px inset + no extra CSS padding).
+- **Maximized spacing:** Maximize the window. Content should not be flush with screen edges -- the same 6px native inset should remain visible rather than collapsing to 0px. Restore the window and verify spacing remains consistent without any extra web-layer padding being applied.
 - **Maximize button:** The header button should show a restore icon when maximized, and a maximize icon when restored.

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -28,6 +28,7 @@ static class Program
     private static volatile bool _muted;
     private static volatile bool _deafened;
     private static volatile string? _closeAction; // null = ask, "minimize", "quit"
+    private static IntPtr _currentBgBrush;
     private static System.Threading.Timer? _zoomSaveTimer;
     private const int ResizeBorderWidth = 6;
 
@@ -388,6 +389,19 @@ static class Program
                 TrayIcon.SetTheme(theme);
                 TaskbarBadge.SetTheme(theme);
                 Win32Window.SetWindowIcon(_hwnd, theme);
+
+                // Update the native resize border brush to match the theme
+                var (r, g, b) = ThemeColors.GetBgDeep(theme);
+                uint colorRef = (uint)(b << 16 | g << 8 | r);
+                var newBrush = Win32Window.CreateBackgroundBrush(colorRef);
+                var oldBrush = Win32Window.SetClassLongPtr(
+                    _hwnd, Win32Window.GCL_HBRBACKGROUND, newBrush);
+                if (oldBrush != IntPtr.Zero && oldBrush != _currentBgBrush)
+                    Win32Window.DeleteObject(oldBrush);
+                if (_currentBgBrush != IntPtr.Zero && _currentBgBrush != oldBrush)
+                    Win32Window.DeleteObject(_currentBgBrush);
+                _currentBgBrush = newBrush;
+                Win32Window.InvalidateRect(_hwnd, IntPtr.Zero, true);
             }
             return Task.CompletedTask;
         });

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -33,9 +33,9 @@ static class Program
     private const int ResizeBorderWidth = 6;
 
     /// <summary>
-    /// Calculates the WebView2 bounds, inset from the client rect by the
-    /// resize border width when the window is not maximized. When maximized
-    /// there is no resize border, so WebView2 fills the full client area.
+    /// Calculates the WebView2 bounds, always inset from the client rect
+    /// by the resize border width so the native background shows through
+    /// on all edges in both normal and maximized states.
     /// </summary>
     private static Rectangle GetWebViewBounds(IntPtr hwnd)
     {
@@ -393,10 +393,8 @@ static class Program
                 var newBrush = Win32Window.CreateBackgroundBrush(colorRef);
                 var oldBrush = Win32Window.SetClassLongPtr(
                     _hwnd, Win32Window.GCL_HBRBACKGROUND, newBrush);
-                if (oldBrush != IntPtr.Zero && oldBrush != _currentBgBrush)
+                if (oldBrush != IntPtr.Zero && oldBrush != newBrush)
                     Win32Window.DeleteObject(oldBrush);
-                if (_currentBgBrush != IntPtr.Zero && _currentBgBrush != oldBrush)
-                    Win32Window.DeleteObject(_currentBgBrush);
                 _currentBgBrush = newBrush;
                 Win32Window.InvalidateRect(_hwnd, IntPtr.Zero, true);
             }

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -482,6 +482,12 @@ static class Program
                 {
                     _controller.Bounds = GetWebViewBounds(hwnd);
                 }
+                var sizeType = (int)(wParam.ToInt64() & 0xFFFF);
+                if (sizeType == Win32Window.SIZE_MAXIMIZED || sizeType == Win32Window.SIZE_RESTORED)
+                {
+                    _bridge?.Send("window.stateChanged", new { maximized = Win32Window.IsZoomed(hwnd) });
+                    _bridge?.NotifyUiThread();
+                }
                 return IntPtr.Zero;
 
             case Win32Window.WM_CLOSE:

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -43,9 +43,6 @@ static class Program
         int w = rect.Right - rect.Left;
         int h = rect.Bottom - rect.Top;
 
-        if (Win32Window.IsZoomed(hwnd))
-            return new Rectangle(0, 0, w, h);
-
         int b = ResizeBorderWidth;
         return new Rectangle(b, b, Math.Max(0, w - 2 * b), Math.Max(0, h - 2 * b));
     }

--- a/src/Brmble.Client/Win32Window.cs
+++ b/src/Brmble.Client/Win32Window.cs
@@ -243,6 +243,32 @@ internal static class Win32Window
     [DllImport("gdi32.dll")]
     private static extern IntPtr CreateSolidBrush(uint crColor);
 
+    [DllImport("gdi32.dll")]
+    public static extern bool DeleteObject(IntPtr hObject);
+
+    [DllImport("user32.dll")]
+    public static extern bool InvalidateRect(IntPtr hWnd, IntPtr lpRect, bool bErase);
+
+    [DllImport("user32.dll", EntryPoint = "SetClassLongPtrW")]
+    private static extern IntPtr SetClassLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+    [DllImport("user32.dll", EntryPoint = "SetClassLongW")]
+    private static extern IntPtr SetClassLongPtr32(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+    public static IntPtr SetClassLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+    {
+        return IntPtr.Size == 8
+            ? SetClassLongPtr64(hWnd, nIndex, dwNewLong)
+            : SetClassLongPtr32(hWnd, nIndex, dwNewLong);
+    }
+
+    public const int GCL_HBRBACKGROUND = -10;
+
+    public static IntPtr CreateBackgroundBrush(uint colorRef)
+    {
+        return CreateSolidBrush(colorRef);
+    }
+
     [DllImport("kernel32.dll")]
     public static extern bool AllocConsole();
 

--- a/src/Brmble.Client/Win32Window.cs
+++ b/src/Brmble.Client/Win32Window.cs
@@ -264,6 +264,9 @@ internal static class Win32Window
 
     public const int GCL_HBRBACKGROUND = -10;
 
+    public const int SIZE_RESTORED = 0;
+    public const int SIZE_MAXIMIZED = 2;
+
     public static IntPtr CreateBackgroundBrush(uint colorRef)
     {
         return CreateSolidBrush(colorRef);

--- a/src/Brmble.Web/src/App.css
+++ b/src/Brmble.Web/src/App.css
@@ -38,6 +38,10 @@
   overflow: hidden;
 }
 
+.app--onboarding .sidebar-resize-handle {
+  display: none;
+}
+
 .app--maximized {
   padding: 6px;
 }

--- a/src/Brmble.Web/src/App.css
+++ b/src/Brmble.Web/src/App.css
@@ -42,10 +42,6 @@
   display: none;
 }
 
-.app--maximized {
-  padding: 6px;
-}
-
 .sidebar-placeholder {
   text-align: center;
   padding: 2rem;

--- a/src/Brmble.Web/src/App.css
+++ b/src/Brmble.Web/src/App.css
@@ -34,6 +34,10 @@
   align-items: center;
 }
 
+.app--onboarding .sidebar {
+  overflow: hidden;
+}
+
 .sidebar-placeholder {
   text-align: center;
   padding: 2rem;

--- a/src/Brmble.Web/src/App.css
+++ b/src/Brmble.Web/src/App.css
@@ -38,6 +38,10 @@
   overflow: hidden;
 }
 
+.app--maximized {
+  padding: 6px;
+}
+
 .sidebar-placeholder {
   text-align: center;
   padding: 2rem;

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2139,7 +2139,7 @@ const handleConnect = (serverData: SavedServer) => {
   }, [dmStore.selectedContact, unreadTracker.roomUnreads, matrixClient.client, unreadTracker, matrixClient?.dmRoomMap]);
 
   return (
-    <div className={`app${showOnboarding ? ' app--onboarding' : ''}${isMaximized ? ' app--maximized' : ''}`}>
+    <div className={`app${showOnboarding ? ' app--onboarding' : ''}`}>
       <ProfileProvider value={certFingerprint}>
       <ErrorBoundary label="Header">
       <Header

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -166,6 +166,7 @@ function App() {
   // Stays true for the entire onboarding flow so the wizard isn't unmounted
   // when certExists flips to true mid-wizard (e.g. after profile activation).
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const [isMaximized, setIsMaximized] = useState(false);
   const [certFingerprint, setCertFingerprint] = useState('');
   const [activeProfileName, setActiveProfileName] = useState('');
   const [profiles, setProfiles] = useState<Array<{ id: string; name: string }>>([]);
@@ -219,6 +220,15 @@ function App() {
   useEffect(() => {
     if (!connected) setShowAvatarEditor(false);
   }, [connected]);
+
+  useEffect(() => {
+    const handleWindowState = (data: { maximized?: boolean }) => {
+      setIsMaximized(data.maximized === true);
+    };
+    bridge.on('window.stateChanged', handleWindowState);
+    return () => bridge.off('window.stateChanged', handleWindowState);
+  }, []);
+
   const [showCloseDialog, setShowCloseDialog] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
   const [hasPendingInvite] = useState(false);
@@ -2129,7 +2139,7 @@ const handleConnect = (serverData: SavedServer) => {
   }, [dmStore.selectedContact, unreadTracker.roomUnreads, matrixClient.client, unreadTracker, matrixClient?.dmRoomMap]);
 
   return (
-    <div className={`app${showOnboarding ? ' app--onboarding' : ''}`}>
+    <div className={`app${showOnboarding ? ' app--onboarding' : ''}${isMaximized ? ' app--maximized' : ''}`}>
       <ProfileProvider value={certFingerprint}>
       <ErrorBoundary label="Header">
       <Header

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2299,7 +2299,7 @@ const handleConnect = (serverData: SavedServer) => {
               setBrmblegotchiEnabledState(parsed.brmblegotchi?.enabled ?? false);
             }
           } catch { /* ignore */ }
-        }} onServersImported={handleServersImported} />
+        }} onServersImported={handleServersImported} isMaximized={isMaximized} />
       )}
 
       <SettingsModal

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -222,8 +222,8 @@ function App() {
   }, [connected]);
 
   useEffect(() => {
-    const handleWindowState = (data: { maximized?: boolean }) => {
-      setIsMaximized(data.maximized === true);
+    const handleWindowState = (data: unknown) => {
+      setIsMaximized((data as { maximized?: boolean }).maximized === true);
     };
     bridge.on('window.stateChanged', handleWindowState);
     return () => bridge.off('window.stateChanged', handleWindowState);
@@ -2170,6 +2170,7 @@ const handleConnect = (serverData: SavedServer) => {
         muteOnCooldown={muteOnCooldown}
         deafOnCooldown={deafOnCooldown}
         onToggleGame={() => setShowGame(prev => !prev)}
+        isMaximized={isMaximized}
       />
       </ErrorBoundary>
       

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2129,7 +2129,7 @@ const handleConnect = (serverData: SavedServer) => {
   }, [dmStore.selectedContact, unreadTracker.roomUnreads, matrixClient.client, unreadTracker, matrixClient?.dmRoomMap]);
 
   return (
-    <div className="app">
+    <div className={`app${showOnboarding ? ' app--onboarding' : ''}`}>
       <ProfileProvider value={certFingerprint}>
       <ErrorBoundary label="Header">
       <Header

--- a/src/Brmble.Web/src/components/Header/Header.tsx
+++ b/src/Brmble.Web/src/components/Header/Header.tsx
@@ -32,9 +32,10 @@ interface HeaderProps {
   leaveVoiceOnCooldown?: boolean;
   muteOnCooldown?: boolean;
   deafOnCooldown?: boolean;
+  isMaximized?: boolean;
 }
 
-export function Header({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onOpenAudioSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, onToggleGame, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown }: HeaderProps) {
+export function Header({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onOpenAudioSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, onToggleGame, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown, isMaximized }: HeaderProps) {
   return (
     <header className="header">
       <div className="header-left">
@@ -77,8 +78,8 @@ export function Header({ username, onToggleDM, dmActive, unreadDMCount, onOpenSe
         <button className="window-btn window-btn-minimize" onClick={() => bridge.send('window.minimize')} aria-label="Minimize">
           <Icon name="window-minimize" size={10} />
         </button>
-        <button className="window-btn window-btn-maximize" onClick={() => bridge.send('window.maximize')} aria-label="Maximize">
-          <Icon name="window-maximize" size={10} />
+        <button className="window-btn window-btn-maximize" onClick={() => bridge.send('window.maximize')} aria-label={isMaximized ? 'Restore' : 'Maximize'}>
+          <Icon name={isMaximized ? 'window-restore' : 'window-maximize'} size={10} />
         </button>
         <button className="window-btn window-btn-close" onClick={() => bridge.send('window.close')} aria-label="Close">
           <Icon name="window-close" size={10} />

--- a/src/Brmble.Web/src/components/Icon/Icon.tsx
+++ b/src/Brmble.Web/src/components/Icon/Icon.tsx
@@ -364,6 +364,15 @@ const iconPaths: Record<string, IconDef> = {
     viewBox: '0 0 10 10',
     paths: <rect x="0.5" y="0.5" width="9" height="9" fill="none" stroke="currentColor" strokeWidth="1" />,
   },
+  'window-restore': {
+    viewBox: '0 0 10 10',
+    paths: (
+      <>
+        <rect x="2.5" y="0.5" width="7" height="7" fill="none" stroke="currentColor" strokeWidth="1" />
+        <rect x="0.5" y="2.5" width="7" height="7" fill="var(--bg-deep, #0f0a14)" stroke="currentColor" strokeWidth="1" />
+      </>
+    ),
+  },
   'window-close': {
     viewBox: '0 0 10 10',
     paths: (

--- a/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -93,6 +93,7 @@ interface ScannedCert {
 interface OnboardingWizardProps {
   onComplete: (fingerprint: string) => void;
   onServersImported?: (labels: string[]) => void;
+  isMaximized?: boolean;
 }
 
 // ── Settings types (local copies to avoid SettingsModal coupling) ──
@@ -169,7 +170,7 @@ function triggerBlobDownload(base64: string, filename: string) {
 
 // ── Main component ────────────────────────────────────────────────
 
-export function OnboardingWizard({ onComplete, onServersImported }: OnboardingWizardProps) {
+export function OnboardingWizard({ onComplete, onServersImported, isMaximized }: OnboardingWizardProps) {
   const [step, setStep] = useState<WizardStep>('welcome');
   const stepIndex = STEPS.indexOf(step);
 
@@ -538,8 +539,8 @@ export function OnboardingWizard({ onComplete, onServersImported }: OnboardingWi
           <button className="window-btn window-btn-minimize" onClick={() => bridge.send('window.minimize')} aria-label="Minimize">
             <Icon name="window-minimize" size={10} />
           </button>
-          <button className="window-btn window-btn-maximize" onClick={() => bridge.send('window.maximize')} aria-label="Maximize">
-            <Icon name="window-maximize" size={10} />
+          <button className="window-btn window-btn-maximize" onClick={() => bridge.send('window.maximize')} aria-label={isMaximized ? 'Restore' : 'Maximize'}>
+            <Icon name={isMaximized ? 'window-restore' : 'window-maximize'} size={10} />
           </button>
           <button className="window-btn window-btn-close" onClick={() => bridge.send('window.quit')} aria-label="Close">
             <Icon name="window-close" size={10} />

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.css
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.css
@@ -1,5 +1,5 @@
 .settings-modal {
-  min-width: 600px;
+  min-width: min(600px, 90vw);
   max-width: 90vw;
   height: 80vh;
   display: flex;

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.css
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.css
@@ -1,6 +1,6 @@
 .settings-modal {
-  width: 100%;
-  max-width: 600px;
+  min-width: 600px;
+  max-width: 90vw;
   height: 80vh;
   display: flex;
   flex-direction: column;
@@ -17,6 +17,13 @@
   gap: var(--space-2xs);
   padding: 0 var(--space-lg);
   border-bottom: 1px solid var(--border-subtle);
+  white-space: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.settings-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .settings-tab {
@@ -50,7 +57,10 @@
 .settings-content {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 0 var(--space-lg);
+  overflow-wrap: break-word;
+  min-width: 0;
 }
 
 /* Shared entrance animation for all tab pages */

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef, useLayoutEffect } from 'react';
 import './SettingsModal.css';
 import bridge from '../../bridge';
 import { applyTheme } from '../../themes/theme-loader';
@@ -100,6 +100,16 @@ export function SettingsModal(props: SettingsModalProps) {
   const { servers } = useServerlist();
   const { hasPermission } = usePermissions();
   const hasAdminPermission = hasPermission(0, Permission.Ban) || hasPermission(0, Permission.Kick);
+
+  const tabsRef = useRef<HTMLDivElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!isOpen || !tabsRef.current || !modalRef.current) return;
+    const tabsWidth = tabsRef.current.scrollWidth;
+    const modalWidth = Math.min(Math.max(tabsWidth, 600), window.innerWidth * 0.9);
+    modalRef.current.style.width = `${modalWidth}px`;
+  }, [isOpen, hasAdminPermission]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -363,13 +373,13 @@ export function SettingsModal(props: SettingsModalProps) {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="settings-modal glass-panel animate-slide-up" onClick={(e) => e.stopPropagation()}>
+      <div ref={modalRef} className="settings-modal glass-panel animate-slide-up" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2 className="heading-title modal-title">Settings</h2>
           <p className="modal-subtitle">Configure your preferences</p>
         </div>
 
-        <div className="settings-tabs">
+        <div ref={tabsRef} className="settings-tabs">
           <button
             className={`settings-tab ${activeTab === 'profile' ? 'active' : ''}`}
             onClick={() => setActiveTab('profile')}

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -105,10 +105,21 @@ export function SettingsModal(props: SettingsModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
-    if (!isOpen || !tabsRef.current || !modalRef.current) return;
-    const tabsWidth = tabsRef.current.scrollWidth;
-    const modalWidth = Math.min(Math.max(tabsWidth, 600), window.innerWidth * 0.9);
-    modalRef.current.style.width = `${modalWidth}px`;
+    if (!isOpen) return;
+
+    const updateModalWidth = () => {
+      if (!tabsRef.current || !modalRef.current) return;
+      const tabsWidth = tabsRef.current.scrollWidth;
+      const modalWidth = Math.min(Math.max(tabsWidth, 600), window.innerWidth * 0.9);
+      modalRef.current.style.width = `${modalWidth}px`;
+    };
+
+    updateModalWidth();
+    window.addEventListener('resize', updateModalWidth);
+
+    return () => {
+      window.removeEventListener('resize', updateModalWidth);
+    };
   }, [isOpen, hasAdminPermission]);
 
   useEffect(() => {

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.css
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.css
@@ -299,12 +299,12 @@
   right: 0;
   bottom: 0;
   width: 2px;
-  background: transparent;
+  background: var(--border-subtle);
   transition: background var(--transition-fast);
 }
 
 .sidebar-resize-handle:hover::after {
-  background: var(--border-subtle);
+  background: var(--accent-primary);
 }
 
 .sidebar-resize-handle--active::after {


### PR DESCRIPTION
## Summary

- Sidebar resize handle -- visible at rest, accent on hover/active; hidden during onboarding wizard
- Onboarding scrollbar -- hidden via .app--onboarding class toggle
- Native border color -- dynamically updates GDI background brush on theme change via SetClassLongPtr
- Maximized spacing -- WebView2 bounds always inset by 6px so native background shows through uniformly
- Maximize/restore icon -- toggles based on window state in both main Header and onboarding titlebar
- Settings modal width -- auto-sizes to fit visible tabs; tab bar scrolls on overflow

## Issues

Closes #381
Closes #409

## Testing

- Switch themes -- border color matches --bg-deep seamlessly
- Maximize/restore -- 6px spacing maintained, icon toggles correctly
- Onboarding -- no sidebar scrollbar or resize handle visible
- Settings modal -- width adapts to tab count, stable when switching tabs
- Small window/high zoom -- settings tabs scroll horizontally

## Notes

- 1 pre-existing test failure (Encrypt_ReturnsDpapiPrefixedBase64) unrelated to this PR
- All other tests pass (191/192)