### PR TITLE
fix: reduce voice transmission choppiness (WASAPI latency + audio thread optimizations)

### DIFF
--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -519,7 +519,7 @@ private int _screenShareHotkeyId = -1;
                 {
                     using var enumerator = new MMDeviceEnumerator();
                     using var device = enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
-                    var wasapi = new WasapiCapture(device, true, 60)
+                    var wasapi = new WasapiCapture(device, true, 20)
                     {
                         ShareMode = AudioClientShareMode.Shared
                     };

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -22,20 +22,55 @@ internal static class AudioLog
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "Brmble", "audio.log");
 
+    private static readonly System.Collections.Concurrent.ConcurrentQueue<string> _queue = new();
+    private static readonly Thread _flushThread;
+    private static readonly System.Threading.ManualResetEventSlim _signal = new(false);
+
     static AudioLog()
     {
         var dir = Path.GetDirectoryName(LogPath);
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             Directory.CreateDirectory(dir);
+
+        _flushThread = new Thread(FlushLoop)
+        {
+            IsBackground = true,
+            Name = "AudioLog-Flush",
+            Priority = ThreadPriority.BelowNormal
+        };
+        _flushThread.Start();
     }
 
     public static void Write(string msg)
     {
-        try
+        _queue.Enqueue($"[{DateTime.Now:HH:mm:ss.fff}] {msg}");
+        _signal.Set();
+    }
+
+    private static void FlushLoop()
+    {
+        var sb = new System.Text.StringBuilder();
+        while (true)
         {
-            File.AppendAllText(LogPath, $"[{DateTime.Now:HH:mm:ss.fff}] {msg}\n");
+            _signal.Wait();
+            _signal.Reset();
+
+            // Drain the queue into a single batch write
+            sb.Clear();
+            while (_queue.TryDequeue(out var line))
+            {
+                sb.AppendLine(line);
+            }
+
+            if (sb.Length > 0)
+            {
+                try
+                {
+                    File.AppendAllText(LogPath, sb.ToString());
+                }
+                catch { }
+            }
         }
-        catch { }
     }
 }
 
@@ -664,9 +699,18 @@ private int _screenShareHotkeyId = -1;
     [ThreadStatic] private static float[]? _wasapiMonoScratch;
     [ThreadStatic] private static byte[]? _wasapiInt16Scratch;
     [ThreadStatic] private static double[]? _resampleDoubleScratch;
