### PR TITLE
Display packet loss in sidebar

### DIFF
--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -1192,8 +1192,8 @@ private int _screenShareHotkeyId = -1;
                 ArrivalTimeMs: (long)Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds
             );
 
-            // Diagnostic logging — first 50 packets per user + every 100th
-            if (sequence < 50 || sequence % 100 == 0)
+            // Diagnostic logging — first 50 packets + every 50th after (~1 second intervals)
+            if (sequence < 50 || sequence % 50 == 0)
                 AudioLog.Write($"[JB] user={userId} seq={sequence} ts={packet.Timestamp} bufCount={jb.GetStats().BufferLevel} payloadLen={opusData.Length}");
 
             jb.InsertPacket(packet);

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -301,6 +301,20 @@ private int _screenShareHotkeyId = -1;
     private ProcessingStack _processingStack = ProcessingStack.Legacy;
     [ThreadStatic] private static byte[]? _processorOutputScratch;
 
+    // Packet loss tracking per user (EMA smoothing to prevent UI jitter)
+    private double _smoothedLoss = -1; // -1 means 'no data'
+    private readonly Dictionary<uint, PerUserLoss> _userLossTrackers = new();
+    private int _totalReceived;
+    private int _totalLost;
+    public event Action<int?>? OnLossReport;
+
+    private class PerUserLoss
+    {
+        public long LastSequence = -1;
+        public int Received;
+        public int Lost;
+    }
+
     private SpeechEnhancementService? _speechEnhancement;
     private AudioResampler? _to16kResampler;
     private AudioResampler? _to48kResampler;
@@ -348,6 +362,19 @@ private int _screenShareHotkeyId = -1;
         _encodePipeline?.SetVolume(_inputVolume);
     }
     public void SetVoiceHoldMs(int ms) => _voiceHoldMs = Math.Clamp(ms, 100, 2000);
+
+    public void ReportLoss(int rawLoss)
+    {
+        int clamped = Math.Clamp(rawLoss, 0, 100);
+        _smoothedLoss = _smoothedLoss < 0 ? clamped : (_smoothedLoss * 0.8) + (clamped * 0.2);
+        OnLossReport?.Invoke((int)Math.Round(_smoothedLoss));
+    }
+
+    public void ResetLossStats()
+    {
+        _smoothedLoss = -1;
+        OnLossReport?.Invoke(null);
+    }
 
     // Allowed Opus bitrates (bps). Must match the UI options in AudioSettingsTab.tsx.
     private static readonly int[] AllowedBitrates = { 24000, 40000, 56000, 72000, 96000, 128000 };
@@ -1102,6 +1129,37 @@ private int _screenShareHotkeyId = -1;
         {
             if (_localMutes.Contains(userId)) return;
 
+            if (!_userLossTrackers.TryGetValue(userId, out var loss))
+            {
+                loss = new PerUserLoss();
+                _userLossTrackers[userId] = loss;
+            }
+            if (sequence < loss.LastSequence)
+            {
+                loss.LastSequence = -1;
+                loss.Received = 0;
+                loss.Lost = 0;
+            }
+            if (loss.LastSequence >= 0 && sequence > loss.LastSequence)
+            {
+                long gap = sequence - loss.LastSequence - 2;
+                if (gap > 50)
+                {
+                    AudioLog.Write($"[Loss] Large gap ({gap}), treating as new stream for user {userId}");
+                    loss.LastSequence = -1;
+                    loss.Received = 0;
+                    loss.Lost = 0;
+                }
+                else if (gap > 0)
+                {
+                    loss.Lost += (int)gap;
+                    _totalLost += (int)gap;
+                }
+            }
+            loss.LastSequence = sequence;
+            loss.Received++;
+            _totalReceived++;
+
             if (!_jitterBuffers.TryGetValue(userId, out var jb))
             {
                 // First packet from this user — create JitterBuffer + WaveOutEvent
@@ -1134,11 +1192,20 @@ private int _screenShareHotkeyId = -1;
                 ArrivalTimeMs: (long)Stopwatch.GetElapsedTime(_startTimestamp).TotalMilliseconds
             );
 
-            // Diagnostic logging — first 30 packets per user + every 100th
-            if (sequence < 30 || sequence % 100 == 0)
+            // Diagnostic logging — first 50 packets per user + every 100th
+            if (sequence < 50 || sequence % 100 == 0)
                 AudioLog.Write($"[JB] user={userId} seq={sequence} ts={packet.Timestamp} bufCount={jb.GetStats().BufferLevel} payloadLen={opusData.Length}");
 
             jb.InsertPacket(packet);
+        }
+
+        // Report packet loss roughly every 50 packets (~1 second of audio)
+        if (_totalReceived > 0 && _totalReceived % 50 == 0)
+        {
+            int total = _totalReceived + _totalLost;
+            int loss = total > 0 ? (int)((double)_totalLost / total * 100) : 0;
+            AudioLog.Write($"[Loss] reporting: lost={_totalLost}, received={_totalReceived}, total={total}, loss={loss}%");
+            ReportLoss(loss);
         }
     }
 

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -311,8 +311,8 @@ private int _screenShareHotkeyId = -1;
     private class PerUserLoss
     {
         public long LastSequence = -1;
-        public int Received;
-        public int Lost;
+        public int ReceivedUnits;
+        public int LostUnits;
     }
 
     private SpeechEnhancementService? _speechEnhancement;
