### PR TITLE
fix(web): improve screen share lifecycle and cancel handling

### DIFF
--- a/docs/superpowers/plans/2026-04-25-screen-share-auto-stop.md
+++ b/docs/superpowers/plans/2026-04-25-screen-share-auto-stop.md
@@ -1,0 +1,426 @@
+# Screen Share Auto-Stop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically stop local screen sharing when the captured source ends externally, classify the stop reason for sharer-only notifications, and keep viewer cleanup silent and reliable.
+
+**Architecture:** Keep `useScreenShare` as the single owner of local share lifecycle and introduce one idempotent local stop pipeline that handles `manual`, `source-closed`, `interrupted`, and `error` reasons. Expose just enough reasoned signal to `App.tsx` so the sharer can get the correct notification copy while remote viewers continue to rely on the existing `livekit.shareStopped` cleanup path.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, LiveKit client, existing notification queue + notification component
+
+---
+
+## File Map
+
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.ts`
+  Purpose: add reason-aware, idempotent local stop handling and capture lifecycle listeners.
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.test.ts`
+  Purpose: lock down manual, source-closed, interrupted, and duplicate-stop behavior.
+- Modify: `src/Brmble.Web/src/App.tsx`
+  Purpose: consume the reasoned share-end signal and show sharer-only notifications with the approved copy.
+
+### Task 1: Make Local Screen Share Stop Reason-Aware And Idempotent
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.ts`
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.test.ts`
+
+- [ ] **Step 1: Add a failing test for manual stop remaining notification-free and still sending one stop event**
+
+Add a reason callback to the hook API in the test first, then assert manual stop reports `manual` and emits `livekit.shareStopped` once.
+
+```ts
+it('classifies manual stop as manual and emits shareStopped once', async () => {
+  let tokenHandler: ((data: unknown) => void) | null = null;
+  (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+    if (type === 'livekit.token') tokenHandler = handler;
+  });
+
+  const onShareEnded = vi.fn();
+  const { result } = renderHook(() => useScreenShare(undefined, undefined, onShareEnded));
+
+  await act(async () => {
+    const promise = result.current.startSharing('channel-1');
+    tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+    await promise;
+  });
+
+  await act(async () => {
+    await result.current.stopSharing();
+  });
+
+  expect(onShareEnded).toHaveBeenCalledWith({ reason: 'manual', roomName: 'channel-1' });
+  expect(bridge.send).toHaveBeenCalledWith('livekit.shareStopped', { roomName: 'channel-1' });
+  expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run the single manual-stop test and confirm it fails**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts -t "classifies manual stop as manual and emits shareStopped once"`
+
+Expected: FAIL because `useScreenShare` does not yet accept or call an `onShareEnded` callback.
+
+- [ ] **Step 3: Add the minimal stop-reason types and callback plumbing in `useScreenShare.ts`**
+
+Introduce explicit local stop reasons and thread an `onShareEnded` callback into the hook signature.
+
+```ts
+export type LocalShareStopReason = 'manual' | 'source-closed' | 'interrupted' | 'error';
+
+export interface LocalShareEndedEvent {
+  reason: LocalShareStopReason;
+  roomName?: string;
+}
+
+export function useScreenShare(
+  onDisconnected?: () => void,
+  screenShareSettings?: ScreenShareSettings,
+  onShareEnded?: (event: LocalShareEndedEvent) => void,
+) {
+  const onShareEndedRef = useRef(onShareEnded);
+  onShareEndedRef.current = onShareEnded;
+```
+
+- [ ] **Step 4: Add a single idempotent local stop pipeline in `useScreenShare.ts`**
+
+Create one internal function that owns all local-share teardown side effects.
+
+```ts
+const localShareStopInFlightRef = useRef(false);
+const localShareTrackCleanupRef = useRef<(() => void) | null>(null);
+
+const finishLocalShare = useCallback(async (reason: LocalShareStopReason, options?: { disableCapture?: boolean }) => {
+  if (localShareStopInFlightRef.current) return;
+  localShareStopInFlightRef.current = true;
+
+  const room = roomRef.current;
+  const roomName = room?.name;
+
+  try {
+    localShareTrackCleanupRef.current?.();
+    localShareTrackCleanupRef.current = null;
+
+    if (options?.disableCapture !== false && room) {
+      try {
+        await room.localParticipant.setScreenShareEnabled(false);
+      } catch {
+        // already stopped externally
+      }
+    }
+
+    isSharingRef.current = false;
+    setIsSharing(false);
+
+    if (roomName) {
+      bridge.send('livekit.shareStopped', { roomName });
+    }
+
+    onShareEndedRef.current?.({ reason, roomName });
+    await maybeDisconnectRoom();
+  } finally {
+    localShareStopInFlightRef.current = false;
+  }
+}, [maybeDisconnectRoom]);
+```
+
+- [ ] **Step 5: Rewire `stopSharing()` to use the shared pipeline and make the manual-stop test pass**
+
+```ts
+const stopSharing = useCallback(async () => {
+  if (!isSharingRef.current && !roomRef.current) {
+    setIsSharing(false);
+    return;
+  }
+  await finishLocalShare('manual');
+}, [finishLocalShare]);
+```
+
+- [ ] **Step 6: Run the single manual-stop test again and confirm it passes**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts -t "classifies manual stop as manual and emits shareStopped once"`
+
+Expected: PASS.
+
+- [ ] **Step 7: Add failing tests for external source end, interrupted disconnect, and duplicate event races**
+
+Extend the mocked local participant so the test can trigger a fake local screen-share track `ended` event.
+
+```ts
+it('classifies external track end as source-closed', async () => {
+  let tokenHandler: ((data: unknown) => void) | null = null;
+  let endedHandler: (() => void) | null = null;
+  mockRoom.localParticipant.getTrackPublication = vi.fn(() => ({
+    track: {
+      mediaStreamTrack: {
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'ended') endedHandler = handler;
+        }),
+        removeEventListener: vi.fn(),
+      },
+    },
+  }));
+
+  (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+    if (type === 'livekit.token') tokenHandler = handler;
+  });
+
+  const onShareEnded = vi.fn();
+  const { result } = renderHook(() => useScreenShare(undefined, undefined, onShareEnded));
+
+  await act(async () => {
+    const promise = result.current.startSharing('channel-1');
+    tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+    await promise;
+  });
+
+  act(() => {
+    endedHandler?.();
+  });
+
+  expect(onShareEnded).toHaveBeenCalledWith({ reason: 'source-closed', roomName: 'channel-1' });
+});
+
+it('classifies room disconnect while sharing as interrupted', async () => {
+  let tokenHandler: ((data: unknown) => void) | null = null;
+  let disconnectedHandler: (() => void) | null = null;
+  (mockRoom.on as ReturnType<typeof vi.fn>).mockImplementation((event: string, handler: () => void) => {
+    if (event === 'disconnected') disconnectedHandler = handler;
+    return mockRoom;
+  });
+
+  (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+    if (type === 'livekit.token') tokenHandler = handler;
+  });
+
+  const onShareEnded = vi.fn();
+  const { result } = renderHook(() => useScreenShare(undefined, undefined, onShareEnded));
+
+  await act(async () => {
+    const promise = result.current.startSharing('channel-1');
+    tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+    await promise;
+  });
+
+  act(() => {
+    disconnectedHandler?.();
+  });
+
+  expect(onShareEnded).toHaveBeenCalledWith({ reason: 'interrupted', roomName: 'channel-1' });
+});
+
+it('emits stop and share-ended callback only once when ended and disconnect race', async () => {
+  expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(1);
+  expect(onShareEnded).toHaveBeenCalledTimes(1);
+});
+```
+
+- [ ] **Step 8: Run the targeted hook tests and confirm they fail for the right reasons**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts -t "source-closed|interrupted|only once"`
+
+Expected: FAIL because `startSharing()` does not yet register local capture lifecycle listeners and `RoomEvent.Disconnected` does not yet classify local interruption.
+
+- [ ] **Step 9: Register capture-end listeners after local screen share starts**
+
+Use the actual local share publication if available, and listen for the underlying media-track end event.
+
+```ts
+const registerLocalShareLifecycle = useCallback((room: Room, roomName: string) => {
+  const publication = room.localParticipant.getTrackPublication?.(Track.Source.ScreenShare);
+  const mediaTrack = publication?.track?.mediaStreamTrack;
+  if (!mediaTrack) return;
+
+  const handleEnded = () => {
+    if (!isSharingRef.current) return;
+    void finishLocalShare('source-closed', { disableCapture: false });
+  };
+
+  mediaTrack.addEventListener?.('ended', handleEnded);
+  localShareTrackCleanupRef.current = () => {
+    mediaTrack.removeEventListener?.('ended', handleEnded);
+  };
+}, [finishLocalShare]);
+```
+
+- [ ] **Step 10: Call the lifecycle registration from `startSharing()`**
+
+```ts
+await room.localParticipant.setScreenShareEnabled(true, captureOptions);
+isSharingRef.current = true;
+setIsSharing(true);
+registerLocalShareLifecycle(room, roomName);
+bridge.send('livekit.shareStarted', { roomName });
+```
+
+- [ ] **Step 11: Make `RoomEvent.Disconnected` fall back to `interrupted` only when a local share was still active**
+
+```ts
+room.on(RoomEvent.Disconnected, () => {
+  const wasSharing = isSharingRef.current;
+  roomRef.current = null;
+  setRemoteVideoEls(new Map());
+  updateWatchingShares([]);
+  setFocusedShare(null);
+
+  if (wasSharing) {
+    isSharingRef.current = false;
+    setIsSharing(false);
+    onDisconnectedRef.current?.();
+    onShareEndedRef.current?.({ reason: 'interrupted', roomName: room.name });
+  }
+});
+```
+
+Then refactor this to reuse the same guard state as `finishLocalShare`, so disconnect and track-end races cannot double-fire.
+
+- [ ] **Step 12: Run the full hook test file and confirm it passes**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts`
+
+Expected: PASS with all existing tests plus the new reason/idempotency tests green.
+
+### Task 2: Show Sharer Notifications For Non-Manual Share Endings
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Modify if needed: `src/Brmble.Web/src/hooks/useScreenShare.test.ts`
+
+- [ ] **Step 1: Write a failing component-level test or extract a small pure mapper for notification copy**
+
+Prefer a small pure mapper in `App.tsx` test scope if that keeps the change narrow.
+
+```ts
+type ShareEndedNotice = {
+  title: string;
+  detail: string;
+};
+
+function getScreenShareEndedNotice(reason: 'source-closed' | 'interrupted' | 'error'): ShareEndedNotice {
+  switch (reason) {
+    case 'source-closed':
+      return { title: 'Share ended', detail: 'The shared window or program was closed.' };
+    case 'interrupted':
+      return { title: 'Share ended', detail: 'The share ended due to an unexpected technical reason.' };
+    case 'error':
+      return { title: 'Share ended', detail: 'The share could not continue because of a technical error.' };
+  }
+}
+```
+
+- [ ] **Step 2: Run the new notification-copy test and confirm it fails**
+
+Run: `npm run test -- src/App.test.tsx -t "Share ended"`
+
+Expected: FAIL if the helper or test does not yet exist.
+
+- [ ] **Step 3: Add minimal App state for local share-ended notifications**
+
+Add local state separate from the existing remote `screenShareToast`.
+
+```ts
+const [screenShareEndedNotification, setScreenShareEndedNotification] = useState<{
+  title: string;
+  detail: string;
+} | null>(null);
+```
+
+- [ ] **Step 4: Pass the new share-ended callback into `useScreenShare()`**
+
+```ts
+const { isSharing, startSharing, stopSharing, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, remoteVideoEls, disconnectViewer, connectAsViewer } = useScreenShare(
+  () => {
+    setSharingChannelId(undefined);
+  },
+  screenShareSettings,
+  (event) => {
+    if (event.reason === 'manual') return;
+
+    const notice = getScreenShareEndedNotice(event.reason === 'error' ? 'error' : event.reason);
+    setScreenShareEndedNotification(notice);
+    notifQueue.register('screen-share-ended', event.reason === 'error' ? 'error' : 'info');
+    setSharingChannelId(undefined);
+  },
+);
+```
+
+- [ ] **Step 5: Render the sharer-only notification in the existing notification stack**
+
+Use the standard `Notification` component and existing notification queue behavior.
+
+```tsx
+{screenShareEndedNotification && notifQueue.isVisible('screen-share-ended') && (
+  <Notification
+    visible={!!screenShareEndedNotification}
+    status="info"
+    title={screenShareEndedNotification.title}
+    detail={screenShareEndedNotification.detail}
+    duration={5000}
+    onDismiss={() => {
+      setScreenShareEndedNotification(null);
+      notifQueue.unregister('screen-share-ended');
+    }}
+  />
+)}
+```
+
+Keep `manual` silent by never creating this notification.
+
+- [ ] **Step 6: Run the App notification test and confirm it passes**
+
+Run: `npm run test -- src/App.test.tsx -t "Share ended"`
+
+Expected: PASS.
+
+### Task 3: Full Regression Verification
+
+**Files:**
+- Modify if needed: `src/Brmble.Web/src/hooks/useScreenShare.ts`
+- Modify if needed: `src/Brmble.Web/src/App.tsx`
+
+- [ ] **Step 1: Run the screen-share hook tests**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run any App-level notification tests added in Task 2**
+
+Run: `npm run test -- src/App.test.tsx`
+
+Expected: PASS for the new notification coverage.
+
+- [ ] **Step 3: Run the sidebar regression tests to make sure the current branch work still passes**
+
+Run: `npm run test -- src/components/Sidebar/ChannelTree.test.tsx src/components/Sidebar/Sidebar.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run a production web build**
+
+Run: `npm run build`
+
+Expected: PASS with no TypeScript or Vite build failures.
+
+- [ ] **Step 5: Perform manual verification**
+
+Manual checklist:
+
+```text
+1. Share a specific application window.
+2. Close that window with X or Ctrl+F4.
+3. Verify the sharer sees 'Share ended' with detail explaining the shared window/program was closed.
+4. Verify viewers silently lose the feed.
+5. Start sharing again and use Brmble's manual stop.
+6. Verify no sharer notification appears.
+7. Use the browser stop-sharing control.
+8. Verify no sharer notification appears.
+9. Simulate or observe an interruption path (for example app-close while sharing).
+10. Verify the sharer gets the technical-reason 'Share ended' notification if the app remains alive to display it.
+```
+
+## Self-Review
+
+- Spec coverage: Task 1 covers stop reasons, capture-end listeners, disconnect fallback, and idempotency. Task 2 covers sharer-only notification mapping and manual-stop silence. Task 3 covers regression verification.
+- Placeholder scan: all tasks include specific file paths, commands, and concrete code snippets for the key changes.
+- Type consistency: the plan uses one reason model (`manual`, `source-closed`, `interrupted`, `error`) consistently across hook logic, notification mapping, and tests.

