### PR TITLE
chore: gitignore .playwright-mcp/ session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -502,3 +502,6 @@ $RECYCLE.BIN/
 src/Brmble.Server/generated/
 src/.github/
 .github/pr-version.json
+
+# Playwright MCP session artifacts (generated on every browser run)
+.playwright-mcp/


### PR DESCRIPTION
## Summary

- Adds `.playwright-mcp/` to `.gitignore` so Playwright MCP's per-session console/page artifacts don't accumulate in the working tree or sneak into future PRs.

Flagged by Codex review as P3 on a previous PR diff.

## Test plan

- [ ] Run a Playwright MCP session, confirm the `.playwright-mcp/` folder it regenerates is not reported by `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)