### PR TITLE
fix(audio): defensive idempotency guard for SetTransmissionMode (#470)

### DIFF
--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -1164,14 +1164,12 @@ private int _screenShareHotkeyId = -1;
         string action = GetActionName(id);
         if (string.IsNullOrEmpty(action)) return;
 
-        bool isMouseButton = key is "XButton1" or "XButton2" or "MouseLeft" or "MouseRight" or "MouseMiddle";
-        
-        if (isMouseButton)
+        if (IsMouseButtonKey(key))
         {
             RegisterMouseHookForShortcut(action, key);
             return;
         }
-        
+
         var vk = KeyNameToVirtualKey(key);
         if (vk == 0) return;
         
@@ -1204,14 +1202,14 @@ private int _screenShareHotkeyId = -1;
     /// </summary>
     public void SetTransmissionMode(TransmissionMode mode, string? key, IntPtr hwnd)
     {
-        // Idempotency guard: bail out if nothing changed AND our underlying
-        // input plumbing is still consistent. Without this, repeated calls
-        // (e.g. from a UI refresh storm) tear down and re-register the mouse
-        // hook / raw input within milliseconds, which historically caused PTT
-        // to silently fail (#470). The consistency check protects against the
-        // shared mouse hook being stolen by SetShortcut, or hook registration
-        // having failed on the previous call — in both cases we must
-        // reconfigure rather than skip.
+        // Idempotency guard: bail out if nothing changed AND the mouse hook /
+        // PTT polling we configured last time is still intact. Without this,
+        // repeated calls (e.g. from a UI refresh storm) would tear down and
+        // re-register the mouse hook within milliseconds, which historically
+        // caused PTT to silently fail (#470). The consistency check
+        // (IsTransmissionConfigStillValid) detects when the shared mouse hook
+        // was stolen by SetShortcut or when hook/polling registration failed
+        // on the previous call — in those cases we must reconfigure.
         if (_transmissionConfigured
             && mode == _transmissionMode
             && key == _lastTransmissionKey
@@ -1246,12 +1244,10 @@ private int _screenShareHotkeyId = -1;
             var vk = KeyNameToVirtualKey(key);
             AudioLog.Write($"[Audio] SetTransmissionMode: mode={mode}, key={key}, vk=0x{vk:X2}, hwnd={hwnd}");
 
-            bool isMouseButton = key is "XButton1" or "XButton2" or "MouseLeft" or "MouseRight" or "MouseMiddle";
-
             // Stop any existing polling before reconfiguring (switching from keyboard to mouse PTT)
             StopPttPolling();
 
-            if (isMouseButton)
+            if (IsMouseButtonKey(key))
             {
                 RegisterMouseHookForButton(key);
             }
@@ -1312,6 +1308,15 @@ private int _screenShareHotkeyId = -1;
     // together.
     private const string MouseHookPttAction = "pushToTalk";
 
+    /// <summary>
+    /// Single source of truth for whether a key name refers to a mouse button.
+    /// Must stay in sync with <see cref="KeyNameToVirtualKey"/> and the
+    /// <c>expectedButton</c> map in <see cref="MouseHookCallback"/>.
+    /// </summary>
+    internal static bool IsMouseButtonKey(string? key) => key is
+        "XButton1" or "XButton2" or "MouseXButton1" or "MouseXButton2"
+        or "MouseLeft" or "MouseRight" or "MouseMiddle";
+
     private PttInputState CurrentPttInputState() => new(
         _mouseHookHandle,
         _shortcutActionForMouse,
@@ -1337,8 +1342,7 @@ private int _screenShareHotkeyId = -1;
             return true;
         }
 
-        bool isMouseButton = key is "XButton1" or "XButton2" or "MouseLeft" or "MouseRight" or "MouseMiddle";
-        if (isMouseButton)
+        if (IsMouseButtonKey(key))
         {
             // The mouse hook is shared with SetShortcut; verify it's still
             // ours (not stolen by a non-PTT shortcut) and actually registered.
@@ -1539,9 +1543,7 @@ private int _screenShareHotkeyId = -1;
         AudioLog.Write($"[Audio] SetShortcut: action={action}, key={key}, _hwnd={_hwnd}");
         if (_hwnd == IntPtr.Zero) return;
 
-        bool isMouseButton = key is "XButton1" or "XButton2" or "MouseLeft" or "MouseRight" or "MouseMiddle";
-
-        if (isMouseButton)
+        if (IsMouseButtonKey(key))
         {
             RegisterMouseHookForShortcut(action, key);
             return;
@@ -1741,8 +1743,8 @@ private int _screenShareHotkeyId = -1;
                     "MouseLeft" => 0,
                     "MouseMiddle" => 2,
                     "MouseRight" => 1,
-                    "XButton1" => 3,
-                    "XButton2" => 4,
+                    "XButton1" or "MouseXButton1" => 3,
+                    "XButton2" or "MouseXButton2" => 4,
                     _ => -1
                 };
 

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -221,6 +221,8 @@ internal sealed class AudioManager : IDisposable
     private volatile bool _muted;
     private volatile bool _deafened;
     private volatile TransmissionMode _transmissionMode = TransmissionMode.Continuous;
+    private string? _lastTransmissionKey;
+    private bool _transmissionConfigured;
     private volatile bool _pttActive;
 internal const int PttHotkeyId = 1;
 internal const int MuteHotkeyId = 2;
@@ -1201,9 +1203,20 @@ private int _screenShareHotkeyId = -1;
     /// </summary>
     public void SetTransmissionMode(TransmissionMode mode, string? key, IntPtr hwnd)
     {
+        // Idempotency guard: bail out if nothing changed. Without this, repeated
+        // calls (e.g. from a UI refresh storm) tear down and re-register the
+        // mouse hook / raw input within milliseconds, which historically caused
+        // PTT to silently fail (#470).
+        if (_transmissionConfigured && mode == _transmissionMode && key == _lastTransmissionKey && hwnd == _hwnd)
+        {
+            return;
+        }
+
         _pttActive = false;
         _hwnd = hwnd;
         _transmissionMode = mode;
+        _lastTransmissionKey = key;
+        _transmissionConfigured = true;
 
         // Unregister any existing hotkey
         if (_hotkeyId >= 0 && _hwnd != IntPtr.Zero)

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -1216,7 +1216,7 @@ private int _screenShareHotkeyId = -1;
             && mode == _transmissionMode
             && key == _lastTransmissionKey
             && hwnd == _hwnd
-            && IsTransmissionConfigStillValid(mode, key, hwnd))
+            && IsTransmissionConfigStillValid(mode, key, hwnd, CurrentPttInputState()))
         {
             return;
         }
@@ -1282,20 +1282,52 @@ private int _screenShareHotkeyId = -1;
         else if (!_muted)
             StartMic();
 
-        // Mark configured at the end so a failure or early return inside the
-        // body leaves the guard open for a retry on the next call.
+        // Mark configured at the end so an exception thrown mid-body leaves
+        // the flag false (next call retries from scratch). For *silent*
+        // failures inside the body — e.g. SetWindowsHookEx returning
+        // IntPtr.Zero, or KeyNameToVirtualKey returning 0 — the flag still
+        // gets set here, but IsTransmissionConfigStillValid will detect the
+        // missing hook/timer/vk on the next call and force a re-run.
         _lastTransmissionKey = key;
         _transmissionConfigured = true;
         TransmissionApplyCount++;
     }
 
     /// <summary>
-    /// Returns true if the runtime input state matches the previously-applied
-    /// (mode, key) — i.e. the hook/polling we set up last time is still ours
-    /// and still alive. Returning false forces SetTransmissionMode to redo
-    /// configuration even when the inputs haven't changed.
+    /// Snapshot of the input plumbing relevant to PTT validity. Extracted as
+    /// a record so <see cref="IsTransmissionConfigStillValid"/> can be a pure
+    /// function (testable without mocking Win32).
     /// </summary>
-    private bool IsTransmissionConfigStillValid(TransmissionMode mode, string? key, IntPtr hwnd)
+    internal readonly record struct PttInputState(
+        IntPtr MouseHookHandle,
+        string? ShortcutActionForMouse,
+        string? ShortcutKeyForMouse,
+        int PttVk,
+        bool PttPollingActive);
+
+    // Sentinel string the mouse hook uses when registered for PTT. Both
+    // PushToTalk and PushToTalkPlus modes route through this single literal —
+    // see RegisterMouseHookForButton. If you ever introduce a separate
+    // "pushToTalkPlus" action, update this and IsTransmissionConfigStillValid
+    // together.
+    private const string MouseHookPttAction = "pushToTalk";
+
+    private PttInputState CurrentPttInputState() => new(
+        _mouseHookHandle,
+        _shortcutActionForMouse,
+        _shortcutKeyForMouse,
+        _pttVk,
+        _pttPollingTimer != null);
+
+    /// <summary>
+    /// Pure check: does the captured input plumbing still match what
+    /// SetTransmissionMode set up last time? Returning false forces
+    /// SetTransmissionMode to redo configuration even when the inputs haven't
+    /// changed — used to recover from the shared mouse hook being stolen by
+    /// SetShortcut, or from a previous SetWindowsHookEx returning IntPtr.Zero.
+    /// </summary>
+    internal static bool IsTransmissionConfigStillValid(
+        TransmissionMode mode, string? key, IntPtr hwnd, PttInputState state)
     {
         bool isPttMode = mode == TransmissionMode.PushToTalk || mode == TransmissionMode.PushToTalkPlus;
         if (!isPttMode || key == null || hwnd == IntPtr.Zero)
@@ -1310,14 +1342,16 @@ private int _screenShareHotkeyId = -1;
         {
             // The mouse hook is shared with SetShortcut; verify it's still
             // ours (not stolen by a non-PTT shortcut) and actually registered.
-            return _mouseHookHandle != IntPtr.Zero
-                && _shortcutActionForMouse == "pushToTalk"
-                && _shortcutKeyForMouse == key;
+            return state.MouseHookHandle != IntPtr.Zero
+                && state.ShortcutActionForMouse == MouseHookPttAction
+                && state.ShortcutKeyForMouse == key;
         }
 
-        // Keyboard PTT: polling timer must be live for our VK.
+        // Keyboard PTT: polling timer must be live for our VK. If the key is
+        // unparseable (vk == 0), we deliberately return false so the body
+        // re-runs — there's nothing meaningful to skip.
         var vk = KeyNameToVirtualKey(key);
-        return vk != 0 && _pttVk == vk && _pttPollingTimer != null;
+        return vk != 0 && state.PttVk == vk && state.PttPollingActive;
     }
 
     private void StartPttPolling()

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -223,6 +223,7 @@ internal sealed class AudioManager : IDisposable
     private volatile TransmissionMode _transmissionMode = TransmissionMode.Continuous;
     private string? _lastTransmissionKey;
     private bool _transmissionConfigured;
+    internal int TransmissionApplyCount { get; private set; } // diagnostic/test signal: increments each time SetTransmissionMode body runs
     private volatile bool _pttActive;
 internal const int PttHotkeyId = 1;
 internal const int MuteHotkeyId = 2;
@@ -1203,11 +1204,19 @@ private int _screenShareHotkeyId = -1;
     /// </summary>
     public void SetTransmissionMode(TransmissionMode mode, string? key, IntPtr hwnd)
     {
-        // Idempotency guard: bail out if nothing changed. Without this, repeated
-        // calls (e.g. from a UI refresh storm) tear down and re-register the
-        // mouse hook / raw input within milliseconds, which historically caused
-        // PTT to silently fail (#470).
-        if (_transmissionConfigured && mode == _transmissionMode && key == _lastTransmissionKey && hwnd == _hwnd)
+        // Idempotency guard: bail out if nothing changed AND our underlying
+        // input plumbing is still consistent. Without this, repeated calls
+        // (e.g. from a UI refresh storm) tear down and re-register the mouse
+        // hook / raw input within milliseconds, which historically caused PTT
+        // to silently fail (#470). The consistency check protects against the
+        // shared mouse hook being stolen by SetShortcut, or hook registration
+        // having failed on the previous call — in both cases we must
+        // reconfigure rather than skip.
+        if (_transmissionConfigured
+            && mode == _transmissionMode
+            && key == _lastTransmissionKey
+            && hwnd == _hwnd
+            && IsTransmissionConfigStillValid(mode, key, hwnd))
         {
             return;
         }
@@ -1215,8 +1224,6 @@ private int _screenShareHotkeyId = -1;
         _pttActive = false;
         _hwnd = hwnd;
         _transmissionMode = mode;
-        _lastTransmissionKey = key;
-        _transmissionConfigured = true;
 
         // Unregister any existing hotkey
         if (_hotkeyId >= 0 && _hwnd != IntPtr.Zero)
@@ -1274,6 +1281,43 @@ private int _screenShareHotkeyId = -1;
             StartMic(); // Always-on: keep mic running
         else if (!_muted)
             StartMic();
+
+        // Mark configured at the end so a failure or early return inside the
+        // body leaves the guard open for a retry on the next call.
+        _lastTransmissionKey = key;
+        _transmissionConfigured = true;
+        TransmissionApplyCount++;
+    }
+
+    /// <summary>
+    /// Returns true if the runtime input state matches the previously-applied
+    /// (mode, key) — i.e. the hook/polling we set up last time is still ours
+    /// and still alive. Returning false forces SetTransmissionMode to redo
+    /// configuration even when the inputs haven't changed.
+    /// </summary>
+    private bool IsTransmissionConfigStillValid(TransmissionMode mode, string? key, IntPtr hwnd)
+    {
+        bool isPttMode = mode == TransmissionMode.PushToTalk || mode == TransmissionMode.PushToTalkPlus;
+        if (!isPttMode || key == null || hwnd == IntPtr.Zero)
+        {
+            // Non-PTT modes (and PTT without a key / without a window) don't
+            // own a hook or polling timer that another caller could disturb.
+            return true;
+        }
+
+        bool isMouseButton = key is "XButton1" or "XButton2" or "MouseLeft" or "MouseRight" or "MouseMiddle";
+        if (isMouseButton)
+        {
+            // The mouse hook is shared with SetShortcut; verify it's still
+            // ours (not stolen by a non-PTT shortcut) and actually registered.
+            return _mouseHookHandle != IntPtr.Zero
+                && _shortcutActionForMouse == "pushToTalk"
+                && _shortcutKeyForMouse == key;
+        }
+
+        // Keyboard PTT: polling timer must be live for our VK.
+        var vk = KeyNameToVirtualKey(key);
+        return vk != 0 && _pttVk == vk && _pttPollingTimer != null;
     }
 
     private void StartPttPolling()

--- a/tests/Brmble.Client.Tests/Services/AudioManagerTransmissionModeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AudioManagerTransmissionModeTests.cs
@@ -1,0 +1,107 @@
+using Brmble.Client.Services.Voice;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+/// <summary>
+/// Covers the idempotency guard added in #470 follow-up. Tests use
+/// hwnd = IntPtr.Zero so SetTransmissionMode skips Win32 hook/hotkey
+/// registration; that path is documented as the test seam in
+/// AudioManager.SetTransmissionMode's XML doc.
+/// </summary>
+[TestClass]
+public class AudioManagerTransmissionModeTests
+{
+    [TestMethod]
+    public void FirstCall_AppliesConfiguration()
+    {
+        using var audio = new AudioManager();
+
+        audio.SetTransmissionMode(TransmissionMode.VoiceActivity, key: null, hwnd: IntPtr.Zero);
+
+        Assert.AreEqual(TransmissionMode.VoiceActivity, audio.TransmissionMode);
+        Assert.AreEqual(1, audio.TransmissionApplyCount);
+    }
+
+    [TestMethod]
+    public void IdenticalSecondCall_IsNoOp()
+    {
+        using var audio = new AudioManager();
+
+        audio.SetTransmissionMode(TransmissionMode.VoiceActivity, key: null, hwnd: IntPtr.Zero);
+        audio.SetTransmissionMode(TransmissionMode.VoiceActivity, key: null, hwnd: IntPtr.Zero);
+        audio.SetTransmissionMode(TransmissionMode.VoiceActivity, key: null, hwnd: IntPtr.Zero);
+
+        Assert.AreEqual(1, audio.TransmissionApplyCount, "guard must skip identical repeats");
+    }
+
+    [TestMethod]
+    public void ChangedMode_BypassesGuard()
+    {
+        using var audio = new AudioManager();
+
+        audio.SetTransmissionMode(TransmissionMode.VoiceActivity, key: null, hwnd: IntPtr.Zero);
+        audio.SetTransmissionMode(TransmissionMode.Continuous, key: null, hwnd: IntPtr.Zero);
+
+        Assert.AreEqual(TransmissionMode.Continuous, audio.TransmissionMode);
+        Assert.AreEqual(2, audio.TransmissionApplyCount);
+    }
+
+    [TestMethod]
+    public void ChangedKey_BypassesGuard()
+    {
+        using var audio = new AudioManager();
+
+        audio.SetTransmissionMode(TransmissionMode.PushToTalk, key: "F1", hwnd: IntPtr.Zero);
+        audio.SetTransmissionMode(TransmissionMode.PushToTalk, key: "F2", hwnd: IntPtr.Zero);
+
+        Assert.AreEqual(2, audio.TransmissionApplyCount);
+    }
+
+    [TestMethod]
+    public void NullVsNonNullKey_BypassesGuard()
+    {
+        using var audio = new AudioManager();
+
+        audio.SetTransmissionMode(TransmissionMode.PushToTalk, key: null, hwnd: IntPtr.Zero);
+        audio.SetTransmissionMode(TransmissionMode.PushToTalk, key: "F1", hwnd: IntPtr.Zero);
+
+        Assert.AreEqual(2, audio.TransmissionApplyCount);
+    }
+
+    [TestMethod]
+    public void ChangedHwnd_BypassesGuard()
+    {
+        using var audio = new AudioManager();
+
+        audio.SetTransmissionMode(TransmissionMode.Continuous, key: null, hwnd: IntPtr.Zero);
+        audio.SetTransmissionMode(TransmissionMode.Continuous, key: null, hwnd: new IntPtr(1));
+
+        Assert.AreEqual(2, audio.TransmissionApplyCount);
+    }
+
+    [TestMethod]
+    public void DefaultMode_StillRunsOnFirstCall()
+    {
+        // _transmissionMode defaults to Continuous; the guard must NOT skip
+        // the very first call even though `mode == _transmissionMode`.
+        using var audio = new AudioManager();
+
+        audio.SetTransmissionMode(TransmissionMode.Continuous, key: null, hwnd: IntPtr.Zero);
+
+        Assert.AreEqual(1, audio.TransmissionApplyCount);
+    }
+
+    [TestMethod]
+    public void RepeatedDefaultMode_StaysIdempotentAfterFirstCall()
+    {
+        using var audio = new AudioManager();
+
+        for (int i = 0; i < 50; i++)
+        {
+            audio.SetTransmissionMode(TransmissionMode.Continuous, key: null, hwnd: IntPtr.Zero);
+        }
+
+        Assert.AreEqual(1, audio.TransmissionApplyCount);
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/AudioManagerTransmissionModeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AudioManagerTransmissionModeTests.cs
@@ -72,7 +72,11 @@ public class AudioManagerTransmissionModeTests
     [TestMethod]
     public void ChangedHwnd_BypassesGuard()
     {
+        // Mute first so the body's StartMic call short-circuits on the second
+        // SetTransmissionMode — without this, hwnd != Zero exits the test
+        // seam and opens a real WASAPI device, which is flaky on CI.
         using var audio = new AudioManager();
+        audio.SetMuted(true);
 
         audio.SetTransmissionMode(TransmissionMode.Continuous, key: null, hwnd: IntPtr.Zero);
         audio.SetTransmissionMode(TransmissionMode.Continuous, key: null, hwnd: new IntPtr(1));
@@ -103,5 +107,143 @@ public class AudioManagerTransmissionModeTests
         }
 
         Assert.AreEqual(1, audio.TransmissionApplyCount);
+    }
+
+    // -- IsTransmissionConfigStillValid (pure helper) ---------------------
+    // These tests exercise the consistency check directly, which the
+    // integration tests above can't reach because hwnd=IntPtr.Zero short-
+    // circuits the helper to "valid".
+
+    private static readonly IntPtr FakeHwnd = new(0x1234);
+
+    private static AudioManager.PttInputState State(
+        IntPtr mouseHookHandle = default,
+        string? shortcutAction = null,
+        string? shortcutKey = null,
+        int pttVk = 0,
+        bool pttPollingActive = false)
+        => new(mouseHookHandle, shortcutAction, shortcutKey, pttVk, pttPollingActive);
+
+    [TestMethod]
+    public void Validity_NonPttMode_AlwaysValid()
+    {
+        // Continuous and VoiceActivity don't own a hook/timer, so any state
+        // is "still valid" — guard takes the fast path on identical args.
+        Assert.IsTrue(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.Continuous, key: "F1", FakeHwnd, State()));
+        Assert.IsTrue(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.VoiceActivity, key: null, FakeHwnd, State()));
+    }
+
+    [TestMethod]
+    public void Validity_HwndZero_AlwaysValid()
+    {
+        // hwnd == Zero is the test seam; nothing was ever registered.
+        Assert.IsTrue(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: "XButton2", IntPtr.Zero, State()));
+    }
+
+    [TestMethod]
+    public void Validity_PttNullKey_AlwaysValid()
+    {
+        // PTT mode without a key configured can't have anything to invalidate.
+        Assert.IsTrue(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: null, FakeHwnd, State()));
+    }
+
+    [TestMethod]
+    public void Validity_MouseHook_OursAndAlive_IsValid()
+    {
+        var state = State(
+            mouseHookHandle: new IntPtr(0xABCD),
+            shortcutAction: "pushToTalk",
+            shortcutKey: "XButton2");
+
+        Assert.IsTrue(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: "XButton2", FakeHwnd, state));
+        Assert.IsTrue(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalkPlus, key: "XButton2", FakeHwnd, state));
+    }
+
+    [TestMethod]
+    public void Validity_MouseHook_StolenByShortcut_IsInvalid()
+    {
+        // Hook is registered but for a different action — SetShortcut stole it.
+        var state = State(
+            mouseHookHandle: new IntPtr(0xABCD),
+            shortcutAction: "toggleMute",
+            shortcutKey: "MouseLeft");
+
+        Assert.IsFalse(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: "XButton2", FakeHwnd, state));
+    }
+
+    [TestMethod]
+    public void Validity_MouseHook_DifferentKey_IsInvalid()
+    {
+        var state = State(
+            mouseHookHandle: new IntPtr(0xABCD),
+            shortcutAction: "pushToTalk",
+            shortcutKey: "XButton1");
+
+        Assert.IsFalse(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: "XButton2", FakeHwnd, state));
+    }
+
+    [TestMethod]
+    public void Validity_MouseHook_NoHandle_IsInvalid()
+    {
+        // Registration failed (SetWindowsHookEx returned IntPtr.Zero).
+        var state = State(
+            mouseHookHandle: IntPtr.Zero,
+            shortcutAction: "pushToTalk",
+            shortcutKey: "XButton2");
+
+        Assert.IsFalse(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: "XButton2", FakeHwnd, state));
+    }
+
+    [TestMethod]
+    public void Validity_KeyboardPtt_PollingActive_IsValid()
+    {
+        var f1Vk = AudioManager.KeyNameToVirtualKey("F1");
+        var state = State(pttVk: f1Vk, pttPollingActive: true);
+
+        Assert.IsTrue(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: "F1", FakeHwnd, state));
+    }
+
+    [TestMethod]
+    public void Validity_KeyboardPtt_PollingDead_IsInvalid()
+    {
+        var f1Vk = AudioManager.KeyNameToVirtualKey("F1");
+        var state = State(pttVk: f1Vk, pttPollingActive: false);
+
+        Assert.IsFalse(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: "F1", FakeHwnd, state));
+    }
+
+    [TestMethod]
+    public void Validity_KeyboardPtt_WrongVk_IsInvalid()
+    {
+        // Tracked vk doesn't match what KeyNameToVirtualKey returns for the
+        // requested key — happens after a key change re-registered for a
+        // different vk and someone else then steals the polling timer.
+        var state = State(pttVk: 0xFE, pttPollingActive: true);
+
+        Assert.IsFalse(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: "F1", FakeHwnd, state));
+    }
+
+    [TestMethod]
+    public void Validity_KeyboardPtt_UnparseableKey_IsInvalid()
+    {
+        // Bogus key → KeyNameToVirtualKey returns 0 → guard refuses to skip,
+        // even with a "live" polling state. Reconfigure each time so a fixed
+        // key binding is picked up immediately.
+        var state = State(pttVk: 0, pttPollingActive: true);
+
+        Assert.IsFalse(AudioManager.IsTransmissionConfigStillValid(
+            TransmissionMode.PushToTalk, key: "ThisKeyDoesNotExist", FakeHwnd, state));
     }
 }


