### PR TITLE
docs: add top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 Self-hosted gaming communication. Voice over Mumble, persistent chat over Matrix, screen sharing over LiveKit — wrapped in a single desktop client.
 
-The voice side is plain Mumble: existing Mumble clients can join the same server. Brmble adds chat history and screen sharing on top, glued together by a single backend container.
+## Mumble compatibility
+
+Brmble is built on top of Mumble, not as a replacement. The voice server is an unmodified Mumble server. That means:
+
+- **Standard Mumble clients work without changes.** Anyone with the official Mumble client (or any third-party Mumble client) can connect to the same server and talk to Brmble users in the same channels.
+- **Mixed use is the intended setup.** A server with the Brmble container running alongside Mumble can host both kinds of clients at the same time. Brmble clients get voice + persistent chat + screen sharing; standard Mumble clients get voice only. Everyone shares the same channels and can hear each other.
+- **No fork, no patched server.** Brmble does not modify the Mumble protocol or the Mumble server. The chat and screen-sharing features live in a separate Brmble container that sits next to Mumble. If you turn the Brmble container off, your server is back to plain Mumble.
+
+The only requirement for cross-client interop is that the Brmble container has to be reachable for clients that want chat and screen sharing. Standard Mumble clients ignore it.
 
 ## Architecture
 
@@ -151,7 +159,7 @@ Make sure the host name in your TLS certificate matches `MATRIX_SERVER_NAME`.
 2. Enter the Mumble host (e.g. `mumble.example.com:64738`) and a username.
 3. On connect, the client reads Mumble's welcome text, pulls the `apiUrl` out of the `<!--brmble:{...}-->` marker, and starts talking to the Brmble server for chat and screen sharing.
 
-If a user connects with a plain Mumble client they get voice only — no chat, no screen sharing, but they can still talk to Brmble users in the same channel.
+A user connecting with a standard Mumble client skips all of the above and gets voice only. They share channels with Brmble users normally — the two client types coexist on the same server without any extra configuration.
 
 ## Updating
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ The only requirement for cross-client interop is that the Brmble container has t
                     ┌──────────────────────────────┐
                     │  Brmble Server (1 container) │
                     │  ┌────────────┐              │
-                    │  │ ASP.NET    │  HTTP :8080  │── client API + /_matrix proxy
+                    │  │ ASP.NET    │  HTTPS :8080 │── client API + /_matrix proxy
                     │  ├────────────┤              │
                     │  │ Continuwuity (Matrix)     │── persistent chat
                     │  ├────────────┤              │
-                    │  │ LiveKit SFU │  :7881 +UDP │── screen sharing
+                    │  │ LiveKit SFU │  :7881 +UDP │── screen sharing (TCP 7881 + UDP 50000-50100)
                     │  └────────────┘              │
                     └─────────────┬────────────────┘
                                   │ ICE :6502 (optional, for user mapping)
@@ -75,7 +75,7 @@ services:
       MUMBLE_CONFIG_ICE: "tcp -h 0.0.0.0 -p 6502"
       MUMBLE_CONFIG_WELCOMETEXT: |
         <br/>Welcome to my server.<br/>
-        <!--brmble:{"apiUrl":"https://chat.example.com:8080"}-->
+        <!--brmble:{"apiUrl":"https://mumble.example.com:8080"}-->
 
       # Recommended (lets Brmble post images, long messages and embeds)
       MUMBLE_CONFIG_IMAGEMESSAGELENGTH: "0"
@@ -89,7 +89,7 @@ volumes:
 Key points:
 
 - **`allowhtml=true`** — required. The Brmble client embeds an HTML comment in the welcome text that points the client to the Brmble server (see below). Mumble strips HTML comments unless HTML is allowed.
