### PR TITLE
chore: reduce server log noise from YARP and Kestrel connections

### DIFF
--- a/src/Brmble.Server/appsettings.json
+++ b/src/Brmble.Server/appsettings.json
@@ -4,7 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.AspNetCore.Server.Kestrel": "Information",
-      "Microsoft.AspNetCore.Server.Kestrel.Connections": "Information",
+      "Microsoft.AspNetCore.Server.Kestrel.Connections": "Warning",
+      "Yarp": "Warning",
       "Brmble.Server.Middleware": "Information",
       "Brmble.Server.Auth": "Information"
     }


### PR DESCRIPTION
## Summary
- Bump `Yarp` log level to `Warning` so proxy forwarder info logs (emitted for every matrix/livekit request) no longer flood the output.
- Drop `Microsoft.AspNetCore.Server.Kestrel.Connections` to `Warning` to silence per-connection connect/disconnect chatter.
- `Brmble.*` categories stay at `Information` so application logs remain visible.

## Test plan
- [ ] Run the server and hit a `/_matrix/*` or `/livekit/*` endpoint; confirm no YARP info logs appear.
- [ ] Confirm Kestrel connection connect/disconnect lines no longer show up in normal traffic.
- [ ] Confirm Brmble middleware/auth logs still appear at Information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)