--- a/docs/superpowers/plans/2026-04-25-screen-share-picker-cancel.md
+++ b/docs/superpowers/plans/2026-04-25-screen-share-picker-cancel.md
@@ -1,0 +1,242 @@
+# Screen Share Picker Cancel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make screen-share picker cancel behave like a manual pre-share abort, with no technical failure notification and no misleading LiveKit error status.
+
+**Architecture:** Narrow the `startSharing()` failure path in `useScreenShare` so known picker-cancel/abort errors do not flow into the generic `error` branch. In `App.tsx`, stop setting LiveKit status to `connecting` before the picker resolves so cancel naturally settles back to `idle` or remains `connected` if the user is already watching shares.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, LiveKit client, existing status/notification plumbing in `App.tsx`
+
+---
+
+## File Map
+
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.ts`
+  Purpose: classify picker cancel as benign/manual-equivalent behavior before the generic error path.
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.test.ts`
+  Purpose: verify picker cancel does not become `error`, does not retain `screenShareError`, and does not emit the technical failure callback path.
+- Modify: `src/Brmble.Web/src/App.tsx`
+  Purpose: remove the misleading `connecting` status update from the share-start button path.
+- Create or modify: narrow App/status tests if needed
+  Purpose: verify status timing and cancel behavior without heavy end-to-end setup.
+
+### Task 1: Classify Picker Cancel As Benign In `useScreenShare`
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.ts`
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.test.ts`
+
+- [ ] **Step 1: Write a failing hook test for picker cancel**
+
+Add a test that simulates the start path rejecting with a browser-style cancel error and proves it is not treated as `error`.
+
+```ts
+it('treats picker cancel as a manual-equivalent abort instead of error', async () => {
+  let tokenHandler: ((data: unknown) => void) | null = null;
+  const cancelError = Object.assign(new Error('Permission denied by user'), { name: 'AbortError' });
+
+  (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+    if (type === 'livekit.token') tokenHandler = handler;
+  });
+
+  mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(cancelError);
+
+  const onLocalShareEnded = vi.fn();
+  const { result } = renderHook(() => useScreenShare(undefined, undefined, onLocalShareEnded));
+
+  await act(async () => {
+    const promise = result.current.startSharing('channel-1');
+    tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+    await promise;
+  });
+
+  expect(result.current.isSharing).toBe(false);
+  expect(result.current.error).toBeNull();
+  expect(onLocalShareEnded).not.toHaveBeenCalledWith('error');
+  expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(0);
+});
+```
+
+- [ ] **Step 2: Run the new picker-cancel test and confirm it fails**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts -t "manual-equivalent abort instead of error"`
+
+Expected: FAIL because the current catch block sets `screenShareError` and routes cancel into `stopLocalShare('error', ...)`.
+
+- [ ] **Step 3: Add a narrow picker-cancel classifier in `useScreenShare.ts`**
+
+Introduce one helper that recognizes known abort/cancel errors without swallowing arbitrary failures.
+
+```ts
+function isScreenSharePickerCancel(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+
+  const name = err.name.toLowerCase();
+  const message = err.message.toLowerCase();
+
+  return name === 'aborterror'
+    || message.includes('permission denied by user')
+    || message.includes('selection canceled')
+    || message.includes('cancelled')
+    || message.includes('canceled');
+}
+```
+
+- [ ] **Step 4: Short-circuit benign cancel before the generic error path**
+
+Update the `startSharing()` catch block so cancel clears temporary share-start state but does not set `screenShareError` or emit the `error` stop reason.
+
+```ts
+} catch (err) {
+  clearLocalShareEndListener();
+
+  if (isScreenSharePickerCancel(err)) {
+    setError(null);
+    isSharingRef.current = false;
+    setIsSharing(false);
+    await maybeDisconnectRoom();
+    return;
+  }
+
+  setError(err instanceof Error ? err.message : 'Screen share failed');
+  await stopLocalShare('error', roomRef.current);
+  await maybeDisconnectRoom();
+}
+```
+
+- [ ] **Step 5: Add a second test to prove true failures still map to `error`**
+
+Keep the existing publish-failure test, but add a cancel-vs-real-failure contrast if needed.
+
+```ts
+it('still classifies real publish failures as error', async () => {
+  const publishError = new Error('Publish failed');
+  mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(publishError);
+
+  // existing expectation stays: error string retained and onLocalShareEnded('error') emitted once
+});
+```
+
+- [ ] **Step 6: Run the full hook test file and confirm it passes**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts`
+
+Expected: PASS with picker-cancel coverage and existing auto-stop tests still green.
+
+### Task 2: Remove Misleading Start-Connecting Status In `App.tsx`
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Create or modify: narrow App/status tests if needed
+
+- [ ] **Step 1: Add a failing narrow test or pure-logic seam for the start-status behavior**
+
+If a lightweight helper is easiest, extract a tiny test seam around the rule that share start does not force `connecting` before success.
+
+```ts
+export function shouldSetConnectingStatusForShareStart(): boolean {
+  return false;
+}
+```
+
+Or add a narrow component logic test that proves no explicit `updateStatus('livekit', { state: 'connecting' ... })` is used from the share-start path.
+
+- [ ] **Step 2: Run the new status test and confirm it fails**
+
+Run: `npm run test -- src/App.screenShareStartStatus.test.ts`
+
+Expected: FAIL if the helper/test seam does not exist yet.
+
+- [ ] **Step 3: Remove the direct `connecting` update from `handleToggleScreenShare` start flow**
+
+Make share start rely on the steady-state `isSharing` / `watchingShares.length` effect instead.
+
+```ts
+const handleToggleScreenShare = useCallback(async () => {
+  if (isSharing) {
+    await stopSharing();
+    setSharingChannelId(undefined);
+  } else if (!selfLeftVoice) {
+    const selfUser = usersRef.current.find(u => u.self);
+    const voiceChannelId = selfUser?.channelId;
+    if (voiceChannelId != null && voiceChannelId !== 0) {
+      try {
+        await startSharing(`channel-${voiceChannelId}`);
+        setSharingChannelId(String(voiceChannelId));
+      } catch {
+        // startSharing manages its own state; benign cancel should remain silent
+      }
+    }
+  }
+}, [isSharing, startSharing, stopSharing, selfLeftVoice]);
+```
+
+- [ ] **Step 4: Ensure the status effects still produce the intended steady states**
+
+Keep the existing effects, which should now naturally settle to:
+
+- `connected` when `isSharing` or watching shares
+- `idle` when neither is true and there is no `screenShareError`
+- `disconnected` only when a true error remains
+
+If needed, add a tiny helper test documenting this intended cancel result.
+
+- [ ] **Step 5: Run the App status test(s) and confirm they pass**
+
+Run: `npm run test -- src/App.screenShareStartStatus.test.ts src/App.screenShareEnded.test.ts`
+
+Expected: PASS.
+
+### Task 3: Regression Verification For `#483`
+
+**Files:**
+- Modify if needed: `src/Brmble.Web/src/hooks/useScreenShare.ts`
+- Modify if needed: `src/Brmble.Web/src/App.tsx`
+
+- [ ] **Step 1: Run the hook tests**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the App-level tests related to share-end notifications and share-start status**
+
+Run: `npm run test -- src/App.screenShareEnded.test.ts src/App.screenShareStartStatus.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the sidebar regressions already on this branch**
+
+Run: `npm run test -- src/components/Sidebar/ChannelTree.test.tsx src/components/Sidebar/Sidebar.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run a production web build**
+
+Run: `npm run build`
+
+Expected: PASS with no TypeScript or Vite build failures.
+
+- [ ] **Step 5: Perform manual verification for issue #483**
+
+Manual checklist:
+
+```text
+1. Join voice without watching any shares.
+2. Click Share Screen and cancel the picker.
+3. Verify no technical-failure notification appears.
+4. Verify LiveKit status returns to idle.
+5. Start watching another user's share.
+6. Click Share Screen and cancel the picker.
+7. Verify no technical-failure notification appears.
+8. Verify LiveKit status stays connected.
+9. Trigger a real share-start failure if feasible.
+10. Verify the true failure path still shows error behavior.
+```
+
+## Self-Review
+
+- Spec coverage: Task 1 covers cancel classification and preserving real `error` behavior. Task 2 covers the misleading pre-picker `connecting` state. Task 3 covers regression verification for both idle and watching states.
+- Placeholder scan: all tasks include exact file paths, commands, and concrete implementation/test snippets.
+- Type consistency: the plan preserves the existing local stop-reason model and intentionally keeps picker cancel out of that product-facing error path.

--- a/docs/superpowers/specs/2026-04-21-screenshare-self-slot-design.md
+++ b/docs/superpowers/specs/2026-04-21-screenshare-self-slot-design.md
@@ -1,0 +1,135 @@
+# Screen Share Self-Slot Bugfix Batch — Design Spec
+
+**Date:** 2026-04-21
+**Status:** Approved
+**Depends on:** Sub-project A2 (Multi-Share Layouts) — implemented
+**Branch:** `fix/screenshare-self-slot`
+
+## Overview
+
+Fix the A2 regression where clicking your own sharing row can reserve an empty slot in the screen-share grid even though self-preview does not exist. In the same patch, clean up the channel-list sharing UI so the share monitor icon no longer occupies the status-icon area near the avatar and no longer displaces mute/deafen indicators.
+
+## Goals
+
+- Prevent the local user's share from being treated like a watched remote share.
+- Preserve the current watch/unwatch behavior for remote sharers.
+- Keep room for a future self-preview feature without shipping broken placeholder behavior now.
+- Move the sharing monitor icon behind the `Sharing` label for all sharers.
+- Keep mute/deafen indicators visible in their normal status area.
+
+## Non-Goals
+
+- Implement self-preview.
+- Add a new toast or notification for self-click behavior.
+- Redesign the entire channel-row layout.
+- Change grid/focus behavior for valid remote watched shares.
+
+## Current Problem
+
+The sidebar and channel tree currently conflate two different states:
+
+- `sharing`: the user is broadcasting their screen
+- `watching`: the viewer is subscribed to that user's share
+
+For the local user, the UI uses `sharingUserSession` as if it also means `watching`. That lets the local sharing row present itself as watched and lets click handlers flow into watch logic, even though the actual `watchingShares` and `remoteVideoEls` state only contain remote participants. The result is inconsistent UI and, in some cases, an empty reserved slot in the grid/focus layout.
+
+## Proposed Behavior
+
+### 1. Local user while sharing
+
+- The local row still shows that the user is `Sharing`.
+- The local row is never shown as `Watching`.
+- Clicking or double-clicking the local sharing row does nothing visible.
+- No notification is shown.
+
+### 2. Remote users while sharing
+
+- Remote sharing rows keep the current watch/unwatch toggle behavior.
+- Remote rows continue to reflect actual watch state from `watchingShares`.
+- Focused and grid layouts continue to be driven only by actual watched remote shares.
+
+### 3. Sharing icon placement
+
+- The monitor icon moves out of the status-icon slot near the avatar.
+- The monitor icon is rendered with the `Sharing` label for all sharers.
+- The status-icon slot remains available for mute/deafen indicators.
+- A user can therefore be both sharing and muted/deafened without losing those indicators.
+
+## Implementation Shape
+
+### Data flow
+
+`useScreenShare` remains the source of truth for real watch state:
+
+- `watchingShares` contains only remote watched shares.
+- `focusedShare` refers only to watched remote shares.
+- `remoteVideoEls` contains only attached remote tracks.
+
+This patch should avoid pushing local-user special cases into the hook unless investigation reveals a genuine hook-level bug. The primary fix belongs in the row rendering and event handling in:
+
+- `src/Brmble.Web/src/components/Sidebar/Sidebar.tsx`
+- `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`
+
+### UI responsibilities
+
+- The status area near the avatar should represent user status icons such as mute/deafen.
+- The sharing affordance should live next to the `Sharing` text.
+- Remote share rows can keep an interactive monitor control.
+- The local share row should render a non-actionable sharing affordance for now so a future self-preview feature can be added without preserving today's broken state mapping.
+
+## Approach Options
+
+### Option 1. UI-only guard with inert local affordance
+
+Keep the icon visible for all sharers, move it next to `Sharing`, and make the local share affordance non-actionable. Remote rows keep the current toggle behavior.
+
+**Pros:** Smallest change, aligns with future self-preview, fixes both bugs together.
+**Cons:** Requires slightly more conditional rendering than simply hiding the control.
+
+### Option 2. Remove local share affordance entirely
+
+Show the monitor icon only for remote sharers and omit it for the local row.
+
+**Pros:** Simplest UX today.
+**Cons:** Less aligned with future self-preview direction.
+
+### Option 3. Hook-level defensive filtering plus UI cleanup
+
+Add extra guardrails in the hook against any self-watch attempt and also update the row layout.
+
+**Pros:** Stronger defense in depth.
+**Cons:** More invasive than needed if the current bug is only caused by UI-state conflation.
+
+## Recommendation
+
+Use Option 1.
+
+It fixes the shipped regression with the smallest correct change, keeps the future self-preview door open, and avoids expanding the patch into unnecessary hook refactoring unless testing reveals another related issue.
+
+## Testing Strategy
+
+### Unit / component coverage
+
+- The local sharing row is not rendered as watched.
+- Local share click and double-click paths do not invoke watch behavior.
+- Remote share rows still invoke watch/unwatch correctly.
+- The sharing monitor icon renders with the `Sharing` label rather than replacing the status area.
+
+### Manual verification
+
+- Share your own screen and click your own row: no empty grid slot appears.
+- Watch one or more remote shares while sharing yourself: only remote watched shares appear in the grid.
+- Confirm mute/deafen indicators remain visible for sharers.
+- Confirm remote sharing toggles still work in both sidebar variants.
+
+## Risks
+
+- `Sidebar.tsx` and `ChannelTree.tsx` currently duplicate similar logic, so the fix must stay consistent in both places.
+- If any other code path assumes `sharingUserSession` implies watch state, tests may reveal a second small follow-up fix.
+
+## Success Criteria
+
+- The local sharer can no longer create an empty viewer slot by clicking their own sharing row.
+- Remote share watch/unwatch behavior remains intact.
+- Sharing rows display the monitor icon next to `Sharing` for all sharers.
+- Mute/deafen icons remain visible while a user is sharing.