### PR DESCRIPTION
## Summary

Closes #470. Adds a defensive idempotency guard to `AudioManager.SetTransmissionMode` so repeat calls with the same `(mode, key, hwnd)` no longer tear down and re-register the mouse hook / raw input plumbing within milliseconds.

The original symptoms in #470 (PTT input dropped after ~11ms, audio cutouts, jitter buffer resets) were already heavily mitigated by the WebRTC APM migration (#451) and the PTT debounce in PR #467 — this is the defensive layer that makes `SetTransmissionMode` itself robust against any remaining upstream UI-refresh storms.

## What's in the change

1. **Equality guard** — bail out early if `mode`, `key` and `hwnd` all match the previously applied configuration.
2. **Consistency check** (`IsTransmissionConfigStillValid`) — extracted as a pure static method so it's unit-testable. Verifies the runtime input plumbing (mouse hook ownership / keyboard polling liveness) still matches the cached config. Returning false forces a re-run, recovering from:
   - The shared mouse hook being stolen by `SetShortcut` (e.g. user binds a non-PTT mouse shortcut)
   - A previous `SetWindowsHookEx` call returning `IntPtr.Zero`
   - A previous `KeyNameToVirtualKey` returning 0 for an unknown key
3. **Deferred flag set** — `_transmissionConfigured = true` is set at the end of the method, so an exception mid-body leaves the guard open for the next call.
4. **`MouseHookPttAction` constant** replacing the `"pushToTalk"` magic string.
5. **Tests** (`AudioManagerTransmissionModeTests`) — 19 cases:
   - 8 integration tests through `SetTransmissionMode` covering first-call, idempotent repeats (50× hammered), and arg-change paths
   - 11 unit tests on the pure `IsTransmissionConfigStillValid` covering every branch (mouse-hook stolen / wrong key / no handle, keyboard PTT polling dead / wrong vk / unparseable key, non-PTT modes, hwnd=0)
