### PR TITLE
fix(audio): use Mumble terminator flag on PTT release instead of silence frames

### DIFF
--- a/lib/MumbleVoiceEngine/Pipeline/EncodePipeline.cs
+++ b/lib/MumbleVoiceEngine/Pipeline/EncodePipeline.cs
@@ -80,10 +80,31 @@ public class EncodePipeline : IDisposable
 
             if (_accumulatorPos >= _frameSizeBytes)
             {
-                EncodeAndEmit();
+                EncodeAndEmit(terminator: false);
                 _accumulatorPos = 0;
             }
         }
+    }
+
+    /// <summary>
+    /// End the current voice transmission. If the accumulator contains a partial
+    /// frame, it is zero-padded to a full frame, encoded, and emitted with the
+    /// Mumble Opus terminator flag set so receivers see a clean end-of-stream.
+    /// If the accumulator is empty, no packet is emitted (matches upstream
+    /// Mumble behaviour). After this call, no further packets will be produced
+    /// unless new PCM is submitted (which restarts the stream at the next
+    /// sequence number — callers normally Dispose() right after FlushFinal()).
+    /// </summary>
+    public void FlushFinal()
+    {
+        if (_accumulatorPos == 0)
+            return;
+
+        // Zero-pad the partial frame so Opus encodes a fixed-size frame.
+        Array.Clear(_accumulator, _accumulatorPos, _frameSizeBytes - _accumulatorPos);
+        _accumulatorPos = _frameSizeBytes;
+        EncodeAndEmit(terminator: true);
+        _accumulatorPos = 0;
     }
 
     // Opus specification guarantees a single packet never exceeds 1275 bytes.
@@ -92,7 +113,7 @@ public class EncodePipeline : IDisposable
     // encode failures. Use the spec-defined safe maximum instead.
     private const int MaxOpusPacketBytes = 1275;
 