--- a/docs/superpowers/specs/2026-04-25-screen-share-auto-stop-design.md
+++ b/docs/superpowers/specs/2026-04-25-screen-share-auto-stop-design.md
@@ -1,0 +1,220 @@
+# Screen Share Auto-Stop Design
+
+**Date:** 2026-04-25
+**Status:** Approved
+**Branch:** `fix/screenshare-self-slot`
+**Related roadmap item:** `docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md` — Broadcaster Controls / Connection & Reliability
+
+## Overview
+
+Brmble should stop local screen sharing automatically when the captured source ends externally, instead of remaining stuck in a sharing state. The sharer should get a reason-appropriate notification for non-manual endings, while viewers should silently stop receiving the feed and clean up their UI through the existing remote stop path.
+
+This design keeps the fix focused on local share lifecycle handling in `useScreenShare`, without broadening into new viewer UX, native-window behavior, or unrelated LiveKit architecture changes.
+
+## Goals
+
+- Auto-stop local sharing when the captured source ends outside Brmble's manual stop flow.
+- Distinguish between normal source closure and unexpected interruption for the sharer's notification copy.
+- Treat app-close while sharing as part of the `interrupted` bucket rather than a separate reason.
+- Ensure remote viewers silently lose the feed and clear state through the existing stop path.
+- Make the local stop pipeline idempotent so duplicate end/disconnect events do not double-clean up or double-notify.
+
+## Non-Goals
+
+- Add new viewer notifications.
+- Introduce a third dedicated stop reason for app shutdown.
+- Redesign the sharing UI beyond existing notification plumbing.
+- Rework the entire LiveKit bridge architecture.
+
+## Current Problem
+
+The current implementation in `src/Brmble.Web/src/hooks/useScreenShare.ts` only handles the local share lifecycle through explicit calls to:
+
+- `startSharing()`
+- `stopSharing()`
+- room disconnect cleanup
+
+It does not currently register lifecycle handling for the captured screen-share track ending externally. As a result:
+
+- the sharer can remain in an incorrect local `isSharing` state after the shared app/window closes
+- the clean stop event path is less reliable on abrupt external endings
+- there is no consistent reason classification for sharer notifications
+
+## Desired Behavior
+
+### Manual stop
+
+Manual stop includes:
+
+- clicking Brmble's stop-sharing control
+- using the browser or OS stop-sharing control intentionally
+
+Behavior:
+
+- local sharing stops cleanly
+- no notification is shown to the sharer
+- remote viewers silently lose the feed through the normal stop path
+
+### Source closed
+
+Source closed includes:
+
+- the shared app/window is closed
+- the chosen capture source disappears in a way that is considered a normal source ending
+
+Behavior:
+
+- local sharing stops automatically
+- sharer sees a notification with:
+  - title: `Share ended`
+  - body: explains the shared window or program was closed
+- remote viewers silently lose the feed
+
+### Interrupted
+
+Interrupted includes:
+
+- capture ends for an unexpected non-manual reason
+- room disconnect occurs while sharing is still considered active and no more specific reason has already been assigned
+- Brmble app shutdown while sharing
+
+Behavior:
+
+- local sharing stops automatically
+- sharer sees a notification with:
+  - title: `Share ended`
+  - body: explains the share ended due to an unexpected technical reason
+- remote viewers silently lose the feed
+
+### Error
+
+Error is reserved for true share failures where the share cannot continue because of an actual technical problem in the publish/share pipeline.
+
+Behavior:
+
+- local sharing stops or fails safely
+- sharer sees error-oriented notification or existing error surface as appropriate
+- remote viewers silently lose the feed if a live share was active
+
+## Architecture
+
+### Single local stop pipeline
+
+`useScreenShare` becomes the single owner of local share termination.
+
+Add one internal stop/cleanup path that:
+
+1. accepts a local stop reason
+2. clears local share state exactly once
+3. sends the bridge stop event exactly once for a real ended share
+4. decides whether a sharer notification should be shown
+5. disconnects the room only when no longer sharing and no longer watching
+
+This replaces scattered local stop behavior with one centralized path.
+
+### Reason model
+
+The local stop pipeline should classify endings into:
+
+- `manual`
+- `source-closed`
+- `interrupted`
+- `error`
+
+This is an internal behavioral model, not necessarily a user-facing protocol change.
+
+### Capture lifecycle listeners
+
+After `startSharing()` successfully enables screen sharing, Brmble should capture references to the local screen-share track and/or media stream lifecycle needed to observe when capture ends externally.
+
+Those listeners should route into the shared stop pipeline rather than directly mutating state.
+
+### Disconnect fallback
+
+If the LiveKit room disconnects while local sharing is still active and no earlier reason has already completed cleanup, the disconnect path should fall back to `interrupted`.
+
+This ensures app-close and abrupt teardown still converge on a predictable stop reason.
+
+## Data Flow
+
+### Start flow
+
+1. `startSharing(roomName)` ensures the room exists.
+2. Local participant enables screen sharing.
+3. Brmble marks local sharing active.
+4. Brmble registers capture-end listeners on the local share track/stream.
+5. Brmble sends the existing `livekit.shareStarted` bridge event.
+
+### Manual stop flow
+
+1. UI calls `stopSharing()`.
+2. `stopSharing()` delegates to the shared stop pipeline with `manual`.
+3. The shared stop pipeline disables screen sharing, clears state, suppresses notifications, and emits the stop event once.
+
+### External end flow
+
+1. Browser/media lifecycle reports the capture ended.
+2. Brmble classifies the end as `source-closed` or `interrupted`.
+3. Brmble runs the shared stop pipeline.
+4. Viewers silently lose the share through the existing stop cleanup path.
+5. Sharer gets notification copy based on the classified reason.
+
+## Notification Rules
+
+- `manual`: no sharer notification
+- `source-closed`: title `Share ended`, body explains the shared window/program was closed
+- `interrupted`: title `Share ended`, body explains the share ended due to an unexpected technical reason
+- viewers: no new notifications from this feature
+
+## Idempotency Requirements
+
+The stop pipeline must tolerate overlapping end signals, for example:
+
+- track `ended`
+- room `Disconnected`
+- UI stop call racing with browser stop
+
+Only one cleanup pass should win. Later signals should no-op.
+
+Required guarantees:
+
+- `isSharing` becomes false once
+- stop bridge event is sent once
+- viewer cleanup is triggered once per ended share
+- sharer notification is shown at most once
+
+## Testing Strategy
+
+### Automated tests
+
+Add or update tests in `src/Brmble.Web/src/hooks/useScreenShare.test.ts` to cover:
+
+- manual stop produces no notification-worthy reason
+- external track end routes through `source-closed`
+- room disconnect while sharing routes through `interrupted`
+- duplicate end/disconnect signals do not double-clean state or emit duplicate stop signaling
+- existing remote viewer cleanup behavior still passes
+
+### Manual verification
+
+Verify these flows manually:
+
+1. Share a specific app/window, then close that app/window.
+2. Share and stop using the browser/OS stop-sharing control.
+3. Share and close Brmble while sharing.
+4. Observe viewer behavior in all cases: feed disappears without any new notification.
+
+## Risks
+
+- LiveKit/browser APIs may not always provide a richly distinguishable reason for why capture ended, so some `source-closed` vs `interrupted` classification may require a pragmatic heuristic.
+- Room disconnect and track-end events may race; idempotent cleanup is required to keep the UI correct.
+- The current code already uses `RoomEvent.Disconnected` for broad cleanup, so introducing reason-aware local stop handling must avoid duplicating side effects.
+
+## Success Criteria
+
+- Closing the shared app/window no longer leaves the sharer stuck in a sharing state.
+- Manual stop still shows no notification.
+- External normal source endings show the neutral `Share ended` notification with source-closed explanation.
+- Unexpected interruption shows the `Share ended` notification with technical-reason explanation.
+- Viewers silently stop seeing the ended share in all these cases.
+- Cleanup remains correct even if multiple stop signals arrive close together.

--- a/docs/superpowers/specs/2026-04-25-screen-share-picker-cancel-design.md
+++ b/docs/superpowers/specs/2026-04-25-screen-share-picker-cancel-design.md
@@ -1,0 +1,163 @@
+# Screen Share Picker Cancel Design
+
+**Date:** 2026-04-25
+**Status:** Approved
+**Branch:** `fix/screenshare-self-slot`
+**Related issue:** `#483` - misleading screen share status when user cancels the share picker
+
+## Overview
+
+Canceling the OS/browser screen-share picker is normal user behavior and must not be treated as a technical failure. Brmble should treat picker cancel exactly like a manual abort before sharing begins: no sharer notification, no retained screen-share error, and LiveKit status returning to the correct non-error state.
+
+This design is a focused follow-up to the recent screen-share auto-stop work. It narrows the start-sharing failure path so benign picker cancellation does not flow into the generic `error` handling intended for actual technical failures.
+
+## Goals
+
+- Treat picker cancel as manual-equivalent product behavior.
+- Prevent the red disconnected/error status after canceling the picker.
+- Prevent the new sharer-side technical failure notification after canceling the picker.
+- Preserve the existing technical failure path for true share-start errors.
+- Remove the misleading temporary `connecting` state while the picker dialog is still open.
+
+## Non-Goals
+
+- Introduce a new user-visible cancel state.
+- Change viewer behavior; no share ever started.
+- Redesign the screen-share button UI.
+- Rework the broader LiveKit status system beyond this cancel path.
+
+## Current Problem
+
+Current `startSharing()` behavior in `src/Brmble.Web/src/hooks/useScreenShare.ts` treats all share-start failures the same:
+
+1. picker or publish attempt throws
+2. `screenShareError` is set
+3. local stop reason flows through `error`
+4. App status becomes disconnected/red with the thrown error string
+5. App notification mapping can show a technical failure message
+
+In parallel, `App.tsx` sets LiveKit status to `connecting` as soon as the user presses the share button, before the picker resolves. That produces a misleading flow:
+
+- button press -> `connecting`
+- user cancels picker -> `error`
+
+Issue `#483` makes it explicit that canceling the picker should not look like permission denial or technical failure.
+
+## Desired Behavior
+
+### Picker cancel
+
+Picker cancel includes the case where the user opens the OS/browser source picker and dismisses it without selecting a source.
+
+Behavior:
+
+- treat it exactly like a manual abort before sharing started
+- do not retain `screenShareError`
+- do not emit the sharer technical failure notification
+- if not watching any shares, LiveKit status returns to `idle`
+- if watching shares, LiveKit status remains `connected`
+
+### True share-start failure
+
+True start failure includes real technical problems after the user intended to share, such as a publish failure or unexpected runtime issue.
+
+Behavior:
+
+- keep the existing technical failure path
+- `screenShareError` may be set
+- technical failure notification may be shown to the sharer
+- LiveKit status may enter disconnected/error state when appropriate
+
+## Architecture
+
+### Pre-share cancel classification
+
+`useScreenShare` should classify picker-cancel errors before the generic `error` path runs.
+
+This is a pre-share decision point in `startSharing()`:
+
+- benign cancel / abort -> manual-equivalent early exit
+- real failure -> existing `error` path
+
+This does not require a new product-level stop reason. Product behavior should remain equivalent to `manual`.
+
+### Status timing
+
+`App.tsx` should not set LiveKit service status to `connecting` merely because the picker was opened.
+
+For the share-start path:
+
+- leave status unchanged while the picker is unresolved
+- once sharing actually starts, normal `connected` state handling takes over through `isSharing`
+- if the picker is canceled, the status effect falls back naturally to `idle` or stays `connected` if the user is watching shares
+
+Viewer-side watch connection behavior can keep its existing `connecting` state because it reflects an actual room subscription attempt.
+
+## Data Flow
+
+### Start-sharing with picker cancel
+
+1. User presses Share Screen.
+2. Brmble opens the OS/browser picker.
+3. User cancels.
+4. `startSharing()` recognizes the thrown error as user-cancel/abort.
+5. Brmble clears any temporary local start state without setting `screenShareError`.
+6. No local share-ended notification is emitted.
+7. Status settles to:
+   - `idle` if not watching
+   - `connected` if still watching
+
+### Start-sharing with true failure
+
+1. User presses Share Screen.
+2. User selects a source or the share start proceeds far enough to represent a real attempt.
+3. A technical failure occurs.
+4. `startSharing()` falls through to the `error` path.
+5. Existing status and sharer-notification error handling remains active.
+
+## Error Recognition Strategy
+
+The implementation should identify browser/LiveKit picker-cancel errors using known abort-style signals rather than treating every thrown start error as equivalent.
+
+Typical examples to consider:
+
+- `AbortError`
+- browser/user-cancel variants exposed by the underlying capture flow
+- user-cancel wording such as permission dialog dismissed or selection canceled
+
+The implementation should keep this recognition narrow so true failures do not get swallowed accidentally.
+
+## Testing Strategy
+
+### Automated tests
+
+Add or update tests for:
+
+- picker cancel is classified as benign/manual-equivalent behavior
+- picker cancel does not set `screenShareError`
+- picker cancel does not trigger the share-ended technical notification path
+- true start failures still map to `error`
+- LiveKit status logic falls back to `idle` or remains `connected` when share start is canceled
+
+### Manual verification
+
+Verify these cases:
+
+1. Join voice, click Share Screen, cancel the picker, while not watching anyone.
+2. Confirm no notification and LiveKit status returns to idle.
+3. Join voice, watch someone else's share, click Share Screen, cancel the picker.
+4. Confirm no notification and LiveKit status stays connected.
+5. Trigger a real share-start failure and confirm technical error behavior still appears.
+
+## Risks
+
+- Browser/platform cancel errors are not always represented with one exact error shape, so the classifier needs to be specific enough to catch known cancel cases without masking real faults.
+- Status logic is currently split between direct `updateStatus(...)` calls and effect-driven state reconciliation, so this fix must avoid creating a new mismatch between immediate status updates and steady-state status.
+
+## Success Criteria
+
+- Canceling the screen-share picker no longer shows a technical failure notification.
+- Canceling the screen-share picker no longer leaves LiveKit in a red/disconnected error state.
+- If not watching, status returns to idle after cancel.
+- If watching, status remains connected after cancel.
+- Real share-start failures still produce the intended error behavior.

