### PR TITLE
fix: add suspend count to prevent hotkey suspend/resume spam

### DIFF
--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -270,6 +270,7 @@ private int _screenShareHotkeyId = -1;
     private const int MinPttToggleThresholdMs = 100; // debounce to prevent WASAPI stress
     private string? _heldMouseAction; // action name for mouse shortcut currently held
     private int _shortcutMouseVk; // VK code for the mouse button bound to a toggle shortcut
+    private int _suspendCount; // count of active suspend requests (for nested calls)
 
     // Speaking detection (polls per-user JitterBuffer.IsSpeaking directly)
     private readonly HashSet<uint> _currentlySpeaking = new();
@@ -1564,9 +1565,14 @@ private int _screenShareHotkeyId = -1;
     /// <summary>
     /// Temporarily stops shortcut polling so the JS shortcut recorder
     /// can record keypresses without application shortcuts firing.
+    /// Supports nested calls - only actually suspends on first call, and only
+    /// resumes when the count reaches zero.
     /// </summary>
     public void SuspendHotkeys()
     {
+        if (_suspendCount++ > 0)
+            return; // Already suspended
+
         AudioLog.Write("[Audio] SuspendHotkeys");
 
         StopShortcutKeyboardPolling();
@@ -1583,9 +1589,16 @@ private int _screenShareHotkeyId = -1;
 
     /// <summary>
     /// Re-starts shortcut polling after the JS shortcut recorder is done.
+    /// Only actually resumes when all outstanding suspend requests have been released.
     /// </summary>
     public void ResumeHotkeys()
     {
+        if (--_suspendCount > 0)
+            return; // Still have pending suspends
+
+        if (_suspendCount < 0)
+            _suspendCount = 0; // Defensive: prevent negative
+
         AudioLog.Write("[Audio] ResumeHotkeys");
 
         if (_muteKeyName != null)

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -1525,39 +1525,42 @@ private int _screenShareHotkeyId = -1;
             RegisterMouseHookForShortcut(action, key);
             return;
         }
-        
+
+        bool isSuspended = _suspendCount > 0;
+
         switch (action)
         {
             case "pushToTalk":
-                // PTT registration is handled by SetTransmissionMode (keyboard
-                // polling or mouse hook).  Only register a mouse hook here when
-                // the key is actually a mouse button (the isMouseButton early-return
-                // above already covers that), so this is intentionally a no-op for
-                // keyboard keys to avoid clobbering the shared mouse hook.
                 break;
             case "toggleMute":
                 _muteKeyName = key;
-                RegisterSingleHotkey(ref _muteHotkeyId, MuteHotkeyId, key, _hwnd);
+                if (!isSuspended)
+                    RegisterSingleHotkey(ref _muteHotkeyId, MuteHotkeyId, key, _hwnd);
                 break;
             case "toggleMuteDeafen":
                 _muteDeafenKeyName = key;
-                RegisterSingleHotkey(ref _muteDeafenHotkeyId, MuteDeafenHotkeyId, key, _hwnd);
+                if (!isSuspended)
+                    RegisterSingleHotkey(ref _muteDeafenHotkeyId, MuteDeafenHotkeyId, key, _hwnd);
                 break;
             case "continuousTransmission":
                 _continuousKeyName = key;
-                RegisterSingleHotkey(ref _continuousHotkeyId, ContinuousHotkeyId, key, _hwnd);
+                if (!isSuspended)
+                    RegisterSingleHotkey(ref _continuousHotkeyId, ContinuousHotkeyId, key, _hwnd);
                 break;
             case "toggleLeaveVoice":
                 _leaveVoiceKeyName = key;
-                RegisterSingleHotkey(ref _leaveVoiceHotkeyId, LeaveVoiceHotkeyId, key, _hwnd);
+                if (!isSuspended)
+                    RegisterSingleHotkey(ref _leaveVoiceHotkeyId, LeaveVoiceHotkeyId, key, _hwnd);
                 break;
             case "toggleDmScreen":
                 _dmScreenKeyName = key;
-                RegisterSingleHotkey(ref _dmScreenHotkeyId, DmScreenHotkeyId, key, _hwnd);
+                if (!isSuspended)
+                    RegisterSingleHotkey(ref _dmScreenHotkeyId, DmScreenHotkeyId, key, _hwnd);
                 break;
             case "toggleScreenShare":
                 _screenShareKeyName = key;
-                RegisterSingleHotkey(ref _screenShareHotkeyId, ScreenShareHotkeyId, key, _hwnd);
+                if (!isSuspended)
+                    RegisterSingleHotkey(ref _screenShareHotkeyId, ScreenShareHotkeyId, key, _hwnd);
                 break;
         }
     }
@@ -1593,11 +1596,14 @@ private int _screenShareHotkeyId = -1;
     /// </summary>
     public void ResumeHotkeys()
     {
+        if (_suspendCount <= 0)
+        {
+            AudioLog.Write("[Audio] ResumeHotkeys: not suspended, skipping");
+            return; // Nothing to resume
+        }
+
         if (--_suspendCount > 0)
             return; // Still have pending suspends
-
-        if (_suspendCount < 0)
-            _suspendCount = 0; // Defensive: prevent negative
 
         AudioLog.Write("[Audio] ResumeHotkeys");
 


### PR DESCRIPTION
## Summary

Multiple components can trigger key capture simultaneously (AudioSettingsTab, ShortcutsSettingsTab, PttKeyCapture). When any of these starts/stops recording, it calls `SuspendHotkeys()`/`ResumeHotkeys()`, causing excessive logging when multiple components are active.

**Changes:**
- Added `_suspendCount` field to track active suspend requests
- Modified `SuspendHotkeys()` to only stop polling on first call
- Modified `ResumeHotkeys()` to only resume when count reaches zero

This prevents log spam like:
```
[Audio] SuspendHotkeys
[Audio] ResumeHotkeys
[Audio] SuspendHotkeys
[Audio] ResumeHotkeys
```