-    private void EncodeAndEmit()
+    private void EncodeAndEmit(bool terminator)
     {
         byte[] scaled;
 
@@ -132,7 +153,7 @@ public class EncodePipeline : IDisposable
             var opusData = new byte[encodedLen];
             Array.Copy(encoded, opusData, encodedLen);
 
-            byte[] packet = VoicePacketBuilder.Build(opusData, _sequenceNumber, _target);
+            byte[] packet = VoicePacketBuilder.Build(opusData, _sequenceNumber, _target, terminator);
             _sequenceNumber++;
 
             _onPacketReady(packet);

--- a/lib/MumbleVoiceEngine/Protocol/VoicePacketBuilder.cs
+++ b/lib/MumbleVoiceEngine/Protocol/VoicePacketBuilder.cs
@@ -2,14 +2,22 @@ namespace MumbleVoiceEngine.Protocol;
 
 public static class VoicePacketBuilder
 {
+    // Mumble Opus size varint: bit 13 signals the last frame of a voice transmission.
+    private const ulong TerminatorBit = 0x2000;
+
     /// <summary>
     /// Build a Mumble Opus voice packet ready for encryption and sending.
+    /// When <paramref name="terminator"/> is true, the size field is OR'd with
+    /// 0x2000 to mark this as the final frame of the current transmission.
     /// </summary>
-    public static byte[] Build(byte[] opusData, long sequenceNumber, int target = 0)
+    public static byte[] Build(byte[] opusData, long sequenceNumber, int target = 0, bool terminator = false)
     {
         byte typeTarget = (byte)((4 << 5) | (target & 0x1F)); // type=4 (Opus)
         byte[] sequence = Varint.Encode((ulong)sequenceNumber);
-        byte[] size = Varint.Encode((ulong)opusData.Length);
+        ulong sizeField = (ulong)opusData.Length;
+        if (terminator)
+            sizeField |= TerminatorBit;
+        byte[] size = Varint.Encode(sizeField);
 
         byte[] packet = new byte[1 + sequence.Length + size.Length + opusData.Length];
         packet[0] = typeTarget;

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -274,7 +274,6 @@ private int _screenShareHotkeyId = -1;
     // Speaking detection (polls per-user JitterBuffer.IsSpeaking directly)
     private readonly HashSet<uint> _currentlySpeaking = new();
     private readonly Timer _speakingTimer;
-    private const int PttSilenceTailFrames = 4; // 4 × 20 ms = 80 ms tail
     private uint _localUserId = 0;
     private long _lastLocalAudioMs; // monotonic timestamp of last local audio submission
     private int _voiceHoldMs = 200;
@@ -706,6 +705,16 @@ private int _screenShareHotkeyId = -1;
         if (!_micStarted) return (false, 0);
 
         _waveIn?.StopRecording();
+        // Flush any partial Opus frame with the Mumble end-of-transmission
+        // terminator bit set, matching upstream Mumble behaviour.
+        try
+        {
+            _encodePipeline?.FlushFinal();
+        }
+        catch (Exception ex)
+        {
+            AudioLog.Write($"[Audio] FlushFinal failed: {ex.Message}");
+        }
         _encodePipeline?.Dispose();
         _encodePipeline = null;
         _deviceResampler?.Dispose();
@@ -715,55 +724,6 @@ private int _screenShareHotkeyId = -1;
         bool wasSpeaking = capturedUserId != 0 && _currentlySpeaking.Remove(capturedUserId);
         AudioLog.Write("[Audio] Mic stopped");
         return (wasSpeaking, capturedUserId);
-    }
-
-    /// <summary>
-    /// Submits <see cref="PttSilenceTailFrames"/> silence frames through the encode pipeline
-    /// then disposes it. Call only when the pipeline is still alive (i.e. mic is running).
-    /// </summary>
-    private void StopMicWithSilenceTail()
-    {
-        bool wasSpeaking = false;
-        uint capturedUserId = 0;
-        lock (_lock)
-        {
-            if (!_micStarted) return;
-
-            // Submit silence frames before stopping so the receiver gets a graceful end-of-stream
-            if (_encodePipeline != null)
-            {
-                // Derive frame size from the actual capture format and the current encoder
-                // frame duration (_opusFrameMs) so the tail is correct for all frame sizes.
-                int frameDurationMs = _opusFrameMs;
-                var fmt = _waveIn?.WaveFormat;
-                int sampleRate = fmt?.SampleRate ?? 48000;
-                int channels = fmt?.Channels ?? 1;
-                int bytesPerSample = (fmt?.BitsPerSample ?? 16) / 8;
-                int frameSizeBytes = sampleRate * frameDurationMs / 1000 * channels * bytesPerSample;
-                var silence = new byte[frameSizeBytes * PttSilenceTailFrames];
-                try
-                {
-                    _encodePipeline.SubmitPcm(new ReadOnlySpan<byte>(silence));
-                    AudioLog.Write($"[Audio] Sent {PttSilenceTailFrames} silence tail frames");
-                }
-                catch (Exception ex)
-                {
-                    AudioLog.Write($"[Audio] Silence tail encode failed: {ex.Message}");
-                }
-            }
-
-            _waveIn?.StopRecording();
-            _encodePipeline?.Dispose();
-            _encodePipeline = null;
-            _deviceResampler?.Dispose();
-            _deviceResampler = null;
-            _micStarted = false;
-            capturedUserId = _localUserId;
-            wasSpeaking = capturedUserId != 0 && _currentlySpeaking.Remove(capturedUserId);
-            AudioLog.Write("[Audio] Mic stopped (with silence tail)");
-        }
-        if (wasSpeaking)
-            UserStoppedSpeaking?.Invoke(capturedUserId);
     }
 
     // Reusable scratch buffers for WASAPI float→int16 conversion (avoid per-callback GC allocations).
@@ -1945,7 +1905,7 @@ private int _screenShareHotkeyId = -1;
                 if (Interlocked.CompareExchange(ref _pttSilenceTailGeneration, generation, generation) != generation)
                     return;
                 if (_pttActive || _muted) return;
-                StopMicWithSilenceTail();
+                StopMic();
             }, null, dueTime: holdMs, period: Timeout.Infinite);
         }
     }

--- a/tests/MumbleVoiceEngine.Tests/Pipeline/EncodePipelineTest.cs
+++ b/tests/MumbleVoiceEngine.Tests/Pipeline/EncodePipelineTest.cs
@@ -244,6 +244,77 @@ namespace MumbleVoiceEngine.Tests.Pipeline
         }
 
         [TestMethod]
