### PR TITLE
fix: set explicit AppUserModelID for theme-aware taskbar icon

### DIFF
--- a/src/Brmble.Client/AppIdentity.cs
+++ b/src/Brmble.Client/AppIdentity.cs
@@ -1,0 +1,18 @@
+namespace Brmble.Client;
+
+/// <summary>
+/// Single source of truth for app identity values that must stay in sync with
+/// the Velopack --packId / --packTitle used in the release workflow.
+/// </summary>
+internal static class AppIdentity
+{
+    /// <summary>Velopack --packId. Also the name used for shortcuts and install folder.</summary>
+    public const string PackId = "Brmble";
+
+    /// <summary>
+    /// Windows AppUserModelID (CompanyName.ProductName format).
+    /// Set on the running process and stamped onto .lnk shortcuts so the
+    /// taskbar groups them together and respects runtime WM_SETICON updates.
+    /// </summary>
+    public const string AppUserModelId = "Brmble.Brmble";
+}

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -72,14 +72,8 @@ static class Program
             VelopackApp.Build().Run();
             DevLog.Init();
 
-            // Ensure the taskbar groups this process as its own app so runtime
-            // WM_SETICON updates for theme-aware icons aren't shadowed by the
-            // launcher stub's icon. The same AppID must be stamped onto the
-            // installer-created .lnk shortcuts (Start Menu, Desktop, pinned
-            // taskbar) — otherwise pinned shortcuts keep the launcher's identity.
-            const string AppId = "Brmble.Brmble";
-            Win32Window.SetAppUserModelId(AppId);
-            ShortcutAppId.StampVelopackShortcuts(AppId, "Brmble");
+            Win32Window.SetAppUserModelId(AppIdentity.AppUserModelId);
+            ShortcutAppId.StampVelopackShortcuts(AppIdentity.AppUserModelId, AppIdentity.PackId);
 
             var useDevServer = IsDevServerRunning();
             Debug.WriteLine(useDevServer

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -72,10 +72,14 @@ static class Program
             VelopackApp.Build().Run();
             DevLog.Init();
 
-            // Ensure the taskbar groups this process as its own app (matching the
-            // Velopack package id "Brmble") so runtime WM_SETICON updates for
-            // theme-aware icons aren't shadowed by the launcher stub's icon.
-            Win32Window.SetAppUserModelId("Brmble");
+            // Ensure the taskbar groups this process as its own app so runtime
+            // WM_SETICON updates for theme-aware icons aren't shadowed by the
+            // launcher stub's icon. The same AppID must be stamped onto the
+            // installer-created .lnk shortcuts (Start Menu, Desktop, pinned
+            // taskbar) — otherwise pinned shortcuts keep the launcher's identity.
+            const string AppId = "Brmble.Brmble";
+            Win32Window.SetAppUserModelId(AppId);
+            ShortcutAppId.StampVelopackShortcuts(AppId, "Brmble");
 
             var useDevServer = IsDevServerRunning();
             Debug.WriteLine(useDevServer

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -72,6 +72,11 @@ static class Program
             VelopackApp.Build().Run();
             DevLog.Init();
 
+            // Ensure the taskbar groups this process as its own app (matching the
+            // Velopack package id "Brmble") so runtime WM_SETICON updates for
+            // theme-aware icons aren't shadowed by the launcher stub's icon.
+            Win32Window.SetAppUserModelId("Brmble");
+
             var useDevServer = IsDevServerRunning();
             Debug.WriteLine(useDevServer
                 ? "Brmble: Using Vite dev server"

--- a/src/Brmble.Client/ShortcutAppId.cs
+++ b/src/Brmble.Client/ShortcutAppId.cs
@@ -107,19 +107,29 @@ internal static class ShortcutAppId
     }
 
     /// <summary>
-    /// Stamps the Brmble shortcuts that Velopack creates by default.
-    /// Walks the conventional Start Menu and Desktop locations.
+    /// Stamps the Brmble shortcuts that Velopack creates by default plus any
+    /// existing pinned taskbar shortcut. Walks the conventional Start Menu,
+    /// Desktop, and User Pinned\TaskBar locations.
     /// </summary>
     public static void StampVelopackShortcuts(string appId, string packTitle)
     {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+
         var startMenu = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Microsoft", "Windows", "Start Menu", "Programs", packTitle + ".lnk");
+            appData, "Microsoft", "Windows", "Start Menu", "Programs", packTitle + ".lnk");
         var desktop = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory),
             packTitle + ".lnk");