@@ -1137,8 +1137,8 @@ private int _screenShareHotkeyId = -1;
             if (sequence < loss.LastSequence)
             {
                 loss.LastSequence = -1;
-                loss.Received = 0;
-                loss.Lost = 0;
+                loss.ReceivedUnits = 0;
+                loss.LostUnits = 0;
             }
             if (loss.LastSequence >= 0 && sequence > loss.LastSequence)
             {
@@ -1147,18 +1147,18 @@ private int _screenShareHotkeyId = -1;
                 {
                     AudioLog.Write($"[Loss] Large gap ({gap}), treating as new stream for user {userId}");
                     loss.LastSequence = -1;
-                    loss.Received = 0;
-                    loss.Lost = 0;
+                    loss.ReceivedUnits = 0;
+                    loss.LostUnits = 0;
                 }
                 else if (gap > 0)
                 {
-                    loss.Lost += (int)gap;
+                    loss.LostUnits += (int)gap;
                     _totalLost += (int)gap;
                 }
             }
             loss.LastSequence = sequence;
-            loss.Received++;
-            _totalReceived++;
+            loss.ReceivedUnits += 2;
+            _totalReceived += 2;
 
             if (!_jitterBuffers.TryGetValue(userId, out var jb))
             {
@@ -1222,6 +1222,7 @@ private int _screenShareHotkeyId = -1;
             }
             if (_jitterBuffers.Remove(userId, out var jb))
                 jb.Dispose();
+            _userLossTrackers.Remove(userId);
             wasSpeaking = _currentlySpeaking.Remove(userId);
         }
         if (wasSpeaking)
@@ -2134,6 +2135,10 @@ private int _screenShareHotkeyId = -1;
                 jb.Dispose();
             _players.Clear();
             _jitterBuffers.Clear();
+            _userLossTrackers.Clear();
+            _totalReceived = 0;
+            _totalLost = 0;
+            _smoothedLoss = -1;
         }
     }
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -219,6 +219,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 var pttKey = newMode == TransmissionMode.PushToTalk ? _currentPttKey : null;
                 _audioManager.SetTransmissionMode(newMode, pttKey, _hwnd);
             };
+            _audioManager.OnLossReport += loss => {
+                _bridge?.Send("voice.loss", new { loss });
+            };
         }
 
         try

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -140,6 +140,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             var pttKey = newMode == TransmissionMode.PushToTalk ? _currentPttKey : null;
             _audioManager.SetTransmissionMode(newMode, pttKey, _hwnd);
         };