+    [ThreadStatic] private static bool _threadPriorityBoosted;
 
     private void OnMicData(object? sender, WaveInEventArgs e)
     {
+        // Boost audio capture thread priority on first callback
+        if (!_threadPriorityBoosted)
+        {
+            _threadPriorityBoosted = true;
+            try { Thread.CurrentThread.Priority = ThreadPriority.Highest; }
+            catch { }
+        }
+
         byte[] processedBuffer = e.Buffer;
         int processedBytes = e.BytesRecorded;
         

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -18,13 +18,16 @@ public enum TransmissionMode { Continuous, VoiceActivity, PushToTalk }
 
 internal static class AudioLog
 {
+    private const int MaxQueueSize = 10000;
+
     private static readonly string LogPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "Brmble", "audio.log");
 
     private static readonly System.Collections.Concurrent.ConcurrentQueue<string> _queue = new();
     private static readonly Thread _flushThread;
-    private static readonly System.Threading.ManualResetEventSlim _signal = new(false);
+    private static readonly ManualResetEvent _signal = new(false);
+    private static volatile bool _shutdown;
 
     static AudioLog()
     {
@@ -43,19 +46,32 @@ internal static class AudioLog
 
     public static void Write(string msg)
     {
+        if (_queue.Count >= MaxQueueSize) return;
         _queue.Enqueue($"[{DateTime.Now:HH:mm:ss.fff}] {msg}");
         _signal.Set();
+    }
+
+    public static void Flush()
+    {
+        _shutdown = true;
+        _signal.Set();
+        _flushThread.Join(1000);
+        _shutdown = false;
     }
 
     private static void FlushLoop()
     {
         var sb = new System.Text.StringBuilder();
-        while (true)
+        while (!_shutdown || _queue.Count > 0)
         {
-            _signal.Wait();
+            _signal.WaitOne();
+            if (_shutdown)
+            {
+                DrainQueue(sb);
+                break;
+            }
             _signal.Reset();
 
-            // Drain the queue into a single batch write
             sb.Clear();
             while (_queue.TryDequeue(out var line))
             {
@@ -70,6 +86,23 @@ internal static class AudioLog
                 }
                 catch { }
             }
+        }
+    }
+
+    private static void DrainQueue(System.Text.StringBuilder sb)
+    {
+        sb.Clear();
+        while (_queue.TryDequeue(out var line))
+        {
+            sb.AppendLine(line);
+        }
+        if (sb.Length > 0)
+        {
+            try
+            {
+                File.AppendAllText(LogPath, sb.ToString());
+            }
+            catch { }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes choppy voice transmission caused by audio packets being sent in ~60ms bursts instead of steady 10-20ms intervals. This resulted in buffer underruns on the receiving side and audible stuttering compared to the official Mumble client.

## Root Cause

Three issues in `AudioManager.cs` combined to produce bursty packet transmission:

1. **High WASAPI capture latency (60ms)** — `WasapiCapture` buffered 60ms of audio before firing `DataAvailable`, batching 6 Opus frames per callback
2. **Blocking disk I/O on the audio thread** — `AudioLog.Write()` called `File.AppendAllText()` synchronously inside `OnMicData`, introducing timing jitter
3. **Default thread priority** — The audio capture thread ran at normal priority, making it susceptible to scheduling delays

## Changes

### 1. Reduce WASAPI capture latency (60ms to 20ms)
**`src/Brmble.Client/Services/Voice/AudioManager.cs`** — `StartMic()`

Changed `new WasapiCapture(device, true, 60)` to `new WasapiCapture(device, true, 20)`. This causes the `DataAvailable` event to fire every ~20ms instead of ~60ms, producing a much steadier stream of 1-2 Opus frames per callback instead of 6.

### 2. Non-blocking AudioLog
**`src/Brmble.Client/Services/Voice/AudioManager.cs`** — `AudioLog` class

Replaced synchronous `File.AppendAllText()` with a lock-free `ConcurrentQueue<string>` + dedicated background flush thread:
- `Write()` now only enqueues a string and signals a `ManualResetEventSlim` — zero disk I/O on the audio thread
- A low-priority background thread (`AudioLog-Flush`) drains the queue in batches and writes to disk
- This eliminates all disk I/O jitter from the audio hot path

### 3. Audio thread priority boost
**`src/Brmble.Client/Services/Voice/AudioManager.cs`** — `OnMicData()`

On the first `OnMicData` callback, the capture thread's priority is set to `ThreadPriority.Highest`. This reduces scheduling latency and ensures audio processing isn't preempted by lower-priority work.

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Packet interval | ~60ms bursts | ~20ms steady |
| Frames per burst | 6 | 1-2 |
| Disk I/O on audio thread | Synchronous (per callback) | None |
| Audio thread priority | Normal | Highest |

## Testing

- [ ] Voice transmission sounds smooth (no choppy/stuttering audio)
- [ ] Audio packets sent at steady ~20ms intervals (check `audio.log` timestamps)
- [ ] No regressions in PTT, VAD, or continuous transmission modes
- [ ] `audio.log` still written correctly (verify log file is populated)
- [ ] No increased CPU usage from the background log flush thread

## Commits

- `90bfe80` — fix: reduce WASAPI capture latency from 60ms to 20ms
- `122c45c` — fix: make AudioLog non-blocking and boost audio thread priority