+        public void FlushFinal_WithPartialFrame_EmitsTerminatorPacket()
+        {
+            var packets = new List<byte[]>();
+            using var pipeline = new EncodePipeline(
+                sampleRate: 48000, channels: 1, bitrate: 72000,
+                onPacketReady: p => packets.Add(p.ToArray()));
+
+            // Submit half a frame (no packet yet)
+            pipeline.SubmitPcm(new byte[960]);
+            Assert.AreEqual(0, packets.Count);
+
+            pipeline.FlushFinal();
+
+            Assert.AreEqual(1, packets.Count, "FlushFinal should emit one final packet");
+
+            // Inspect the size varint and verify the terminator bit is set
+            using var reader = new PacketReader(new MemoryStream(packets[0], 1, packets[0].Length - 1));
+            reader.ReadVarInt64(); // sequence
+            int rawSize = (int)reader.ReadVarInt64();
+            Assert.AreEqual(0x2000, rawSize & 0x2000, "Last frame must carry the Mumble terminator bit");
+            Assert.IsTrue((rawSize & 0x1FFF) > 0, "Padded final frame must have non-empty Opus payload");
+        }
+
+        [TestMethod]
+        public void FlushFinal_WithEmptyAccumulator_EmitsNothing()
+        {
+            var packets = new List<byte[]>();
+            using var pipeline = new EncodePipeline(
+                sampleRate: 48000, channels: 1, bitrate: 72000,
+                onPacketReady: p => packets.Add(p.ToArray()));
+
+            // Submit exactly one full frame — accumulator drains to 0
+            pipeline.SubmitPcm(new byte[960 * 2]);
+            Assert.AreEqual(1, packets.Count);
+
+            pipeline.FlushFinal();
+
+            // No second packet — matches upstream Mumble (no synthetic terminator)
+            Assert.AreEqual(1, packets.Count, "FlushFinal must not emit when accumulator is empty");
+        }
+
+        [TestMethod]
+        public void FlushFinal_RegularFramesUnmarked_OnlyFinalCarriesTerminator()
+        {
+            var packets = new List<byte[]>();
+            using var pipeline = new EncodePipeline(
+                sampleRate: 48000, channels: 1, bitrate: 72000,
+                onPacketReady: p => packets.Add(p.ToArray()));
+
+            // Two full regular frames + a partial one
+            pipeline.SubmitPcm(new byte[960 * 2]);
+            pipeline.SubmitPcm(new byte[960 * 2]);
+            pipeline.SubmitPcm(new byte[960]); // partial
+            pipeline.FlushFinal();
+
+            Assert.AreEqual(3, packets.Count);
+
+            for (int i = 0; i < packets.Count; i++)
+            {
+                using var reader = new PacketReader(new MemoryStream(packets[i], 1, packets[i].Length - 1));
+                reader.ReadVarInt64(); // sequence
+                int rawSize = (int)reader.ReadVarInt64();
+                bool isLast = (rawSize & 0x2000) != 0;
+                if (i < packets.Count - 1)
+                    Assert.IsFalse(isLast, $"Packet {i} should not have terminator set");
+                else
+                    Assert.IsTrue(isLast, "Final packet must have terminator set");
+            }
+        }
+
+        [TestMethod]
         public void Pipeline_CurrentSequence_ReturnsCorrectValue()
         {
             using var pipeline = new EncodePipeline(

--- a/tests/MumbleVoiceEngine.Tests/Protocol/VoicePacketBuilderTest.cs
+++ b/tests/MumbleVoiceEngine.Tests/Protocol/VoicePacketBuilderTest.cs
@@ -51,6 +51,54 @@ namespace MumbleVoiceEngine.Tests.Protocol
         }
 
         [TestMethod]
+        public void Build_WithTerminator_SetsBit13InSize()
+        {
+            byte[] opusData = new byte[] { 0xAA, 0xBB, 0xCC };
+            byte[] packet = VoicePacketBuilder.Build(opusData, sequenceNumber: 0, target: 0, terminator: true);
+
+            using var reader = new PacketReader(new MemoryStream(packet, 1, packet.Length - 1));
+            reader.ReadVarInt64(); // sequence
+            int rawSize = (int)reader.ReadVarInt64();
+
+            Assert.AreEqual(0x2000, rawSize & 0x2000, "Terminator bit (0x2000) must be set");
+            Assert.AreEqual(3, rawSize & 0x1FFF, "Lower 13 bits must encode payload length");
+        }
+
+        [TestMethod]
+        public void Build_WithoutTerminator_LeavesBit13Unset()
+        {
+            byte[] opusData = new byte[] { 0xAA, 0xBB, 0xCC };
+            byte[] packet = VoicePacketBuilder.Build(opusData, sequenceNumber: 0, target: 0, terminator: false);
+
+            using var reader = new PacketReader(new MemoryStream(packet, 1, packet.Length - 1));
+            reader.ReadVarInt64(); // sequence
+            int rawSize = (int)reader.ReadVarInt64();
+
+            Assert.AreEqual(0, rawSize & 0x2000, "Terminator bit must NOT be set");
+            Assert.AreEqual(3, rawSize, "Plain length without terminator");
+        }
+
+        [TestMethod]
+        public void Build_WithTerminator_RemainsParseable()
+        {
+            // Receivers mask 0x2000 off — the payload must still parse correctly.
+            byte[] opusData = new byte[] { 0xAA, 0xBB, 0xCC };
+            byte[] clientPacket = VoicePacketBuilder.Build(opusData, sequenceNumber: 7, target: 0, terminator: true);
+
+            // Simulate server prepending session ID (parser expects server format)
+            byte[] sessionVarint = Varint.Encode(1);
+            byte[] serverPacket = new byte[1 + sessionVarint.Length + clientPacket.Length - 1];
+            serverPacket[0] = clientPacket[0];
+            Array.Copy(sessionVarint, 0, serverPacket, 1, sessionVarint.Length);
+            Array.Copy(clientPacket, 1, serverPacket, 1 + sessionVarint.Length, clientPacket.Length - 1);
+
+            var parsed = VoicePacketParser.Parse(serverPacket);
+            Assert.IsNotNull(parsed);
+            Assert.AreEqual(7L, parsed.Value.Sequence);
+            CollectionAssert.AreEqual(opusData, parsed.Value.OpusData);
+        }
+
+        [TestMethod]
         public void Build_Parse_ViaServerFormat_RoundTrips()
         {
             // Simulate server relaying: take builder output, prepend session ID


### PR DESCRIPTION
## Summary

Fixes a visible flicker of the speaker's voice indicator that briefly re-lit for ~80ms after every PTT release, by replacing the silence-tail hack from PR #209 with the actual Mumble end-of-stream signal (bit `0x2000` of the Opus size varint, aka `isLastFrame`).

## The bug

After a remote user released their PTT button, observers saw the speaker's voice indicator go off and then briefly flash on again ~200-300ms later for a few milliseconds.

## Root cause

`AudioManager.StopMicWithSilenceTail` (added in #209) submitted 4 frames of zero-PCM into the encoder ~200ms after PTT release, intending to give receivers a graceful end-of-stream. But upstream Mumble's actual end-of-stream mechanism is the **terminator bit** in the Opus size varint, which Brmble never set. Brmble's `VoicePacketParser` already masks `size &= 0x1FFF`, ignoring bit `0x2000`.

On the receiver, `JitterBuffer.IsSpeaking` is driven by `_realAudioTicks` (increment on Normal frames, decrement on PLC). Timeline after PTT release:

| t (ms) | Event | IsSpeaking | UI |
|---|---|---|---|
| 0 | last real audio packet | true | — |
| ~50 | packet buffer drains, PLC starts | true → false | — |
| 100 | poll | false | userSilent → indicator OFF |
| 200+lat | 4 silence-tail packets arrive | false → **true** | — |
| 300 | poll | true | userSpeaking → indicator briefly ON |
| ~280 | tail drained, PLC again | true → false | — |
| 400 | poll | false | userSilent → indicator OFF |

The flicker is the `OFF → briefly ON → OFF` sequence caused by the late silence packets re-triggering the speaking heuristic.

## The fix

Stop sending silence packets and instead set the protocol's actual terminator bit on the last frame of each transmission, matching upstream Mumble (`AudioInput.cpp`).

- **`VoicePacketBuilder.Build`** gains a `terminator` parameter; OR's `0x2000` into the size varint when set.
- **`EncodePipeline.FlushFinal()`** zero-pads any partial accumulator to a full Opus frame, encodes it, and emits with `terminator=true`. On an empty accumulator it does nothing — matching upstream Mumble (no synthetic zero-payload terminator, which would be untested against Murmur and dropped by Brmble's own parser).
- **`AudioManager.StopMicLocked`** calls `FlushFinal()` before disposing the encoder. The dedicated `StopMicWithSilenceTail` method and the `PttSilenceTailFrames` constant are removed.

The 200ms `_voiceHoldMs` hold (rapid re-press protection) is preserved — `FlushFinal` runs at the end of the hold via the existing timer.

## Backwards compatibility

A non-empty final packet with the terminator bit set is decoded normally by every existing Mumble parser (including Brmble's own), since they all mask `& 0x1FFF` to read the length. Older clients see a regular last frame; updated/upstream-Mumble clients additionally observe the end-of-stream signal.

## Tests

New tests in `tests/MumbleVoiceEngine.Tests/`:
- `Build_WithTerminator_SetsBit13InSize`
- `Build_WithoutTerminator_LeavesBit13Unset`
- `Build_WithTerminator_RemainsParseable`
- `FlushFinal_WithPartialFrame_EmitsTerminatorPacket`
- `FlushFinal_WithEmptyAccumulator_EmitsNothing`
- `FlushFinal_RegularFramesUnmarked_OnlyFinalCarriesTerminator`

All voice-related tests pass: 88 (MumbleVoiceEngine) + 56 (Brmble.Audio).

## Test plan

- [ ] Connect with two clients (one PTT, one observer)
- [ ] Speaker uses regular PTT (not PTT+ or VAD)
- [ ] Speaker presses PTT, talks, releases — observer's voice indicator goes off once and stays off (no flash)
- [ ] No audible click or audio cutoff at end of transmission
- [ ] Rapid re-press within 200ms still works without restarting the encoder
- [ ] Connecting to a real Murmur server (non-Brmble) — verify Murmur forwards the terminator-flagged final packet correctly to other clients

## Future follow-up (not in this PR)

`VoicePacketParser` could be extended to surface the terminator flag, and `JitterBuffer` could act on it (e.g. force-end IsSpeaking immediately rather than waiting for PLC decay). That would also benefit receivers when the speaker is on a non-Brmble Mumble client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)