--- a/src/Brmble.Web/src/App.screenShareEnded.test.ts
+++ b/src/Brmble.Web/src/App.screenShareEnded.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as AppModule from './App';
+import { createQueuedScreenShareEndedNotification, getScreenShareEndedNotification } from './App';
+import { useNotificationQueue } from './hooks/useNotificationQueue';
+
+type ReplaceScreenShareEndedNotification = (
+  current: ReturnType<typeof createQueuedScreenShareEndedNotification>,
+  reason: 'manual' | 'source-closed' | 'interrupted' | 'error',
+  sequence: number,
+  notifQueue: { unregister: (id: string) => void },
+) => ReturnType<typeof createQueuedScreenShareEndedNotification>;
+
+describe('getScreenShareEndedNotification', () => {
+  it('keeps manual share endings silent', () => {
+    expect(getScreenShareEndedNotification('manual')).toBeNull();
+  });
+
+  it('maps source-closed to an info notification', () => {
+    expect(getScreenShareEndedNotification('source-closed')).toEqual({
+      status: 'info',
+      title: 'Share ended',
+      detail: 'Your screen share ended because the shared window or program was closed.',
+    });
+  });
+
+  it('maps interrupted to an info notification', () => {
+    expect(getScreenShareEndedNotification('interrupted')).toEqual({
+      status: 'info',
+      title: 'Share ended',
+      detail: 'Your screen share ended because of an unexpected technical issue.',
+    });
+  });
+
+  it('maps error to an error notification', () => {
+    expect(getScreenShareEndedNotification('error')).toEqual({
+      status: 'error',
+      title: 'Screen share failed',
+      detail: 'Brmble could not keep your screen share running because of a technical issue.',
+    });
+  });
+
+  it('requeues share-ended notifications with fresh queue metadata', () => {
+    const { result } = renderHook(() => useNotificationQueue());
+
+    act(() => {
+      result.current.register('warning-1', 'warning');
+      result.current.register('warning-2', 'warning');
+      result.current.register('warning-3', 'warning');
+    });
+
+    const interrupted = createQueuedScreenShareEndedNotification('interrupted', 0);
+    expect(interrupted).not.toBeNull();
+
+    act(() => {
+      result.current.register(interrupted!.id, interrupted!.status);
+    });
+
+    expect(result.current.isVisible(interrupted!.id)).toBe(false);
+
+    const errored = createQueuedScreenShareEndedNotification('error', 1);
+    expect(errored).not.toBeNull();
+    expect(errored!.id).not.toBe(interrupted!.id);
+
+    act(() => {
+      result.current.unregister(interrupted!.id);
+      result.current.register(errored!.id, errored!.status);
+    });
+
+    expect(result.current.isVisible(errored!.id)).toBe(true);
+    expect(result.current.isVisible('warning-3')).toBe(false);
+  });
+
+  it('automatically unregisters the previous share-ended queue id when App replaces it', () => {
+    const replaceScreenShareEndedNotification = (AppModule as {
+      replaceScreenShareEndedNotification?: ReplaceScreenShareEndedNotification;
+    }).replaceScreenShareEndedNotification;
+    const unregister = vi.fn();
+    const interrupted = createQueuedScreenShareEndedNotification('interrupted', 0);
+
+    expect(replaceScreenShareEndedNotification).toBeTypeOf('function');
+
+    const errored = replaceScreenShareEndedNotification!(
+      interrupted,
+      'error',
+      1,
+      { unregister },
+    );
+
+    expect(unregister).toHaveBeenCalledWith(interrupted!.id);
+    expect(errored).toEqual(createQueuedScreenShareEndedNotification('error', 1));
+  });
+});

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getNextLiveKitStatusUpdate, shouldClearLocalShareStartPending, toggleLocalScreenShare } from './App';
+
+describe('toggleLocalScreenShare', () => {
+  it('starts sharing in the current voice channel without changing LiveKit status first', async () => {
+    const startSharing = vi.fn().mockResolvedValue(undefined);
+    const stopSharing = vi.fn();
+    const setSharingChannelId = vi.fn();
+
+    await toggleLocalScreenShare({
+      isSharing: false,
+      selfLeftVoice: false,
+      voiceChannelId: 7,
+      startSharing,
+      stopSharing,
+      setSharingChannelId,
+    });
+
+    expect(startSharing).toHaveBeenCalledWith('channel-7');
+    expect(setSharingChannelId).toHaveBeenCalledWith('7');
+    expect(stopSharing).not.toHaveBeenCalled();
+  });
+});
+
+describe('getNextLiveKitStatusUpdate', () => {
+  it('preserves the previous LiveKit status while the share picker is unresolved after clearing an error', () => {
+    expect(getNextLiveKitStatusUpdate({
+      isSharing: false,
+      watchingShareCount: 0,
+      screenShareError: null,
+      isLocalShareStartPending: true,
+    })).toBeNull();
+  });
+
+  it('keeps LiveKit connected while watching a share even if local share start is still pending', () => {
+    expect(getNextLiveKitStatusUpdate({
+      isSharing: false,
+      watchingShareCount: 1,
+      screenShareError: null,
+      isLocalShareStartPending: true,
+    })).toEqual({ state: 'connected', error: undefined });
+  });
+});
+
+describe('shouldClearLocalShareStartPending', () => {
+  it('clears a pending local share start when the app leaves voice before the picker resolves', () => {
+    expect(shouldClearLocalShareStartPending({
+      isLocalShareStartPending: true,
+      selfLeftVoice: true,
+      voiceChannelId: 7,
+    })).toBe(true);
+  });
+});

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -5,6 +5,7 @@ import { encodeForMumble } from './utils/imageUpload';
 import { useMatrixClient } from './hooks/useMatrixClient';
 import type { MatrixCredentials } from './hooks/useMatrixClient';
 import { useScreenShare } from './hooks/useScreenShare';
+import type { LocalShareStopReason } from './hooks/useScreenShare';
 import { useLeaveVoiceCooldown } from './hooks/useLeaveVoiceCooldown';
 import { useNotificationQueue } from './hooks/useNotificationQueue';
 import { useUnreadTracker, resetMarkersCache } from './hooks/useUnreadTracker';
@@ -37,8 +38,72 @@ import { ProfileProvider } from './contexts/ProfileContext';
 import { UpdateNotification } from './components/UpdateNotification/UpdateNotification';
 import { BrokenCertNotification } from './components/BrokenCertNotification/BrokenCertNotification';
 import { Notification } from './components/Notification/Notification';
+import type { NotificationStatus } from './components/Notification/Notification';
 import { migrateLocalStorage } from './utils/migrateLocalStorage';
 import './App.css';
+
+export interface ScreenShareEndedNotification {
+  status: NotificationStatus;
+  title: string;
+  detail: string;
+}
+
+export interface QueuedScreenShareEndedNotification extends ScreenShareEndedNotification {
+  id: string;
+}
+
+export function getScreenShareEndedNotification(reason: 'manual' | 'source-closed' | 'interrupted' | 'error'): ScreenShareEndedNotification | null {
+  switch (reason) {
+    case 'manual':
+      return null;
+    case 'source-closed':
+      return {
+        status: 'info',
+        title: 'Share ended',
+        detail: 'Your screen share ended because the shared window or program was closed.',
+      };
+    case 'interrupted':
+      return {
+        status: 'info',
+        title: 'Share ended',
+        detail: 'Your screen share ended because of an unexpected technical issue.',
+      };
+    case 'error':
+      return {
+        status: 'error',
+        title: 'Screen share failed',
+        detail: 'Brmble could not keep your screen share running because of a technical issue.',
+      };
+  }
+}
+
+export function createQueuedScreenShareEndedNotification(
+  reason: 'manual' | 'source-closed' | 'interrupted' | 'error',
+  sequence: number,
+): QueuedScreenShareEndedNotification | null {
+  const notification = getScreenShareEndedNotification(reason);
+  if (!notification) {
+    return null;
+  }
+
+  return {
+    id: `screen-share-ended-${sequence}`,
+    ...notification,
+  };
+}
+
+export function replaceScreenShareEndedNotification(
+  current: QueuedScreenShareEndedNotification | null,
+  reason: 'manual' | 'source-closed' | 'interrupted' | 'error',
+  sequence: number,
+  notifQueue: { unregister: (id: string) => void },
+): QueuedScreenShareEndedNotification | null {
+  if (current) {
+    notifQueue.unregister(current.id);
+  }
+
+  return createQueuedScreenShareEndedNotification(reason, sequence);
+}
 
 const SETTINGS_STORAGE_KEY = 'brmble-settings';
 
@@ -1843,14 +1908,13 @@ const handleConnect = (serverData: SavedServer) => {
     };
   }, []);
 
-  const { isSharing, startSharing, stopSharing, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, remoteVideoEls, disconnectViewer, connectAsViewer } = useScreenShare(() => {
-    setSharingChannelId(undefined);
-  }, screenShareSettings);
-  disconnectViewerRef.current = disconnectViewer;
   const [sharingChannelId, setSharingChannelId] = useState<string | undefined>();
   const [screenShareToast, setScreenShareToast] = useState<{
     userName: string; roomName: string; userId?: number; matrixUserId?: string;
   } | null>(null);
+  const [screenShareEndedNotification, setScreenShareEndedNotification] = useState<QueuedScreenShareEndedNotification | null>(null);
+  const nextScreenShareEndedNotificationIdRef = useRef(0);
+  const screenShareEndedNotificationRef = useRef<QueuedScreenShareEndedNotification | null>(null);
   const [copyToast, setCopyToast] = useState<{ message: string } | null>(null);
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null);
   const [updateProgress, setUpdateProgress] = useState<number | null>(null);
@@ -1863,6 +1927,24 @@ const handleConnect = (serverData: SavedServer) => {
   interface ServerImportToast { id: string; label: string; visible: boolean; }
   const [serverImportToasts, setServerImportToasts] = useState<ServerImportToast[]>([]);
   const nextServerImportToastIdRef = useRef(0);
+
+  const handleLocalScreenShareEnded = useCallback((reason: LocalShareStopReason) => {
+    setSharingChannelId(undefined);
+
+    const notification = replaceScreenShareEndedNotification(
+      screenShareEndedNotificationRef.current,
+      reason,
+      nextScreenShareEndedNotificationIdRef.current++,
+      notifQueue,
+    );
+    screenShareEndedNotificationRef.current = notification;
+    setScreenShareEndedNotification(notification);
+  }, [notifQueue]);
+
+  const { isSharing, startSharing, stopSharing, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, remoteVideoEls, disconnectViewer, connectAsViewer } = useScreenShare(() => {
+    setSharingChannelId(undefined);
+  }, screenShareSettings, handleLocalScreenShareEnded);
+  disconnectViewerRef.current = disconnectViewer;
 
   const handleServersImported = useCallback((labels: string[]) => {
     const toasts = labels.map((label) => ({ id: `srv-${nextServerImportToastIdRef.current++}`, label, visible: true }));
@@ -1894,6 +1976,15 @@ const handleConnect = (serverData: SavedServer) => {
     }
     prevBrokenIdsRef.current = currentIds;
   }, [brokenCertInfo, notifQueue]);
+
+  useEffect(() => {
+    if (screenShareEndedNotification) {
+      notifQueue.register(screenShareEndedNotification.id, screenShareEndedNotification.status);
+    } else {
+      // Existing queued share-ended notifications are explicitly unregistered
+      // from dismissal/exit handlers so a replacement event gets fresh metadata.
+    }
+  }, [screenShareEndedNotification, notifQueue]);
 
   const { isOnCooldown: leaveVoiceOnCooldown, trigger: triggerLeaveVoiceCooldown } = useLeaveVoiceCooldown(1000);
   const { isOnCooldown: muteOnCooldown, trigger: triggerMuteCooldown } = useLeaveVoiceCooldown(1000);
@@ -2422,6 +2513,27 @@ const handleConnect = (serverData: SavedServer) => {
             }}
             onExited={() => {
               notifQueue.unregister('screen-share');
+            }}
+          />
+        )}
+        {screenShareEndedNotification && notifQueue.isVisible(screenShareEndedNotification.id) && (
+          <Notification
+            key={screenShareEndedNotification.id}
+            status={screenShareEndedNotification.status}
+            position="top-right"
+            visible={!!screenShareEndedNotification}
+            title={screenShareEndedNotification.title}
+            detail={screenShareEndedNotification.detail}
+            onDismiss={() => {
+              notifQueue.unregister(screenShareEndedNotification.id);
+              screenShareEndedNotificationRef.current = null;
+              setScreenShareEndedNotification(null);
+            }}
+            onExited={() => {
+              notifQueue.unregister(screenShareEndedNotification.id);
+              if (screenShareEndedNotificationRef.current?.id === screenShareEndedNotification.id) {
+                screenShareEndedNotificationRef.current = null;
+              }
             }}
           />
         )}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -52,7 +52,7 @@ export interface QueuedScreenShareEndedNotification extends ScreenShareEndedNoti
   id: string;
 }
 