-- **`MUMBLE_CONFIG_WELCOMETEXT`** — must include an HTML comment of the form `<!--brmble:{"apiUrl":"https://<host>:<port>"}-->`, e.g. `https://chat.example.com:8080` or `https://203.0.113.10:8080`. This is how a Brmble client discovers the matching Brmble server when a user connects to your Mumble server. Plain Mumble clients ignore the comment.
+- **`MUMBLE_CONFIG_WELCOMETEXT`** — must include an HTML comment of the form `<!--brmble:{"apiUrl":"https://<host>:<port>"}-->`, e.g. `https://chat.example.com:8080` or `https://203.0.113.10:8080`. The `apiUrl` host **must match the Mumble server host** the user connected to — if a user connects to `mumble.example.com`, the marker must use `https://mumble.example.com:8080`, not a different hostname. This is how a Brmble client discovers the matching Brmble server when a user connects to your Mumble server. Plain Mumble clients ignore the comment.
 - **`MUMBLE_CONFIG_ICE`** — exposes Mumble's ICE control plane on TCP `6502` so the Brmble server can map Mumble sessions to Matrix users. Bind it to a private network (or the docker-compose internal network) — never expose it to the public internet. Set an ICE secret on Mumble and pass the same value to Brmble via `Ice__Secret` if you need authentication.
 - `IMAGEMESSAGELENGTH` and `TEXTMESSAGELENGTH` default to small values; `0` means unlimited and is required for embeds, link previews and longer messages.
 
@@ -103,7 +103,7 @@ services:
     ports:
       - "8080:8080"                   # HTTPS (self-signed)
       - "7881:7881"                   # LiveKit RTC TCP
-      - "50100-50200:50100-50200/udp" # LiveKit RTC UDP
+      - "50000-50100:50000-50100/udp" # LiveKit RTC UDP
     volumes:
       - brmble-data:/data
     environment:
@@ -143,7 +143,7 @@ Optional environment:
 Ports:
 
 - `8080/tcp` — single HTTPS entry point, served with a built-in self-signed certificate. The Brmble client accepts the self-signed cert directly. Map it to a different host port if `8080` is already in use.
-- `7881/tcp` and `50100-50200/udp` — LiveKit RTC. Expose these directly. UDP is what actually carries WebRTC media; TCP `7881` is fallback only.
+- `7881/tcp` and `50000-50100/udp` — LiveKit RTC. Expose these directly. UDP is what actually carries WebRTC media; TCP `7881` is fallback only.
 
 The first start runs ~30 seconds while the bundled Matrix homeserver initialises and registers the appservice. State after first start lives entirely in the `brmble-data` volume.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Brmble
 