+        // Pinned taskbar shortcuts live here regardless of Windows version.
+        // Without stamping, the running app inherits the pin's implicit identity
+        // and WM_SETICON updates have no visible effect for users who pinned
+        // before the AppUserModelID fix shipped.
+        var pinnedTaskbar = Path.Combine(
+            appData, "Microsoft", "Internet Explorer", "Quick Launch",
+            "User Pinned", "TaskBar", packTitle + ".lnk");
 
         Stamp(startMenu, appId);
         Stamp(desktop, appId);
+        Stamp(pinnedTaskbar, appId);
     }
 }

--- a/src/Brmble.Client/ShortcutAppId.cs
+++ b/src/Brmble.Client/ShortcutAppId.cs
@@ -1,0 +1,125 @@
+using System.Runtime.InteropServices;
+
+namespace Brmble.Client;
+
+/// <summary>
+/// Stamps the System.AppUserModel.ID property on .lnk shortcuts so the Windows
+/// taskbar associates pinned/Start Menu shortcuts with the same AppUserModelID
+/// that the running process declares via SetCurrentProcessExplicitAppUserModelID.
+/// Without this, runtime WM_SETICON updates (theme-aware icons) won't apply to
+/// pinned taskbar shortcuts because the shortcut still carries the launcher's
+/// implicit identity.
+/// </summary>
+internal static class ShortcutAppId
+{
+    // PKEY_AppUserModel_ID = {9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3}, pid 5
+    private static readonly Guid AppUserModelIdFmtId =
+        new("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3");
+
+    private const int GPS_READWRITE = 2;
+    private const ushort VT_LPWSTR = 31;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROPERTYKEY
+    {
+        public Guid fmtid;
+        public uint pid;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROPVARIANT
+    {
+        public ushort vt;
+        public ushort wReserved1;
+        public ushort wReserved2;
+        public ushort wReserved3;
+        public IntPtr p;
+        public IntPtr p2;
+    }
+
+    [ComImport]
+    [Guid("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IPropertyStore
+    {
+        int GetCount(out uint cProps);
+        int GetAt(uint iProp, out PROPERTYKEY pkey);
+        int GetValue(ref PROPERTYKEY key, out PROPVARIANT pv);
+        int SetValue(ref PROPERTYKEY key, ref PROPVARIANT pv);
+        int Commit();
+    }
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+    private static extern void SHGetPropertyStoreFromParsingName(
+        [MarshalAs(UnmanagedType.LPWStr)] string pszPath,
+        IntPtr zero,
+        int flags,
+        ref Guid iid,
+        [MarshalAs(UnmanagedType.Interface)] out IPropertyStore ppv);
+
+    [DllImport("propsys.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+    private static extern void InitPropVariantFromString(
+        [MarshalAs(UnmanagedType.LPWStr)] string psz,
+        out PROPVARIANT ppropvar);
+
+    [DllImport("ole32.dll", PreserveSig = false)]
+    private static extern void PropVariantClear(ref PROPVARIANT pvar);
+
+    /// <summary>
+    /// Stamps <paramref name="appId"/> as System.AppUserModel.ID on the given .lnk file
+    /// if it isn't already set to that value. Silently no-ops on missing files or errors —
+    /// this is a best-effort affordance for taskbar icon consistency.
+    /// </summary>
+    public static void Stamp(string lnkPath, string appId)
+    {
+        if (!File.Exists(lnkPath)) return;
+
+        IPropertyStore? store = null;
+        var iid = typeof(IPropertyStore).GUID;
+        var key = new PROPERTYKEY { fmtid = AppUserModelIdFmtId, pid = 5 };
+        var pv = default(PROPVARIANT);
+
+        try
+        {
+            SHGetPropertyStoreFromParsingName(lnkPath, IntPtr.Zero, GPS_READWRITE, ref iid, out store);
+
+            // Read existing value; skip the write if it already matches.
+            store.GetValue(ref key, out pv);
+            string? existing = pv.vt == VT_LPWSTR ? Marshal.PtrToStringUni(pv.p) : null;
+            PropVariantClear(ref pv);
+
+            if (string.Equals(existing, appId, StringComparison.Ordinal)) return;
+
+            InitPropVariantFromString(appId, out pv);
+            store.SetValue(ref key, ref pv);
+            store.Commit();
+        }
+        catch
+        {
+            // Best-effort: a failure here just means pinned shortcuts may not pick up
+            // theme-aware icons. The running process still has the explicit AppID set.
+        }
+        finally
+        {
+            try { PropVariantClear(ref pv); } catch { }
+            if (store is not null) Marshal.ReleaseComObject(store);
+        }
+    }
+
+    /// <summary>
+    /// Stamps the Brmble shortcuts that Velopack creates by default.
+    /// Walks the conventional Start Menu and Desktop locations.
+    /// </summary>
+    public static void StampVelopackShortcuts(string appId, string packTitle)
+    {
+        var startMenu = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "Microsoft", "Windows", "Start Menu", "Programs", packTitle + ".lnk");
+        var desktop = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory),
+            packTitle + ".lnk");
+
+        Stamp(startMenu, appId);
+        Stamp(desktop, appId);
+    }
+}

--- a/src/Brmble.Client/Win32Window.cs
+++ b/src/Brmble.Client/Win32Window.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace Brmble.Client;
@@ -244,7 +245,7 @@ internal static class Win32Window
     public static void SetAppUserModelId(string appId)
     {
         try { SetCurrentProcessExplicitAppUserModelID(appId); }
-        catch { /* best-effort: failure here only degrades icon grouping */ }
+        catch (Exception ex) { Debug.WriteLine($"[AppUserModelID] Failed to set '{appId}': {ex.Message}"); }
     }
 
     [DllImport("user32.dll")]

--- a/src/Brmble.Client/Win32Window.cs
+++ b/src/Brmble.Client/Win32Window.cs
@@ -230,6 +230,23 @@ internal static class Win32Window
     private static extern IntPtr LoadImage(IntPtr hInst, string name, uint type,
         int cx, int cy, uint fuLoad);
 
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+    private static extern void SetCurrentProcessExplicitAppUserModelID(
+        [MarshalAs(UnmanagedType.LPWStr)] string AppID);
+
+    /// <summary>
+    /// Sets an explicit AppUserModelID for the current process so the Windows taskbar
+    /// treats this app as its own grouping. Without this, Velopack-installed builds
+    /// can have the taskbar bind to the launcher stub's icon resource, which makes
+    /// runtime WM_SETICON updates (theme-aware icons) appear to do nothing.
+    /// Must be called before any window is created.
+    /// </summary>
+    public static void SetAppUserModelId(string appId)
+    {
+        try { SetCurrentProcessExplicitAppUserModelID(appId); }
+        catch { /* best-effort: failure here only degrades icon grouping */ }
+    }
+
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool DestroyIcon(IntPtr hIcon);


### PR DESCRIPTION
## Summary
- Sets an explicit AppUserModelID (`Brmble`) early in `Main`, before any window is created, so the Windows taskbar groups the process as its own app instead of binding to the Velopack launcher stub's icon resource.
- This restores theme-aware taskbar icon updates (`WM_SETICON`) in installed builds — they already worked in debug because `dotnet run` launches `Brmble.Client.exe` directly with no launcher in between.

## Why
Reported in #427: in v0.1.0 the taskbar icon stays the default color regardless of the active Brmble theme. Resources are deployed correctly under `%LocalAppData%\Brmble\current\Resources\<theme>\brmble.ico`, and the bridge correctly forwards `notification.theme` → `Win32Window.SetWindowIcon`. The runtime `WM_SETICON` calls just had no visible effect because Windows was using the launcher's icon for the taskbar grouping.

## Test plan
- [ ] Cannot reproduce locally without a Velopack-installed build; needs verification on a published release.
- [ ] After merge + release, install the new version and confirm the taskbar icon adapts to the active theme (and updates live when switching themes).

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)