-export function getScreenShareEndedNotification(reason: 'manual' | 'source-closed' | 'interrupted' | 'error'): ScreenShareEndedNotification | null {
+export function getScreenShareEndedNotification(reason: LocalShareStopReason): ScreenShareEndedNotification | null {
   switch (reason) {
     case 'manual':
       return null;
@@ -74,11 +74,15 @@ export function getScreenShareEndedNotification(reason: 'manual' | 'source-close
         title: 'Screen share failed',
         detail: 'Brmble could not keep your screen share running because of a technical issue.',
       };
+    default: {
+      const exhaustiveReason: never = reason;
+      return exhaustiveReason;
+    }
   }
 }
 
 export function createQueuedScreenShareEndedNotification(
-  reason: 'manual' | 'source-closed' | 'interrupted' | 'error',
+  reason: LocalShareStopReason,
   sequence: number,
 ): QueuedScreenShareEndedNotification | null {
   const notification = getScreenShareEndedNotification(reason);
@@ -94,7 +98,7 @@ export function createQueuedScreenShareEndedNotification(
 
 export function replaceScreenShareEndedNotification(
   current: QueuedScreenShareEndedNotification | null,
-  reason: 'manual' | 'source-closed' | 'interrupted' | 'error',
+  reason: LocalShareStopReason,
   sequence: number,
   notifQueue: { unregister: (id: string) => void },
 ): QueuedScreenShareEndedNotification | null {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import bridge from './bridge';
-import type { ConnectionStatus, ChatMessage } from './types';
+import type { ConnectionStatus, ChatMessage, ServiceStatus } from './types';
 import { encodeForMumble } from './utils/imageUpload';
 import { useMatrixClient } from './hooks/useMatrixClient';
 import type { MatrixCredentials } from './hooks/useMatrixClient';
@@ -103,6 +103,83 @@ export function replaceScreenShareEndedNotification(
   }
 
   return createQueuedScreenShareEndedNotification(reason, sequence);
+}
+
+interface ToggleLocalScreenShareOptions {
+  isSharing: boolean;
+  selfLeftVoice: boolean;
+  voiceChannelId?: number;
+  startSharing: (roomName: string) => Promise<void>;
+  stopSharing: () => Promise<void>;
+  setSharingChannelId: (channelId: string | undefined) => void;
+}
+
+interface NextLiveKitStatusOptions {
+  isSharing: boolean;
+  watchingShareCount: number;
+  screenShareError: string | null;
+  isLocalShareStartPending: boolean;
+}
+
+interface LocalShareStartPendingTeardownOptions {
+  isLocalShareStartPending: boolean;
+  selfLeftVoice: boolean;
+  voiceChannelId?: number;
+}
+
+export function getNextLiveKitStatusUpdate({
+  isSharing,
+  watchingShareCount,
+  screenShareError,
+  isLocalShareStartPending,
+}: NextLiveKitStatusOptions): Partial<ServiceStatus> | null {
+  if (isSharing || watchingShareCount > 0) {
+    return { state: 'connected', error: undefined };
+  }
+
+  if (isLocalShareStartPending) {
+    return null;
+  }
+
+  if (!screenShareError) {
+    return { state: 'idle', error: undefined };
+  }
+
+  return null;
+}
+
+export function shouldClearLocalShareStartPending({
+  isLocalShareStartPending,
+  selfLeftVoice,
+  voiceChannelId,
+}: LocalShareStartPendingTeardownOptions): boolean {
+  return isLocalShareStartPending && (selfLeftVoice || voiceChannelId == null || voiceChannelId === 0);
+}
+
+export async function toggleLocalScreenShare({
+  isSharing,
+  selfLeftVoice,
+  voiceChannelId,
+  startSharing,
+  stopSharing,
+  setSharingChannelId,
+}: ToggleLocalScreenShareOptions) {
+  if (isSharing) {
+    await stopSharing();
+    setSharingChannelId(undefined);
+    return;
+  }
+
+  if (selfLeftVoice || voiceChannelId == null || voiceChannelId === 0) {
+    return;
+  }
+
+  try {
+    await startSharing(`channel-${voiceChannelId}`);
+    setSharingChannelId(String(voiceChannelId));
+  } catch {
+    // startSharing sets error state internally; App effects handle status updates.
+  }
 }
 
 const SETTINGS_STORAGE_KEY = 'brmble-settings';
@@ -1909,6 +1986,7 @@ const handleConnect = (serverData: SavedServer) => {
   }, []);
 
   const [sharingChannelId, setSharingChannelId] = useState<string | undefined>();
+  const [isLocalShareStartPending, setIsLocalShareStartPending] = useState(false);
   const [screenShareToast, setScreenShareToast] = useState<{
     userName: string; roomName: string; userId?: number; matrixUserId?: string;
   } | null>(null);
@@ -2055,13 +2133,29 @@ const handleConnect = (serverData: SavedServer) => {
 
   // Track screenshare connection state for service status indicator
   useEffect(() => {
-    if (isSharing || watchingShares.length > 0) {
-      updateStatus('livekit', { state: 'connected', error: undefined });
-    } else if (!screenShareError) {
-      // Only reset to idle if there's no active error (error case handled above)
-      updateStatus('livekit', { state: 'idle', error: undefined });
+    const nextStatus = getNextLiveKitStatusUpdate({
+      isSharing,
+      watchingShareCount: watchingShares.length,
+      screenShareError,
+      isLocalShareStartPending,
+    });
+
+    if (nextStatus) {
+      updateStatus('livekit', nextStatus);
     }
-  }, [isSharing, watchingShares.length, screenShareError, updateStatus]);
+  }, [isSharing, watchingShares.length, screenShareError, isLocalShareStartPending, updateStatus]);
+
+  const selfVoiceChannelId = users.find(u => u.self)?.channelId;
+
+  useEffect(() => {
+    if (shouldClearLocalShareStartPending({
+      isLocalShareStartPending,
+      selfLeftVoice,
+      voiceChannelId: selfVoiceChannelId,
+    })) {
+      setIsLocalShareStartPending(false);
+    }
+  }, [isLocalShareStartPending, selfLeftVoice, selfVoiceChannelId]);
 
   // Show toast notification when someone starts sharing in the user's voice channel
   useEffect(() => {
@@ -2098,23 +2192,26 @@ const handleConnect = (serverData: SavedServer) => {
   }, [currentChannelId, disconnectViewer]);
 
   const handleToggleScreenShare = useCallback(async () => {
-    if (isSharing) {
-      await stopSharing();
-      setSharingChannelId(undefined);
-    } else if (!selfLeftVoice) {
-      const selfUser = usersRef.current.find(u => u.self);
-      const voiceChannelId = selfUser?.channelId;
-      if (voiceChannelId != null && voiceChannelId !== 0) {
-        updateStatus('livekit', { state: 'connecting', error: undefined });
-        try {
-          await startSharing(`channel-${voiceChannelId}`);
-          setSharingChannelId(String(voiceChannelId));
-        } catch {
-          // startSharing sets error state internally; useEffect above handles status
-        }
-      }
+    const selfUser = usersRef.current.find(u => u.self);
+    const shouldStartSharing = !isSharing && !selfLeftVoice && selfUser?.channelId != null && selfUser.channelId !== 0;
+
+    if (shouldStartSharing) {
+      setIsLocalShareStartPending(true);
     }
-  }, [isSharing, startSharing, stopSharing, selfLeftVoice, updateStatus]);
+
+    await toggleLocalScreenShare({
+      isSharing,
+      selfLeftVoice,
+      voiceChannelId: selfUser?.channelId,
+      startSharing,
+      stopSharing,
+      setSharingChannelId,
+    });
+
+    if (shouldStartSharing) {
+      setIsLocalShareStartPending(false);
+    }
+  }, [isSharing, startSharing, stopSharing, selfLeftVoice]);
   handleToggleScreenShareRef.current = handleToggleScreenShare;
 
   const handleWatchScreenShare = useCallback((roomName: string, userId?: number, matrixUserId?: string) => {

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
@@ -226,6 +226,26 @@
   filter: drop-shadow(0 0 3px var(--accent-secondary));
 }
 
+.sharing-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  flex-shrink: 0;
+}
+
+.sharing-indicator .user-status-icon-btn {
+  flex-shrink: 0;
+}
+
+.sharing-badge {
+  font-size: var(--text-2xs);
+  color: var(--accent-primary);
+  padding: 1px var(--space-xs);
+  background: var(--accent-primary-subtle);
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+}
+
 .user-name {
   flex: 1;
   overflow: hidden;

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChannelTree } from './ChannelTree';
+import type { ShareInfo } from '../../hooks/useScreenShare';
+
+const { bridgeMock, usePermissionsMock } = vi.hoisted(() => ({
+  bridgeMock: {
+    on: vi.fn(),
+    off: vi.fn(),
+    send: vi.fn(),
+  },
+  usePermissionsMock: vi.fn(() => ({
+    hasPermission: vi.fn(() => false),
+    Permission: {
+      Move: 0x20,
+      MakeChannel: 0x40,
+      Write: 0x1,
+      Kick: 0x10000,
+      Ban: 0x20000,
+      MuteDeafen: 0x10,
+    },
+    requestPermissions: vi.fn(),
+  })),
+}));
+
+vi.mock('../ContextMenu/ContextMenu', () => ({
+  ContextMenu: ({ items }: { items: Array<{ label?: string; type: string }> }) => (
+    <div data-testid="context-menu">
+      {items.map((item, index) =>
+        item.type === 'item' ? <button key={`${item.label}-${index}`}>{item.label}</button> : <hr key={`divider-${index}`} />
+      )}
+    </div>
+  ),
+}));
+
+vi.mock('../UserInfoDialog/UserInfoDialog', () => ({
+  UserInfoDialog: () => null,
+}));
+
+vi.mock('../Tooltip/Tooltip', () => ({
+  Tooltip: ({ children }: { children: unknown }) => <>{children}</>,
+}));
+
+vi.mock('../UserTooltip/UserTooltip', () => ({
+  UserTooltip: ({ children }: { children: unknown }) => <>{children}</>,
+}));
+
+vi.mock('../EditChannelDialog/EditChannelDialog', () => ({
+  EditChannelDialog: () => null,
+}));
+
+vi.mock('../RenameConfirmDialog/RenameConfirmDialog', () => ({
+  RenameConfirmDialog: () => null,
+}));
+
+vi.mock('../Avatar/Avatar', () => ({
+  default: ({ user }: { user: { name: string } }) => <div data-testid={`avatar-${user.name}`} />,
+}));
+
+vi.mock('../Icon/Icon', () => ({
+  Icon: ({ name, className }: { name: string; className?: string }) => (
+    <span data-icon={name} className={className} />
+  ),
+}));
+
+vi.mock('../../bridge', () => ({
+  default: bridgeMock,
+}));
+
+vi.mock('../../hooks/usePrompt', () => ({
+  prompt: vi.fn(),
+}));
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => usePermissionsMock(),
+}));
+
+const channels = [{ id: 1, name: 'General' }];
+
+const makeShare = (overrides: Partial<ShareInfo> = {}): ShareInfo => ({
+  roomName: 'channel-1',
+  userName: 'Alice',
+  userId: 42,
+  matrixUserId: '@alice:example.com',
+  sessionId: 2,
+  ...overrides,
+});
+
+describe('ChannelTree screen share behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows local sharing without watch controls or watch actions', () => {
+    const onWatchScreenShare = vi.fn();
+
+    render(
+      <ChannelTree
+        channels={channels}
+        users={[
+          { session: 1, name: 'Me', channelId: 1, self: true },
+        ]}
+        currentChannelId={1}
+        onJoinChannel={vi.fn()}
+        onWatchScreenShare={onWatchScreenShare}
+        sharingUserSession={1}
+      />
+    );
+
+    const row = screen.getByText('Me').closest('.user-row');
+    expect(row).not.toBeNull();
+    fireEvent.doubleClick(row!);
+
+    expect(screen.getByText('Sharing')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Watch screen share from Me')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Watching screen share from Me')).not.toBeInTheDocument();
+    expect(row?.querySelector('.user-status-area [data-icon="monitor"]')).toBeNull();
+    expect(row?.querySelector('.sharing-indicator [data-icon="monitor"]')).not.toBeNull();
+    expect(onWatchScreenShare).not.toHaveBeenCalled();
+  });
+
+  it('does not expose remote watch behavior when self also appears in active shares', () => {
+    const onWatchScreenShare = vi.fn();
+    const selfShare = makeShare({
+      userName: 'Me',
+      userId: 1,
+      sessionId: 1,
+      matrixUserId: '@me:example.com',
+    });
+
+    render(
+      <ChannelTree
+        channels={channels}
+        users={[
+          { session: 1, name: 'Me', channelId: 1, self: true, matrixUserId: '@me:example.com' },
+        ]}
+        currentChannelId={1}
+        onJoinChannel={vi.fn()}
+        onWatchScreenShare={onWatchScreenShare}
+        sharingUserSession={1}
+        activeShares={[selfShare]}
+        watchingShares={[selfShare]}
+      />
+    );
+
+    const row = screen.getByText('Me').closest('.user-row');
+    expect(row).not.toBeNull();
+
+    fireEvent.doubleClick(row!);
+    fireEvent.contextMenu(row!);
+
+    expect(screen.getByText('Sharing')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Watch screen share from Me')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Watching screen share from Me')).not.toBeInTheDocument();
+    expect(screen.queryByText('Watch Stream')).not.toBeInTheDocument();
+    expect(row?.querySelector('.user-status-icon-btn')).toBeNull();
+    expect(row?.querySelector('.user-status-icon--watching')).toBeNull();
+    expect(onWatchScreenShare).not.toHaveBeenCalled();
+  });
+
+  it('keeps remote watch behavior and leaves mute and deafen in the status area', () => {
+    const onWatchScreenShare = vi.fn();
+    const share = makeShare();
+
+    render(
+      <ChannelTree
+        channels={channels}
+        users={[
+          { session: 2, name: 'Alice', channelId: 1, muted: true, deafened: true, matrixUserId: '@alice:example.com' },
+        ]}
+        currentChannelId={1}
+        onJoinChannel={vi.fn()}
+        onWatchScreenShare={onWatchScreenShare}
+        activeShares={[share]}
+      />
+    );
+
+    const row = screen.getByText('Alice').closest('.user-row');
+    expect(row).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Watch screen share from Alice'));
+
+    expect(onWatchScreenShare).toHaveBeenCalledWith('channel-1', 42, '@alice:example.com');
+    expect(row?.querySelector('.user-status-area [data-icon="monitor"]')).toBeNull();
+    expect(row?.querySelector('.sharing-indicator [data-icon="monitor"]')).not.toBeNull();
+    expect(row?.querySelector('.user-status-area .user-status-icon--muted')).not.toBeNull();
+    expect(row?.querySelector('.user-status-area .user-status-icon--deaf')).not.toBeNull();
+  });
+
+  it('still lets remote watched shares unwatch', () => {
+    const onStopWatching = vi.fn();
+    const share = makeShare();
+
+    render(
+      <ChannelTree
+        channels={channels}
+        users={[
+          { session: 2, name: 'Alice', channelId: 1, matrixUserId: '@alice:example.com' },
+        ]}
+        currentChannelId={1}
+        onJoinChannel={vi.fn()}
+        onStopWatching={onStopWatching}
+        activeShares={[share]}
+        watchingShares={[share]}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Watching screen share from Alice'));
+
+    expect(onStopWatching).toHaveBeenCalledWith(42);
+  });
+
+  it('renders the Sharing text before the monitor icon', () => {
+    const share = makeShare();
+
+    render(
+      <ChannelTree
+        channels={channels}
+        users={[
+          { session: 2, name: 'Alice', channelId: 1, matrixUserId: '@alice:example.com' },
+        ]}
+        currentChannelId={1}
+        onJoinChannel={vi.fn()}
+        activeShares={[share]}
+      />
+    );
+
+    const indicator = screen.getByText('Sharing').closest('.sharing-indicator');
+    expect(indicator).not.toBeNull();
+    expect(indicator?.firstElementChild).toHaveTextContent('Sharing');
+  });
+});

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -310,77 +310,76 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
         
         {isExpanded && (
           <div className="channel-children">
-            {channel.users.map(user => (
-              <UserTooltip key={user.session} user={user}>
-              <div
-                className={`user-row ${user.self ? 'self' : ''} ${speakingUsers?.has(user.session) ? 'speaking' : ''}${canDragUsers && !user.self ? ' user-row--draggable' : ''}`}
-                style={{ paddingLeft: `calc(4px + ${level * 20}px)` }}
-                draggable={canDragUsers && !user.self}
-                onDragStart={(e) => {
-                  if (!canDragUsers || user.self) return;
-                  e.dataTransfer.setData('text/plain', String(user.session));
-                  e.dataTransfer.effectAllowed = 'move';
-                  setDraggedUser(user.session);
-                }}
-                onDragEnd={() => {
-                  setDraggedUser(null);
-                  setDropTargetChannel(null);
-                }}
-                onContextMenu={(e) => {
-                  e.preventDefault();
-                  setContextMenu({ x: e.clientX, y: e.clientY, userId: String(user.session), userName: user.name, isSelf: !!user.self, channelId: channel.id });
-                }}
-                onDoubleClick={(() => {
-                  const share = activeShares?.find(s => s.sessionId === user.session);
-                  if (share) return () => onWatchScreenShare?.(`channel-${channel.id}`, share.userId, share.matrixUserId);
-                  if (user.session === sharingUserSession) return () => onWatchScreenShare?.(`channel-${channel.id}`);
-                  return undefined;
-                })()}
-              >
-                <span className="user-status-area">
-                  {(activeShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession) ? (
-                    <button
-                      className={`user-status-icon-btn${(watchingShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession) ? ' user-status-icon-btn--watching' : ''}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        const share = activeShares?.find(s => s.sessionId === user.session);
-                        if (share) {
-                          const isWatching = watchingShares?.some(s => s.userId === share.userId);
-                          if (isWatching) {
-                            onStopWatching?.(share.userId);
-                          } else {
-                            onWatchScreenShare?.(`channel-${channel.id}`, share.userId, share.matrixUserId);
-                          }
-                        } else {
-                          onWatchScreenShare?.(`channel-${channel.id}`);
-                        }
-                      }}
-                      aria-label={`${(watchingShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession) ? 'Watching' : 'Watch'} screen share from ${user.name}`}
-                      aria-pressed={!!(watchingShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession)}
-                    >
-                      <Icon name="monitor" size={11} className={`user-status-icon user-status-icon--sharing${watchingShares?.some(s => s.sessionId === user.session) ? ' user-status-icon--watching' : ''}`} stroke="var(--accent-primary)" strokeWidth={2.5} />
-                    </button>
-                  ) : (
-                    <>
+            {channel.users.map(user => {
+              const share = activeShares?.find(s => s.sessionId === user.session);
+              const isLocalSharer = !!user.self && user.session === sharingUserSession;
+              const isRemoteSharer = !!share && !user.self;
+              const isSharer = isLocalSharer || isRemoteSharer;
+              const isWatchingRemoteShare = !!share && !!watchingShares?.some(s => s.userId === share.userId);
+
+              return (
+                <UserTooltip key={user.session} user={user}>
+                  <div
+                    className={`user-row ${user.self ? 'self' : ''} ${speakingUsers?.has(user.session) ? 'speaking' : ''}${canDragUsers && !user.self ? ' user-row--draggable' : ''}`}
+                    style={{ paddingLeft: `calc(4px + ${level * 20}px)` }}
+                    draggable={canDragUsers && !user.self}
+                    onDragStart={(e) => {
+                      if (!canDragUsers || user.self) return;
+                      e.dataTransfer.setData('text/plain', String(user.session));
+                      e.dataTransfer.effectAllowed = 'move';
+                      setDraggedUser(user.session);
+                    }}
+                    onDragEnd={() => {
+                      setDraggedUser(null);
+                      setDropTargetChannel(null);
+                    }}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      setContextMenu({ x: e.clientX, y: e.clientY, userId: String(user.session), userName: user.name, isSelf: !!user.self, channelId: channel.id });
+                    }}
+                    onDoubleClick={isRemoteSharer ? () => onWatchScreenShare?.(`channel-${channel.id}`, share?.userId, share?.matrixUserId) : undefined}
+                  >
+                    <span className="user-status-area">
                       {user.deafened && (
                         <Icon name="headphones-off" size={11} className="user-status-icon user-status-icon--deaf" strokeWidth={2.5} />
                       )}
                       {user.muted && (
                         <Icon name="mic-off" size={11} className="user-status-icon user-status-icon--muted" strokeWidth={2.5} />
                       )}
-                    </>
-                  )}
-                </span>
-                <Avatar user={{ name: user.name, matrixUserId: user.matrixUserId, avatarUrl: user.avatarUrl }} size={20} isMumbleOnly={!user.self && !user.isBrmbleClient} />
-                <span className="user-name">{user.name}</span>
-                {user.self && <span className="self-badge">(you)</span>}
-                {user.isBrmbleClient && <Tooltip content="Brmble user"><span className="brmble-badge" /></Tooltip>}
-                {(activeShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession) && (
-                  <span className="sharing-badge">Sharing</span>
-                )}
-              </div>
-              </UserTooltip>
-            ))}
+                    </span>
+                    <Avatar user={{ name: user.name, matrixUserId: user.matrixUserId, avatarUrl: user.avatarUrl }} size={20} isMumbleOnly={!user.self && !user.isBrmbleClient} />
+                    <span className="user-name">{user.name}</span>
+                    {user.self && <span className="self-badge">(you)</span>}
+                    {user.isBrmbleClient && <Tooltip content="Brmble user"><span className="brmble-badge" /></Tooltip>}
+                    {isSharer && (
+                      <span className="sharing-indicator">
+                        <span className="sharing-badge">Sharing</span>
+                        {isRemoteSharer ? (
+                          <button
+                            className={`user-status-icon-btn${isWatchingRemoteShare ? ' user-status-icon-btn--watching' : ''}`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (!share) return;
+                              if (isWatchingRemoteShare) {
+                                onStopWatching?.(share.userId);
+                              } else {
+                                onWatchScreenShare?.(`channel-${channel.id}`, share.userId, share.matrixUserId);
+                              }
+                            }}
+                            aria-label={`${isWatchingRemoteShare ? 'Watching' : 'Watch'} screen share from ${user.name}`}
+                            aria-pressed={isWatchingRemoteShare}
+                          >
+                            <Icon name="monitor" size={11} className={`user-status-icon user-status-icon--sharing${isWatchingRemoteShare ? ' user-status-icon--watching' : ''}`} stroke="var(--accent-primary)" strokeWidth={2.5} />
+                          </button>
+                        ) : (
+                          <Icon name="monitor" size={11} className="user-status-icon user-status-icon--sharing" stroke="var(--accent-primary)" strokeWidth={2.5} />
+                        )}
+                      </span>
+                    )}
+                  </div>
+                </UserTooltip>
+              );
+            })}
             {channel.children.map(child => renderChannel(child, level + 1))}
           </div>
         )}
@@ -448,7 +447,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
           x={contextMenu.x}
           y={contextMenu.y}
           items={[
-            ...((activeShares?.some(s => s.sessionId === Number(contextMenu.userId)) || contextMenu.userId === String(sharingUserSession)) && onWatchScreenShare ? [{
+            ...(activeShares?.some(s => s.sessionId === Number(contextMenu.userId)) && !contextMenu.isSelf && onWatchScreenShare ? [{
               type: 'item' as const,
               label: 'Watch Stream',
               icon: (

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.css
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.css
@@ -198,6 +198,47 @@
   color: color-mix(in srgb, var(--accent-primary) 55%, transparent);
 }
 
+.root-user-row .user-status-area {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  width: 24px;
+  flex-shrink: 0;
+}
+
+.root-user-row .user-status-icon-btn {
+  background: none;
+  border: none;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.root-user-row .user-status-icon-btn:hover {
+  background: var(--accent-primary-wash);
+}
+
+.root-user-row .user-status-icon-btn--watching {
+  background: var(--accent-secondary-subtle);
+}
+
+.root-user-row .user-status-icon-btn--watching .user-status-icon--sharing {
+  stroke: var(--accent-secondary) !important;
+}
+
+.root-user-row .user-status-icon-btn--watching:hover {
+  background: var(--accent-secondary-subtle);
+  opacity: 0.85;
+}
+
+.root-user-row .user-status-icon--watching {
+  filter: drop-shadow(0 0 3px var(--accent-secondary));
+}
+
 .root-user-name {
   flex: 1;
   overflow: hidden;
@@ -225,13 +266,23 @@
   text-transform: lowercase;
 }
 
+.sharing-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  flex-shrink: 0;
+}
+
+.sharing-indicator .user-status-icon-btn {
+  flex-shrink: 0;
+}
+
 .sharing-badge {
   font-size: var(--text-2xs);
   color: var(--accent-primary);
   padding: 1px var(--space-xs);
   background: var(--accent-primary-subtle);
   border-radius: var(--radius-md);
-  margin-left: var(--space-2xs);
   flex-shrink: 0;
 }
 

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Sidebar } from './Sidebar';
+import type { ShareInfo } from '../../hooks/useScreenShare';
+
+const { bridgeMock, usePermissionsMock, useServiceStatusMock, useResizableMock } = vi.hoisted(() => ({
+  bridgeMock: {
+    send: vi.fn(),
+  },
+  usePermissionsMock: vi.fn(() => ({
+    hasPermission: vi.fn(() => false),
+    Permission: {
+      Kick: 0x10000,
+      Ban: 0x20000,
+      MuteDeafen: 0x10,
+      Move: 0x20,
+      MakeChannel: 0x40,
+      Write: 0x1,
+    },
+    requestPermissions: vi.fn(),
+  })),
+  useServiceStatusMock: vi.fn(() => ({
+    statuses: {
+      voice: { state: 'idle' },
+      chat: { state: 'idle' },
+      server: { state: 'idle' },
+      livekit: { state: 'idle' },
+    },
+  })),
+  useResizableMock: vi.fn(() => ({
+    width: 340,
+    isDragging: false,
+    handleProps: {
+      ref: null,
+      onPointerDown: vi.fn(),
+      onDoubleClick: vi.fn(),
+    },
+  })),
+}));
+
+vi.mock('./ChannelTree', () => ({
+  ChannelTree: () => <div data-testid="channel-tree" />,
+}));
+
+vi.mock('../ContextMenu/ContextMenu', () => ({
+  ContextMenu: () => null,
+}));
+
+vi.mock('../UserInfoDialog/UserInfoDialog', () => ({
+  UserInfoDialog: () => null,
+}));
+
+vi.mock('../UserTooltip/UserTooltip', () => ({
+  UserTooltip: ({ children }: { children: unknown }) => <>{children}</>,
+}));
+
+vi.mock('../Tooltip/Tooltip', () => ({
+  Tooltip: ({ children }: { children: unknown }) => <>{children}</>,
+}));
+
+vi.mock('../Avatar/Avatar', () => ({
+  default: ({ user }: { user: { name: string } }) => <div data-testid={`avatar-${user.name}`} />,
+}));
+
+vi.mock('../Icon/Icon', () => ({
+  Icon: ({ name, className }: { name: string; className?: string }) => (
+    <span data-icon={name} className={className} />
+  ),
+}));
+
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => usePermissionsMock(),
+}));
+
+vi.mock('../../hooks/useServiceStatus', () => ({
+  useServiceStatus: () => useServiceStatusMock(),
+}));
+
+vi.mock('../../hooks/useResizable', () => ({
+  useResizable: () => useResizableMock(),
+}));
+
+vi.mock('../../contexts/ProfileContext', () => ({
+  useProfileFingerprint: () => 'fingerprint',
+}));
+
+vi.mock('../../hooks/usePrompt', () => ({
+  prompt: vi.fn(),
+}));
+
+vi.mock('../../bridge', () => ({
+  default: bridgeMock,
+}));
+
+const channels = [{ id: 0, name: 'Connected', parent: 0 }];
+
+const makeShare = (overrides: Partial<ShareInfo> = {}): ShareInfo => ({
+  roomName: 'channel-0',
+  userName: 'Alice',
+  userId: 42,
+  matrixUserId: '@alice:example.com',
+  sessionId: 2,
+  ...overrides,
+});
+
+function renderSidebar(props: Partial<React.ComponentProps<typeof Sidebar>> = {}) {
+  return render(
+    <Sidebar
+      channels={channels}
+      users={[]}
+      connectionStatus="connected"
+      onJoinChannel={vi.fn()}
+      onSelectChannel={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+describe('Sidebar root user screen share behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows local sharing without watch controls or watch actions', () => {
+    const onWatchScreenShare = vi.fn();
+
+    renderSidebar({
+      users: [
+        { session: 1, name: 'Me', channelId: 0, self: true },
+      ],
+      onWatchScreenShare,
+      sharingUserSession: 1,
+    });
+
+    const row = screen.getByText('Me').closest('.root-user-row');
+    expect(row).not.toBeNull();
+
+    fireEvent.doubleClick(row!);
+
+    expect(screen.getByText('Sharing')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Watch screen share from Me')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Watching screen share from Me')).not.toBeInTheDocument();
+    expect(row?.querySelector('.user-status-area [data-icon="monitor"]')).toBeNull();
+    expect(row?.querySelector('.sharing-indicator [data-icon="monitor"]')).not.toBeNull();
+    expect(onWatchScreenShare).not.toHaveBeenCalled();
+  });
+
+  it('does not expose watch behavior when self also appears in active shares', () => {
+    const onWatchScreenShare = vi.fn();
+    const selfShare = makeShare({
+      userName: 'Me',
+      userId: 1,
+      sessionId: 1,
+      matrixUserId: '@me:example.com',
+    });
+
+    renderSidebar({
+      users: [
+        { session: 1, name: 'Me', channelId: 0, self: true, matrixUserId: '@me:example.com' },
+      ],
+      onWatchScreenShare,
+      sharingUserSession: 1,
+      activeShares: [selfShare],
+      watchingShares: [selfShare],
+    });
+
+    const row = screen.getByText('Me').closest('.root-user-row');
+    expect(row).not.toBeNull();
+
+    fireEvent.doubleClick(row!);
+
+    expect(screen.getByText('Sharing')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Watch screen share from Me')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Watching screen share from Me')).not.toBeInTheDocument();
+    expect(row?.querySelector('.user-status-icon-btn')).toBeNull();
+    expect(row?.querySelector('.user-status-icon--watching')).toBeNull();
+    expect(onWatchScreenShare).not.toHaveBeenCalled();
+  });
+
+  it('keeps remote watch behavior and leaves mute and deafen in the status area', () => {
+    const onWatchScreenShare = vi.fn();
+    const share = makeShare();
+
+    renderSidebar({
+      users: [
+        { session: 2, name: 'Alice', channelId: 0, muted: true, deafened: true, matrixUserId: '@alice:example.com' },
+      ],
+      onWatchScreenShare,
+      activeShares: [share],
+    });
+
+    const row = screen.getByText('Alice').closest('.root-user-row');
+    expect(row).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Watch screen share from Alice'));
+
+    expect(onWatchScreenShare).toHaveBeenCalledWith('channel-0', 42, '@alice:example.com');
+    expect(row?.querySelector('.user-status-area [data-icon="monitor"]')).toBeNull();
+    expect(row?.querySelector('.sharing-indicator [data-icon="monitor"]')).not.toBeNull();
+    expect(row?.querySelector('.user-status-area .user-status-icon--muted')).not.toBeNull();
+    expect(row?.querySelector('.user-status-area .user-status-icon--deaf')).not.toBeNull();
+  });
+
+  it('stops watching a remote root user share when the watched control is clicked', () => {
+    const onWatchScreenShare = vi.fn();
+    const onStopWatching = vi.fn();
+    const share = makeShare();
+
+    renderSidebar({
+      users: [
+        { session: 2, name: 'Alice', channelId: 0, matrixUserId: '@alice:example.com' },
+      ],
+      onWatchScreenShare,
+      onStopWatching,
+      activeShares: [share],
+      watchingShares: [share],
+    });
+
+    fireEvent.click(screen.getByLabelText('Watching screen share from Alice'));
+
+    expect(onStopWatching).toHaveBeenCalledWith(42);
+    expect(onWatchScreenShare).not.toHaveBeenCalled();
+  });
+
+  it('renders the Sharing text before the monitor icon', () => {
+    const share = makeShare();
+
+    renderSidebar({
+      users: [
+        { session: 2, name: 'Alice', channelId: 0, matrixUserId: '@alice:example.com' },
+      ],
+      activeShares: [share],
+    });
+
+    const indicator = screen.getByText('Sharing').closest('.sharing-indicator');
+    expect(indicator).not.toBeNull();
+    expect(indicator?.firstElementChild).toHaveTextContent('Sharing');
+  });
+});

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -274,65 +274,64 @@ export function Sidebar({
             <span className="root-users-count">{rootUsers.length}</span>
           </div>
           <div className="root-users-list">
-            {rootUsers.map((user, i) => (
-              <UserTooltip key={user.session} user={user}>
-              <div
-                className={`root-user-row${user.self ? ' root-user-self' : ''}`}
-                style={{ animationDelay: `${i * 50}ms` }}
-                onContextMenu={(e) => {
-                  e.preventDefault();
-                  setContextMenu({ x: e.clientX, y: e.clientY, userId: String(user.session), userName: user.name, isSelf: !!user.self });
-                }}
-                onDoubleClick={(() => {
-                  const share = activeShares?.find(s => s.sessionId === user.session);
-                  if (share) return () => onWatchScreenShare?.(`channel-${rootChannel?.id ?? 0}`, share.userId);
-                  if (user.session === sharingUserSession) return () => onWatchScreenShare?.(`channel-${rootChannel?.id ?? 0}`);
-                  return undefined;
-                })()}
-              >
-                <span className="user-status-area">
-                  {(activeShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession) ? (
-                    <button
-                      className={`user-status-icon-btn${(watchingShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession) ? ' user-status-icon-btn--watching' : ''}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        const share = activeShares?.find(s => s.sessionId === user.session);
-                        if (share) {
-                          const isWatching = watchingShares?.some(s => s.userId === share.userId);
-                          if (!isWatching) {
-                            onWatchScreenShare?.(`channel-${rootChannel?.id ?? 0}`, share.userId, share.matrixUserId);
-                          } else {
-                            onStopWatching?.(share.userId);
-                          }
-                        } else {
-                          onWatchScreenShare?.(`channel-${rootChannel?.id ?? 0}`);
-                        }
-                      }}
-                      aria-label={`${(watchingShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession) ? 'Watching' : 'Watch'} screen share from ${user.name}`}
-                      aria-pressed={!!(watchingShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession)}
-                    >
-                      <Icon name="monitor" size={11} className={`user-status-icon user-status-icon--sharing${watchingShares?.some(s => s.sessionId === user.session) ? ' user-status-icon--watching' : ''}`} stroke="var(--accent-primary)" strokeWidth="2.5" />
-                    </button>
-                  ) : (
-                    <>
+            {rootUsers.map((user, i) => {
+              const share = activeShares?.find(s => s.sessionId === user.session);
+              const isLocalSharer = !!user.self && user.session === sharingUserSession;
+              const isRemoteSharer = !!share && !user.self;
+              const isSharer = isLocalSharer || isRemoteSharer;
+              const isWatchingRemoteShare = !!share && !!watchingShares?.some(s => s.userId === share.userId);
+
+              return (
+                <UserTooltip key={user.session} user={user}>
+                  <div
+                    className={`root-user-row${user.self ? ' root-user-self' : ''}`}
+                    style={{ animationDelay: `${i * 50}ms` }}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      setContextMenu({ x: e.clientX, y: e.clientY, userId: String(user.session), userName: user.name, isSelf: !!user.self });
+                    }}
+                    onDoubleClick={isRemoteSharer ? () => onWatchScreenShare?.(`channel-${rootChannel?.id ?? 0}`, share.userId, share.matrixUserId) : undefined}
+                  >
+                    <span className="user-status-area">
                       {user.deafened && (
                         <Icon name="headphones-off" size={11} className="user-status-icon user-status-icon--deaf" strokeWidth="2.5" />
                       )}
                       {user.muted && (
                         <Icon name="mic-off" size={11} className="user-status-icon user-status-icon--muted" strokeWidth="2.5" />
                       )}
-                    </>
-                  )}
-                </span>
-                <Avatar user={{ name: user.name, matrixUserId: user.matrixUserId, avatarUrl: user.avatarUrl }} size={20} isMumbleOnly={!user.self && !user.isBrmbleClient} />
-                <span className="root-user-name">{user.name}</span>
-                {user.self && <span className="root-self-badge">you</span>}
-                {(activeShares?.some(s => s.sessionId === user.session) || user.session === sharingUserSession) && (
-                  <span className="sharing-badge">Sharing</span>
-                )}
-              </div>
-              </UserTooltip>
-            ))}
+                    </span>
+                    <Avatar user={{ name: user.name, matrixUserId: user.matrixUserId, avatarUrl: user.avatarUrl }} size={20} isMumbleOnly={!user.self && !user.isBrmbleClient} />
+                    <span className="root-user-name">{user.name}</span>
+                    {user.self && <span className="root-self-badge">you</span>}
+                    {isSharer && (
+                      <span className="sharing-indicator">
+                        <span className="sharing-badge">Sharing</span>
+                        {isRemoteSharer ? (
+                          <button
+                            className={`user-status-icon-btn${isWatchingRemoteShare ? ' user-status-icon-btn--watching' : ''}`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (!share) return;
+                              if (isWatchingRemoteShare) {
+                                onStopWatching?.(share.userId);
+                              } else {
+                                onWatchScreenShare?.(`channel-${rootChannel?.id ?? 0}`, share.userId, share.matrixUserId);
+                              }
+                            }}
+                            aria-label={`${isWatchingRemoteShare ? 'Watching' : 'Watch'} screen share from ${user.name}`}
+                            aria-pressed={isWatchingRemoteShare}
+                          >
+                            <Icon name="monitor" size={11} className={`user-status-icon user-status-icon--sharing${isWatchingRemoteShare ? ' user-status-icon--watching' : ''}`} stroke="var(--accent-primary)" strokeWidth="2.5" />
+                          </button>
+                        ) : (
+                          <Icon name="monitor" size={11} className="user-status-icon user-status-icon--sharing" stroke="var(--accent-primary)" strokeWidth="2.5" />
+                        )}
+                      </span>
+                    )}
+                  </div>
+                </UserTooltip>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -3,6 +3,41 @@ import { renderHook, act } from '@testing-library/react';
 import { useScreenShare } from './useScreenShare';
 import bridge from '../bridge';
 
+const roomEventHandlers = new Map<string, Set<(...args: unknown[]) => void>>();
+const localTrackEventHandlers = new Map<string, Set<() => void>>();
+let localSharePublicationEnabled = false;
+
+const mockLocalScreenShareTrack = {
+  addEventListener: vi.fn((event: string, handler: () => void) => {
+    const handlers = localTrackEventHandlers.get(event) ?? new Set<() => void>();
+    handlers.add(handler);
+    localTrackEventHandlers.set(event, handlers);
+  }),
+  removeEventListener: vi.fn((event: string, handler: () => void) => {
+    localTrackEventHandlers.get(event)?.delete(handler);
+  }),
+  on: vi.fn((event: string, handler: () => void) => {
+    const handlers = localTrackEventHandlers.get(event) ?? new Set<() => void>();
+    handlers.add(handler);
+    localTrackEventHandlers.set(event, handlers);
+  }),
+  off: vi.fn((event: string, handler: () => void) => {
+    localTrackEventHandlers.get(event)?.delete(handler);
+  }),
+};
+
+const emitRoomEvent = (event: string, ...args: unknown[]) => {
+  for (const handler of roomEventHandlers.get(event) ?? []) {
+    handler(...args);
+  }
+};
+
+const emitLocalTrackEvent = (event: string) => {
+  for (const handler of localTrackEventHandlers.get(event) ?? []) {
+    handler();
+  }
+};
+
 // Mock livekit-client
 const mockRoom = {
   connect: vi.fn().mockImplementation(async () => { mockRoom.state = 'connected'; }),
@@ -10,10 +45,27 @@ const mockRoom = {
   name: 'channel-1',
   state: undefined as string | undefined,
   localParticipant: {
-    setScreenShareEnabled: vi.fn().mockResolvedValue(undefined),
+    setScreenShareEnabled: vi.fn().mockImplementation(async (enabled: boolean) => {
+      localSharePublicationEnabled = enabled;
+    }),
+    getTrackPublication: vi.fn((source: string) => {
+      if (source !== 'screen_share' || !localSharePublicationEnabled) {
+        return undefined;
+      }
+
+      return {
+        track: mockLocalScreenShareTrack,
+        source: 'screen_share',
+      };
+    }),
   },
   remoteParticipants: new Map(),
-  on: vi.fn().mockReturnThis(),
+  on: vi.fn().mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+    const handlers = roomEventHandlers.get(event) ?? new Set<(...args: unknown[]) => void>();
+    handlers.add(handler);
+    roomEventHandlers.set(event, handlers);
+    return mockRoom;
+  }),
 };
 
 vi.mock('livekit-client', () => ({
@@ -49,6 +101,9 @@ describe('useScreenShare', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRoom.state = undefined;
+    roomEventHandlers.clear();
+    localTrackEventHandlers.clear();
+    localSharePublicationEnabled = false;
   });
 
   it('starts in idle state with empty activeShares', () => {
@@ -286,6 +341,210 @@ describe('useScreenShare', () => {
     });
 
     expect(result.current.isSharing).toBe(false);
+  });
+
+  it('surfaces the manual local stop reason once without triggering disconnect callback', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    await act(async () => {
+      await result.current.stopSharing();
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledWith('manual');
+    expect(bridge.send).toHaveBeenCalledWith('livekit.shareStopped', { roomName: 'channel-1' });
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(1);
+  });
+
+  it('classifies local capture ending as source-closed and only stops once', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    await act(async () => {
+      emitLocalTrackEvent('ended');
+      await Promise.resolve();
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledWith('source-closed');
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(1);
+  });
+
+  it('classifies active-share room disconnect as interrupted and notifies once', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    act(() => {
+      emitRoomEvent('disconnected');
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledWith('interrupted');
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(1);
+  });
+
+  it('deduplicates local stop cleanup when source end and disconnect race', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    await act(async () => {
+      emitLocalTrackEvent('ended');
+      emitRoomEvent('disconnected');
+      await Promise.resolve();
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledWith('source-closed');
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(1);
+  });
+
+  it('removes the local ended listener on unmount', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const onLocalShareEnded = vi.fn();
+    const { result, unmount } = renderHook(() => useScreenShare(undefined, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(mockLocalScreenShareTrack.addEventListener).toHaveBeenCalledWith('ended', expect.any(Function));
+
+    unmount();
+
+    expect(mockLocalScreenShareTrack.removeEventListener).toHaveBeenCalledWith('ended', expect.any(Function));
+
+    await act(async () => {
+      emitLocalTrackEvent('ended');
+      await Promise.resolve();
+    });
+
+    expect(onLocalShareEnded).not.toHaveBeenCalled();
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(0);
+  });
+
+  it('classifies start publish failure as error and emits local stop callback once', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    const publishError = new Error('Publish failed');
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+    mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(publishError);
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(result.current.error).toBe('Publish failed');
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledWith('error');
+  });
+
+  it('reports error on quick restart even when previous stop already set the stop guard', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    const publishError = new Error('Publish failed');
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    await act(async () => {
+      await result.current.stopSharing();
+    });
+
+    mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(publishError);
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(result.current.error).toBe('Publish failed');
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(2);
+    expect(onLocalShareEnded).toHaveBeenNthCalledWith(1, 'manual');
+    expect(onLocalShareEnded).toHaveBeenNthCalledWith(2, 'error');
   });
 
   it('passes correct capture options to setScreenShareEnabled', async () => {

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -510,6 +510,186 @@ describe('useScreenShare', () => {
     expect(onLocalShareEnded).toHaveBeenCalledWith('error');
   });
 
+  it('treats picker cancel as a benign pre-share abort', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    const pickerCancelError = new DOMException('Selection canceled by user', 'AbortError');
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+    mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(pickerCancelError);
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).not.toHaveBeenCalled();
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(0);
+  });
+
+  it('keeps close-but-real start failures on the error path', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    const publishError = new DOMException('Permission denied by user while starting capture pipeline', 'AbortError');
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+    mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(publishError);
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(result.current.error).toBe('Permission denied by user while starting capture pipeline');
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledWith('error');
+  });
+
+  it('treats plain exact permission denied by user as benign picker cancel', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    const pickerCancelError = { message: 'Permission denied by user' };
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+    mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(pickerCancelError);
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).not.toHaveBeenCalled();
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(0);
+  });
+
+  it('keeps non-picker errors with longer permission denied wording on the error path', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    const publishError = { message: 'Permission denied by user while starting capture pipeline' };
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+    mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(publishError);
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(result.current.error).toBe('Permission denied by user while starting capture pipeline');
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledWith('error');
+  });
+
+  it('treats DOMException NotAllowedError with permission denied by user as benign picker cancel', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    const pickerCancelError = new DOMException('Permission denied by user', 'NotAllowedError');
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+    mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(pickerCancelError);
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).not.toHaveBeenCalled();
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(0);
+  });
+
+  it('treats DOMException AbortError with permission denied by user as benign picker cancel', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    const pickerCancelError = new DOMException('Permission denied by user', 'AbortError');
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+    mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(pickerCancelError);
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).not.toHaveBeenCalled();
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(0);
+  });
+
+  it('keeps spec-style DOMException NotAllowedError permission denials on the error path', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    const publishError = new DOMException(
+      'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.',
+      'NotAllowedError',
+    );
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+    mockRoom.localParticipant.setScreenShareEnabled.mockRejectedValueOnce(publishError);
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.({ token: 'test-jwt', url: 'ws://localhost/livekit' });
+      await promise;
+    });
+
+    expect(result.current.isSharing).toBe(false);
+    expect(result.current.error).toBe(
+      'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.',
+    );
+    expect(onDisconnected).not.toHaveBeenCalled();
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledWith('error');
+  });
+
   it('reports error on quick restart even when previous stop already set the stop guard', async () => {
     let tokenHandler: ((data: unknown) => void) | null = null;
     const publishError = new Error('Publish failed');

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -33,6 +33,72 @@ type LocalTrackLike = {
   off?: (event: string, handler: () => void) => void;
 };
 
+type ErrorLike = {
+  name?: unknown;
+  message?: unknown;
+  constructor?: {
+    name?: unknown;
+  };
+};
+
+const getErrorLikeDetails = (err: unknown) => {
+  if (!err || typeof err !== 'object') {
+    return null;
+  }
+
+  const { name, message } = err as ErrorLike;
+  return {
+    name: typeof name === 'string' ? name : '',
+    message: typeof message === 'string' ? message : '',
+  };
+};
+
+const isScreenSharePickerCancel = (err: unknown) => {
+  const details = getErrorLikeDetails(err);
+  if (!details) {
+    return false;
+  }
+
+   const normalizedMessage = details.message.trim().toLowerCase();
+
+   if (normalizedMessage === 'permission denied by user') {
+     return true;
+   }
+
+  const isDomExceptionLike = err instanceof DOMException
+    || (typeof (err as ErrorLike).constructor?.name === 'string' && (err as ErrorLike).constructor?.name === 'DOMException');
+
+  if (!isDomExceptionLike) {
+    return false;
+  }
+
+  const normalizedName = details.name.trim().toLowerCase();
+
+  if (normalizedName === 'aborterror') {
+    const knownAbortCancelMessages = new Set([
+      'canceled',
+      'cancelled',
+      'permission denied by user',
+      'selection canceled by user',
+      'selection cancelled by user',
+    ]);
+
+    return knownAbortCancelMessages.has(normalizedMessage);
+  }
+
+  if (normalizedName === 'notallowederror') {
+    const knownDismissMessages = new Set([
+      'permission denied by user',
+      'dismissed',
+      'permission dismissed',
+    ]);
+
+    return knownDismissMessages.has(normalizedMessage);
+  }
+
+  return false;
+};
+
 export function useScreenShare(
   onDisconnected?: () => void,
   screenShareSettings?: ScreenShareSettings,
@@ -344,7 +410,13 @@ export function useScreenShare(
       bridge.send('livekit.shareStarted', { roomName });
     } catch (err) {
       clearLocalShareEndListener();
-      setError(err instanceof Error ? err.message : 'Screen share failed');
+
+      if (isScreenSharePickerCancel(err)) {
+        await maybeDisconnectRoom();
+        return;
+      }
+
+      setError(getErrorLikeDetails(err)?.message || 'Screen share failed');
       await stopLocalShare('error', roomRef.current);
       // Disconnect room if we're not watching anyone either
       await maybeDisconnectRoom();

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -24,7 +24,20 @@ export interface ScreenShareSettings {
   systemAudio: boolean;
 }
 
-export function useScreenShare(onDisconnected?: () => void, screenShareSettings?: ScreenShareSettings) {
+export type LocalShareStopReason = 'manual' | 'source-closed' | 'interrupted' | 'error';
+
+type LocalTrackLike = {
+  addEventListener?: (event: string, handler: () => void) => void;
+  removeEventListener?: (event: string, handler: () => void) => void;
+  on?: (event: string, handler: () => void) => void;
+  off?: (event: string, handler: () => void) => void;
+};
+
+export function useScreenShare(
+  onDisconnected?: () => void,
+  screenShareSettings?: ScreenShareSettings,
+  onLocalShareEnded?: (reason: LocalShareStopReason) => void,
+) {
   const [isSharing, setIsSharing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeShares, setActiveShares] = useState<ShareInfo[]>([]);
@@ -38,7 +51,16 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
   const isSharingRef = useRef(false);
   const focusedShareRef = useRef<ShareInfo | null>(null);
   const onDisconnectedRef = useRef(onDisconnected);
+  const onLocalShareEndedRef = useRef(onLocalShareEnded);
+  const localShareEndCleanupRef = useRef<(() => void) | null>(null);
+  const localShareStopHandledRef = useRef(false);
   onDisconnectedRef.current = onDisconnected;
+  onLocalShareEndedRef.current = onLocalShareEnded;
+
+  const clearLocalShareEndListener = useCallback(() => {
+    localShareEndCleanupRef.current?.();
+    localShareEndCleanupRef.current = null;
+  }, []);
 
   const setFocusedShare: typeof _setFocusedShare = useCallback((action) => {
     _setFocusedShare(prev => {
@@ -123,6 +145,78 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
     });
   }, []);
 
+  // Try to disconnect the room, but only if we're not sharing AND not watching
+  const maybeDisconnectRoom = useCallback(async () => {
+    if (!isSharingRef.current && watchingSharesRef.current.length === 0 && roomRef.current) {
+      try { await roomRef.current.disconnect(); } catch { /* ignore */ }
+      roomRef.current = null;
+    }
+  }, []);
+
+  const stopLocalShare = useCallback(async (
+    reason: LocalShareStopReason,
+    roomOverride?: Room | null,
+  ) => {
+    const wasSharing = isSharingRef.current;
+    const shouldHandleErrorBeforeShareStarts = reason === 'error' && !localShareStopHandledRef.current;
+
+    if (localShareStopHandledRef.current || (!wasSharing && !shouldHandleErrorBeforeShareStarts)) {
+      return;
+    }
+
+    localShareStopHandledRef.current = true;
+    clearLocalShareEndListener();
+
+    const room = roomOverride ?? roomRef.current;
+    const roomName = room?.name;
+
+    if (wasSharing && reason !== 'interrupted' && room) {
+      try { await room.localParticipant.setScreenShareEnabled(false); } catch { /* ignore */ }
+    }
+
+    isSharingRef.current = false;
+    setIsSharing(false);
+
+    if (wasSharing && roomName) {
+      bridge.send('livekit.shareStopped', { roomName });
+    }
+
+    onLocalShareEndedRef.current?.(reason);
+
+    if (reason === 'interrupted') {
+      onDisconnectedRef.current?.();
+    }
+
+    await maybeDisconnectRoom();
+  }, [clearLocalShareEndListener, maybeDisconnectRoom]);
+
+  const bindLocalShareEndListener = useCallback((room: Room) => {
+    clearLocalShareEndListener();
+
+    const publication = (room.localParticipant as {
+      getTrackPublication?: (source: string) => { track?: LocalTrackLike } | undefined;
+    }).getTrackPublication?.(Track.Source.ScreenShare);
+    const track = publication?.track;
+    if (!track) {
+      return;
+    }
+
+    const onEnded = () => {
+      void stopLocalShare('source-closed', room);
+    };
+
+    if (typeof track.addEventListener === 'function' && typeof track.removeEventListener === 'function') {
+      track.addEventListener('ended', onEnded);
+      localShareEndCleanupRef.current = () => track.removeEventListener?.('ended', onEnded);
+      return;
+    }
+
+    if (typeof track.on === 'function' && typeof track.off === 'function') {
+      track.on('ended', onEnded);
+      localShareEndCleanupRef.current = () => track.off?.('ended', onEnded);
+    }
+  }, [clearLocalShareEndListener, stopLocalShare]);
+
   // Ensure we have a connected room for the given channel.
   // Returns the existing room if already connected to this channel, otherwise connects.
   const ensureRoom = useCallback(async (roomName: string): Promise<Room> => {
@@ -180,9 +274,7 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
       roomRef.current = null;
       setRemoteVideoEls(new Map());
       if (isSharingRef.current) {
-        setIsSharing(false);
-        isSharingRef.current = false;
-        onDisconnectedRef.current?.();
+        void stopLocalShare('interrupted', room);
       }
       updateWatchingShares([]);
       setFocusedShare(null);
@@ -191,18 +283,11 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
     await room.connect(url, token);
     roomRef.current = room;
     return room;
-  }, [requestToken, updateWatchingShares]);
-
-  // Try to disconnect the room, but only if we're not sharing AND not watching
-  const maybeDisconnectRoom = useCallback(async () => {
-    if (!isSharingRef.current && watchingSharesRef.current.length === 0 && roomRef.current) {
-      try { await roomRef.current.disconnect(); } catch { /* ignore */ }
-      roomRef.current = null;
-    }
-  }, []);
+  }, [requestToken, updateWatchingShares, stopLocalShare]);
 
   const startSharing = useCallback(async (roomName: string) => {
     setError(null);
+    localShareStopHandledRef.current = false;
 
     try {
       const room = await ensureRoom(roomName);
@@ -254,35 +339,21 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
 
       isSharingRef.current = true;
       setIsSharing(true);
+      bindLocalShareEndListener(room);
 
       bridge.send('livekit.shareStarted', { roomName });
     } catch (err) {
+      clearLocalShareEndListener();
       setError(err instanceof Error ? err.message : 'Screen share failed');
-      setIsSharing(false);
-      isSharingRef.current = false;
+      await stopLocalShare('error', roomRef.current);
       // Disconnect room if we're not watching anyone either
       await maybeDisconnectRoom();
     }
-  }, [screenShareSettings, ensureRoom]);
+  }, [screenShareSettings, ensureRoom, bindLocalShareEndListener, clearLocalShareEndListener, maybeDisconnectRoom, stopLocalShare]);
 
   const stopSharing = useCallback(async () => {
-    const room = roomRef.current;
-    if (room) {
-      const roomName = room.name;
-      try { await room.localParticipant.setScreenShareEnabled(false); } catch { /* already stopped */ }
-      isSharingRef.current = false;
-      setIsSharing(false);
-      if (roomName) {
-        bridge.send('livekit.shareStopped', { roomName });
-      }
-
-      // Disconnect only if not watching anyone
-      await maybeDisconnectRoom();
-    } else {
-      isSharingRef.current = false;
-      setIsSharing(false);
-    }
-  }, [maybeDisconnectRoom]);
+    await stopLocalShare('manual');
+  }, [stopLocalShare]);
 
   // --- Viewer logic ---
 