-Self-hosted gaming communication. Voice over Mumble, persistent chat over Matrix, screen sharing over LiveKit — wrapped in a single desktop client.
+Self-hosted gaming communication. Voice over Mumble, persistent chat over Matrix, screen sharing over LiveKit — wrapped in a single desktop client (Windows only).
+
+The client is a native desktop app with a current web-stack UI rendered inside it, so it looks and feels like the chat apps people use today rather than the dated Qt interface of the official Mumble client — while staying fully interoperable with it on the wire.
+
+## Screenshots
+
+_Coming soon._
 
 ## Mumble compatibility
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,194 @@
+# Brmble
+
+Self-hosted gaming communication. Voice over Mumble, persistent chat over Matrix, screen sharing over LiveKit — wrapped in a single desktop client.
+
+The voice side is plain Mumble: existing Mumble clients can join the same server. Brmble adds chat history and screen sharing on top, glued together by a single backend container.
+
+## Architecture
+
+```
+                    ┌──────────────────────────────┐
+                    │  Brmble Server (1 container) │
+                    │  ┌────────────┐              │
+                    │  │ ASP.NET    │  HTTP :8080  │── client API + /_matrix proxy
+                    │  ├────────────┤              │
+                    │  │ Continuwuity (Matrix)     │── persistent chat
+                    │  ├────────────┤              │
+                    │  │ LiveKit SFU │  :7881 +UDP │── screen sharing
+                    │  └────────────┘              │
+                    └─────────────┬────────────────┘
+                                  │ ICE :6502 (optional, for user mapping)
+                                  ▼
+                    ┌──────────────────────────────┐
+                    │  Mumble Server (separate)    │── voice (TCP/UDP :64738)
+                    └──────────────────────────────┘
+```
+
+The Brmble server bundles ASP.NET Core, Continuwuity (Matrix homeserver) and LiveKit into one image. Mumble runs separately — Brmble does not replace it.
+
+## Install the client
+
+Download the latest release from <https://github.com/brmble/brmble/releases/latest>:
+
+- `Brmble-win-Setup.exe` — installer, auto-updates from GitHub releases.
+- `Brmble-win-Portable.zip` — standalone, no install, no auto-update.
+
+Windows 10/11 only. The client embeds WebView2 (installed automatically by the setup if missing).
+
+On first launch the client generates a self-signed X.509 certificate that becomes your identity across voice, chat and screen sharing. **Back it up via Settings → Export Certificate.** If the certificate is lost, you become a new user with empty chat history, even if you reuse the same Mumble username.
+
+## Install the server
+
+You need two containers: one for Mumble, one for Brmble. The two examples below assume a host that already has a TLS reverse proxy (Caddy, Traefik, nginx) sitting in front, terminating HTTPS and forwarding to the Brmble container on port `8080`.
+
+### 1. Mumble server
+
+The official image works as-is, but a few settings matter for the Brmble integration:
+
+```yaml
+services:
+  mumble:
+    image: mumblevoip/mumble-server:latest
+    restart: unless-stopped
+    ports:
+      - "64738:64738"
+      - "64738:64738/udp"
+    volumes:
+      - mumble-data:/data
+    environment:
+      # Required for Brmble integration
+      MUMBLE_CONFIG_ALLOWHTML: "true"
+      MUMBLE_CONFIG_ICE: "tcp -h 0.0.0.0 -p 6502"
+      MUMBLE_CONFIG_WELCOMETEXT: |
+        <br/>Welcome to my server.<br/>
+        <!--brmble:{"apiUrl":"https://chat.example.com"}-->
+
+      # Recommended (lets Brmble post images, long messages and embeds)
+      MUMBLE_CONFIG_IMAGEMESSAGELENGTH: "0"
+      MUMBLE_CONFIG_TEXTMESSAGELENGTH: "0"
+      MUMBLE_ACCEPT_UNKNOWN_SETTINGS: "true"
+
+volumes:
+  mumble-data:
+```
+
+Key points:
+
+- **`allowhtml=true`** — required. The Brmble client embeds an HTML comment in the welcome text that points the client to the Brmble server (see below). Mumble strips HTML comments unless HTML is allowed.
+- **`MUMBLE_CONFIG_WELCOMETEXT`** — must include `<!--brmble:{"apiUrl":"https://your-brmble-host"}-->`. This is how a Brmble client discovers the matching Brmble server when a user connects to your Mumble server. Plain Mumble clients ignore the comment.
+- **`MUMBLE_CONFIG_ICE`** — exposes Mumble's ICE control plane on TCP `6502` so the Brmble server can map Mumble sessions to Matrix users. Bind it to a private network (or the docker-compose internal network) — never expose it to the public internet. Set an ICE secret on Mumble and pass the same value to Brmble via `Ice__Secret` if you need authentication.
+- `IMAGEMESSAGELENGTH` and `TEXTMESSAGELENGTH` default to small values; `0` means unlimited and is required for embeds, link previews and longer messages.
+
+### 2. Brmble server
+
+```yaml
+services:
+  brmble:
+    image: ghcr.io/brmble/brmble-server:latest
+    restart: unless-stopped
+    ports:
+      - "8080:8080"                   # HTTP — put HTTPS reverse proxy in front
+      - "7881:7881"                   # LiveKit RTC TCP
+      - "50100-50200:50100-50200/udp" # LiveKit RTC UDP
+    volumes:
+      - brmble-data:/data
+    environment:
+      # Required
+      MATRIX_SERVER_NAME: chat.example.com
+      MATRIX_APPSERVICE_TOKEN: ${MATRIX_APPSERVICE_TOKEN}
+
+      # Optional — connect to your Mumble server's ICE endpoint
+      Ice__Host: mumble
+      Ice__Port: "6502"
+      Ice__Secret: ""
+
+      # Optional — force LiveKit to advertise a specific public IP
+      # LIVEKIT_NODE_IP: "203.0.113.10"
+
+volumes:
+  brmble-data:
+```
+
+Required environment:
+
+| Variable | Description |
+|---|---|
+| `MATRIX_SERVER_NAME` | Public Matrix domain. Must match the host clients reach over HTTPS (e.g. `chat.example.com`). Matrix user IDs become `@<id>:<MATRIX_SERVER_NAME>`. Cannot be changed after first start without resetting `/data`. |
+| `MATRIX_APPSERVICE_TOKEN` | Shared secret between the bundled Matrix homeserver and the Brmble backend. Generate with `openssl rand -hex 32`. Keep stable across restarts. |
+
+Optional environment:
+
+| Variable | Default | Description |
+|---|---|---|
+| `Ice__Host` / `Ice__Port` / `Ice__Secret` | `mumble-server` / `6502` / *(empty)* | Mumble ICE endpoint. Without this, Mumble↔Matrix user mapping is disabled. |
+| `LIVEKIT_NODE_IP` | *(auto)* | Pin LiveKit's advertised IP. Useful for local/LAN setups; leave unset on public servers and LiveKit will auto-detect. |
+| `MATRIX_ADMIN_USER` / `MATRIX_ADMIN_PASSWORD` | `brmble-admin` / *(generated)* | Override the auto-created Matrix admin. Generated password is stored in `/data/admin-password`. |
+| `MATRIX_ALLOW_REGISTRATION` | `false` | Set to `true` to allow open Matrix registration after first-run setup. Brmble does not need this — clients register themselves via the appservice. |
+| `CONDUWUIT_STARTUP_TIMEOUT` | `60` | Seconds to wait for the Matrix homeserver on first boot. |
+
+Ports:
+
+- `8080/tcp` — single HTTP entry point. Behind a reverse proxy that terminates HTTPS. The proxy must forward both regular HTTP traffic and WebSocket upgrades.
+- `7881/tcp` and `50100-50200/udp` — LiveKit RTC. Forward these directly (do not proxy). UDP is required for working WebRTC; TCP `7881` is fallback only.
+
+The first start runs ~30 seconds while the bundled Matrix homeserver initialises and registers the appservice. State after first start lives entirely in the `brmble-data` volume.
+
+### 3. Reverse proxy
+
+Anything that terminates HTTPS works. A minimal Caddyfile:
+
+```
+chat.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+Make sure the host name in your TLS certificate matches `MATRIX_SERVER_NAME`.
+
+## Connecting the client
+
+1. Open the Brmble client and add a server.
+2. Enter the Mumble host (e.g. `mumble.example.com:64738`) and a username.
+3. On connect, the client reads Mumble's welcome text, pulls the `apiUrl` out of the `<!--brmble:{...}-->` marker, and starts talking to the Brmble server for chat and screen sharing.
+
+If a user connects with a plain Mumble client they get voice only — no chat, no screen sharing, but they can still talk to Brmble users in the same channel.
+
+## Updating
+
+- **Client**: auto-updates from GitHub releases on installer builds; portable builds need to be replaced manually.
+- **Server**: pull a newer image and recreate the container. The `/data` volume migrates automatically.
+  ```bash
+  docker compose pull brmble && docker compose up -d brmble
+  ```
+
+## Building from source
+
+Requirements: .NET 10 SDK, Node 20+, Docker.
+
+```bash
+# Server image
+docker build -t brmble-server:dev -f src/Brmble.Server/Dockerfile .
+
+# Client (Windows)
+cd src/Brmble.Web && npm install && npm run build
+dotnet publish src/Brmble.Client/Brmble.Client.csproj -c Release -r win-x64 --self-contained -o publish
+```
+
+For day-to-day development, see [`CLAUDE.md`](CLAUDE.md) (running the client with hot reload, Docker setup, build commands).
+
+## Repository layout
+
+```
+src/Brmble.Server/   ASP.NET backend, Dockerfile, Matrix/LiveKit glue
+src/Brmble.Client/   Win32 + WebView2 desktop client
+src/Brmble.Web/      React + Vite frontend (rendered inside the client)
+lib/MumbleSharp/     Mumble protocol library (vendored)
+docker-local/        docker-compose for local dev (Mumble + Brmble)
+docs/                Architecture notes, specs, integration guides
+```
+
+Relevant docs:
+
+- [`docs/tech-stack.md`](docs/tech-stack.md) — component overview and licensing
+- [`docs/auth-specification.md`](docs/auth-specification.md) — certificate-based identity model
+- [`docs/mumble-integration-guide.md`](docs/mumble-integration-guide.md) — how the client talks to Mumble

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ services:
       MUMBLE_CONFIG_ICE: "tcp -h 0.0.0.0 -p 6502"
       MUMBLE_CONFIG_WELCOMETEXT: |
         <br/>Welcome to my server.<br/>
-        <!--brmble:{"apiUrl":"https://chat.example.com:1912"}-->
+        <!--brmble:{"apiUrl":"https://chat.example.com:8080"}-->
 
       # Recommended (lets Brmble post images, long messages and embeds)
       MUMBLE_CONFIG_IMAGEMESSAGELENGTH: "0"
@@ -89,7 +89,7 @@ volumes:
 Key points:
 
 - **`allowhtml=true`** — required. The Brmble client embeds an HTML comment in the welcome text that points the client to the Brmble server (see below). Mumble strips HTML comments unless HTML is allowed.
-- **`MUMBLE_CONFIG_WELCOMETEXT`** — must include `<!--brmble:{"apiUrl":"https://your-brmble-host"}-->`. This is how a Brmble client discovers the matching Brmble server when a user connects to your Mumble server. Plain Mumble clients ignore the comment.
+- **`MUMBLE_CONFIG_WELCOMETEXT`** — must include an HTML comment of the form `<!--brmble:{"apiUrl":"https://<host>:<port>"}-->`, e.g. `https://chat.example.com:8080` or `https://203.0.113.10:8080`. This is how a Brmble client discovers the matching Brmble server when a user connects to your Mumble server. Plain Mumble clients ignore the comment.
 - **`MUMBLE_CONFIG_ICE`** — exposes Mumble's ICE control plane on TCP `6502` so the Brmble server can map Mumble sessions to Matrix users. Bind it to a private network (or the docker-compose internal network) — never expose it to the public internet. Set an ICE secret on Mumble and pass the same value to Brmble via `Ice__Secret` if you need authentication.
 - `IMAGEMESSAGELENGTH` and `TEXTMESSAGELENGTH` default to small values; `0` means unlimited and is required for embeds, link previews and longer messages.
 