6. **Diagnostic counter** `TransmissionApplyCount` — increments on each successful body run, used as a deterministic test signal.

## Review history

This PR was reviewed twice by Codex and once independently. The hardening commit `3f78422` and refactor commit `5451623` directly address the resulting concerns:

- ✅ Mouse hook theft via `SetShortcut` → consistency check
- ✅ Failed-registration permanently blocking retries → deferred flag + consistency check
- ✅ Tests couldn't exercise the consistency check (hwnd=0 short-circuits) → pure static refactor + 11 unit tests
- ✅ `ChangedHwnd` test exited the seam → mute-first to keep WASAPI closed
- ✅ Misleading "guard open on failure" comment → corrected

## Known follow-ups (not in this PR)

- **The deeper bug**: PTT and other mouse shortcuts share a single mouse hook handle, so they can steal from each other. This PR's consistency check is a *workaround* — it ensures PTT recovers from theft, but doesn't prevent theft from happening or restore the stolen-from shortcut. Tracked separately (issue to follow).
- **Concurrency**: `SetTransmissionMode` is not locked against concurrent entry. Pre-existing — not made worse — but the new state has more shared fields. Worth a separate audit.

## Test plan

- [x] `dotnet build` — clean
- [x] `dotnet test tests/Brmble.Client.Tests` — 97/98 (the 1 failure is the pre-existing DPAPI test on main, unrelated)
- [ ] Manual verification: open client, switch transmission modes (Continuous → VoiceActivity → PTT keyboard → PTT mouse → PTT+ keyboard), bind/rebind PTT keys, verify PTT still works after settings reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)