### PR TITLE
fix: linkify URLs in outgoing Mumble messages

### DIFF
--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -29,6 +29,7 @@ import { Version } from './components/Version/Version';
 import { ZoomIndicator } from './components/ZoomIndicator/ZoomIndicator';
 import { useChatStore, addMessageToStore, clearChatStorage, purgeEphemeralMessages } from './hooks/useChatStore';
 import { parseMessageMedia } from './utils/parseMessageMedia';
+import { linkifyForMumble } from './utils/linkifyForMumble';
 import { useDMStore } from './hooks/useDMStore';
 import { DMContactList } from './components/DMContactList/DMContactList';
 import { usePrompt, confirm } from './hooks/usePrompt';
@@ -510,7 +511,7 @@ function App() {
     users,
     username,
     sendMumbleDM: (targetSession: number, text: string) => {
-      bridge.send('voice.sendPrivateMessage', { message: text, targetSession });
+      bridge.send('voice.sendPrivateMessage', { message: linkifyForMumble(text), targetSession });
     },
   });
 
@@ -1649,10 +1650,11 @@ const handleConnect = (serverData: SavedServer) => {
         addMessage(username, content);
       }
 
+      const mumbleHtml = linkifyForMumble(content);
       if (channelId === 'server-root') {
-        bridge.send('voice.sendMessage', { message: content, channelId: 0 });
+        bridge.send('voice.sendMessage', { message: mumbleHtml, channelId: 0 });
       } else {
-        bridge.send('voice.sendMessage', { message: content, channelId: Number(channelId) });
+        bridge.send('voice.sendMessage', { message: mumbleHtml, channelId: Number(channelId) });
         if (isMatrixChannel) {
           matrixClient.sendMessage(channelId, content).catch(console.error);
         }

--- a/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
@@ -20,17 +20,17 @@ describe('linkifyForMumble', () => {
       .toBe('<a href="http://example.com">http://example.com</a>');
   });
 
-  it('wraps a www-prefixed URL with an https scheme in href', () => {
+  it('does not linkify www-prefixed URLs (native Mumble handles those itself)', () => {
     expect(linkifyForMumble('Check out www.google.com today'))
-      .toBe('Check out <a href="https://www.google.com">www.google.com</a> today');
+      .toBe('Check out www.google.com today');
   });
 
-  it('handles multiple URLs in one message', () => {
-    expect(linkifyForMumble('see https://a.com and www.b.com'))
-      .toBe('see <a href="https://a.com">https://a.com</a> and <a href="https://www.b.com">www.b.com</a>');
+  it('handles multiple http(s) URLs in one message', () => {
+    expect(linkifyForMumble('see https://a.com and http://b.com'))
+      .toBe('see <a href="https://a.com">https://a.com</a> and <a href="http://b.com">http://b.com</a>');
   });
 
-  it('does not linkify bare domains without www prefix', () => {
+  it('does not linkify bare domains', () => {
     expect(linkifyForMumble('example.com is great')).toBe('example.com is great');
   });
 

--- a/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
@@ -20,18 +20,27 @@ describe('linkifyForMumble', () => {
       .toBe('<a href="http://example.com">http://example.com</a>');
   });
 
-  it('does not wrap www-prefixed URLs (native Mumble auto-links those itself)', () => {
+  it('rewrites www. URLs by prepending https:// to both the visible text and the href', () => {
     expect(linkifyForMumble('Check out www.google.com today'))
-      .toBe('Check out www.google.com today');
+      .toBe('Check out <a href="https://www.google.com">https://www.google.com</a> today');
   });
 
-  it('handles multiple http(s) URLs in one message', () => {
-    expect(linkifyForMumble('see https://a.com and http://b.com here'))
-      .toBe('see <a href="https://a.com">https://a.com</a> and <a href="http://b.com">http://b.com</a> here');
+  it('handles a mix of http(s) and www. URLs in one message', () => {
+    expect(linkifyForMumble('see https://a.com and www.b.com'))
+      .toBe('see <a href="https://a.com">https://a.com</a> and <a href="https://www.b.com">https://www.b.com</a>');
   });
 
-  it('does not linkify bare domains', () => {
+  it('does not linkify bare domains without a www. prefix', () => {
     expect(linkifyForMumble('example.com is great')).toBe('example.com is great');
+  });
+
+  it('matches www at a word boundary, not embedded inside another word', () => {
+    expect(linkifyForMumble('foowww.google.com')).toBe('foowww.google.com');
+  });
+
+  it('preserves preceding punctuation when matching www', () => {
+    expect(linkifyForMumble('(www.google.com)'))
+      .toBe('(<a href="https://www.google.com">https://www.google.com</a>)');
   });
 
   it('escapes ampersands in URLs to keep the href valid', () => {

--- a/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { linkifyForMumble } from './linkifyForMumble';
+
+describe('linkifyForMumble', () => {
+  it('returns empty string unchanged', () => {
+    expect(linkifyForMumble('')).toBe('');
+  });
+
+  it('escapes HTML special characters in plain text', () => {
+    expect(linkifyForMumble('a & b < c > d')).toBe('a &amp; b &lt; c &gt; d');
+  });
+
+  it('wraps an https URL in an anchor tag', () => {
+    expect(linkifyForMumble('see https://example.com here'))
+      .toBe('see <a href="https://example.com">https://example.com</a> here');
+  });
+
+  it('wraps an http URL in an anchor tag', () => {
+    expect(linkifyForMumble('http://example.com'))
+      .toBe('<a href="http://example.com">http://example.com</a>');
+  });
+
+  it('wraps a www-prefixed URL with an https scheme in href', () => {
+    expect(linkifyForMumble('Check out www.google.com today'))
+      .toBe('Check out <a href="https://www.google.com">www.google.com</a> today');
+  });
+
+  it('handles multiple URLs in one message', () => {
+    expect(linkifyForMumble('see https://a.com and www.b.com'))
+      .toBe('see <a href="https://a.com">https://a.com</a> and <a href="https://www.b.com">www.b.com</a>');
+  });
+
+  it('does not linkify bare domains without www prefix', () => {
+    expect(linkifyForMumble('example.com is great')).toBe('example.com is great');
+  });
+
+  it('escapes ampersands in URLs to keep the href valid', () => {
+    expect(linkifyForMumble('https://x.com/a?b=1&c=2'))
+      .toBe('<a href="https://x.com/a?b=1&amp;c=2">https://x.com/a?b=1&amp;c=2</a>');
+  });
+
+  it('escapes user-typed angle brackets even when a URL is present', () => {
+    expect(linkifyForMumble('<script>alert(1)</script> https://safe.com'))
+      .toBe('&lt;script&gt;alert(1)&lt;/script&gt; <a href="https://safe.com">https://safe.com</a>');
+  });
+
+  it('does not match URL inside an existing tag-like fragment', () => {
+    // The regex stops at <, so "foo<https://..." would still linkify the URL part.
+    // What we care about is that we never emit an unescaped tag boundary.
+    const out = linkifyForMumble('foo<https://x.com>');
+    expect(out).not.toContain('<https');
+    expect(out).toContain('&lt;');
+  });
+});

--- a/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
@@ -60,4 +60,56 @@ describe('linkifyForMumble', () => {
     expect(out).not.toContain('<https');
     expect(out).toContain('&lt;');
   });
+
+  it('does not include a trailing period in the URL', () => {
+    expect(linkifyForMumble('see https://example.com.'))
+      .toBe('see <a href="https://example.com">https://example.com</a>.');
+  });
+
+  it('does not include a trailing comma in the URL', () => {
+    expect(linkifyForMumble('see https://x.com, then go home'))
+      .toBe('see <a href="https://x.com">https://x.com</a>, then go home');
+  });
+
+  it('does not include trailing sentence punctuation (?, !, ;, :)', () => {
+    expect(linkifyForMumble('really https://x.com?'))
+      .toBe('really <a href="https://x.com">https://x.com</a>?');
+    expect(linkifyForMumble('wow https://x.com!'))
+      .toBe('wow <a href="https://x.com">https://x.com</a>!');
+    expect(linkifyForMumble('see https://x.com; later'))
+      .toBe('see <a href="https://x.com">https://x.com</a>; later');
+    expect(linkifyForMumble('here https://x.com: yes'))
+      .toBe('here <a href="https://x.com">https://x.com</a>: yes');
+  });
+
+  it('drops trailing punctuation on www. URLs too', () => {
+    expect(linkifyForMumble('go to www.google.com.'))
+      .toBe('go to <a href="https://www.google.com">https://www.google.com</a>.');
+  });
+
+  it('preserves ports, paths, query strings, and fragments inside the URL', () => {
+    const url = 'https://example.com:8080/path/to?a=1&b=2#section';
+    const out = linkifyForMumble(url);
+    expect(out).toContain('href="https://example.com:8080/path/to?a=1&amp;b=2#section"');
+    expect(out).toContain('>https://example.com:8080/path/to?a=1&amp;b=2#section<');
+  });
+
+  it('does not linkify javascript: or data: URLs (only http/https/www)', () => {
+    expect(linkifyForMumble('javascript:alert(1)')).toBe('javascript:alert(1)');
+    expect(linkifyForMumble('data:text/html,<script>alert(1)</script>'))
+      .toBe('data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(linkifyForMumble('ftp://x.com')).toBe('ftp://x.com');
+  });
+
+  it('does not linkify URLs that follow another word with no boundary', () => {
+    // Pattern uses \b for www. so foowww.x.com stays plain text.
+    expect(linkifyForMumble('foowww.example.com')).toBe('foowww.example.com');
+  });
+
+  it('round-trips a literal &amp; from user input as a single-pass entity', () => {
+    // User typed literal "&amp;" — linkifyForMumble escapes the & to "&amp;",
+    // producing "&amp;amp;" on the wire. parseMessageMedia decodes once back
+    // to "&amp;". This test just confirms our outgoing escape.
+    expect(linkifyForMumble('typed &amp; literally')).toBe('typed &amp;amp; literally');
+  });
 });

--- a/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.test.ts
@@ -20,14 +20,14 @@ describe('linkifyForMumble', () => {
       .toBe('<a href="http://example.com">http://example.com</a>');
   });
 
-  it('does not linkify www-prefixed URLs (native Mumble handles those itself)', () => {
+  it('does not wrap www-prefixed URLs (native Mumble auto-links those itself)', () => {
     expect(linkifyForMumble('Check out www.google.com today'))
       .toBe('Check out www.google.com today');
   });
 
   it('handles multiple http(s) URLs in one message', () => {
-    expect(linkifyForMumble('see https://a.com and http://b.com'))
-      .toBe('see <a href="https://a.com">https://a.com</a> and <a href="http://b.com">http://b.com</a>');
+    expect(linkifyForMumble('see https://a.com and http://b.com here'))
+      .toBe('see <a href="https://a.com">https://a.com</a> and <a href="http://b.com">http://b.com</a> here');
   });
 
   it('does not linkify bare domains', () => {

--- a/src/Brmble.Web/src/utils/linkifyForMumble.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.ts
@@ -16,7 +16,11 @@
  * positive rate (mid-sentence punctuation, version numbers, file names).
  */
 
-const URL_PATTERN = /(https?:\/\/[^\s<>"')\]]+)|(\bwww\.[^\s<>"')\]]+)/gi;
+// Inner char class excludes whitespace and tag/quote/bracket delimiters.
+// The required final char additionally excludes sentence punctuation
+// (.,;:!?) so a URL at the end of a sentence doesn't swallow the period.
+const URL_PATTERN =
+  /(?:https?:\/\/|\bwww\.)[^\s<>"')\]]*[^\s<>"')\].,;:!?]/gi;
 
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, ch => {
@@ -38,10 +42,10 @@ export function linkifyForMumble(text: string): string {
   let m: RegExpExecArray | null;
   while ((m = URL_PATTERN.exec(text)) !== null) {
     out += escapeHtml(text.slice(lastIndex, m.index));
-    // m[1] = http(s) match, m[2] = www match. For www, prepend https:// so
-    // the URL is fully qualified everywhere (Mumble visible text, anchor
-    // href, and any Brmble receiver post-anchor-strip).
-    const url = m[1] ? m[0] : `https://${m[0]}`;
+    // For www-prefixed URLs, prepend https:// so the URL is fully qualified
+    // everywhere (Mumble visible text, anchor href, and any Brmble receiver
+    // post-anchor-strip).
+    const url = m[0].startsWith('www.') ? `https://${m[0]}` : m[0];
     out += `<a href="${escapeHtml(url)}">${escapeHtml(url)}</a>`;
     lastIndex = URL_PATTERN.lastIndex;
   }

--- a/src/Brmble.Web/src/utils/linkifyForMumble.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.ts
@@ -4,14 +4,19 @@
  * them as clickable links. The Mumble server must have allowHTML enabled
  * (default true in Brmble's docker-local config).
  *
- * Only http(s):// URLs are linkified. Native Mumble already auto-detects
- * www-prefixed URLs in plain text (it prepends https:// itself), so wrapping
- * them in our own anchor would be a no-op at best and could conflict with
- * Mumble's own link rendering. Bare domains like "example.com" have too high
- * a false-positive rate to wrap.
+ * URLs supported:
+ * - http(s)://...   → wrapped as-is in an anchor
+ * - www....         → rewritten to "https://www...." (both as visible text
+ *                     and href) so the outgoing message contains a fully-
+ *                     qualified URL that any client can resolve. Brmble
+ *                     receivers see the rewritten URL too, which their own
+ *                     linkifyText then handles.
+ *
+ * Bare domains like "example.com" are NOT linkified — too high a false-
+ * positive rate (mid-sentence punctuation, version numbers, file names).
  */
 
-const URL_PATTERN = /(https?:\/\/[^\s<>"')\]]+)/gi;
+const URL_PATTERN = /(https?:\/\/[^\s<>"')\]]+)|(\bwww\.[^\s<>"')\]]+)/gi;
 
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, ch => {
@@ -33,7 +38,10 @@ export function linkifyForMumble(text: string): string {
   let m: RegExpExecArray | null;
   while ((m = URL_PATTERN.exec(text)) !== null) {
     out += escapeHtml(text.slice(lastIndex, m.index));
-    const url = m[0];
+    // m[1] = http(s) match, m[2] = www match. For www, prepend https:// so
+    // the URL is fully qualified everywhere (Mumble visible text, anchor
+    // href, and any Brmble receiver post-anchor-strip).
+    const url = m[1] ? m[0] : `https://${m[0]}`;
     out += `<a href="${escapeHtml(url)}">${escapeHtml(url)}</a>`;
     lastIndex = URL_PATTERN.lastIndex;
   }

--- a/src/Brmble.Web/src/utils/linkifyForMumble.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.ts
@@ -4,15 +4,12 @@
  * them as clickable links. The Mumble server must have allowHTML enabled
  * (default true in Brmble's docker-local config).
  *
- * URLs supported:
- * - http(s)://...   → href is the URL as-is
- * - www....         → href is "https://" + URL (visible text stays "www....")
- *
- * Bare domains like "example.com" are NOT linkified — the false-positive rate
- * (e.g. mid-sentence punctuation, version numbers) is too high.
+ * Only http(s):// URLs are linkified — Mumble already auto-links www. URLs
+ * itself (it prepends https:// when resolving them), and bare domains like
+ * "example.com" have too high a false-positive rate to wrap.
  */
 
-const URL_PATTERN = /(https?:\/\/[^\s<>"')\]]+)|(\bwww\.[^\s<>"')\]]+)/gi;
+const URL_PATTERN = /(https?:\/\/[^\s<>"')\]]+)/gi;
 
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, ch => {
@@ -35,8 +32,7 @@ export function linkifyForMumble(text: string): string {
   while ((m = URL_PATTERN.exec(text)) !== null) {
     out += escapeHtml(text.slice(lastIndex, m.index));
     const url = m[0];
-    const href = m[1] ? url : `https://${url}`;
-    out += `<a href="${escapeHtml(href)}">${escapeHtml(url)}</a>`;
+    out += `<a href="${escapeHtml(url)}">${escapeHtml(url)}</a>`;
     lastIndex = URL_PATTERN.lastIndex;
   }
   out += escapeHtml(text.slice(lastIndex));

--- a/src/Brmble.Web/src/utils/linkifyForMumble.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.ts
@@ -1,0 +1,44 @@
+/**
+ * Convert a plain-text message into HTML safe for sending over the Mumble
+ * protocol, wrapping URLs in `<a href="...">` so native Mumble clients render
+ * them as clickable links. The Mumble server must have allowHTML enabled
+ * (default true in Brmble's docker-local config).
+ *
+ * URLs supported:
+ * - http(s)://...   → href is the URL as-is
+ * - www....         → href is "https://" + URL (visible text stays "www....")
+ *
+ * Bare domains like "example.com" are NOT linkified — the false-positive rate
+ * (e.g. mid-sentence punctuation, version numbers) is too high.
+ */
+
+const URL_PATTERN = /(https?:\/\/[^\s<>"')\]]+)|(\bwww\.[^\s<>"')\]]+)/gi;
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, ch => {
+    switch (ch) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '"': return '&quot;';
+      case "'": return '&#39;';
+      default: return ch;
+    }
+  });
+}
+
+export function linkifyForMumble(text: string): string {
+  let out = '';
+  let lastIndex = 0;
+  URL_PATTERN.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = URL_PATTERN.exec(text)) !== null) {
+    out += escapeHtml(text.slice(lastIndex, m.index));
+    const url = m[0];
+    const href = m[1] ? url : `https://${url}`;
+    out += `<a href="${escapeHtml(href)}">${escapeHtml(url)}</a>`;
+    lastIndex = URL_PATTERN.lastIndex;
+  }
+  out += escapeHtml(text.slice(lastIndex));
+  return out;
+}

--- a/src/Brmble.Web/src/utils/linkifyForMumble.ts
+++ b/src/Brmble.Web/src/utils/linkifyForMumble.ts
@@ -4,9 +4,11 @@
  * them as clickable links. The Mumble server must have allowHTML enabled
  * (default true in Brmble's docker-local config).
  *
- * Only http(s):// URLs are linkified — Mumble already auto-links www. URLs
- * itself (it prepends https:// when resolving them), and bare domains like
- * "example.com" have too high a false-positive rate to wrap.
+ * Only http(s):// URLs are linkified. Native Mumble already auto-detects
+ * www-prefixed URLs in plain text (it prepends https:// itself), so wrapping
+ * them in our own anchor would be a no-op at best and could conflict with
+ * Mumble's own link rendering. Bare domains like "example.com" have too high
+ * a false-positive rate to wrap.
  */
 
 const URL_PATTERN = /(https?:\/\/[^\s<>"')\]]+)/gi;

--- a/src/Brmble.Web/src/utils/linkifyText.test.tsx
+++ b/src/Brmble.Web/src/utils/linkifyText.test.tsx
@@ -95,4 +95,52 @@ describe('linkifyText', () => {
     const result = linkifyText('foowww.google.com');
     expect(result).toBe('foowww.google.com');
   });
+
+  it('excludes a trailing period from the linkified URL', () => {
+    const result = linkifyText('check https://example.com.');
+    expect(result).toBeInstanceOf(Array);
+    const parts = result as unknown[];
+    const anchor = parts[1] as ReactElement<{ href: string; children: string }>;
+    expect(anchor.props.children).toBe('https://example.com');
+    expect(parts[2]).toBe('.');
+  });
+
+  it('excludes a trailing comma from the linkified URL', () => {
+    const result = linkifyText('see https://x.com, then later');
+    const parts = result as unknown[];
+    const anchor = parts[1] as ReactElement<{ href: string; children: string }>;
+    expect(anchor.props.children).toBe('https://x.com');
+    expect(parts[2]).toBe(', then later');
+  });
+
+  it('preserves ports, paths, query strings, and fragments inside the URL', () => {
+    const result = linkifyText('go to https://example.com:8080/path?a=1&b=2#frag now');
+    const parts = result as unknown[];
+    const anchor = parts[1] as ReactElement<{ href: string; children: string }>;
+    expect(anchor.props.href).toBe('https://example.com:8080/path?a=1&b=2#frag');
+    expect(parts[2]).toBe(' now');
+  });
+
+  it('does not linkify javascript: or data: schemes', () => {
+    expect(linkifyText('javascript:alert(1)')).toBe('javascript:alert(1)');
+    expect(linkifyText('data:text/html,foo')).toBe('data:text/html,foo');
+  });
+
+  it('safely handles HTML-like input by linkifying the URL portion only', () => {
+    // Contract: linkifyText takes plain text. If a caller passes serialized
+    // HTML, the surrounding tag fragments stay as plain text (React escapes
+    // them) — no broken DOM is produced.
+    const result = linkifyText('<a href="https://example.com">label</a>');
+    // Contains an anchor for the URL portion
+    expect(result).toBeInstanceOf(Array);
+    const parts = result as unknown[];
+    const anchor = parts.find((p) => typeof p !== 'string') as
+      | ReactElement<{ href: string; children: string }>
+      | undefined;
+    expect(anchor).toBeDefined();
+    expect(anchor!.props.href).toBe('https://example.com');
+    // The literal angle-bracket text remains as a string fragment that React
+    // will safely escape during rendering.
+    expect(parts.some((p) => typeof p === 'string' && p.startsWith('<a href='))).toBe(true);
+  });
 });

--- a/src/Brmble.Web/src/utils/linkifyText.test.tsx
+++ b/src/Brmble.Web/src/utils/linkifyText.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { describe, it, expect } from 'vitest';
 import { linkifyText } from './linkifyText';
 
@@ -75,5 +76,23 @@ describe('linkifyText', () => {
     const parts = result as unknown[];
     expect(parts).toHaveLength(3);
     expect(parts[0]).toBe('old link ');
+  });
+
+  it('linkifies www-prefixed URLs and prepends https:// to the href', () => {
+    const result = linkifyText('Check out www.google.com today');
+    expect(result).toBeInstanceOf(Array);
+    const parts = result as unknown[];
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toBe('Check out ');
+    expect(parts[2]).toBe(' today');
+
+    const anchor = parts[1] as ReactElement<{ href: string; children: string }>;
+    expect(anchor.props.href).toBe('https://www.google.com');
+    expect(anchor.props.children).toBe('www.google.com');
+  });
+
+  it('does not linkify "www." embedded inside another word', () => {
+    const result = linkifyText('foowww.google.com');
+    expect(result).toBe('foowww.google.com');
   });
 });

--- a/src/Brmble.Web/src/utils/linkifyText.tsx
+++ b/src/Brmble.Web/src/utils/linkifyText.tsx
@@ -7,9 +7,12 @@ import type { ReactNode } from 'react';
  *                     the user typed it.
  *
  * The whole match is wrapped in a single capturing group so String.split()
- * preserves the matched URLs at odd indices.
+ * preserves the matched URLs at odd indices. The required final char excludes
+ * sentence punctuation (.,;:!?) so a URL at the end of a sentence doesn't
+ * swallow the period.
  */
-const URL_PATTERN = /((?:https?:\/\/|\bwww\.)[^\s<>"')\]]+)/gi;
+const URL_PATTERN =
+  /((?:https?:\/\/|\bwww\.)[^\s<>"')\]]*[^\s<>"')\].,;:!?])/gi;
 
 /**
  * Takes a plain text string and returns an array of React nodes where

--- a/src/Brmble.Web/src/utils/linkifyText.tsx
+++ b/src/Brmble.Web/src/utils/linkifyText.tsx
@@ -1,10 +1,15 @@
 import type { ReactNode } from 'react';
 
 /**
- * Regex to match HTTP/HTTPS URLs in plain text.
- * Uses a capturing group so String.split() preserves the matched URLs.
+ * Regex to match URLs in plain text:
+ * - http(s)://...   → href is the URL as-is
+ * - www....         → href gets https:// prepended; visible text stays as
+ *                     the user typed it.
+ *
+ * The whole match is wrapped in a single capturing group so String.split()
+ * preserves the matched URLs at odd indices.
  */
-const URL_PATTERN = /(https?:\/\/[^\s<>"')\]]+)/gi;
+const URL_PATTERN = /((?:https?:\/\/|\bwww\.)[^\s<>"')\]]+)/gi;
 
 /**
  * Takes a plain text string and returns an array of React nodes where
@@ -19,14 +24,15 @@ export function linkifyText(text: string): ReactNode {
   // No URLs found — split produces a single-element array
   if (parts.length === 1) return text;
 
-  // With a single capturing group in URL_PATTERN, split() puts URLs at odd indices.
-  return parts.map((part, i) =>
-    i % 2 === 1 ? (
-      <a key={i} href={part} target="_blank" rel="noopener noreferrer">
-        {part}
-      </a>
-    ) : (
-      part
-    )
-  );
+  return parts.map((part, i) => {
+    if (i % 2 === 1) {
+      const href = part.startsWith('www.') ? `https://${part}` : part;
+      return (
+        <a key={i} href={href} target="_blank" rel="noopener noreferrer">
+          {part}
+        </a>
+      );
+    }
+    return part;
+  });
 }

--- a/src/Brmble.Web/src/utils/parseMessageMedia.test.ts
+++ b/src/Brmble.Web/src/utils/parseMessageMedia.test.ts
@@ -89,4 +89,23 @@ describe('parseMessageMedia', () => {
     expect(result.media).toHaveLength(1);
     expect(result.media[0].type).toBe('image');
   });
+
+  it('strips anchor tags from a Brmble peer back to plain URL text', () => {
+    const html = 'see <a href="https://example.com">https://example.com</a> here';
+    const result = parseMessageMedia(html);
+    expect(result.text).toBe('see https://example.com here');
+    expect(result.media).toHaveLength(0);
+  });
+
+  it('decodes escaped ampersands in stripped anchor text so URLs round-trip cleanly', () => {
+    const html = '<a href="https://x.com/a?b=1&amp;c=2">https://x.com/a?b=1&amp;c=2</a>';
+    const result = parseMessageMedia(html);
+    expect(result.text).toBe('https://x.com/a?b=1&c=2');
+  });
+
+  it('decodes escaped angle brackets that were html-escaped on the way out', () => {
+    const html = '&lt;hi&gt;';
+    const result = parseMessageMedia(html);
+    expect(result.text).toBe('<hi>');
+  });
 });

--- a/src/Brmble.Web/src/utils/parseMessageMedia.test.ts
+++ b/src/Brmble.Web/src/utils/parseMessageMedia.test.ts
@@ -108,4 +108,25 @@ describe('parseMessageMedia', () => {
     const result = parseMessageMedia(html);
     expect(result.text).toBe('<hi>');
   });
+
+  it('decode is single-pass — &amp;lt; stays as &lt; (does not become <)', () => {
+    // A user who literally typed "&lt;" gets the original "&lt;" back: linkify
+    // escaped & → &amp;, so wire is "&amp;lt;"; one decode pass yields "&lt;".
+    const html = '&amp;lt;hi&amp;gt;';
+    const result = parseMessageMedia(html);
+    expect(result.text).toBe('&lt;hi&gt;');
+  });
+
+  it('round-trips a Brmble-sent message containing an http URL plus &/<', () => {
+    // Simulates what linkifyForMumble produces for: "Hello & <world> https://x.com"
+    const wire = 'Hello &amp; &lt;world&gt; <a href="https://x.com">https://x.com</a>';
+    const result = parseMessageMedia(wire);
+    expect(result.text).toBe('Hello & <world> https://x.com');
+  });
+
+  it('strips an anchor wrapping a www-rewritten URL back to https://www....', () => {
+    const wire = 'visit <a href="https://www.example.com">https://www.example.com</a>!';
+    const result = parseMessageMedia(wire);
+    expect(result.text).toBe('visit https://www.example.com!');
+  });
 });

--- a/src/Brmble.Web/src/utils/parseMessageMedia.test.ts
+++ b/src/Brmble.Web/src/utils/parseMessageMedia.test.ts
@@ -129,4 +129,22 @@ describe('parseMessageMedia', () => {
     const result = parseMessageMedia(wire);
     expect(result.text).toBe('visit https://www.example.com!');
   });
+
+  it('preserves the href when an anchor has descriptive (non-URL) inner text', () => {
+    const wire = 'see <a href="https://example.com">click here</a> please';
+    const result = parseMessageMedia(wire);
+    expect(result.text).toBe('see click here (https://example.com) please');
+  });
+
+  it('keeps just the inner text when the anchor inner already contains a URL', () => {
+    const wire = '<a href="https://example.com">visit https://example.com now</a>';
+    const result = parseMessageMedia(wire);
+    expect(result.text).toBe('visit https://example.com now');
+  });
+
+  it('falls back to inner (href) when the inner text is empty', () => {
+    const wire = '<a href="https://example.com"></a>';
+    const result = parseMessageMedia(wire);
+    expect(result.text).toBe('(https://example.com)');
+  });
 });

--- a/src/Brmble.Web/src/utils/parseMessageMedia.ts
+++ b/src/Brmble.Web/src/utils/parseMessageMedia.ts
@@ -60,8 +60,13 @@ export function parseMessageMedia(message: string): ParsedMessage {
   }
 
   // Replace anchor tags with their inner text (the URL we sent), then decode
-  // the HTML entities we escaped on the way out so the local linkifier sees a
-  // clean URL like "https://x.com/a?b=1&c=2" rather than the escaped form.
+  // the HTML entities we escaped on the way out. The decode is intentionally
+  // applied to the WHOLE message — linkifyForMumble escapes both URL and
+  // non-URL text so Mumble's HTML parser doesn't eat literal '<' or '&', and
+  // we have to reverse that on the receiver side to recover the original
+  // text. A single-pass decode (no recursive expansion) means a user who
+  // typed literal '&lt;' on the way out gets back literal '&lt;' here, which
+  // is the correct round-trip for our outgoing format.
   text = text.replace(ANCHOR_REGEX, (_m, inner) => inner);
   text = decodeEntities(text);
 

--- a/src/Brmble.Web/src/utils/parseMessageMedia.ts
+++ b/src/Brmble.Web/src/utils/parseMessageMedia.ts
@@ -3,9 +3,13 @@ import type { MediaAttachment } from '../types';
 export const MAX_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
 export const ALLOWED_MIMETYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
 const IMG_REGEX = /<img\s+[^>]*src=["']data:(image\/[^;]+);base64,([^"']+)["'][^>]*\/?>/gi;
-// Anchor tag from a Brmble peer (linkifyForMumble) — strip back to inner text
-// so the local renderer's own URL detection (linkifyText) creates the React link.
-const ANCHOR_REGEX = /<a\s+[^>]*href=["'][^"']*["'][^>]*>([\s\S]*?)<\/a>/gi;
+// Anchor tag from a Brmble peer (linkifyForMumble) or any other Mumble HTML
+// sender. Captures the href so we can preserve the URL even when the visible
+// text is descriptive (e.g. <a href="https://example.com">click here</a>).
+const ANCHOR_REGEX = /<a\s+[^>]*href=["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi;
+// Quick check whether a string already contains a URL the local linkifier
+// will recognize. Mirrors the lead-in of linkifyText's URL_PATTERN.
+const URL_HINT_PATTERN = /(?:https?:\/\/|\bwww\.)\S/i;
 
 const HTML_ENTITIES: Record<string, string> = {
   '&amp;': '&',
@@ -59,15 +63,24 @@ export function parseMessageMedia(message: string): ParsedMessage {
     });
   }
 
-  // Replace anchor tags with their inner text (the URL we sent), then decode
-  // the HTML entities we escaped on the way out. The decode is intentionally
-  // applied to the WHOLE message — linkifyForMumble escapes both URL and
-  // non-URL text so Mumble's HTML parser doesn't eat literal '<' or '&', and
-  // we have to reverse that on the receiver side to recover the original
-  // text. A single-pass decode (no recursive expansion) means a user who
-  // typed literal '&lt;' on the way out gets back literal '&lt;' here, which
-  // is the correct round-trip for our outgoing format.
-  text = text.replace(ANCHOR_REGEX, (_m, inner) => inner);
+  // Replace anchor tags with a plain-text rendering. If the visible text
+  // already contains a URL (the common case when the anchor came from
+  // linkifyForMumble — visible == href), keep just the inner text and let
+  // the local linkifier re-wrap it into a React link. Otherwise the inner
+  // text is descriptive ("click here") and dropping the href would lose the
+  // URL, so we render as "inner (href)" to preserve both label and URL.
+  text = text.replace(ANCHOR_REGEX, (_m, href, inner) => {
+    const innerStr = String(inner);
+    if (URL_HINT_PATTERN.test(innerStr)) return innerStr;
+    return `${innerStr} (${href})`;
+  });
+  // Decode the HTML entities we escaped on the way out. The decode is
+  // intentionally applied to the WHOLE message — linkifyForMumble escapes
+  // both URL and non-URL text so Mumble's HTML parser doesn't eat literal
+  // '<' or '&', and we have to reverse that on the receiver side to recover
+  // the original text. A single-pass decode (no recursive expansion) means
+  // a user who typed literal '&lt;' on the way out gets back literal '&lt;'
+  // here, which is the correct round-trip for our outgoing format.
   text = decodeEntities(text);
 
   return { text: text.trim(), media };

--- a/src/Brmble.Web/src/utils/parseMessageMedia.ts
+++ b/src/Brmble.Web/src/utils/parseMessageMedia.ts
@@ -3,6 +3,20 @@ import type { MediaAttachment } from '../types';
 export const MAX_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
 export const ALLOWED_MIMETYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
 const IMG_REGEX = /<img\s+[^>]*src=["']data:(image\/[^;]+);base64,([^"']+)["'][^>]*\/?>/gi;
+// Anchor tag from a Brmble peer (linkifyForMumble) — strip back to inner text
+// so the local renderer's own URL detection (linkifyText) creates the React link.
+const ANCHOR_REGEX = /<a\s+[^>]*href=["'][^"']*["'][^>]*>([\s\S]*?)<\/a>/gi;
+
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+};
+function decodeEntities(s: string): string {
+  return s.replace(/&(amp|lt|gt|quot|#39);/g, m => HTML_ENTITIES[m] ?? m);
+}
 
 export interface ParsedMessage {
   text: string;
@@ -44,6 +58,12 @@ export function parseMessageMedia(message: string): ParsedMessage {
       size: estimatedSize,
     });
   }
+
+  // Replace anchor tags with their inner text (the URL we sent), then decode
+  // the HTML entities we escaped on the way out so the local linkifier sees a
+  // clean URL like "https://x.com/a?b=1&c=2" rather than the escaped form.
+  text = text.replace(ANCHOR_REGEX, (_m, inner) => inner);
+  text = decodeEntities(text);
 
   return { text: text.trim(), media };
 }


### PR DESCRIPTION
## Summary
- Wrap \`http(s)://\` and \`www.\` URLs in \`<a href="...">\` anchor tags before sending channel messages and DMs over the Mumble protocol so native Mumble clients render them as clickable hyperlinks (the server config already has \`allowHTML\` enabled).
- Strip incoming anchor tags back to plain URL text in \`parseMessageMedia\` so Brmble→Brmble rendering looks identical to before — the local \`linkifyText\` re-creates a React link from the URL for display.
- Bare domains like \`example.com\` are deliberately left alone (too many false positives in normal sentences/version numbers).

## Why
#474: Brmble users sending URLs in chat saw them rendered as clickable links locally, but native Mumble clients receiving the same message saw plain text only.

## Test plan
- [x] New unit tests for \`linkifyForMumble\` (10 cases incl. http, https, www, multiple URLs, ampersand-in-URL, XSS-attempt escaping)
- [x] Updated \`parseMessageMedia\` tests cover stripped anchors and entity round-trip
- [x] All non-NeonD tests pass; NeonD localStorage failures are pre-existing on \`main\`
- [ ] Manual verification: send a URL from Brmble, confirm it's clickable in native Mumble client

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)