@@ -101,7 +101,7 @@ services:
     image: ghcr.io/brmble/brmble-server:latest
     restart: unless-stopped
     ports:
-      - "1912:8080"                   # HTTPS (self-signed) — pick any host port you like
+      - "8080:8080"                   # HTTPS (self-signed)
       - "7881:7881"                   # LiveKit RTC TCP
       - "50100-50200:50100-50200/udp" # LiveKit RTC UDP
     volumes:
@@ -142,7 +142,7 @@ Optional environment:
 
 Ports:
 
-- `8080/tcp` (in container) — single HTTPS entry point, served with a built-in self-signed certificate. Map it to whatever public port you like (`1912` is the convention). The Brmble client accepts the self-signed cert directly.
+- `8080/tcp` — single HTTPS entry point, served with a built-in self-signed certificate. The Brmble client accepts the self-signed cert directly. Map it to a different host port if `8080` is already in use.
 - `7881/tcp` and `50100-50200/udp` — LiveKit RTC. Expose these directly. UDP is what actually carries WebRTC media; TCP `7881` is fallback only.
 
 The first start runs ~30 seconds while the bundled Matrix homeserver initialises and registers the appservice. State after first start lives entirely in the `brmble-data` volume.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ On first launch the client generates a self-signed X.509 certificate that become
 
 ## Install the server
 