+        _audioManager.OnLossReport += loss => {
+            _bridge?.Send("voice.loss", new { loss });
+        };
     }
 
     public void Initialize(NativeBridge bridge) { }

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1304,6 +1304,10 @@ function App() {
     bridge.on('voice.brmbleClientActivated', onBrmbleClientActivated);
     bridge.on('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
     bridge.on('voice.registrationStatus', onRegistrationStatus);
+    bridge.on('voice.loss', (data: unknown) => {
+      const { loss } = data as { loss: number };
+      updateStatus('voice', { loss });
+    });
 
     const onUpdateAvailable = (data: unknown) => {
       setUpdateInfo(data as { version: string });

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1304,10 +1304,12 @@ function App() {
     bridge.on('voice.brmbleClientActivated', onBrmbleClientActivated);
     bridge.on('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
     bridge.on('voice.registrationStatus', onRegistrationStatus);
-    bridge.on('voice.loss', (data: unknown) => {
-      const { loss } = data as { loss: number };
+    const onVoiceLoss = (data: unknown) => {
+      const payload = data as { loss?: number } | null;
+      const loss = typeof payload?.loss === 'number' ? payload.loss : undefined;
       updateStatus('voice', { loss });
-    });
+    };
+    bridge.on('voice.loss', onVoiceLoss);
 
     const onUpdateAvailable = (data: unknown) => {
       setUpdateInfo(data as { version: string });
@@ -1337,6 +1339,7 @@ function App() {
       bridge.off('voice.userSpeaking', onVoiceUserSpeaking);
       bridge.off('voice.userSilent', onVoiceUserSilent);
       bridge.off('voice.userCommentChanged', onVoiceUserCommentChanged);
+      bridge.off('voice.loss', onVoiceLoss);
       bridge.off('voice.shortcutPressed', onShortcutPressed);
       bridge.off('voice.shortcutReleased', onShortcutReleased);
       bridge.off('voice.toggleDmScreen', onToggleDmScreen);

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -101,6 +101,10 @@ export function Sidebar({
     const name = SERVICE_DISPLAY_NAMES[svc];
     const state = stateLabel(statuses[svc].state);
     const error = statuses[svc].error;
+    if (svc === 'voice' && statuses[svc].state === 'connected' && typeof statuses[svc].loss === 'number') {
+      const quality = statuses[svc].loss < 2 ? ' (goed)' : statuses[svc].loss < 10 ? ' (matig)' : ' (slecht)';
+      return `${name}: ${state}\nPacket loss: ${statuses[svc].loss}%${quality}`;
+    }
     return error ? `${name}: ${state} — ${error}` : `${name}: ${state}`;
   };
 

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -102,7 +102,7 @@ export function Sidebar({
     const state = stateLabel(statuses[svc].state);
     const error = statuses[svc].error;
     if (svc === 'voice' && statuses[svc].state === 'connected' && typeof statuses[svc].loss === 'number') {
-      const quality = statuses[svc].loss < 2 ? ' (goed)' : statuses[svc].loss < 10 ? ' (matig)' : ' (slecht)';
+      const quality = statuses[svc].loss < 2 ? ' (good)' : statuses[svc].loss < 10 ? ' (fair)' : ' (poor)';
       return `${name}: ${state}\nPacket loss: ${statuses[svc].loss}%${quality}`;
     }
     return error ? `${name}: ${state} — ${error}` : `${name}: ${state}`;

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -68,6 +68,7 @@ export interface ServiceStatus {
   state: ServiceState;
   error?: string;
   label?: string;
+  loss?: number;
 }
 
 export type ServiceStatusMap = Record<ServiceName, ServiceStatus>;


### PR DESCRIPTION
## Summary

Displays real-time packet loss percentage in the sidebar service status tooltip when connected to a voice server. The packet loss is tracked per-user using sequence gap detection with EMA smoothing to prevent UI jitter.

## Changes

### Client (C#)

**`src/Brmble.Client/Services/Voice/AudioManager.cs`**
- Added `PerUserLoss` class to track packet loss per user session
- Added `ReportLoss()` with EMA smoothing (80% old / 20% new) to smooth UI jitter
- Added `ResetLossStats()` to reset on disconnect
- Added packet loss tracking in `FeedVoice()`:
  - Per-user sequence gap detection (gap > 2 = lost packet)
  - Large gap detection (> 50 packets) to handle PTT start/stop as new streams
  - Reports loss every ~50 packets (~1 second of audio)

**`src/Brmble.Client/Services/Voice/MumbleAdapter.cs`**
- Wired `_audioManager.OnLossReport` to bridge event `voice.loss`

### Frontend (TypeScript/React)

**`src/Brmble.Web/src/types/index.ts`**
- Added `loss?: number` to `ServiceStatus` interface

**`src/Brmble.Web/src/App.tsx`**
- Added `voice.loss` listener to update service status

**`src/Brmble.Web/src/components/Sidebar/Sidebar.tsx`**
- Updated tooltip to show packet loss when voice is connected
- Shows quality indicator: goed (<2%), matig (<10%), slecht (>=10%)

## Design Decisions

1. **EMA smoothing**: Prevents the tooltip from jumping wildly when network conditions fluctuate slightly
2. **Large gap handling**: PTT creates natural gaps (server stops sending when you're silent). Gap > 50 treats as new stream, not packet loss
3. **Per-user tracking**: Each user has their own sequence space - track loss separately per user
4. **Quality thresholds**: Dutch labels for quick visual assessment

## Testing

- [ ] Connect to voice server with another user speaking
- [ ] Verify tooltip shows packet loss percentage
- [ ] Stop and resume speaking - verify loss resets to 0%
- [ ] Simulate network issues to see loss increase

## Related

- Part of voice quality monitoring feature set