### PR TITLE
docs: update Docker local dev commands for Rancher Desktop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,10 +138,10 @@ See `docs/UI_GUIDE.md` section 11 for full icon list, adding new icons, and conv
 
 ## Running Docker (local dev)
 
-Docker runs in WSL. Use `wsl` to execute docker commands:
+Docker runs natively via Rancher Desktop. No WSL prefix needed:
 ```bash
-wsl docker compose -f docker-local/docker-compose.yml up -d --build brmble
-wsl docker compose -f docker-local/docker-compose.yml logs -f brmble
+docker compose -f docker-local/docker-compose.yml up -d --build brmble
+docker compose -f docker-local/docker-compose.yml logs -f brmble
 ```
 
 ## Build & Test (repeatable commands)


### PR DESCRIPTION
## Summary
- Drop the \`wsl\` prefix from the Docker local-dev commands in CLAUDE.md.
- Docker runs natively via Rancher Desktop now, so the WSL hop isn't needed.

## Test plan
- [ ] N/A — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)