-You need two containers: one for Mumble, one for Brmble. The two examples below assume a host that already has a TLS reverse proxy (Caddy, Traefik, nginx) sitting in front, terminating HTTPS and forwarding to the Brmble container on port `8080`.
+You need two containers: one for Mumble, one for Brmble. The Brmble container speaks HTTPS directly on port `8080` with a built-in self-signed certificate; the Brmble client trusts it without any extra setup, so you do not need a reverse proxy unless you want a custom domain or a real CA-signed certificate. (No browser ever talks to it directly — only the Brmble client does.)
 
 ### 1. Mumble server
 
@@ -75,7 +75,7 @@ services:
       MUMBLE_CONFIG_ICE: "tcp -h 0.0.0.0 -p 6502"
       MUMBLE_CONFIG_WELCOMETEXT: |
         <br/>Welcome to my server.<br/>
-        <!--brmble:{"apiUrl":"https://chat.example.com"}-->
+        <!--brmble:{"apiUrl":"https://chat.example.com:1912"}-->
 
       # Recommended (lets Brmble post images, long messages and embeds)
       MUMBLE_CONFIG_IMAGEMESSAGELENGTH: "0"
@@ -101,7 +101,7 @@ services:
     image: ghcr.io/brmble/brmble-server:latest
     restart: unless-stopped
     ports:
