### PR TITLE
docs: remove stale review notes from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,19 +88,6 @@ git push -u origin feature/my-feature
 - ❌ Merge PRs without review
 - ❌ Commit plans or any changes before moving work to a worktree
 
-## Review Notes
-
-- This patch updates CLAUDE.md to improve guidance for multi-agent collaboration and contributor onboarding.
-- No code changes; intended to support the open Bridge PR with better context for reviewers.
-- Please verify the added sections render clearly in the PR diff and that terminology remains consistent with the rest of CLAUDE.md.
-- If minor wording tweaks are needed, we can push a follow-up small edit.
-
-## Extra: Design for Multi-Agent Collaboration
-
-This project supports modular bridge architecture. The following guidelines help AI agents collaborate:
-- Never commit to main; create feature branches and PRs
-- Use a consistent, explicit planning and review workflow
-
 ## Tech Stack (Summary)
 - Frontend: React + TypeScript + Vite
 - Backend: ASP.NET Core


### PR DESCRIPTION
## Summary

- Removes the \"Review Notes\" section from CLAUDE.md — it was PR-review meta-content from an old Bridge PR that ended up committed verbatim and has been stale ever since (\"intended to support the open Bridge PR\")
- Removes the \"Extra: Design for Multi-Agent Collaboration\" section — duplicates rules already covered in the Branch Management Rules section directly above

Surfaced by a Codex review pass on a separate refactor branch.

## Test plan

- [x] Diff is doc-only, no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)