### PR TITLE
feat: Neon D localStorage persistence + themed confirm modal

### DIFF
--- a/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
+++ b/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useGameEngine } from './hooks/useGameEngine';
 import type { Dealer, DealerUpgrade } from './types';
 import { UNLOCK_COSTS, PRODUCT_TIERS, SLOT_UNLOCK_COSTS } from './constants';
+import { confirm } from '../../hooks/usePrompt';
 import styles from './NeonD.module.css';
 
 
@@ -397,8 +398,14 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                         </button>
                         <button
                           className={styles.dangerButton}
-                          onClick={() => {
-                            if (window.confirm(`Fire ${dealer.name}? All equipment upgrades will be lost forever.`)) {
+                          onClick={async () => {
+                            const confirmed = await confirm({
+                              title: 'Fire Dealer?',
+                              message: `Fire ${dealer.name}? All equipment upgrades will be lost forever.`,
+                              confirmLabel: 'Fire',
+                              cancelLabel: 'Cancel',
+                            });
+                            if (confirmed) {
                               fireDealer(slot.id);
                             }
                           }}

--- a/src/Brmble.Web/src/components/NeonD/hooks/__tests__/usePersistedGameState.test.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/__tests__/usePersistedGameState.test.ts
@@ -52,7 +52,7 @@ describe('usePersistedGameState', () => {
     expect(JSON.parse(localStorage.getItem('test_key') || '{}')).toEqual({ a: 55, nested: { b: 2, c: 3 } });
   });
 
-  it('clears localStorage and resets when clear function is called', () => {
+  it('clears localStorage when clear function is called', () => {
     localStorage.setItem('test_key', JSON.stringify({ a: 99, nested: { b: 99, c: 99 } }));
     const { result } = renderHook(() => usePersistedGameState('test_key', initial));
     act(() => {

--- a/src/Brmble.Web/src/components/NeonD/hooks/__tests__/usePersistedGameState.test.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/__tests__/usePersistedGameState.test.ts
@@ -1,0 +1,63 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePersistedGameState } from '../usePersistedGameState';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('usePersistedGameState', () => {
+  const initial = { a: 1, nested: { b: 2, c: 3 } };
+
+  it('loads initial state when local storage is empty', () => {
+    const { result } = renderHook(() => usePersistedGameState('test_key', initial));
+    expect(result.current[0]).toEqual(initial);
+  });
+
+  it('deep merges stored state with initial state (soft versioning)', () => {
+    localStorage.setItem('test_key', JSON.stringify({ a: 10, nested: { b: 20 } })); // 'c' is missing
+    const { result } = renderHook(() => usePersistedGameState('test_key', initial));
+    expect(result.current[0]).toEqual({ a: 10, nested: { b: 20, c: 3 } });
+  });
+
+  it('falls back to initial state if JSON parsing fails', () => {
+    localStorage.setItem('test_key', 'invalid json');
+    const { result } = renderHook(() => usePersistedGameState('test_key', initial));
+    expect(result.current[0]).toEqual(initial);
+  });
+
+  it('saves to localStorage after 30 seconds interval', () => {
+    const { result } = renderHook(() => usePersistedGameState('test_key', initial));
+    act(() => {
+      result.current[1]({ a: 99, nested: { b: 2, c: 3 } });
+    });
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+    expect(JSON.parse(localStorage.getItem('test_key') || '{}')).toEqual({ a: 99, nested: { b: 2, c: 3 } });
+  });
+
+  it('saves to localStorage on beforeunload', () => {
+    const { result } = renderHook(() => usePersistedGameState('test_key', initial));
+    act(() => {
+      result.current[1]({ a: 55, nested: { b: 2, c: 3 } });
+    });
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(JSON.parse(localStorage.getItem('test_key') || '{}')).toEqual({ a: 55, nested: { b: 2, c: 3 } });
+  });
+
+  it('clears localStorage and resets when clear function is called', () => {
+    localStorage.setItem('test_key', JSON.stringify({ a: 99, nested: { b: 99, c: 99 } }));
+    const { result } = renderHook(() => usePersistedGameState('test_key', initial));
+    act(() => {
+      result.current[2](); // call clear
+    });
+    expect(localStorage.getItem('test_key')).toBeNull();
+  });
+});

--- a/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
@@ -1,7 +1,8 @@
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import type { GameState, Dealer, DealerUpgrade } from '../types';
 import { INITIAL_GAME_STATE, UNLOCK_COSTS, PRODUCT_TIERS, DEALER_FIRST_NAMES, DEALER_LAST_NAMES, SLOT_UNLOCK_COSTS } from '../constants';
 import { useInterval } from './useInterval';
+import { usePersistedGameState } from './usePersistedGameState';
 
 const generateRandomDealer = (unlockedProducts: string[], totalEarned: number): Dealer => {
   const firstNames = DEALER_FIRST_NAMES;
@@ -34,7 +35,7 @@ const generateRandomDealer = (unlockedProducts: string[], totalEarned: number): 
 };
 
 export const useGameEngine = () => {
-  const [state, setState] = useState<GameState>(() => {
+  const [state, setState, clearStorage] = usePersistedGameState<GameState>('brmble_neon_d_save', () => {
     const initial = INITIAL_GAME_STATE;
     return {
       ...initial,
@@ -259,6 +260,7 @@ export const useGameEngine = () => {
   };
 
   const resetGame = useCallback(() => {
+    clearStorage();
     setState({
       ...INITIAL_GAME_STATE,
       activeDealers: [null, null, null],
@@ -267,9 +269,9 @@ export const useGameEngine = () => {
         generateRandomDealer(INITIAL_GAME_STATE.unlockedProduction, INITIAL_GAME_STATE.totalEarned)
       )
     });
-  }, []);
+  }, [setState, clearStorage]);
 
   useInterval(tick, 1000);
   
-  return { state, upgrade, unlockProduction, hireDealer, fireDealer, refreshPool, resetGame, unlockSlot, setDealerSelling, buyEquipment };
+  return { state, upgrade, unlockProduction, hireDealer, fireDealer, refreshPool, resetGame, unlockSlot, setDealerSelling, buyEquipment, clearStorage };
 };

--- a/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
@@ -269,9 +269,9 @@ export const useGameEngine = () => {
         generateRandomDealer(INITIAL_GAME_STATE.unlockedProduction, INITIAL_GAME_STATE.totalEarned)
       )
     });
-  }, [setState, clearStorage]);
+  }, [setState]);
 
   useInterval(tick, 1000);
   
-  return { state, upgrade, unlockProduction, hireDealer, fireDealer, refreshPool, resetGame, unlockSlot, setDealerSelling, buyEquipment, clearStorage };
+  return { state, upgrade, unlockProduction, hireDealer, fireDealer, refreshPool, resetGame, unlockSlot, setDealerSelling, buyEquipment };
 };

--- a/src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts
@@ -5,17 +5,36 @@ function isObject(item: unknown): item is Record<string, unknown> {
   return (item !== null && typeof item === 'object' && !Array.isArray(item));
 }
 
+const DANGEROUS_PROPERTIES = new Set(['__proto__', 'constructor', 'prototype']);
+
+function mergeValue(target: unknown, source: unknown): unknown {
+  if (Array.isArray(target) && Array.isArray(source)) {
+    const maxLength = Math.max(target.length, source.length);
+    return Array.from({ length: maxLength }, (_, i) => {
+      const targetVal = target[i];
+      const sourceVal = source[i];
+      if (sourceVal === undefined) return targetVal;
+      if (targetVal === undefined) return sourceVal;
+      if (isObject(targetVal) && isObject(sourceVal)) {
+        return deepMerge(targetVal, sourceVal);
+      }
+      return sourceVal;
+    });
+  }
+  if (isObject(target) && isObject(source)) {
+    return deepMerge(target, source);
+  }
+  return source !== undefined ? source : target;
+}
+
 function deepMerge<T extends object>(target: T, source: Partial<T>): T {
   const output = { ...target } as Record<string, unknown>;
   if (isObject(target) && isObject(source)) {
     Object.keys(source).forEach(key => {
+      if (DANGEROUS_PROPERTIES.has(key)) return;
       const sourceVal = (source as Record<string, unknown>)[key];
       const targetVal = (target as Record<string, unknown>)[key];
-      if (isObject(sourceVal) && isObject(targetVal)) {
-        output[key] = deepMerge(targetVal, sourceVal);
-      } else if (sourceVal !== undefined) {
-        output[key] = sourceVal;
-      }
+      output[key] = mergeValue(targetVal, sourceVal);
     });
   }
   return output as T;

--- a/src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts
@@ -5,25 +5,23 @@ function isObject(item: unknown): item is Record<string, unknown> {
   return (item !== null && typeof item === 'object' && !Array.isArray(item));
 }
 
-function deepMerge<T extends Record<string, unknown>>(target: T, source: T): T {
-  const output = { ...target };
+function deepMerge<T extends object>(target: T, source: Partial<T>): T {
+  const output = { ...target } as Record<string, unknown>;
   if (isObject(target) && isObject(source)) {
     Object.keys(source).forEach(key => {
-      if (isObject(source[key])) {
-        if (!(key in target)) {
-          output[key] = source[key] as T[Extract<keyof T, string>];
-        } else {
-          output[key] = deepMerge(target[key] as T[Extract<keyof T, string>], source[key] as T[Extract<keyof T, string>]);
-        }
-      } else {
-        output[key] = source[key] as T[Extract<keyof T, string>];
+      const sourceVal = (source as Record<string, unknown>)[key];
+      const targetVal = (target as Record<string, unknown>)[key];
+      if (isObject(sourceVal) && isObject(targetVal)) {
+        output[key] = deepMerge(targetVal, sourceVal);
+      } else if (sourceVal !== undefined) {
+        output[key] = sourceVal;
       }
     });
   }
-  return output;
+  return output as T;
 }
 
-export function usePersistedGameState<T extends Record<string, unknown>>(
+export function usePersistedGameState<T extends object>(
   key: string,
   initialState: T | (() => T)
 ): [T, React.Dispatch<React.SetStateAction<T>>, () => void] {

--- a/src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts
@@ -1,0 +1,79 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useInterval } from './useInterval';
+
+function isObject(item: unknown): item is Record<string, unknown> {
+  return (item !== null && typeof item === 'object' && !Array.isArray(item));
+}
+
+function deepMerge<T extends Record<string, unknown>>(target: T, source: T): T {
+  const output = { ...target };
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach(key => {
+      if (isObject(source[key])) {
+        if (!(key in target)) {
+          output[key] = source[key] as T[Extract<keyof T, string>];
+        } else {
+          output[key] = deepMerge(target[key] as T[Extract<keyof T, string>], source[key] as T[Extract<keyof T, string>]);
+        }
+      } else {
+        output[key] = source[key] as T[Extract<keyof T, string>];
+      }
+    });
+  }
+  return output;
+}
+
+export function usePersistedGameState<T extends Record<string, unknown>>(
+  key: string,
+  initialState: T | (() => T)
+): [T, React.Dispatch<React.SetStateAction<T>>, () => void] {
+
+  const [state, setReactState] = useState<T>(() => {
+    const initial = typeof initialState === 'function' ? (initialState as () => T)() : initialState;
+    try {
+      const item = localStorage.getItem(key);
+      if (item) {
+        const parsed = JSON.parse(item);
+        return deepMerge(initial, parsed);
+      }
+    } catch (error) {
+      console.warn(`Error reading localStorage key "${key}":`, error);
+    }
+    return initial;
+  });
+
+  const stateRef = useRef(state);
+
+  const setState: React.Dispatch<React.SetStateAction<T>> = useCallback((value) => {
+    setReactState((prev) => {
+      const nextState = typeof value === 'function' ? (value as (prev: T) => T)(prev) : value;
+      stateRef.current = nextState;
+      return nextState;
+    });
+  }, []);
+
+  const saveToStorage = useCallback(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(stateRef.current));
+    } catch (error) {
+      console.warn(`Error saving to localStorage key "${key}":`, error);
+    }
+  }, [key]);
+
+  const clearStorage = useCallback(() => {
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.warn(`Error clearing localStorage key "${key}":`, error);
+    }
+  }, [key]);
+
+  useInterval(saveToStorage, 30000);
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', saveToStorage);
+    return () => window.removeEventListener('beforeunload', saveToStorage);
+  }, [saveToStorage]);
+
+  return [state, setState, clearStorage];
+}


### PR DESCRIPTION
## Summary

- Adds `usePersistedGameState` hook for localStorage persistence with deep merge (soft versioning)
- Saves game state every 30 seconds and on browser close
- Integrated into `useGameEngine` for automatic persistence
- Replaced ugly `window.confirm` popup with themed glass-panel confirm modal

## Changes

### New files

- `usePersistedGameState.ts` — Custom hook with deep merge, interval saving, and beforeunload handler
- `usePersistedGameState.test.ts` — 6 tests covering all persistence behaviors

### Modified files

- `useGameEngine.ts` — Swapped `useState` for `usePersistedGameState`
- `NeonDGame.tsx` — Uses `confirm()` from `usePrompt` instead of `window.confirm`

## Test Plan

- [ ] Play Neon D game, make progress (earn money, hire dealers)
- [ ] Close and reopen the app — progress should persist
- [ ] Test "Fire Dealer" button — should show themed confirm modal
- [ ] All 27 tests pass (usePersistedGameState + useGameEngine)