-      - "8080:8080"                   # HTTP — put HTTPS reverse proxy in front
+      - "1912:8080"                   # HTTPS (self-signed) — pick any host port you like
       - "7881:7881"                   # LiveKit RTC TCP
       - "50100-50200:50100-50200/udp" # LiveKit RTC UDP
     volumes:
@@ -127,7 +127,7 @@ Required environment:
 
 | Variable | Description |
 |---|---|
-| `MATRIX_SERVER_NAME` | Public Matrix domain. Must match the host clients reach over HTTPS (e.g. `chat.example.com`). Matrix user IDs become `@<id>:<MATRIX_SERVER_NAME>`. Cannot be changed after first start without resetting `/data`. |
+| `MATRIX_SERVER_NAME` | Public Matrix domain. Should match the host clients reach (e.g. `chat.example.com`). Matrix user IDs become `@<id>:<MATRIX_SERVER_NAME>`. Cannot be changed after first start without resetting `/data`. |
 | `MATRIX_APPSERVICE_TOKEN` | Shared secret between the bundled Matrix homeserver and the Brmble backend. Generate with `openssl rand -hex 32`. Keep stable across restarts. |
 
 Optional environment:
@@ -142,22 +142,14 @@ Optional environment:
 
 Ports:
 
-- `8080/tcp` — single HTTP entry point. Behind a reverse proxy that terminates HTTPS. The proxy must forward both regular HTTP traffic and WebSocket upgrades.
-- `7881/tcp` and `50100-50200/udp` — LiveKit RTC. Forward these directly (do not proxy). UDP is required for working WebRTC; TCP `7881` is fallback only.
+- `8080/tcp` (in container) — single HTTPS entry point, served with a built-in self-signed certificate. Map it to whatever public port you like (`1912` is the convention). The Brmble client accepts the self-signed cert directly.
+- `7881/tcp` and `50100-50200/udp` — LiveKit RTC. Expose these directly. UDP is what actually carries WebRTC media; TCP `7881` is fallback only.
 
 The first start runs ~30 seconds while the bundled Matrix homeserver initialises and registers the appservice. State after first start lives entirely in the `brmble-data` volume.
 
