### PR TITLE
fix: preserve line breaks in pasted/multi-line messages

### DIFF
--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
@@ -54,6 +54,10 @@
   word-wrap: break-word;
 }
 
+p.message-text {
+  white-space: pre-wrap;
+}
+
 .message-text a {
   color: var(--accent-primary);
   text-decoration: underline;


### PR DESCRIPTION
Closes #448

## Summary
- Add `white-space: pre-wrap` to `p.message-text` so `\n` in plain-text message bodies renders as line breaks instead of collapsing to spaces.
- Scoped to `p` so the HTML-rendered path (`<div class="message-text">` with `dangerouslySetInnerHTML` for Matrix `formatted_body`) is unaffected — otherwise whitespace between tags in the raw HTML would surface as blank lines.

## Root cause
The non-reply send path (`useMatrixClient.ts:446`) sends `{ msgtype, body }` without a `formatted_body`. The receiving render path uses `<p className="message-text">{...}</p>`, and the CSS lacked `white-space: pre-wrap`, so newlines collapsed. The reply path was unaffected because it sends HTML with `<br>`.

## Test plan
- [ ] Paste multi-line text into a channel message and send — verify line breaks render
- [ ] Paste multi-line text into a DM and send — verify line breaks render
- [ ] Send a reply containing multi-line text — verify line breaks still render (HTML path)
- [ ] Verify messages received from other Matrix clients (formatted HTML) do not gain spurious blank lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)