@@ -449,6 +520,12 @@ export function useScreenShare(onDisconnected?: () => void, screenShareSettings?
       bridge.off('livekit.activeShareResult', onActiveShareResult);
     };
   }, [removeWatchingShare]);
+
+  useEffect(() => {
+    return () => {
+      clearLocalShareEndListener();
+    };
+  }, [clearLocalShareEndListener]);
 
   // Backward compat: expose first active share as activeShare
   const activeShare: ActiveShare | null = activeShares.length > 0


### PR DESCRIPTION
## Summary
- fix self-share UI behavior so your own share does not create an empty viewer slot, is not watchable, and uses a consistent sidebar sharing row layout
- add reason-aware screen share lifecycle handling, including auto-stop when the shared source closes and sharer-only notifications for non-manual endings
- treat canceled screen share picker flows as benign aborts so canceling no longer shows a technical error or leaves LiveKit in a misleading state

## Test Plan
- [x] Manual: canceled the native screen share picker and confirmed no error notification appeared
- [x] Manual: verified self-share UI, sidebar sharing row, auto-stop behavior, and quick retry flows
- [x] npm test -- src/hooks/useScreenShare.test.ts src/App.screenShareStart.test.ts src/App.screenShareEnded.test.ts src/components/Sidebar/ChannelTree.test.tsx src/components/Sidebar/Sidebar.test.tsx
- [x] npm run build