-### 3. Reverse proxy
+### 3. Optional: custom certificate / domain
 
-Anything that terminates HTTPS works. A minimal Caddyfile:
-
-```
-chat.example.com {
-    reverse_proxy localhost:8080
-}
-```
-
-Make sure the host name in your TLS certificate matches `MATRIX_SERVER_NAME`.
+If you'd rather not ship the bundled self-signed cert (e.g. you want a real CA-signed certificate for `chat.example.com`), put any TLS-terminating reverse proxy (Caddy, Traefik, nginx) in front of the container — it just needs to forward HTTP traffic and WebSocket upgrades to port `8080`. This is purely cosmetic; voice, chat and screen sharing all work without it.
 
 ## Connecting the client
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ On first launch the client generates a self-signed X.509 certificate that become
 
 ## Install the server
 
-You need two containers: one for Mumble, one for Brmble. The Brmble container speaks HTTPS directly on port `8080` with a built-in self-signed certificate; the Brmble client trusts it without any extra setup, so you do not need a reverse proxy unless you want a custom domain or a real CA-signed certificate. (No browser ever talks to it directly — only the Brmble client does.)
+You need two containers: one for Mumble, one for Brmble. The Brmble container speaks HTTPS directly on port `8080` with a built-in self-signed certificate; the Brmble client trusts it without any extra setup. No browser ever talks to it directly — only the Brmble client does.
 
 ### 1. Mumble server
 
@@ -146,10 +146,6 @@ Ports:
 - `7881/tcp` and `50100-50200/udp` — LiveKit RTC. Expose these directly. UDP is what actually carries WebRTC media; TCP `7881` is fallback only.
 
 The first start runs ~30 seconds while the bundled Matrix homeserver initialises and registers the appservice. State after first start lives entirely in the `brmble-data` volume.
-
-### 3. Optional: custom certificate / domain
-
-If you'd rather not ship the bundled self-signed cert (e.g. you want a real CA-signed certificate for `chat.example.com`), put any TLS-terminating reverse proxy (Caddy, Traefik, nginx) in front of the container — it just needs to forward HTTP traffic and WebSocket upgrades to port `8080`. This is purely cosmetic; voice, chat and screen sharing all work without it.
 
 ## Connecting the client
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Self-hosted gaming communication. Voice over Mumble, persistent chat over Matrix, screen sharing over LiveKit — wrapped in a single desktop client (Windows only).
 
-The client is a native desktop app with a current web-stack UI rendered inside it, so it looks and feels like the chat apps people use today rather than the dated Qt interface of the official Mumble client — while staying fully interoperable with it on the wire.
+The client is a native desktop app with a modern web-based UI inside, including theming and a familiar chat-app layout.
 
 ## Screenshots
 


### PR DESCRIPTION
## Summary
- Add a `README.md` at the repo root covering client install (GitHub releases), server install (docker-compose for Mumble + Brmble), required Mumble settings for Brmble integration, and the env-var reference for the server image.
- Emphasise Mumble cross-compatibility: standard Mumble clients work unchanged, mixed Brmble + Mumble clients on the same server is the intended setup.
- Document that the Brmble container speaks HTTPS directly on `8080` with a built-in self-signed cert — no reverse proxy required.
- Reserve a `Screenshots` section to fill in once we have images.

## Test plan
- [x] Render the README on GitHub and confirm the architecture diagram, env tables and code blocks all look right.
- [ ] Sanity-check the docker-compose snippets against a fresh deploy.
- [ ] Verify the welcome-text marker example matches `MumbleAdapter.ParseBrmbleApiUrl` (covered by `MumbleAdapterParseTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)