### PR TITLE
perf(chat): lazy-load Matrix history; fix WebView2 idle leak

### DIFF
--- a/docs/superpowers/plans/2026-05-03-lazy-chat-loading.md
+++ b/docs/superpowers/plans/2026-05-03-lazy-chat-loading.md
@@ -1,0 +1,1299 @@
+# Lazy chat loading — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the unbounded `messages: Map<string, ChatMessage[]>` in `useMatrixClient`, fix two related growth paths in `useChatStore`/`useDMStore`, and lower `initialSyncLimit` from 20 to 5 — so the WebView2 frontend stops leaking memory at idle and cold-starts faster.
+
+**Architecture:** React-state holds only the active chat. matrix-js-sdk's `room.getLiveTimeline()` is the source of truth; we transform events to `ChatMessage` lazily (on channel-open) instead of eagerly (on every sync event). A small `lastMessages` map of one preview entry per room replaces full message arrays for sidebar rendering.
+
+**Tech Stack:** React + TypeScript + Vite, matrix-js-sdk, Vitest + @testing-library/react.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-lazy-chat-loading-design.md`
+
+**Branch:** `feature/lazy-chat-loading` (already created, spec already committed).
+
+---
+
+## File map
+
+| File | Change kind | Responsibility |
+|---|---|---|
+| `src/Brmble.Web/src/hooks/useChatStore.ts` | Modify | Add cap for non-server-root channels (mirror existing server-root cap). |
+| `src/Brmble.Web/src/hooks/useChatStore.test.ts` | Modify | Add tests covering non-server-root cap. |
+| `src/Brmble.Web/src/hooks/useDMStore.ts` | Modify | Cap mumbleMessages per contact; remove pending Matrix DM on send failure; consume new `activeDmMessages` and `matrixDmLastMessages` from `useMatrixClient`. |
+| `src/Brmble.Web/src/hooks/useDMStore.test.ts` | Create | Cover the new caps and the failure-path cleanup. |
+| `src/Brmble.Web/src/hooks/useMatrixClient.ts` | Modify (major) | Replace `messages` and `dmMessages` Maps with active-only state + `lastMessages` previews; extract pure event-to-ChatMessage transformer; lower initialSyncLimit. |
+| `src/Brmble.Web/src/hooks/useMatrixClient.test.ts` | Modify | Update existing tests to new API; add tests for `setActiveChannel`, `lastMessages`, version-guard race. |
+| `src/Brmble.Web/src/App.tsx` | Modify | Wire `setActiveChannel`/`setActiveDmContact` based on UI active selection; pass new props to `useDMStore`. |
+
+---
+
+## Task 1: Cap non-server-root channels in useChatStore
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useChatStore.ts`
+- Modify: `src/Brmble.Web/src/hooks/useChatStore.test.ts`
+
+- [ ] **Step 1: Replace existing "does NOT cap" test with a "DOES cap" test**
+
+In `src/Brmble.Web/src/hooks/useChatStore.test.ts`, find the test at line 58-68 (`'does NOT cap non-server-root channels'`) and replace its body to assert the cap IS applied:
+
+```ts
+  it('caps non-server-root channels at 200 messages via addMessage', () => {
+    const { result } = renderHook(() => useChatStore('channel-5'));
+
+    act(() => {
+      for (let i = 0; i < 210; i++) {
+        result.current.addMessage('User', `msg-${i}`);
+      }
+    });
+
+    expect(result.current.messages).toHaveLength(200);
+    expect(result.current.messages[0].content).toBe('msg-10');
+    expect(result.current.messages[199].content).toBe('msg-209');
+  });
+```
+
+- [ ] **Step 2: Add a parallel test for the addMessageToStore path**
+
+After the test from Step 1, add:
+
+```ts
+  it('caps non-server-root channels at 200 messages via addMessageToStore', () => {
+    const existing = Array.from({ length: 195 }, (_, i) => ({
+      id: `id-${i}`,
+      channelId: 'channel-5',
+      sender: 'User',
+      content: `old-${i}`,
+      timestamp: new Date().toISOString(),
+    }));
+    localStorage.setItem('brmble_chat_channel-5', JSON.stringify(existing));
+
+    for (let i = 0; i < 10; i++) {
+      addMessageToStore('channel-5', 'User', `new-${i}`);
+    }
+
+    const stored = JSON.parse(localStorage.getItem('brmble_chat_channel-5')!);
+    expect(stored).toHaveLength(200);
+    expect(stored[0].content).toBe('old-5');
+    expect(stored[199].content).toBe('new-9');
+  });
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `(cd src/Brmble.Web && npm test -- useChatStore --run)`
+Expected: both new tests FAIL — first fails with `expected length 200, got 210`; second fails with `expected length 200, got 205`.
+
+- [ ] **Step 4: Implement the cap in useChatStore.ts**
+
+In `src/Brmble.Web/src/hooks/useChatStore.ts`:
+
+a) After line 6 (`const SERVER_ROOT_MAX_MESSAGES = 200;`), add:
+
+```ts
+const NON_SERVER_ROOT_MAX_MESSAGES = 200;
+```
+
+b) In `addMessage` (around line 202-209), change the slice condition from server-root-only to all channels:
+
+```ts
+    setMessages(prev => {
+      let updated = [...prev, newMessage];
+      const cap = isServerRoot ? SERVER_ROOT_MAX_MESSAGES : NON_SERVER_ROOT_MAX_MESSAGES;
+      if (updated.length > cap) {
+        updated = updated.slice(updated.length - cap);
+      }
+      saveMessages(updated);
+      return updated;
+    });
+```
+
+c) In `addMessageToStore` (around line 257-269, the non-server-root path), apply the same slice after the push:
+
+```ts
+  // Non-server-root: immediate write
+  const fullKey = `${STORAGE_KEY_PREFIX}${storeKey}`;
+  let messages: ChatMessage[] = [];
+  const stored = localStorage.getItem(fullKey);
+  if (stored) {
+    try {
+      messages = JSON.parse(stored);
+    } catch {
+      messages = [];
+    }
+  }
+  messages.push(newMessage);
+  if (messages.length > NON_SERVER_ROOT_MAX_MESSAGES) {
+    messages = messages.slice(messages.length - NON_SERVER_ROOT_MAX_MESSAGES);
+  }
+  localStorage.setItem(fullKey, JSON.stringify(messages));
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `(cd src/Brmble.Web && npm test -- useChatStore --run)`
+Expected: all useChatStore tests pass (including the existing server-root cap tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useChatStore.ts src/Brmble.Web/src/hooks/useChatStore.test.ts
+git commit -m "$(cat <<'EOF'
+fix(chat): cap non-server-root chat history at 200 messages
+
+Previously only server-root chat had a 200-message cap. Per-channel
+chat (non-server-root) and the addMessageToStore background path
+appended without bound, growing localStorage and the JS heap on
+every channel reload.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Cap mumbleMessages and fix pendingMessages cleanup in useDMStore
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useDMStore.ts`
+- Create: `src/Brmble.Web/src/hooks/useDMStore.test.ts`
+
+- [ ] **Step 1: Create the test file with vitest setup**
+
+Create `src/Brmble.Web/src/hooks/useDMStore.test.ts` with:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDMStore } from './useDMStore';
+import type { DMStoreOptions } from './useDMStore';
+
+function makeOptions(overrides: Partial<DMStoreOptions> = {}): DMStoreOptions {
+  return {
+    matrixDmMessages: new Map(),
+    matrixDmRoomMap: new Map(),
+    matrixDmUserDisplayNames: new Map(),
+    matrixDmUserAvatarUrls: new Map(),
+    sendMatrixDM: vi.fn().mockResolvedValue(undefined),
+    fetchDMHistory: vi.fn().mockResolvedValue(undefined),
+    sendMumbleDM: vi.fn(),
+    users: [{ id: 1, name: 'me', session: 1 }] as DMStoreOptions['users'],
+    username: 'me',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useDMStore mumbleMessages cap', () => {
+  it('caps mumbleMessages per contact at 200 on receiveMumbleDM', () => {
+    const { result } = renderHook(() => useDMStore(makeOptions()));
+
+    act(() => {
+      for (let i = 0; i < 210; i++) {
+        result.current.receiveMumbleDM('cert-1', 1, 'Alice', `msg-${i}`);
+      }
+    });
+
+    // Select contact so messages are exposed via .messages
+    act(() => result.current.selectContact('cert-1'));
+
+    expect(result.current.messages).toHaveLength(200);
+    expect(result.current.messages[0].content).toBe('msg-10');
+    expect(result.current.messages[199].content).toBe('msg-209');
+  });
+
+  it('caps mumbleMessages on outgoing Mumble sendMessage', () => {
+    const { result } = renderHook(() => useDMStore(makeOptions()));
+
+    act(() => {
+      result.current.startMumbleDM('cert-1', 1, 'Alice');
+    });
+
+    act(() => {
+      for (let i = 0; i < 210; i++) {
+        result.current.sendMessage(`out-${i}`);
+      }
+    });
+
+    expect(result.current.messages).toHaveLength(200);
+    expect(result.current.messages[0].content).toBe('out-10');
+  });
+});
+
+describe('useDMStore pendingMessages on Matrix send failure', () => {
+  it('removes the optimistic pending message when sendMatrixDM rejects', async () => {
+    const sendMatrixDM = vi.fn().mockRejectedValue(new Error('network down'));
+    const matrixDmRoomMap = new Map([['@bob:example.com', '!bob:example.com']]);
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({ sendMatrixDM, matrixDmRoomMap }))
+    );
+
+    act(() => result.current.selectContact('@bob:example.com'));
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+      // Allow the rejected promise to settle
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // No pending optimistic message should remain
+    const pending = result.current.messages.filter(m => m.pending);
+    expect(pending).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `(cd src/Brmble.Web && npm test -- useDMStore --run)`
+Expected: cap tests FAIL (length 210, expected 200); pending-cleanup test FAIL (1 pending, expected 0).
+
+- [ ] **Step 3: Implement the cap in useDMStore.ts**
+
+In `src/Brmble.Web/src/hooks/useDMStore.ts`:
+
+a) After the type declarations (around line 51, before the hook), add:
+
+```ts
+const MUMBLE_MESSAGES_MAX_PER_CONTACT = 200;
+```
+
+b) In `receiveMumbleDM` (around line 333-338), apply slice-from-end:
+
+```ts
+    setMumbleMessages(prev => {
+      const next = new Map(prev);
+      const existing = next.get(certHash) ?? [];
+      let updated = [...existing, msg];
+      if (updated.length > MUMBLE_MESSAGES_MAX_PER_CONTACT) {
+        updated = updated.slice(updated.length - MUMBLE_MESSAGES_MAX_PER_CONTACT);
+      }
+      next.set(certHash, updated);
+      return next;
+    });
+```
+
+c) In `sendMessage`, the Mumble path (around line 246-251), apply the same slice:
+
+```ts
+      setMumbleMessages(prev => {
+        const next = new Map(prev);
+        const existing = next.get(selectedContactId!) ?? [];
+        let updated = [...existing, msg];
+        if (updated.length > MUMBLE_MESSAGES_MAX_PER_CONTACT) {
+          updated = updated.slice(updated.length - MUMBLE_MESSAGES_MAX_PER_CONTACT);
+        }
+        next.set(selectedContactId!, updated);
+        return next;
+      });
+```
+
+- [ ] **Step 4: Implement the pendingMessages cleanup-on-failure**
+
+In `src/Brmble.Web/src/hooks/useDMStore.ts`, the `.catch(console.error)` around line 283 needs to also remove the optimistic message. Replace:
+
+```ts
+        .catch(console.error);
+```
+
+with:
+
+```ts
+        .catch(err => {
+          console.error('Matrix DM send failed:', err);
+          setPendingMessages(prev => {
+            const next = new Map(prev);
+            const existing = next.get(selectedContactId!) ?? [];
+            next.set(selectedContactId!, existing.filter(m => m.id !== optimisticMsg.id));
+            return next;
+          });
+        });
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `(cd src/Brmble.Web && npm test -- useDMStore --run)`
+Expected: all 3 useDMStore tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useDMStore.ts src/Brmble.Web/src/hooks/useDMStore.test.ts
+git commit -m "$(cat <<'EOF'
+fix(dm): cap mumbleMessages per contact and clean up failed Matrix DMs
+
+- Cap mumbleMessages.get(contactId) at 200 messages (slice oldest).
+- Remove the optimistic pending message when sendMatrixDM rejects;
+  previously failures only logged to console, leaving the optimistic
+  message stuck forever and growing pendingMessages over time.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Extract pure MatrixEvent → ChatMessage transformer in useMatrixClient
+
+This is a refactor with no behavior change. It pulls the duplicated channel-message and DM-message transformation logic into a single pure function so subsequent tasks can call it from multiple sites without redundant code. After this task, `useMatrixClient.ts` should be smaller and the existing test suite should still pass unchanged.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.ts`
+
+- [ ] **Step 1: Add a pure transformer function near the top of the file**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`, after the `insertMessage` function (line 25) and before the `MatrixCredentials` interface, add:
+
+```ts
+/**
+ * Transform a Matrix `m.room.message` event into a ChatMessage.
+ * Pure: only depends on its arguments. No SDK calls beyond what's
+ * passed in via `client` (used for mxc → http URL resolution).
+ *
+ * Returns null for non-message events.
+ */
+function transformEventToChatMessage(
+  event: MatrixEvent,
+  room: Room | undefined,
+  channelId: string,
+  client: MatrixClient | null,
+): ChatMessage | null {
+  if (event.getType() !== EventType.RoomMessage) return null;
+
+  const senderId = event.getSender() ?? 'Unknown';
+  const senderMember = room?.getMember(senderId);
+  const displayName = senderMember?.rawDisplayName || senderMember?.name || senderId;
+
+  const content = event.getContent() as {
+    body?: string;
+    msgtype?: string;
+    url?: string;
+    info?: { thumbnail_url?: string; w?: number; h?: number; mimetype?: string; size?: number };
+    'm.relates_to'?: { 'm.in_reply_to'?: { event_id: string } };
+  };
+
+  let media: MediaAttachment[] | undefined;
+  if (content.msgtype === 'm.image' && content.url) {
+    const fullUrl = client?.mxcUrlToHttp(content.url) ?? content.url;
+    media = [{
+      type: content.info?.mimetype?.toLowerCase() === 'image/gif' ? 'gif' : 'image',
+      url: fullUrl,
+      width: content.info?.w,
+      height: content.info?.h,
+      mimetype: content.info?.mimetype,
+      size: content.info?.size,
+    }];
+  }
+
+  const rawBody = content.body ?? '';
+  const isBridgeBotSender = /^@brmble[_-]?/.test(senderId);
+  const bridgeMatch = isBridgeBotSender ? rawBody.match(/^\[(.+?)\]:\s*/) : null;
+  const messageSender = bridgeMatch ? bridgeMatch[1] : displayName;
+  let messageContent = bridgeMatch ? rawBody.slice(bridgeMatch[0].length) : rawBody;
+
+  // Strip reply fallback from body (lines starting with > )
+  messageContent = messageContent.split('\n').filter(line => !/^> ?/.test(line)).join('\n').trim();
+
+  // For image-only messages, body is just the filename — don't show it as text
+  const displayContent = media ? '' : messageContent;
+
+  const relatesTo = content['m.relates_to'] as { 'm.in_reply_to'?: { event_id: string } } | undefined;
+  const replyToEventId = relatesTo?.['m.in_reply_to']?.event_id;
+
+  return {
+    id: event.getId() ?? crypto.randomUUID(),
+    channelId,
+    sender: messageSender,
+    senderMatrixUserId: senderId,
+    content: displayContent,
+    timestamp: new Date(event.getTs()),
+    ...(media && { media }),
+    ...(replyToEventId && { replyToEventId }),
+  };
+}
+```
+
+- [ ] **Step 2: Replace the channel transformation block in onTimeline**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`, the `onTimeline` function — replace the entire block from line 87 through to the `setMessages(prev => …)` block (around line 152), keeping the DM handling that follows:
+
+```ts
+    const onTimeline = (event: MatrixEvent, room: Room | undefined) => {
+      if (event.getType() !== EventType.RoomMessage) return;
+      const channelId = roomIdToChannelId.get(room?.roomId ?? '');
+      if (channelId) {
+        const message = transformEventToChatMessage(event, room, channelId, clientRef.current);
+        if (!message) return;
+
+        setMessages(prev => {
+          const existing = prev.get(channelId) ?? [];
+          const updated = insertMessage(existing, message);
+          if (updated === existing) return prev;
+          return new Map(prev).set(channelId, updated);
+        });
+        return;
+      }
+
+      // DM message handling
+      const dmUserId = roomIdToDMUserIdRef.current.get(room?.roomId ?? '');
+      if (!dmUserId) {
+        if (!isPrepared && room?.roomId) {
+          bufferedDmEvents.push({ room, event });
+        }
+        return;
+      }
+
+      const dmMessage = transformEventToChatMessage(event, room, dmUserId, clientRef.current);
+      if (!dmMessage) return;
+
+      setDmMessages(prev => {
+        const existing = prev.get(dmUserId) ?? [];
+        const updated = insertMessage(existing, dmMessage);
+        if (updated === existing) return prev;
+        return new Map(prev).set(dmUserId, updated);
+      });
+    };
+```
+
+- [ ] **Step 3: Replace the DM-backfill block in registerDMRoom**
+
+In `registerDMRoom` (around lines 285-351), replace the manual transformation loop with a call to the helper:
+
+```ts
+    const registerDMRoom = (room: Room, otherUserId: string) => {
+      if (roomIdToDMUserIdRef.current.has(room.roomId)) return;
+
+      setDmRoomMap(prev => new Map(prev).set(otherUserId, room.roomId));
+      dmRoomMapRef.current = new Map(dmRoomMapRef.current).set(otherUserId, room.roomId);
+      roomIdToDMUserIdRef.current = new Map(roomIdToDMUserIdRef.current).set(room.roomId, otherUserId);
+
+      const timelineEvents = room.getLiveTimeline().getEvents();
+      const backfillMsgs: ChatMessage[] = [];
+      for (const ev of timelineEvents) {
+        const msg = transformEventToChatMessage(ev, room, otherUserId, clientRef.current);
+        if (msg) backfillMsgs.push(msg);
+      }
+
+      if (backfillMsgs.length > 0) {
+        setDmMessages(prev => {
+          const existing = prev.get(otherUserId) ?? [];
+          let merged = existing;
+          for (const msg of backfillMsgs) {
+            merged = insertMessage(merged, msg);
+          }
+          if (merged === existing) return prev;
+          return new Map(prev).set(otherUserId, merged);
+        });
+      }
+    };
+```
+
+- [ ] **Step 4: Run existing tests to verify no regression**
+
+Run: `(cd src/Brmble.Web && npm test -- useMatrixClient --run)`
+Expected: all existing tests pass (refactor preserves behavior).
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `(cd src/Brmble.Web && npm run build)`
+Expected: build completes without TS errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useMatrixClient.ts
+git commit -m "$(cat <<'EOF'
+refactor(matrix): extract pure event-to-ChatMessage transformer
+
+Pulls the duplicated channel and DM transformation logic in onTimeline
+and registerDMRoom into a single pure helper. No behavior change;
+prepares for active-only state in the next change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add lastMessages and dmLastMessages preview maps + bootstrap
+
+This task adds the bounded sidebar-preview maps as new outputs of `useMatrixClient`. It is purely additive: the existing `messages`/`dmMessages` Maps are unchanged, so callers continue to work. After this task `useMatrixClient` has both old and new outputs.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.ts`
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.test.ts`
+
+- [ ] **Step 1: Add tests for lastMessages**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.test.ts`, append these tests inside the existing `describe('useMatrixClient', …)` block:
+
+```ts
+  it('lastMessages and dmLastMessages start empty', () => {
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+    expect(result.current.lastMessages.size).toBe(0);
+    expect(result.current.dmLastMessages.size).toBe(0);
+  });
+
+  it('updates lastMessages when a channel timeline event arrives', () => {
+    const mockRoom = {
+      roomId: '!room:example.com',
+      getMember: vi.fn(() => ({ rawDisplayName: 'Alice', name: 'Alice' })),
+    };
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    const onTimeline = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'Room.timeline')?.[1] as
+      | ((ev: unknown, r: unknown) => void)
+      | undefined;
+    expect(onTimeline).toBeDefined();
+
+    const fakeEvent = {
+      getType: () => 'm.room.message',
+      getId: () => '$evt-1',
+      getSender: () => '@alice:example.com',
+      getContent: () => ({ body: 'hi there' }),
+      getTs: () => 1_700_000_000_000,
+    };
+
+    act(() => onTimeline!(fakeEvent, mockRoom));
+
+    expect(result.current.lastMessages.get('42')).toEqual({
+      content: 'hi there',
+      ts: 1_700_000_000_000,
+      sender: 'Alice',
+    });
+  });
+```
+
+- [ ] **Step 2: Run new tests, verify they fail**
+
+Run: `(cd src/Brmble.Web && npm test -- useMatrixClient --run)`
+Expected: 2 new tests FAIL (`lastMessages` is undefined on `result.current`).
+
+- [ ] **Step 3: Add the MessagePreview type and state**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`:
+
+a) Below the `MatrixCredentials` interface, export a new type:
+
+```ts
+export interface MessagePreview {
+  content: string;
+  ts: number;
+  sender: string;
+}
+```
+
+b) Inside the hook body, alongside `const [messages, setMessages] = ...` (line 38), add:
+
+```ts
+  const [lastMessages, setLastMessages] = useState<Map<string, MessagePreview>>(new Map());
+  const [dmLastMessages, setDmLastMessages] = useState<Map<string, MessagePreview>>(new Map());
+```
+
+- [ ] **Step 4: Update onTimeline to also write lastMessages / dmLastMessages**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`, modify the channel branch of `onTimeline` (after the `setMessages(...)` call, before the `return`):
+
+```ts
+        setMessages(prev => {
+          const existing = prev.get(channelId) ?? [];
+          const updated = insertMessage(existing, message);
+          if (updated === existing) return prev;
+          return new Map(prev).set(channelId, updated);
+        });
+
+        setLastMessages(prev => {
+          const existing = prev.get(channelId);
+          if (existing && existing.ts >= message.timestamp.getTime()) return prev;
+          const next = new Map(prev);
+          next.set(channelId, {
+            content: message.content,
+            ts: message.timestamp.getTime(),
+            sender: message.sender,
+          });
+          return next;
+        });
+        return;
+```
+
+And in the DM branch (after `setDmMessages(...)`):
+
+```ts
+      setDmMessages(prev => {
+        const existing = prev.get(dmUserId) ?? [];
+        const updated = insertMessage(existing, dmMessage);
+        if (updated === existing) return prev;
+        return new Map(prev).set(dmUserId, updated);
+      });
+
+      setDmLastMessages(prev => {
+        const existing = prev.get(dmUserId);
+        if (existing && existing.ts >= dmMessage.timestamp.getTime()) return prev;
+        const next = new Map(prev);
+        next.set(dmUserId, {
+          content: dmMessage.content,
+          ts: dmMessage.timestamp.getTime(),
+          sender: dmMessage.sender,
+        });
+        return next;
+      });
+```
+
+- [ ] **Step 5: Bootstrap lastMessages on PREPARED**
+
+In `onSync`, inside the `if (state === 'PREPARED')` block (around line 237 in current code), after the existing DM-room-map population and bufferedDmEvents replay, add:
+
+```ts
+          // Bootstrap last-message previews from the SDK timelines now
+          // that initial sync is complete. This avoids waiting for new
+          // RoomEvent.Timeline events to populate the sidebar.
+          const bootChannelPreviews = new Map<string, MessagePreview>();
+          const bootDmPreviews = new Map<string, MessagePreview>();
+          for (const room of client.getRooms()) {
+            const channelId = roomIdToChannelId.get(room.roomId);
+            const dmUserId = roomIdToDMUserIdRef.current.get(room.roomId);
+            const target = channelId ?? dmUserId;
+            if (!target) continue;
+
+            const events = room.getLiveTimeline().getEvents();
+            for (let i = events.length - 1; i >= 0; i--) {
+              const ev = events[i];
+              if (ev.getType() !== EventType.RoomMessage) continue;
+              const msg = transformEventToChatMessage(ev, room, target, clientRef.current);
+              if (!msg) continue;
+              const preview: MessagePreview = {
+                content: msg.content,
+                ts: msg.timestamp.getTime(),
+                sender: msg.sender,
+              };
+              if (channelId) bootChannelPreviews.set(channelId, preview);
+              else if (dmUserId) bootDmPreviews.set(dmUserId, preview);
+              break;
+            }
+          }
+          if (bootChannelPreviews.size > 0) setLastMessages(bootChannelPreviews);
+          if (bootDmPreviews.size > 0) setDmLastMessages(bootDmPreviews);
+```
+
+- [ ] **Step 6: Reset previews on credentials = null**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`, the credentials-null branch (around line 64-75) currently resets `setMessages(new Map())` etc. Add the new resets:
+
+```ts
+      setMessages(new Map());
+      setLastMessages(new Map());
+      setDmRoomMap(new Map());
+      setDmMessages(new Map());
+      setDmLastMessages(new Map());
+```
+
+- [ ] **Step 7: Add lastMessages and dmLastMessages to the hook's return object**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`, the `return { ... }` at the end of the hook (around line 629-631), add:
+
+```ts
+  return { messages, lastMessages, sendMessage, sendImageMessage, uploadContent, fetchHistory,
+           dmMessages, dmLastMessages, dmRoomMap,
+           dmUserDisplayNames, dmUserAvatarUrls, sendDMMessage, fetchDMHistory,
+           fetchAvatarUrl, client };
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `(cd src/Brmble.Web && npm test -- useMatrixClient --run)`
+Expected: all tests pass — both new lastMessages tests and existing tests.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useMatrixClient.ts src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+git commit -m "$(cat <<'EOF'
+feat(matrix): add bounded lastMessages preview maps
+
+Adds lastMessages and dmLastMessages: one MessagePreview entry per room,
+populated on PREPARED from SDK timelines and updated on every
+RoomEvent.Timeline. Prepares the sidebar to drop full message arrays
+in the next change. Existing messages/dmMessages Maps are unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Add active-only message state + setActiveChannel/setActiveDmContact
+
+Adds the new "active room" state alongside the existing eager Maps. Still purely additive — old API works, new API works. No consumer change yet.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.ts`
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.test.ts`
+
+- [ ] **Step 1: Add tests for setActiveChannel**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.test.ts`, append:
+
+```ts
+  it('setActiveChannel rebuilds activeMessages from SDK timeline', () => {
+    const aliceMember = { rawDisplayName: 'Alice', name: 'Alice' };
+    const fakeEvents = [
+      {
+        getType: () => 'm.room.message',
+        getId: () => '$e1',
+        getSender: () => '@alice:example.com',
+        getContent: () => ({ body: 'first' }),
+        getTs: () => 1000,
+      },
+      {
+        getType: () => 'm.room.message',
+        getId: () => '$e2',
+        getSender: () => '@alice:example.com',
+        getContent: () => ({ body: 'second' }),
+        getTs: () => 2000,
+      },
+    ];
+    const mockRoom = {
+      roomId: '!room:example.com',
+      getMember: () => aliceMember,
+      getLiveTimeline: () => ({ getEvents: () => fakeEvents }),
+    };
+    mockClient.getRoom.mockReturnValue(mockRoom);
+
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    act(() => result.current.setActiveChannel('42'));
+
+    expect(result.current.activeMessages).toHaveLength(2);
+    expect(result.current.activeMessages[0].content).toBe('first');
+    expect(result.current.activeMessages[1].content).toBe('second');
+  });
+
+  it('setActiveChannel(null) clears activeMessages', () => {
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+    act(() => result.current.setActiveChannel(null));
+    expect(result.current.activeMessages).toEqual([]);
+  });
+
+  it('rapid setActiveChannel switches commit only the latest load', () => {
+    // Build two rooms and have getRoom toggle between them.
+    const roomA = {
+      roomId: '!a:example.com',
+      getMember: () => ({ rawDisplayName: 'A', name: 'A' }),
+      getLiveTimeline: () => ({ getEvents: () => [
+        { getType: () => 'm.room.message', getId: () => '$a1', getSender: () => '@a:example.com',
+          getContent: () => ({ body: 'A-msg' }), getTs: () => 1 },
+      ]}),
+    };
+    const roomB = {
+      roomId: '!b:example.com',
+      getMember: () => ({ rawDisplayName: 'B', name: 'B' }),
+      getLiveTimeline: () => ({ getEvents: () => [
+        { getType: () => 'm.room.message', getId: () => '$b1', getSender: () => '@b:example.com',
+          getContent: () => ({ body: 'B-msg' }), getTs: () => 1 },
+      ]}),
+    };
+    mockClient.getRoom.mockImplementation((id: string) =>
+      id === '!a:example.com' ? roomA : id === '!b:example.com' ? roomB : null);
+
+    const credsAB: MatrixCredentials = {
+      ...creds,
+      roomMap: { 'A': '!a:example.com', 'B': '!b:example.com' },
+    };
+    const { result } = renderHook(() => useMatrixClient(credsAB), { wrapper });
+
+    act(() => {
+      result.current.setActiveChannel('A');
+      result.current.setActiveChannel('B');
+      result.current.setActiveChannel('A');
+    });
+
+    expect(result.current.activeMessages).toHaveLength(1);
+    expect(result.current.activeMessages[0].content).toBe('A-msg');
+  });
+```
+
+- [ ] **Step 2: Run new tests, verify they fail**
+
+Run: `(cd src/Brmble.Web && npm test -- useMatrixClient --run)`
+Expected: 3 new tests FAIL (`setActiveChannel is not a function`).
+
+- [ ] **Step 3: Add active state and setActiveChannel**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`, near the existing useState declarations (after `dmLastMessages`), add:
+
+```ts
+  const [activeMessages, setActiveMessages] = useState<ChatMessage[]>([]);
+  const [activeDmMessages, setActiveDmMessages] = useState<ChatMessage[]>([]);
+  const activeChannelIdRef = useRef<string | null>(null);
+  const activeDmContactIdRef = useRef<string | null>(null);
+  const activeRoomVersionRef = useRef(0);
+  const activeDmVersionRef = useRef(0);
+```
+
+Then, inside the hook body but outside the main `useEffect`, add the helper callbacks:
+
+```ts
+  const setActiveChannel = useCallback((channelId: string | null) => {
+    activeRoomVersionRef.current += 1;
+    const myVersion = activeRoomVersionRef.current;
+    activeChannelIdRef.current = channelId;
+
+    if (!channelId) {
+      setActiveMessages([]);
+      return;
+    }
+    const client = clientRef.current;
+    if (!credentials || !client) {
+      setActiveMessages([]);
+      return;
+    }
+    const roomId = credentials.roomMap[channelId];
+    if (!roomId) {
+      setActiveMessages([]);
+      return;
+    }
+    const room = client.getRoom(roomId);
+    if (!room) {
+      setActiveMessages([]);
+      return;
+    }
+
+    const events = room.getLiveTimeline().getEvents();
+    const messages: ChatMessage[] = [];
+    for (const ev of events) {
+      const m = transformEventToChatMessage(ev, room, channelId, client);
+      if (m) messages.push(m);
+    }
+
+    if (activeRoomVersionRef.current === myVersion) {
+      setActiveMessages(messages);
+    }
+  }, [credentials]);
+
+  const setActiveDmContact = useCallback((matrixUserId: string | null) => {
+    activeDmVersionRef.current += 1;
+    const myVersion = activeDmVersionRef.current;
+    activeDmContactIdRef.current = matrixUserId;
+
+    if (!matrixUserId) {
+      setActiveDmMessages([]);
+      return;
+    }
+    const client = clientRef.current;
+    if (!client) {
+      setActiveDmMessages([]);
+      return;
+    }
+    const roomId = dmRoomMapRef.current.get(matrixUserId);
+    if (!roomId) {
+      setActiveDmMessages([]);
+      return;
+    }
+    const room = client.getRoom(roomId);
+    if (!room) {
+      setActiveDmMessages([]);
+      return;
+    }
+
+    const events = room.getLiveTimeline().getEvents();
+    const messages: ChatMessage[] = [];
+    for (const ev of events) {
+      const m = transformEventToChatMessage(ev, room, matrixUserId, client);
+      if (m) messages.push(m);
+    }
+
+    if (activeDmVersionRef.current === myVersion) {
+      setActiveDmMessages(messages);
+    }
+  }, []);
+```
+
+- [ ] **Step 4: Have onTimeline append to active state when matched**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`, modify the channel branch of `onTimeline` so it also appends to `activeMessages` when the room is currently active. After the existing `setLastMessages(...)` block, add:
+
+```ts
+        if (activeChannelIdRef.current === channelId) {
+          setActiveMessages(prev => {
+            const updated = insertMessage(prev, message);
+            return updated === prev ? prev : updated;
+          });
+        }
+```
+
+In the DM branch, after the `setDmLastMessages(...)` block, add:
+
+```ts
+      if (activeDmContactIdRef.current === dmUserId) {
+        setActiveDmMessages(prev => {
+          const updated = insertMessage(prev, dmMessage);
+          return updated === prev ? prev : updated;
+        });
+      }
+```
+
+- [ ] **Step 5: Reset active state on credentials = null**
+
+In the credentials-null branch (where the other Maps reset), add:
+
+```ts
+      setActiveMessages([]);
+      setActiveDmMessages([]);
+      activeChannelIdRef.current = null;
+      activeDmContactIdRef.current = null;
+```
+
+- [ ] **Step 6: Add to return object**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`, append to the hook return:
+
+```ts
+  return { messages, lastMessages, activeMessages, setActiveChannel,
+           sendMessage, sendImageMessage, uploadContent, fetchHistory,
+           dmMessages, dmLastMessages, activeDmMessages, setActiveDmContact, dmRoomMap,
+           dmUserDisplayNames, dmUserAvatarUrls, sendDMMessage, fetchDMHistory,
+           fetchAvatarUrl, client };
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `(cd src/Brmble.Web && npm test -- useMatrixClient --run)`
+Expected: all tests pass — including the 3 new setActiveChannel tests and existing ones.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useMatrixClient.ts src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+git commit -m "$(cat <<'EOF'
+feat(matrix): add active-only message state with version-guarded loads
+
+Adds activeMessages, activeDmMessages, setActiveChannel, and
+setActiveDmContact. Reads room timeline from the SDK on activation
+and appends real-time events only when the room is active. Uses
+monotonic version refs so a stale load cannot overwrite a newer one.
+
+Old messages/dmMessages Maps are still maintained — consumers will
+migrate in the next change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Migrate App.tsx and useDMStore to the new API; remove old Maps
+
+Switch consumers off the eager Maps and remove them from `useMatrixClient`. After this task, the old `messages`/`dmMessages` paths are gone and the leak is fixed.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useDMStore.ts`
+- Modify: `src/Brmble.Web/src/hooks/useDMStore.test.ts`
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.ts`
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.test.ts`
+
+- [ ] **Step 1: Update DMStoreOptions in useDMStore.ts**
+
+In `src/Brmble.Web/src/hooks/useDMStore.ts`, change the `DMStoreOptions` interface:
+
+```ts
+export interface DMStoreOptions {
+  matrixDmLastMessages: Map<string, { content: string; ts: number; sender: string }> | undefined;
+  activeDmMessages: ChatMessage[] | undefined;
+  matrixDmRoomMap: Map<string, string> | undefined;
+  matrixDmUserDisplayNames: Map<string, string> | undefined;
+  matrixDmUserAvatarUrls: Map<string, string> | undefined;
+  sendMatrixDM: ((targetMatrixUserId: string, text: string) => Promise<void>) | undefined;
+  fetchDMHistory: ((targetMatrixUserId: string) => Promise<void>) | undefined;
+  sendMumbleDM?: (targetSession: number, text: string) => void;
+  users: User[];
+  username: string;
+}
+```
+
+Update the destructure at the top of `useDMStore`:
+
+```ts
+  const {
+    matrixDmLastMessages,
+    activeDmMessages,
+    matrixDmRoomMap,
+    matrixDmUserDisplayNames,
+    matrixDmUserAvatarUrls,
+    sendMatrixDM,
+    fetchDMHistory,
+    sendMumbleDM,
+    users,
+    username,
+  } = options;
+```
+
+- [ ] **Step 2: Use matrixDmLastMessages in the contacts useMemo**
+
+In `src/Brmble.Web/src/hooks/useDMStore.ts`, the `contacts` useMemo currently reads:
+
+```ts
+        const msgs = matrixDmMessages?.get(matrixUserId);
+        const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
+        // ...
+          lastMessage: lastMsg?.content,
+          lastMessageTime: lastMsg?.timestamp.getTime(),
+```
+
+Replace with:
+
+```ts
+        const lastPreview = matrixDmLastMessages?.get(matrixUserId);
+        // ...
+          lastMessage: lastPreview?.content,
+          lastMessageTime: lastPreview?.ts,
+```
+
+Update the useMemo dependency list: replace `matrixDmMessages` with `matrixDmLastMessages`:
+
+```ts
+  }, [matrixDmRoomMap, matrixDmLastMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, users, pendingMatrixContacts, mumbleContacts, mumbleMessages]);
+```
+
+- [ ] **Step 3: Use activeDmMessages in the messages useMemo**
+
+In `src/Brmble.Web/src/hooks/useDMStore.ts`, the `messages` useMemo currently reads:
+
+```ts
+    const matrixMsgs = matrixDmMessages?.get(selectedContactId) ?? [];
+    const pending = pendingMessages.get(selectedContactId) ?? [];
+    return [...matrixMsgs, ...pending];
+```
+
+Replace with:
+
+```ts
+    const matrixMsgs = activeDmMessages ?? [];
+    const pending = pendingMessages.get(selectedContactId) ?? [];
+    return [...matrixMsgs, ...pending];
+```
+
+Update the dependency list: replace `matrixDmMessages` with `activeDmMessages`:
+
+```ts
+  }, [selectedContactId, activeDmMessages, pendingMessages, mumbleMessages]);
+```
+
+- [ ] **Step 4: Update useDMStore.test.ts options helper**
+
+In `src/Brmble.Web/src/hooks/useDMStore.test.ts`, update `makeOptions` to match the new signature:
+
+```ts
+function makeOptions(overrides: Partial<DMStoreOptions> = {}): DMStoreOptions {
+  return {
+    matrixDmLastMessages: new Map(),
+    activeDmMessages: [],
+    matrixDmRoomMap: new Map(),
+    matrixDmUserDisplayNames: new Map(),
+    matrixDmUserAvatarUrls: new Map(),
+    sendMatrixDM: vi.fn().mockResolvedValue(undefined),
+    fetchDMHistory: vi.fn().mockResolvedValue(undefined),
+    sendMumbleDM: vi.fn(),
+    users: [{ id: 1, name: 'me', session: 1 }] as DMStoreOptions['users'],
+    username: 'me',
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 5: Update App.tsx to call setActiveChannel/setActiveDmContact**
+
+In `src/Brmble.Web/src/App.tsx`, the variable that drives the visible Matrix channel is `activeChannelId` (see line 1955: `const activeChannelId = currentChannelId && currentChannelId !== 'server-root' ? currentChannelId : null;`).
+
+After the `dmStore = useDMStore({ ... })` block (line 531-543), add two effects to mirror selection into `useMatrixClient`:
+
+```tsx
+  useEffect(() => {
+    matrixClient.setActiveChannel(activeChannelId);
+  }, [activeChannelId, matrixClient.setActiveChannel]);
+
+  useEffect(() => {
+    matrixClient.setActiveDmContact(dmStore.selectedContact?.id ?? null);
+  }, [dmStore.selectedContact?.id, matrixClient.setActiveDmContact]);
+```
+
+Note: `activeChannelId` is computed below the `useDMStore` call in the current file — you must move its declaration up to before the new effects, or place the effects below where it is currently computed (around line 1955+). Either is fine; the simpler change is to move `activeChannelId` up so it lives next to `dmStore`.
+
+- [ ] **Step 6: Update App.tsx to pass new props to useDMStore**
+
+In `src/Brmble.Web/src/App.tsx`, the useDMStore call site is at lines 531-543. Replace the `matrixDmMessages: matrixClient.dmMessages` line (line 532) with two new props, keeping all other lines including the existing `sendMumbleDM` arrow function:
+
+```tsx
+  const dmStore = useDMStore({
+    matrixDmLastMessages: matrixClient.dmLastMessages,
+    activeDmMessages: matrixClient.activeDmMessages,
+    matrixDmRoomMap: matrixClient.dmRoomMap,
+    matrixDmUserDisplayNames: matrixClient.dmUserDisplayNames,
+    matrixDmUserAvatarUrls: matrixClient.dmUserAvatarUrls,
+    sendMatrixDM: matrixClient.sendDMMessage,
+    fetchDMHistory: matrixClient.fetchDMHistory,
+    users,
+    username,
+    sendMumbleDM: (targetSession: number, text: string) => {
+      bridge.send('voice.sendPrivateMessage', { message: linkifyForMumble(text), targetSession });
+    },
+  });
+```
+
+- [ ] **Step 7: Update App.tsx channel ChatPanel to use activeMessages and lastMessages**
+
+In `src/Brmble.Web/src/App.tsx`, line 1959-1960 currently reads:
+
+```tsx
+  const matrixMessages = activeChannelId
+    ? matrixClient.messages.get(activeChannelId)
+```
+
+Replace with:
+
+```tsx
+  const matrixMessages = activeChannelId
+    ? matrixClient.activeMessages
+```
+
+(The fallback after the conditional, and any `?? []`, stays as-is.)
+
+Then `grep -n "matrixClient\.messages\|matrixClient\.dmMessages" src/Brmble.Web/src/App.tsx` to find any other call sites and update each:
+- For sidebar last-message previews per channel: `matrixClient.lastMessages.get(channelId)?.content`.
+- For DM previews per contact: already handled via `dmStore.contacts` consuming `matrixDmLastMessages`.
+- For the active DM message list: `matrixClient.activeDmMessages` (already wired through `dmStore.messages`).
+
+- [ ] **Step 8: Remove the old messages and dmMessages state from useMatrixClient**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.ts`:
+
+a) Delete the `messages` and `dmMessages` `useState` lines.
+
+b) In `onTimeline`, delete the `setMessages(...)` and `setDmMessages(...)` blocks. The function should now only call `setLastMessages` / `setDmLastMessages` and (when active) `setActiveMessages` / `setActiveDmMessages`.
+
+c) In `registerDMRoom`, delete the `setDmMessages(prev => ...)` block (its job is now done by onTimeline + setActiveDmContact-driven loads). Keep the rest of the function (room map updates).
+
+d) In the credentials-null branch, remove `setMessages(new Map())` and `setDmMessages(new Map())`.
+
+e) Lower the initialSyncLimit from 20 to 5:
+
+```ts
+    client.startClient({ initialSyncLimit: 5 });
+```
+
+f) In the return object, remove `messages` and `dmMessages`. Final return:
+
+```ts
+  return { lastMessages, activeMessages, setActiveChannel,
+           sendMessage, sendImageMessage, uploadContent, fetchHistory,
+           dmLastMessages, activeDmMessages, setActiveDmContact, dmRoomMap,
+           dmUserDisplayNames, dmUserAvatarUrls, sendDMMessage, fetchDMHistory,
+           fetchAvatarUrl, client };
+```
+
+- [ ] **Step 9: Update existing useMatrixClient tests that reference the old Maps**
+
+In `src/Brmble.Web/src/hooks/useMatrixClient.test.ts`:
+
+a) The test `'calls stopClient and clears messages when credentials become null'` at line 76-84 references `result.current.messages.size`. Replace `messages` with `lastMessages` and `dmLastMessages`:
+
+```ts
+    expect(mockClient.stopClient).toHaveBeenCalled();
+    expect(result.current.lastMessages.size).toBe(0);
+    expect(result.current.dmLastMessages.size).toBe(0);
+    expect(result.current.activeMessages).toEqual([]);
+    expect(result.current.activeDmMessages).toEqual([]);
+```
+
+b) Update the `'calls startClient when credentials are provided'` test to expect the new sync limit:
+
+```ts
+    expect(mockClient.startClient).toHaveBeenCalledWith({ initialSyncLimit: 5 });
+```
+
+c) Any other test that asserts on `result.current.messages` (or `dmMessages`) — delete or rewrite to use `activeMessages` after a `setActiveChannel(...)` call.
+
+- [ ] **Step 10: Run all hook tests**
+
+Run: `(cd src/Brmble.Web && npm test -- --run hooks/)`
+Expected: all hook tests pass.
+
+- [ ] **Step 11: Run full frontend build to catch type errors in App.tsx**
+
+Run: `(cd src/Brmble.Web && npm run build)`
+Expected: build succeeds. If not, fix the type errors in App.tsx (likely places where `matrixClient.messages` or `matrixClient.dmMessages` are still referenced).
+
+- [ ] **Step 12: Run dotnet build to make sure nothing native broke**
+
+Run: `dotnet build`
+Expected: build succeeds (frontend dist is copied as part of build per CLAUDE.md).
+
+- [ ] **Step 13: Manual smoke test**
+
+Start dev server and client:
+
+```bash
+(cd src/Brmble.Web && npm run dev)
+# in another terminal:
+dotnet run --project src/Brmble.Client
+```
+
+Verify:
+- Open the app, channels appear in sidebar with "last message" preview text.
+- Click a channel → messages render correctly.
+- Switch between channels rapidly → no errors in `%TEMP%/brmble-tls.log` or DevTools console.
+- Send a new message → it appears in the active channel and updates the sidebar preview.
+- Open a DM → DM messages render. Switch DM contacts → previews update.
+- Scroll back in the active channel → older messages backfill.
+- Leave app idle for 5+ minutes (shorter repro) → no DevTools "out of memory" warnings; private bytes (Task Manager → brmble.client.exe) remains roughly stable.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useDMStore.ts \
+        src/Brmble.Web/src/hooks/useDMStore.test.ts \
+        src/Brmble.Web/src/hooks/useMatrixClient.ts \
+        src/Brmble.Web/src/hooks/useMatrixClient.test.ts \
+        src/Brmble.Web/src/App.tsx
+git commit -m "$(cat <<'EOF'
+perf(chat): drop eager per-room message Maps; only active room in state
+
+useMatrixClient now keeps only the active channel and active DM in
+React state. Sidebar previews come from a bounded lastMessages map
+(one entry per room). matrix-js-sdk's internal timeline cache is the
+source of truth; ChatMessage transformation runs once per channel
+open instead of for every event in every room.
+
+initialSyncLimit lowered 20 -> 5 to cut cold-start payload by 75%.
+Real-time messages still arrive via incremental sync regardless.
+
+Fixes the WebView2 "page out of memory" symptom from the original
+30-min idle repro and reduces cold-start time-to-first-paint.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Verification (after Task 6)
+
+- [ ] All hook tests pass: `(cd src/Brmble.Web && npm test -- --run hooks/)`
+- [ ] Full frontend test suite passes: `(cd src/Brmble.Web && npm test -- --run)`
+- [ ] Frontend build clean: `(cd src/Brmble.Web && npm run build)`
+- [ ] Dotnet build clean: `dotnet build`
+- [ ] Manual smoke test from Task 6 Step 13 passes.
+- [ ] Optional: 30-min idle test (compare private bytes before/after; expectation: flat).
+
+If verification passes, the branch is ready for the user to review and decide on PR/merge.

--- a/docs/superpowers/specs/2026-05-03-lazy-chat-loading-design.md
+++ b/docs/superpowers/specs/2026-05-03-lazy-chat-loading-design.md
@@ -1,0 +1,119 @@
+# Lazy chat loading — design
+
+**Date:** 2026-05-03
+**Branch:** `feature/lazy-chat-loading`
+**Status:** approved (verbal); pending written-spec review
+
+## Problem
+
+Two compounding issues in the WebView2 frontend:
+
+1. **Memory leak.** `useMatrixClient` keeps a `Map<string, ChatMessage[]>` per Matrix room and per Matrix DM contact. Both grow unbounded — `insertMessage` only appends, never evicts. Over a long session (channel browsing + scrollback + incoming messages), the JS heap grows without bound. `useDMStore.mumbleMessages` and `useChatStore` non-server-root entries have the same shape. Reported symptom (commit `94cc38c`): WebView2 *page out of memory* after ~30 minutes idle. The throttle-rerenders fix removed the largest sustained churn but explicitly did not fix the underlying leak.
+
+2. **Slow cold start.** `client.startClient({ initialSyncLimit: 20 })` causes the matrix-js-sdk `/sync` to return 20 events per room. With N rooms, that's 20×N events on the wire and 20×N transformations through `onTimeline` before first paint. Each transformation does mxc-URL resolution, reply-relation parsing, mention detection, and `setMessages` (a re-render trigger).
+
+The two issues share a root cause: **the React-state holds a transformed copy of every message in every room, eagerly populated at sync time and never pruned.** The matrix-js-sdk already caches the underlying events itself (`room.getLiveTimeline()`), so we are storing each Matrix message twice — once in the SDK and once as a `ChatMessage` in React.
+
+## Goal
+
+Eliminate the duplicate storage. Make React-state hold only what is currently rendered. Drastically reduce work done at cold start.
+
+Non-goals:
+
+- Persisting chat history beyond the SDK's existing cache.
+- Implementing message search (would require a separate index).
+- Fixing all Codex/explore findings — only those that fall out of this redesign or are tightly coupled (`pendingMessages` cleanup, `pendingRoomCreations` cleanup).
+
+## Approach
+
+**Approach A — "only-active-room" with derived sidebar previews.** Selected after evaluating cap-per-room (does not solve cold start) and LRU-window (overengineered for the gain over A).
+
+**Principle:** each chat source has a source of truth that is not React. React-state is a transient view over the source of truth, scoped to what the user is currently looking at.
+
+| Source | Source of truth | What React holds |
+|---|---|---|
+| Matrix channels | `matrix-js-sdk` internal timeline (`room.getLiveTimeline()`) | Active channel only, as `ChatMessage[]` |
+| Matrix DMs | idem | Active DM only, as `ChatMessage[]` |
+| Mumble channel-root | `localStorage` per channel | Active channel only (already so) |
+| Mumble session DMs | in-memory map (session-scoped, capped) | Active contact only |
+
+For sidebar rendering, a small bounded `lastMessages: Map<roomId, {content, ts, sender}>` holds a single preview entry per room (≤1 ChatMessage worth of data per room).
+
+The transformation `MatrixEvent → ChatMessage` is no longer eager. It runs once per channel-open from the SDK cache (~5 events post-sync), and incrementally for new real-time messages in the active room.
+
+## Per-store changes
+
+### `useMatrixClient.ts`
+
+- Replace `messages: Map<string, ChatMessage[]>` with `activeMessages: ChatMessage[]` and an `activeChannelId: string | null` setter exposed as a new `setActiveChannel(channelId | null)`.
+- Same shape for DMs: `activeDmMessages: ChatMessage[]` and `setActiveDmContact(matrixUserId | null)`.
+- New: `lastMessages: Map<string, MessagePreview>` where `MessagePreview = { content: string; ts: number; sender: string }`. Bounded to one entry per room. Populated on PREPARED by iterating `client.getRooms()` and reading the last `m.room.message` from each room's live timeline; updated on every `RoomEvent.Timeline`. Same for `dmLastMessages`.
+- New helper: `loadActiveMessages(roomId: string)` — reads `room.getLiveTimeline().getEvents()`, filters to `m.room.message`, transforms to `ChatMessage[]`, and stores. Uses an `activeRoomVersionRef` (monotonic counter) so a stale load cannot overwrite a newer active room.
+- `onTimeline` is now: always update `lastMessages` for the room; if `room.roomId === activeRoomId`, also update `activeMessages` via the existing `insertMessage` logic. No other branches.
+- `startClient` parameter changes: `initialSyncLimit: 20 → 5`. Five is enough to bootstrap previews and unread-since-marker logic; reduces cold-start payload by 75%.
+- `fetchHistory(channelId)`: unchanged externally — still calls `scrollback(room, 50)`. The SDK's resulting backfill events fire `RoomEvent.Timeline`, which our new `onTimeline` will only commit to `activeMessages` when the channel is active. Behaviour identical to before for the user.
+- Hook return shape changes: `messages` and `dmMessages` Maps are removed; new exports are `activeMessages`, `activeDmMessages`, `lastMessages`, `dmLastMessages`, `setActiveChannel`, `setActiveDmContact`.
+
+### `useChatStore.ts`
+
+- React-state is already only-active. Single change: introduce `NON_SERVER_ROOT_MAX_MESSAGES = 200` and apply slice-from-end cap in both `addMessage` (when `!isServerRoot`) and `addMessageToStore`'s non-server-root path.
+- No localStorage migration — existing oversized entries shrink at the next write.
+
+### `useDMStore.ts`
+
+- Cap `mumbleMessages.get(contactId)` at 200 messages in `receiveMumbleDM` and the Mumble path of `sendMessage` (slice-from-end).
+- Fix `pendingMessages` accumulation on send failure: in `.catch` of `sendMatrixDM`, remove the optimistic message from `pendingMessages` (drop on failure; retry UI is out of scope).
+- `DMStoreOptions` prop changes:
+  - **Drop** `matrixDmMessages: Map<string, ChatMessage[]>` (no longer maintained per-contact).
+  - **Add** `matrixDmLastMessages: Map<string, MessagePreview>` — used in the `contacts` useMemo to derive `lastMessage` and `lastMessageTime` for every DM contact in the sidebar (one preview per contact, bounded by contact count).
+  - **Add** `activeDmMessages: ChatMessage[]` — used in the `messages` useMemo for the currently selected contact only.
+  - `App.tsx` wires both new props from the corresponding `useMatrixClient` exports.
+
+## Data flow
+
+**Cold start:** `App` mounts → `MatrixClient.startClient({ initialSyncLimit: 5 })` → SDK populates internal timelines from `/sync` → `ClientEvent.Sync == PREPARED` → bootstrap `lastMessages` and `dmLastMessages` by iterating `client.getRooms()` → unread-tracker reads server unread counts → sidebar renders.
+
+**User opens channel X:** `App.tsx` calls `setActiveChannel(X)` → useEffect on `activeChannelId` increments `activeRoomVersionRef`, captures the version, reads `client.getRoom(roomMap[X]).getLiveTimeline().getEvents()`, filters and transforms (~5 items, sub-ms), and sets `activeMessages` only if the captured version still matches.
+
+**New message arrives in any room:** `RoomEvent.Timeline` fires → `onTimeline` always updates `lastMessages.set(roomId, preview)` → if room is active, also updates `activeMessages` via `insertMessage`. `useUnreadTracker` updates its badge independently via its own listener.
+
+**User scrolls back:** `ChatPanel` detects top-reached, calls `fetchHistory(activeChannelId)` → `scrollback(room, 50)` → backfill events fire `RoomEvent.Timeline` → `onTimeline` appends them to `activeMessages` because the room is active. No special-case code path.
+
+**User switches X → Y:** version ref bumps, invalidating any in-flight load for X. `activeMessages` reset, then rebuilt for Y from SDK cache. X's events remain in SDK cache, so re-visiting X is also a synchronous read with no network call.
+
+## Edge cases
+
+1. **Channel switch race.** Rapid X→Y→X within milliseconds. Mitigated by `activeRoomVersionRef`. Each `loadActiveMessages` captures the current version before its (synchronous) work and only commits if it still matches. Synchronous transformation of ~5 events makes the race window microscopic, but the guard is essentially free.
+
+2. **Reply-to events outside the active window.** Today, replies whose target is not in the messages array fall back to rendering with only `replyToEventId` (no body). Same fallback applies in the new model. Optional future improvement: use `room.findEventById()` to look up the body from the SDK cache; not in scope for this design.
+
+3. **Optimistic image blob URLs.** Codex finding #10 — failed Matrix uploads and the non-Matrix path leak `blob:` URLs. Out of scope here, but called out: dropping a message from `activeMessages` on channel switch does not free a blob whose owner is `optimisticImages` state. Separate one-line fix in `App.tsx` upload handlers.
+
+4. **DM first-time flow.** Pending contact has no room → `setActiveDmContact(userId)` sets `activeDmMessages = []` and renders empty. When the room appears via `registerDMRoom`, the version ref bumps and the load runs against the now-existing room. No extra code required.
+
+5. **Scrollback for inactive room.** Cannot occur via UI (only the active channel exposes scrollback), but if it did, `onTimeline` would only update `lastMessages` for the inactive room — the desired behavior.
+
+6. **Sidebar badges.** `useUnreadTracker` is decoupled from the messages map; channel switching does not affect badge rendering.
+
+## Testing
+
+**Unit (Vitest, existing pattern in `src/Brmble.Web/src/hooks/*.test.ts`):**
+
+- `useMatrixClient.test.ts`:
+  - `setActiveChannel` rebuilds `activeMessages` from a mocked SDK timeline.
+  - `onTimeline` updates `lastMessages` for any room; updates `activeMessages` only for the active room.
+  - Rapid switch X→Y→X commits only the latest load (version guard).
+- `useChatStore.test.ts`: non-server-root cap respected on `addMessage` and `addMessageToStore`.
+- `useDMStore.test.ts`: `mumbleMessages` cap respected; pending Matrix DM removed on send failure.
+
+**Integration / manual:**
+
+- Cold-start measurement: time-to-first-paint and JS heap snapshot before/after, on a test server with 20 channels × 50 messages.
+- 30-minute idle test (the original repro from commit `94cc38c`): private bytes + V8 heap before/after. Expectation: flat.
+- Switch-storm: 100× rapid channel switches, no errors or hangs.
+
+## Migration
+
+- No localStorage schema migration required. Read markers untouched. Existing chat history entries shrink to the new cap on the next write.
+- The `initialSyncLimit` change is a single-line config edit in `useMatrixClient`.
+- The `useDMStore` prop signature changes: `matrixDmMessages` is removed and `activeDmMessages` is read directly from `useMatrixClient`. Callers (`App.tsx`) must be updated in the same change.

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1970,6 +1970,14 @@ const handleConnect = (serverData: SavedServer) => {
     ? matrixClient.activeMessages
     : undefined;
 
+  const channelChatMessages = useMemo(
+    () => [
+      ...(isMatrixActive ? (matrixMessages ?? []) : messages),
+      ...optimisticImages.filter(m => m.channelId === currentChannelId),
+    ],
+    [isMatrixActive, matrixMessages, messages, optimisticImages, currentChannelId],
+  );
+
   const { Prompt, PromptWithInput } = usePrompt();
 
   const [screenShareSettings, setScreenShareSettings] = useState<ScreenShareSettings>(DEFAULT_SCREEN_SHARE);
@@ -2469,7 +2477,7 @@ const handleConnect = (serverData: SavedServer) => {
                    <ChatPanel
                     channelId={currentChannelId || undefined}
                     channelName={currentChannelId === 'server-root' ? (serverLabel || 'Server') : currentChannelName}
-                    messages={[...(isMatrixActive ? (matrixMessages ?? []) : messages), ...optimisticImages.filter(m => m.channelId === currentChannelId)]}
+                    messages={channelChatMessages}
                     currentUsername={username}
                     onSendMessage={handleSendMessage}
                     onDismissMessage={handleDismissMessage}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react';
 import bridge from './bridge';
 import type { ConnectionStatus, ChatMessage, ServiceStatus } from './types';
 import { encodeForMumble } from './utils/imageUpload';
@@ -547,11 +547,11 @@ function App() {
     },
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     matrixClient.setActiveChannel(activeChannelId ?? null);
   }, [activeChannelId, matrixClient.setActiveChannel]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     matrixClient.setActiveDmContact(dmStore.selectedContact?.id ?? null);
   }, [dmStore.selectedContact?.id, matrixClient.setActiveDmContact]);
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -528,8 +528,13 @@ function App() {
   const { messages, addMessage } = useChatStore(channelKey);
   const [optimisticImages, setOptimisticImages] = useState<ChatMessage[]>([]);
 
+  const activeChannelId = currentChannelId && currentChannelId !== 'server-root'
+    ? currentChannelId
+    : undefined;
+
   const dmStore = useDMStore({
-    matrixDmMessages: matrixClient.dmMessages,
+    matrixDmLastMessages: matrixClient.dmLastMessages,
+    activeDmMessages: matrixClient.activeDmMessages,
     matrixDmRoomMap: matrixClient.dmRoomMap,
     matrixDmUserDisplayNames: matrixClient.dmUserDisplayNames,
     matrixDmUserAvatarUrls: matrixClient.dmUserAvatarUrls,
@@ -541,6 +546,14 @@ function App() {
       bridge.send('voice.sendPrivateMessage', { message: linkifyForMumble(text), targetSession });
     },
   });
+
+  useEffect(() => {
+    matrixClient.setActiveChannel(activeChannelId ?? null);
+  }, [activeChannelId, matrixClient.setActiveChannel]);
+
+  useEffect(() => {
+    matrixClient.setActiveDmContact(dmStore.selectedContact?.id ?? null);
+  }, [dmStore.selectedContact?.id, matrixClient.setActiveDmContact]);
 
   // Determine active Matrix room ID (depends on dmStore.selectedContact)
   const activeMatrixRoomId = useMemo(() => {
@@ -1952,12 +1965,9 @@ const handleConnect = (serverData: SavedServer) => {
     }
   }, [notifQueue]);
 
-  const activeChannelId = currentChannelId && currentChannelId !== 'server-root'
-    ? currentChannelId
-    : undefined;
   const isMatrixActive = !!activeChannelId && matrixCredentials?.roomMap[activeChannelId] !== undefined;
   const matrixMessages = activeChannelId
-    ? matrixClient.messages.get(activeChannelId)
+    ? matrixClient.activeMessages
     : undefined;
 
   const { Prompt, PromptWithInput } = usePrompt();

--- a/src/Brmble.Web/src/hooks/useChatStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.test.ts
@@ -55,7 +55,7 @@ describe('useChatStore hard cap (server-root)', () => {
     expect(result.current.messages[199].content).toBe('msg-209');
   });
 
-  it('does NOT cap non-server-root channels', () => {
+  it('caps non-server-root channels at 200 messages via addMessage', () => {
     const { result } = renderHook(() => useChatStore('channel-5'));
 
     act(() => {
@@ -64,7 +64,29 @@ describe('useChatStore hard cap (server-root)', () => {
       }
     });
 
-    expect(result.current.messages).toHaveLength(210);
+    expect(result.current.messages).toHaveLength(200);
+    expect(result.current.messages[0].content).toBe('msg-10');
+    expect(result.current.messages[199].content).toBe('msg-209');
+  });
+
+  it('caps non-server-root channels at 200 messages via addMessageToStore', () => {
+    const existing = Array.from({ length: 195 }, (_, i) => ({
+      id: `id-${i}`,
+      channelId: 'channel-5',
+      sender: 'User',
+      content: `old-${i}`,
+      timestamp: new Date().toISOString(),
+    }));
+    localStorage.setItem('brmble_chat_channel-5', JSON.stringify(existing));
+
+    for (let i = 0; i < 10; i++) {
+      addMessageToStore('channel-5', 'User', `new-${i}`);
+    }
+
+    const stored = JSON.parse(localStorage.getItem('brmble_chat_channel-5')!);
+    expect(stored).toHaveLength(200);
+    expect(stored[0].content).toBe('old-5');
+    expect(stored[199].content).toBe('new-9');
   });
 
   it('trims oldest messages when exceeding 200 via addMessageToStore', () => {

--- a/src/Brmble.Web/src/hooks/useChatStore.ts
+++ b/src/Brmble.Web/src/hooks/useChatStore.ts
@@ -4,6 +4,7 @@ import type { ChatMessage, MediaAttachment } from '../types';
 const STORAGE_KEY_PREFIX = 'brmble_chat_';
 const SERVER_ROOT_KEY = 'server-root';
 const SERVER_ROOT_MAX_MESSAGES = 200;
+const NON_SERVER_ROOT_MAX_MESSAGES = 200;
 const DEBOUNCE_MS = 500;
 
 const EPHEMERAL_TYPES = new Set(['connecting', 'welcome', 'userJoined', 'userLeft']);
@@ -201,8 +202,9 @@ export function useChatStore(channelId: string) {
     };
     setMessages(prev => {
       let updated = [...prev, newMessage];
-      if (isServerRoot && updated.length > SERVER_ROOT_MAX_MESSAGES) {
-        updated = updated.slice(updated.length - SERVER_ROOT_MAX_MESSAGES);
+      const cap = isServerRoot ? SERVER_ROOT_MAX_MESSAGES : NON_SERVER_ROOT_MAX_MESSAGES;
+      if (updated.length > cap) {
+        updated = updated.slice(updated.length - cap);
       }
       saveMessages(updated);
       return updated;
@@ -266,6 +268,9 @@ export function addMessageToStore(
     }
   }
   messages.push(newMessage);
+  if (messages.length > NON_SERVER_ROOT_MAX_MESSAGES) {
+    messages = messages.slice(messages.length - NON_SERVER_ROOT_MAX_MESSAGES);
+  }
   localStorage.setItem(fullKey, JSON.stringify(messages));
 }
 

--- a/src/Brmble.Web/src/hooks/useDMStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.test.ts
@@ -12,7 +12,7 @@ function makeOptions(overrides: Partial<DMStoreOptions> = {}): DMStoreOptions {
     sendMatrixDM: vi.fn().mockResolvedValue(undefined),
     fetchDMHistory: vi.fn().mockResolvedValue(undefined),
     sendMumbleDM: vi.fn(),
-    users: [{ id: 1, name: 'me', session: 1 }] as DMStoreOptions['users'],
+    users: [{ name: 'me', session: 1 }] as DMStoreOptions['users'],
     username: 'me',
     ...overrides,
   };

--- a/src/Brmble.Web/src/hooks/useDMStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDMStore } from './useDMStore';
+import type { DMStoreOptions } from './useDMStore';
+
+function makeOptions(overrides: Partial<DMStoreOptions> = {}): DMStoreOptions {
+  return {
+    matrixDmMessages: new Map(),
+    matrixDmRoomMap: new Map(),
+    matrixDmUserDisplayNames: new Map(),
+    matrixDmUserAvatarUrls: new Map(),
+    sendMatrixDM: vi.fn().mockResolvedValue(undefined),
+    fetchDMHistory: vi.fn().mockResolvedValue(undefined),
+    sendMumbleDM: vi.fn(),
+    users: [{ id: 1, name: 'me', session: 1 }] as DMStoreOptions['users'],
+    username: 'me',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useDMStore mumbleMessages cap', () => {
+  it('caps mumbleMessages per contact at 200 on receiveMumbleDM', () => {
+    const { result } = renderHook(() => useDMStore(makeOptions()));
+
+    act(() => {
+      for (let i = 0; i < 210; i++) {
+        result.current.receiveMumbleDM('cert-1', 1, 'Alice', `msg-${i}`);
+      }
+    });
+
+    // Select contact so messages are exposed via .messages
+    act(() => result.current.selectContact('cert-1'));
+
+    expect(result.current.messages).toHaveLength(200);
+    expect(result.current.messages[0].content).toBe('msg-10');
+    expect(result.current.messages[199].content).toBe('msg-209');
+  });
+
+  it('caps mumbleMessages on outgoing Mumble sendMessage', () => {
+    const { result } = renderHook(() => useDMStore(makeOptions()));
+
+    act(() => {
+      result.current.startMumbleDM('cert-1', 1, 'Alice');
+    });
+
+    act(() => {
+      for (let i = 0; i < 210; i++) {
+        result.current.sendMessage(`out-${i}`);
+      }
+    });
+
+    expect(result.current.messages).toHaveLength(200);
+    expect(result.current.messages[0].content).toBe('out-10');
+  });
+});
+
+describe('useDMStore pendingMessages on Matrix send failure', () => {
+  it('removes the optimistic pending message when sendMatrixDM rejects', async () => {
+    const sendMatrixDM = vi.fn().mockRejectedValue(new Error('network down'));
+    const matrixDmRoomMap = new Map([['@bob:example.com', '!bob:example.com']]);
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({ sendMatrixDM, matrixDmRoomMap }))
+    );
+
+    act(() => result.current.selectContact('@bob:example.com'));
+
+    await act(async () => {
+      result.current.sendMessage('hello');
+      // Allow the rejected promise to settle
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // No pending optimistic message should remain
+    const pending = result.current.messages.filter(m => m.pending);
+    expect(pending).toHaveLength(0);
+  });
+});

--- a/src/Brmble.Web/src/hooks/useDMStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.test.ts
@@ -5,7 +5,8 @@ import type { DMStoreOptions } from './useDMStore';
 
 function makeOptions(overrides: Partial<DMStoreOptions> = {}): DMStoreOptions {
   return {
-    matrixDmMessages: new Map(),
+    matrixDmLastMessages: new Map(),
+    activeDmMessages: [],
     matrixDmRoomMap: new Map(),
     matrixDmUserDisplayNames: new Map(),
     matrixDmUserAvatarUrls: new Map(),

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import type { ChatMessage, User } from '../types';
+import type { MessagePreview } from './useMatrixClient';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -20,7 +21,7 @@ export interface DMContact {
 }
 
 export interface DMStoreOptions {
-  matrixDmLastMessages: Map<string, { content: string; ts: number; sender: string }> | undefined;
+  matrixDmLastMessages: Map<string, MessagePreview> | undefined;
   activeDmMessages: ChatMessage[] | undefined;
   matrixDmRoomMap: Map<string, string> | undefined;
   matrixDmUserDisplayNames: Map<string, string> | undefined;
@@ -281,13 +282,13 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     });
 
     if (sendMatrixDM) {
-      sendMatrixDM(selectedContactId, content)
+      const contactId = selectedContactId;
+      sendMatrixDM(contactId, content)
         .then(() => {
-          // Remove optimistic message -- the real one arrives via sync
           setPendingMessages(prev => {
             const next = new Map(prev);
-            const existing = next.get(selectedContactId!) ?? [];
-            next.set(selectedContactId!, existing.filter(m => m.id !== optimisticMsg.id));
+            const existing = next.get(contactId!) ?? [];
+            next.set(contactId!, existing.filter(m => m.id !== optimisticMsg.id));
             return next;
           });
         })
@@ -295,8 +296,8 @@ export function useDMStore(options: DMStoreOptions): DMStore {
           console.error('Matrix DM send failed:', err);
           setPendingMessages(prev => {
             const next = new Map(prev);
-            const existing = next.get(selectedContactId!) ?? [];
-            next.set(selectedContactId!, existing.filter(m => m.id !== optimisticMsg.id));
+            const existing = next.get(contactId!) ?? [];
+            next.set(contactId!, existing.filter(m => m.id !== optimisticMsg.id));
             return next;
           });
         });

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -51,6 +51,12 @@ export interface DMStore {
 }
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MUMBLE_MESSAGES_MAX_PER_CONTACT = 200;
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
@@ -246,7 +252,11 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       setMumbleMessages(prev => {
         const next = new Map(prev);
         const existing = next.get(selectedContactId!) ?? [];
-        next.set(selectedContactId!, [...existing, msg]);
+        let updated = [...existing, msg];
+        if (updated.length > MUMBLE_MESSAGES_MAX_PER_CONTACT) {
+          updated = updated.slice(updated.length - MUMBLE_MESSAGES_MAX_PER_CONTACT);
+        }
+        next.set(selectedContactId!, updated);
         return next;
       });
       sendMumbleDM?.(contact.mumbleSessionId, content);
@@ -280,7 +290,15 @@ export function useDMStore(options: DMStoreOptions): DMStore {
             return next;
           });
         })
-        .catch(console.error);
+        .catch(err => {
+          console.error('Matrix DM send failed:', err);
+          setPendingMessages(prev => {
+            const next = new Map(prev);
+            const existing = next.get(selectedContactId!) ?? [];
+            next.set(selectedContactId!, existing.filter(m => m.id !== optimisticMsg.id));
+            return next;
+          });
+        });
     }
   }, [selectedContactId, username, sendMatrixDM, mumbleContacts, sendMumbleDM]);
 
@@ -333,7 +351,11 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     setMumbleMessages(prev => {
       const next = new Map(prev);
       const existing = next.get(certHash) ?? [];
-      next.set(certHash, [...existing, msg]);
+      let updated = [...existing, msg];
+      if (updated.length > MUMBLE_MESSAGES_MAX_PER_CONTACT) {
+        updated = updated.slice(updated.length - MUMBLE_MESSAGES_MAX_PER_CONTACT);
+      }
+      next.set(certHash, updated);
       return next;
     });
     // Increment unread if not currently viewing this contact

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -20,7 +20,8 @@ export interface DMContact {
 }
 
 export interface DMStoreOptions {
-  matrixDmMessages: Map<string, ChatMessage[]> | undefined;
+  matrixDmLastMessages: Map<string, { content: string; ts: number; sender: string }> | undefined;
+  activeDmMessages: ChatMessage[] | undefined;
   matrixDmRoomMap: Map<string, string> | undefined;
   matrixDmUserDisplayNames: Map<string, string> | undefined;
   matrixDmUserAvatarUrls: Map<string, string> | undefined;
@@ -62,7 +63,8 @@ const MUMBLE_MESSAGES_MAX_PER_CONTACT = 200;
 
 export function useDMStore(options: DMStoreOptions): DMStore {
   const {
-    matrixDmMessages,
+    matrixDmLastMessages,
+    activeDmMessages,
     matrixDmRoomMap,
     matrixDmUserDisplayNames,
     matrixDmUserAvatarUrls,
@@ -120,8 +122,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       for (const [matrixUserId] of matrixDmRoomMap) {
         seen.add(matrixUserId);
         const user = users.find(u => u.matrixUserId === matrixUserId);
-        const msgs = matrixDmMessages?.get(matrixUserId);
-        const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
+        const lastPreview = matrixDmLastMessages?.get(matrixUserId);
 
         // Resolve display name: Matrix room membership > Mumble user list > parse Matrix ID
         const displayName = matrixDmUserDisplayNames?.get(matrixUserId)
@@ -132,8 +133,8 @@ export function useDMStore(options: DMStoreOptions): DMStore {
           id: matrixUserId,
           displayName,
           avatarUrl: user?.avatarUrl ?? matrixDmUserAvatarUrls?.get(matrixUserId),
-          lastMessage: lastMsg?.content,
-          lastMessageTime: lastMsg?.timestamp.getTime(),
+          lastMessage: lastPreview?.content,
+          lastMessageTime: lastPreview?.ts,
           unreadCount: 0, // Matrix unread is tracked globally via matrixDmUnreadCount
         });
       }
@@ -159,7 +160,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
     result.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
     return result;
-  }, [matrixDmRoomMap, matrixDmMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, users, pendingMatrixContacts, mumbleContacts, mumbleMessages]);
+  }, [matrixDmRoomMap, matrixDmLastMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, users, pendingMatrixContacts, mumbleContacts, mumbleMessages]);
 
   // ---- Selected contact ----------------------------------------------------
 
@@ -176,10 +177,10 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     const mumbleMsgs = mumbleMessages.get(selectedContactId);
     if (mumbleMsgs) return mumbleMsgs;
     // Otherwise Matrix messages
-    const matrixMsgs = matrixDmMessages?.get(selectedContactId) ?? [];
+    const matrixMsgs = activeDmMessages ?? [];
     const pending = pendingMessages.get(selectedContactId) ?? [];
     return [...matrixMsgs, ...pending];
-  }, [selectedContactId, matrixDmMessages, pendingMessages, mumbleMessages]);
+  }, [selectedContactId, activeDmMessages, pendingMessages, mumbleMessages]);
 
   // ---- Actions -------------------------------------------------------------
 

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -22,6 +22,7 @@ const mockClient = {
   off: vi.fn(),
   once: vi.fn(),
   getRoom: vi.fn(),
+  getRooms: vi.fn().mockReturnValue([]),
   getAccountData: vi.fn(),
   setAccountData: vi.fn().mockResolvedValue(undefined),
   createRoom: vi.fn().mockResolvedValue({ room_id: '!new:example.com' }),
@@ -367,5 +368,46 @@ describe('useMatrixClient', () => {
 
     expect(result.current.activeMessages).toHaveLength(1);
     expect(result.current.activeMessages[0].content).toBe('A-msg');
+  });
+
+  it('PREPARED reloads activeMessages when a channel was activated before sync completed', () => {
+    // Initially the SDK has no room — setActiveChannel will bail out.
+    mockClient.getRoom.mockReturnValue(null);
+
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    // Activate before PREPARED — load returns [] because the room is not yet known.
+    act(() => result.current.setActiveChannel('42'));
+    expect(result.current.activeMessages).toEqual([]);
+
+    // Now simulate the SDK having the room and the timeline populated.
+    const aliceMember = { rawDisplayName: 'Alice', name: 'Alice' };
+    const fakeEvents = [
+      {
+        getType: () => 'm.room.message',
+        getId: () => '$e-prep-1',
+        getSender: () => '@alice:example.com',
+        getContent: () => ({ body: 'sync-delivered' }),
+        getTs: () => 5000,
+      },
+    ];
+    const mockRoom = {
+      roomId: '!room:example.com',
+      getMember: () => aliceMember,
+      getLiveTimeline: () => ({ getEvents: () => fakeEvents }),
+    };
+    mockClient.getRoom.mockReturnValue(mockRoom);
+    mockClient.getRooms.mockReturnValue([mockRoom]);
+
+    // Fire the registered onSync handler with PREPARED.
+    const onSync = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
+      | ((state: string) => void)
+      | undefined;
+    expect(onSync).toBeDefined();
+
+    act(() => onSync!('PREPARED'));
+
+    expect(result.current.activeMessages).toHaveLength(1);
+    expect(result.current.activeMessages[0].content).toBe('sync-delivered');
   });
 });

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -59,7 +59,7 @@ beforeEach(() => {
 describe('useMatrixClient', () => {
   it('calls startClient when credentials are provided', () => {
     renderHook(() => useMatrixClient(creds), { wrapper });
-    expect(mockClient.startClient).toHaveBeenCalledWith({ initialSyncLimit: 20 });
+    expect(mockClient.startClient).toHaveBeenCalledWith({ initialSyncLimit: 5 });
   });
 
   it('does not call startClient when credentials are null', () => {
@@ -73,14 +73,17 @@ describe('useMatrixClient', () => {
     expect(mockClient.stopClient).toHaveBeenCalled();
   });
 
-  it('calls stopClient and clears messages when credentials become null', () => {
+  it('calls stopClient and clears state when credentials become null', () => {
     const { result, rerender } = renderHook(
       ({ c }: { c: MatrixCredentials | null }) => useMatrixClient(c),
       { initialProps: { c: creds as MatrixCredentials | null }, wrapper }
     );
     act(() => rerender({ c: null }));
     expect(mockClient.stopClient).toHaveBeenCalled();
-    expect(result.current.messages.size).toBe(0);
+    expect(result.current.lastMessages.size).toBe(0);
+    expect(result.current.dmLastMessages.size).toBe(0);
+    expect(result.current.activeMessages).toEqual([]);
+    expect(result.current.activeDmMessages).toEqual([]);
   });
 
   it('registers RoomEvent.Timeline listener', () => {
@@ -112,7 +115,11 @@ describe('useMatrixClient', () => {
   });
 
   it('timeline handler uses member display name as sender', () => {
+    mockClient.getRoom.mockReturnValue(null);
     const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    // Activate channel '42' so timeline events populate activeMessages
+    act(() => result.current.setActiveChannel('42'));
 
     // Extract the registered timeline handler
     const onCall = mockClient.on.mock.calls.find(
@@ -137,9 +144,8 @@ describe('useMatrixClient', () => {
     };
 
     act(() => handler(mockEvent, mockRoom));
-    const msgs = result.current.messages.get('42');
-    expect(msgs).toHaveLength(1);
-    expect(msgs![0].sender).toBe('Alice');
+    expect(result.current.activeMessages).toHaveLength(1);
+    expect(result.current.activeMessages[0].sender).toBe('Alice');
   });
 
   it('exposes the Matrix client instance', () => {
@@ -153,7 +159,11 @@ describe('useMatrixClient', () => {
   });
 
   it('timeline handler falls back to senderId when member has no display name', () => {
+    mockClient.getRoom.mockReturnValue(null);
     const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    // Activate channel '42' so timeline events populate activeMessages
+    act(() => result.current.setActiveChannel('42'));
 
     const onCall = mockClient.on.mock.calls.find(
       (c: unknown[]) => c[0] === 'Room.timeline'
@@ -173,14 +183,17 @@ describe('useMatrixClient', () => {
     };
 
     act(() => handler(mockEvent, mockRoom));
-    const msgs = result.current.messages.get('42');
-    expect(msgs).toBeDefined();
-    const last = msgs![msgs!.length - 1];
+    expect(result.current.activeMessages.length).toBeGreaterThanOrEqual(1);
+    const last = result.current.activeMessages[result.current.activeMessages.length - 1];
     expect(last.sender).toBe('@99:example.com');
   });
 
   it('timeline handler extracts sender from bridge prefix when sent by bridge bot', () => {
+    mockClient.getRoom.mockReturnValue(null);
     const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    // Activate channel '42' so timeline events populate activeMessages
+    act(() => result.current.setActiveChannel('42'));
 
     const onCall = mockClient.on.mock.calls.find(
       (c: unknown[]) => c[0] === 'Room.timeline'
@@ -203,15 +216,18 @@ describe('useMatrixClient', () => {
     };
 
     act(() => handler(mockEvent, mockRoom));
-    const msgs = result.current.messages.get('42');
-    expect(msgs).toBeDefined();
-    const last = msgs![msgs!.length - 1];
+    expect(result.current.activeMessages.length).toBeGreaterThanOrEqual(1);
+    const last = result.current.activeMessages[result.current.activeMessages.length - 1];
     expect(last.sender).toBe('Bob');
     expect(last.content).toBe('hello from bridge');
   });
 
   it('timeline handler does NOT parse bridge prefix for non-bot senders', () => {
+    mockClient.getRoom.mockReturnValue(null);
     const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    // Activate channel '42' so timeline events populate activeMessages
+    act(() => result.current.setActiveChannel('42'));
 
     const onCall = mockClient.on.mock.calls.find(
       (c: unknown[]) => c[0] === 'Room.timeline'
@@ -234,9 +250,8 @@ describe('useMatrixClient', () => {
     };
 
     act(() => handler(mockEvent, mockRoom));
-    const msgs = result.current.messages.get('42');
-    expect(msgs).toBeDefined();
-    const last = msgs![msgs!.length - 1];
+    expect(result.current.activeMessages.length).toBeGreaterThanOrEqual(1);
+    const last = result.current.activeMessages[result.current.activeMessages.length - 1];
     // Sender should be the display name, not parsed from the prefix
     expect(last.sender).toBe('Alice');
     // Content should be the full body, not stripped

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -277,4 +277,80 @@ describe('useMatrixClient', () => {
       sender: 'Alice',
     });
   });
+
+  it('setActiveChannel rebuilds activeMessages from SDK timeline', () => {
+    const aliceMember = { rawDisplayName: 'Alice', name: 'Alice' };
+    const fakeEvents = [
+      {
+        getType: () => 'm.room.message',
+        getId: () => '$e1',
+        getSender: () => '@alice:example.com',
+        getContent: () => ({ body: 'first' }),
+        getTs: () => 1000,
+      },
+      {
+        getType: () => 'm.room.message',
+        getId: () => '$e2',
+        getSender: () => '@alice:example.com',
+        getContent: () => ({ body: 'second' }),
+        getTs: () => 2000,
+      },
+    ];
+    const mockRoom = {
+      roomId: '!room:example.com',
+      getMember: () => aliceMember,
+      getLiveTimeline: () => ({ getEvents: () => fakeEvents }),
+    };
+    mockClient.getRoom.mockReturnValue(mockRoom);
+
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    act(() => result.current.setActiveChannel('42'));
+
+    expect(result.current.activeMessages).toHaveLength(2);
+    expect(result.current.activeMessages[0].content).toBe('first');
+    expect(result.current.activeMessages[1].content).toBe('second');
+  });
+
+  it('setActiveChannel(null) clears activeMessages', () => {
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+    act(() => result.current.setActiveChannel(null));
+    expect(result.current.activeMessages).toEqual([]);
+  });
+
+  it('rapid setActiveChannel switches commit only the latest load', () => {
+    const roomA = {
+      roomId: '!a:example.com',
+      getMember: () => ({ rawDisplayName: 'A', name: 'A' }),
+      getLiveTimeline: () => ({ getEvents: () => [
+        { getType: () => 'm.room.message', getId: () => '$a1', getSender: () => '@a:example.com',
+          getContent: () => ({ body: 'A-msg' }), getTs: () => 1 },
+      ]}),
+    };
+    const roomB = {
+      roomId: '!b:example.com',
+      getMember: () => ({ rawDisplayName: 'B', name: 'B' }),
+      getLiveTimeline: () => ({ getEvents: () => [
+        { getType: () => 'm.room.message', getId: () => '$b1', getSender: () => '@b:example.com',
+          getContent: () => ({ body: 'B-msg' }), getTs: () => 1 },
+      ]}),
+    };
+    mockClient.getRoom.mockImplementation((id: string) =>
+      id === '!a:example.com' ? roomA : id === '!b:example.com' ? roomB : null);
+
+    const credsAB: MatrixCredentials = {
+      ...creds,
+      roomMap: { 'A': '!a:example.com', 'B': '!b:example.com' },
+    };
+    const { result } = renderHook(() => useMatrixClient(credsAB), { wrapper });
+
+    act(() => {
+      result.current.setActiveChannel('A');
+      result.current.setActiveChannel('B');
+      result.current.setActiveChannel('A');
+    });
+
+    expect(result.current.activeMessages).toHaveLength(1);
+    expect(result.current.activeMessages[0].content).toBe('A-msg');
+  });
 });

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -242,4 +242,39 @@ describe('useMatrixClient', () => {
     // Content should be the full body, not stripped
     expect(last.content).toBe('[Alice]: this is not bridged');
   });
+
+  it('lastMessages and dmLastMessages start empty', () => {
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+    expect(result.current.lastMessages.size).toBe(0);
+    expect(result.current.dmLastMessages.size).toBe(0);
+  });
+
+  it('updates lastMessages when a channel timeline event arrives', () => {
+    const mockRoom = {
+      roomId: '!room:example.com',
+      getMember: vi.fn(() => ({ rawDisplayName: 'Alice', name: 'Alice' })),
+    };
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    const onTimeline = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'Room.timeline')?.[1] as
+      | ((ev: unknown, r: unknown) => void)
+      | undefined;
+    expect(onTimeline).toBeDefined();
+
+    const fakeEvent = {
+      getType: () => 'm.room.message',
+      getId: () => '$evt-1',
+      getSender: () => '@alice:example.com',
+      getContent: () => ({ body: 'hi there' }),
+      getTs: () => 1_700_000_000_000,
+    };
+
+    act(() => onTimeline!(fakeEvent, mockRoom));
+
+    expect(result.current.lastMessages.get('42')).toEqual({
+      content: 'hi there',
+      ts: 1_700_000_000_000,
+      sender: 'Alice',
+    });
+  });
 });

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -410,4 +410,205 @@ describe('useMatrixClient', () => {
     expect(result.current.activeMessages).toHaveLength(1);
     expect(result.current.activeMessages[0].content).toBe('sync-delivered');
   });
+
+  // ── DM activeDmMessages + setActiveDmContact ──
+
+  it('setActiveDmContact rebuilds activeDmMessages from SDK timeline', () => {
+    mockClient.getRoom.mockReturnValue(null); // reset from PREPARED bootstrap
+
+    const credsWithDm: MatrixCredentials = {
+      ...creds,
+      dmRoomMap: { '@bob:example.com': '!dm-bob:example.com' },
+    };
+    const { result } = renderHook(() => useMatrixClient(credsWithDm), { wrapper });
+
+    const onSync = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
+      | ((state: string) => void)
+      | undefined;
+    act(() => onSync!('PREPARED'));
+
+    const bobMember = { rawDisplayName: 'Bob', name: 'Bob', getAvatarUrl: () => null };
+    const dmFakeEvents = [
+      { getType: () => 'm.room.message', getId: () => '$dm1', getSender: () => '@bob:example.com',
+        getContent: () => ({ body: 'hey' }), getTs: () => 1000 },
+      { getType: () => 'm.room.message', getId: () => '$dm2', getSender: () => '@bob:example.com',
+        getContent: () => ({ body: 'you there?' }), getTs: () => 2000 },
+    ];
+    const mockDmRoom = {
+      roomId: '!dm-bob:example.com',
+      getMember: () => bobMember,
+      getLiveTimeline: () => ({ getEvents: () => dmFakeEvents }),
+    };
+    mockClient.getRoom.mockReturnValue(mockDmRoom);
+
+    act(() => result.current.setActiveDmContact('@bob:example.com'));
+
+    expect(result.current.activeDmMessages).toHaveLength(2);
+    expect(result.current.activeDmMessages[0].content).toBe('hey');
+    expect(result.current.activeDmMessages[1].content).toBe('you there?');
+  });
+
+  it('setActiveDmContact(null) clears activeDmMessages', () => {
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+    act(() => result.current.setActiveDmContact(null));
+    expect(result.current.activeDmMessages).toEqual([]);
+  });
+
+  it('rapid setActiveDmContact switches commit only the latest load', () => {
+    mockClient.getRoom.mockReturnValue(null); // reset from bootstrap
+
+    const credsWithDms: MatrixCredentials = {
+      ...creds,
+      dmRoomMap: {
+        '@bob:example.com': '!bob:example.com',
+        '@carol:example.com': '!carol:example.com',
+      },
+    };
+    const { result } = renderHook(() => useMatrixClient(credsWithDms), { wrapper });
+
+    const onSync = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
+      | ((state: string) => void)
+      | undefined;
+    act(() => onSync!('PREPARED'));
+
+    const roomBob = {
+      roomId: '!bob:example.com',
+      getMember: () => ({ rawDisplayName: 'Bob', name: 'Bob', getAvatarUrl: () => null }),
+      getLiveTimeline: () => ({ getEvents: () => [
+        { getType: () => 'm.room.message', getId: () => '$b1', getSender: () => '@bob:example.com',
+          getContent: () => ({ body: 'Bob-msg' }), getTs: () => 1 },
+      ]}),
+    };
+    const roomCarol = {
+      roomId: '!carol:example.com',
+      getMember: () => ({ rawDisplayName: 'Carol', name: 'Carol', getAvatarUrl: () => null }),
+      getLiveTimeline: () => ({ getEvents: () => [
+        { getType: () => 'm.room.message', getId: () => '$c1', getSender: () => '@carol:example.com',
+          getContent: () => ({ body: 'Carol-msg' }), getTs: () => 1 },
+      ]}),
+    };
+    mockClient.getRoom.mockImplementation((id: string) =>
+      id === '!bob:example.com' ? roomBob : id === '!carol:example.com' ? roomCarol : null);
+
+    act(() => {
+      result.current.setActiveDmContact('@bob:example.com');
+      result.current.setActiveDmContact('@carol:example.com');
+      result.current.setActiveDmContact('@bob:example.com');
+    });
+
+    expect(result.current.activeDmMessages).toHaveLength(1);
+    expect(result.current.activeDmMessages[0].content).toBe('Bob-msg');
+  });
+
+  it('PREPARED reloads activeDmMessages when a DM was activated before sync completed', () => {
+    mockClient.getRoom.mockReturnValue(null);
+
+    const credsWithDm: MatrixCredentials = {
+      ...creds,
+      dmRoomMap: { '@bob:example.com': '!dm-bob:example.com' },
+    };
+    const { result } = renderHook(() => useMatrixClient(credsWithDm), { wrapper });
+
+    act(() => result.current.setActiveDmContact('@bob:example.com'));
+    expect(result.current.activeDmMessages).toEqual([]);
+
+    const bobMember = { rawDisplayName: 'Bob', name: 'Bob', getAvatarUrl: () => null };
+    const dmFakeEvents = [
+      { getType: () => 'm.room.message', getId: () => '$dm-prep-1', getSender: () => '@bob:example.com',
+        getContent: () => ({ body: 'late arrival' }), getTs: () => 5000 },
+    ];
+    const mockDmRoom = {
+      roomId: '!dm-bob:example.com',
+      getMember: () => bobMember,
+      getLiveTimeline: () => ({ getEvents: () => dmFakeEvents }),
+    };
+    mockClient.getRoom.mockReturnValue(mockDmRoom);
+    mockClient.getRooms.mockReturnValue([mockDmRoom]);
+
+    const onSync = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
+      | ((state: string) => void)
+      | undefined;
+    expect(onSync).toBeDefined();
+    act(() => onSync!('PREPARED'));
+
+    expect(result.current.activeDmMessages).toHaveLength(1);
+    expect(result.current.activeDmMessages[0].content).toBe('late arrival');
+  });
+
+  // ── dmLastMessages sidebar previews ──
+
+  it('updates dmLastMessages when a DM timeline event arrives', () => {
+    mockClient.getRoom.mockReturnValue(null);
+
+    const credsWithDm: MatrixCredentials = {
+      ...creds,
+      dmRoomMap: { '@bob:example.com': '!dm-bob:example.com' },
+    };
+    const { result } = renderHook(() => useMatrixClient(credsWithDm), { wrapper });
+
+    const onSync = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
+      | ((state: string) => void)
+      | undefined;
+    act(() => onSync!('PREPARED'));
+
+    const dmMockRoom = {
+      roomId: '!dm-bob:example.com',
+      getMember: vi.fn(() => ({ rawDisplayName: 'Bob', name: 'Bob', getAvatarUrl: () => null })),
+    };
+    const onTimeline = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'Room.timeline')?.[1] as
+      | ((ev: unknown, r: unknown) => void)
+      | undefined;
+    expect(onTimeline).toBeDefined();
+
+    const fakeEvent = {
+      getType: () => 'm.room.message',
+      getId: () => '$dm-ev-1',
+      getSender: () => '@bob:example.com',
+      getContent: () => ({ body: 'dm preview text' }),
+      getTs: () => 1_700_000_000_000,
+    };
+
+    act(() => onTimeline!(fakeEvent, dmMockRoom));
+
+    expect(result.current.dmLastMessages.get('@bob:example.com')).toEqual({
+      content: 'dm preview text',
+      ts: 1_700_000_000_000,
+      sender: 'Bob',
+    });
+  });
+
+  it('dmLastMessages are bootstrapped on PREPARED from SDK timelines', () => {
+    mockClient.getRoom.mockReturnValue(null);
+
+    const dmRoom = {
+      roomId: '!dm-bob:example.com',
+      getMember: vi.fn(() => ({ rawDisplayName: 'Bob', name: 'Bob', getAvatarUrl: () => null })),
+      getLiveTimeline: () => ({ getEvents: () => [
+        { getType: () => 'm.room.message', getId: () => '$e1', getSender: () => '@bob:example.com',
+          getContent: () => ({ body: 'first' }), getTs: () => 1000 },
+        { getType: () => 'm.room.message', getId: () => '$e2', getSender: () => '@bob:example.com',
+          getContent: () => ({ body: 'last one' }), getTs: () => 2000 },
+      ]}),
+    };
+    mockClient.getRooms.mockReturnValue([dmRoom]);
+
+    const credsWithDm: MatrixCredentials = {
+      ...creds,
+      dmRoomMap: { '@bob:example.com': '!dm-bob:example.com' },
+    };
+    const { result } = renderHook(() => useMatrixClient(credsWithDm), { wrapper });
+
+    expect(result.current.dmLastMessages.size).toBe(0);
+
+    const onSync = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
+      | ((state: string) => void)
+      | undefined;
+    act(() => onSync!('PREPARED'));
+
+    expect(result.current.dmLastMessages.get('@bob:example.com')).toEqual({
+      content: 'last one',
+      ts: 2000,
+      sender: 'Bob',
+    });
+  });
 });

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -336,8 +336,9 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       }
     };
 
-    /** Register a newly-discovered DM room in local maps and backfill any messages
-     *  that onTimeline may have dropped before the mapping existed. */
+    /** Register a newly-discovered DM room in local maps. If this room is the
+     *  currently active DM contact, also rebuild activeDmMessages from its
+     *  timeline (version-guarded against rapid contact switches). */
     const registerDMRoom = (room: Room, otherUserId: string) => {
       if (roomIdToDMUserIdRef.current.has(room.roomId)) return;
 

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -99,6 +99,12 @@ export interface MatrixCredentials {
   dmRoomMap?: Record<string, string>; // matrixUserId → matrixRoomId (from server)
 }
 
+export interface MessagePreview {
+  content: string;
+  ts: number;
+  sender: string;
+}
+
 export function useMatrixClient(credentials: MatrixCredentials | null) {
   const clientRef = useRef<MatrixClient | null>(null);
   const [client, setClient] = useState<MatrixClient | null>(null);
@@ -109,6 +115,10 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
   const [dmRoomMap, setDmRoomMap] = useState<Map<string, string>>(new Map());
   // DM messages: matrixUserId -> ChatMessage[]
   const [dmMessages, setDmMessages] = useState<Map<string, ChatMessage[]>>(new Map());
+
+  // Last-message previews: one entry per channel/DM user (bounded)
+  const [lastMessages, setLastMessages] = useState<Map<string, MessagePreview>>(new Map());
+  const [dmLastMessages, setDmLastMessages] = useState<Map<string, MessagePreview>>(new Map());
 
   const dmRoomMapRef = useRef<Map<string, string>>(new Map());
   // Keep ref in sync
@@ -133,8 +143,10 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       clientRef.current = null;
       setClient(null);
       setMessages(new Map());
-      setDmRoomMap(new Map());
+      setLastMessages(new Map());
       setDmMessages(new Map());
+      setDmLastMessages(new Map());
+      setDmRoomMap(new Map());
       dmRoomMapRef.current = new Map();
       roomIdToDMUserIdRef.current = new Map();
       lastSyncStateRef.current = null;
@@ -164,6 +176,17 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
           if (updated === existing) return prev;
           return new Map(prev).set(channelId, updated);
         });
+        setLastMessages(prev => {
+          const existing = prev.get(channelId);
+          if (existing && existing.ts >= message.timestamp.getTime()) return prev;
+          const next = new Map(prev);
+          next.set(channelId, {
+            content: message.content,
+            ts: message.timestamp.getTime(),
+            sender: message.sender,
+          });
+          return next;
+        });
         return;
       }
 
@@ -184,6 +207,17 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
         const updated = insertMessage(existing, dmMessage);
         if (updated === existing) return prev;
         return new Map(prev).set(dmUserId, updated);
+      });
+      setDmLastMessages(prev => {
+        const existing = prev.get(dmUserId);
+        if (existing && existing.ts >= dmMessage.timestamp.getTime()) return prev;
+        const next = new Map(prev);
+        next.set(dmUserId, {
+          content: dmMessage.content,
+          ts: dmMessage.timestamp.getTime(),
+          sender: dmMessage.sender,
+        });
+        return next;
       });
     };
 
@@ -218,6 +252,36 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
             onTimeline(event, room);
           }
           bufferedDmEvents.length = 0;
+
+          // Bootstrap last-message previews from the SDK timelines now
+          // that initial sync is complete. This avoids waiting for new
+          // RoomEvent.Timeline events to populate the sidebar.
+          const bootChannelPreviews = new Map<string, MessagePreview>();
+          const bootDmPreviews = new Map<string, MessagePreview>();
+          for (const room of client.getRooms()) {
+            const channelId = roomIdToChannelId.get(room.roomId);
+            const dmUserId = roomIdToDMUserIdRef.current.get(room.roomId);
+            const target = channelId ?? dmUserId;
+            if (!target) continue;
+
+            const events = room.getLiveTimeline().getEvents();
+            for (let i = events.length - 1; i >= 0; i--) {
+              const ev = events[i];
+              if (ev.getType() !== EventType.RoomMessage) continue;
+              const msg = transformEventToChatMessage(ev, room, target, clientRef.current);
+              if (!msg) continue;
+              const preview: MessagePreview = {
+                content: msg.content,
+                ts: msg.timestamp.getTime(),
+                sender: msg.sender,
+              };
+              if (channelId) bootChannelPreviews.set(channelId, preview);
+              else if (dmUserId) bootDmPreviews.set(dmUserId, preview);
+              break;
+            }
+          }
+          if (bootChannelPreviews.size > 0) setLastMessages(bootChannelPreviews);
+          if (bootDmPreviews.size > 0) setDmLastMessages(bootDmPreviews);
         }
       } else if (state === 'ERROR') {
         derivedState = 'disconnected';
@@ -548,7 +612,8 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
     return urls;
   }, [client, dmRoomMap]);
 
-  return { messages, sendMessage, sendImageMessage, uploadContent, fetchHistory, dmMessages, dmRoomMap,
+  return { messages, lastMessages, sendMessage, sendImageMessage, uploadContent, fetchHistory,
+           dmMessages, dmLastMessages, dmRoomMap,
            dmUserDisplayNames, dmUserAvatarUrls, sendDMMessage, fetchDMHistory,
            fetchAvatarUrl, client };
 }

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -311,6 +311,35 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
           }
           if (bootChannelPreviews.size > 0) setLastMessages(bootChannelPreviews);
           if (bootDmPreviews.size > 0) setDmLastMessages(bootDmPreviews);
+
+          // If a channel/DM was activated before PREPARED finished, re-run
+          // the load now that the SDK has the room and its timeline.
+          // Bumping the version invalidates any earlier load that committed
+          // an empty array against this same channel/DM id.
+          if (activeChannelIdRef.current && credentials) {
+            const channelId = activeChannelIdRef.current;
+            const roomId = credentials.roomMap[channelId];
+            if (roomId) {
+              activeRoomVersionRef.current += 1;
+              const myVersion = activeRoomVersionRef.current;
+              const messages = loadMessagesFromTimeline(client, roomId, channelId);
+              if (activeRoomVersionRef.current === myVersion) {
+                setActiveMessages(messages);
+              }
+            }
+          }
+          if (activeDmContactIdRef.current) {
+            const dmContactId = activeDmContactIdRef.current;
+            const dmRoomId = dmRoomMapRef.current.get(dmContactId);
+            if (dmRoomId) {
+              activeDmVersionRef.current += 1;
+              const myVersion = activeDmVersionRef.current;
+              const messages = loadMessagesFromTimeline(client, dmRoomId, dmContactId);
+              if (activeDmVersionRef.current === myVersion) {
+                setActiveDmMessages(messages);
+              }
+            }
+          }
         }
       } else if (state === 'ERROR') {
         derivedState = 'disconnected';

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -130,13 +130,10 @@ export interface MessagePreview {
 export function useMatrixClient(credentials: MatrixCredentials | null) {
   const clientRef = useRef<MatrixClient | null>(null);
   const [client, setClient] = useState<MatrixClient | null>(null);
-  const [messages, setMessages] = useState<Map<string, ChatMessage[]>>(new Map());
   const { updateStatus } = useServiceStatus();
 
   // DM room tracking: matrixUserId -> roomId
   const [dmRoomMap, setDmRoomMap] = useState<Map<string, string>>(new Map());
-  // DM messages: matrixUserId -> ChatMessage[]
-  const [dmMessages, setDmMessages] = useState<Map<string, ChatMessage[]>>(new Map());
 
   // Last-message previews: one entry per channel/DM user (bounded)
   const [lastMessages, setLastMessages] = useState<Map<string, MessagePreview>>(new Map());
@@ -172,9 +169,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       clientRef.current?.stopClient();
       clientRef.current = null;
       setClient(null);
-      setMessages(new Map());
       setLastMessages(new Map());
-      setDmMessages(new Map());
       setDmLastMessages(new Map());
       setActiveMessages([]);
       setActiveDmMessages([]);
@@ -204,12 +199,6 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
         const message = transformEventToChatMessage(event, room, channelId, clientRef.current);
         if (!message) return;
 
-        setMessages(prev => {
-          const existing = prev.get(channelId) ?? [];
-          const updated = insertMessage(existing, message);
-          if (updated === existing) return prev;
-          return new Map(prev).set(channelId, updated);
-        });
         setLastMessages(prev => {
           const existing = prev.get(channelId);
           if (existing && existing.ts >= message.timestamp.getTime()) return prev;
@@ -242,12 +231,6 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       const dmMessage = transformEventToChatMessage(event, room, dmUserId, clientRef.current);
       if (!dmMessage) return;
 
-      setDmMessages(prev => {
-        const existing = prev.get(dmUserId) ?? [];
-        const updated = insertMessage(existing, dmMessage);
-        if (updated === existing) return prev;
-        return new Map(prev).set(dmUserId, updated);
-      });
       setDmLastMessages(prev => {
         const existing = prev.get(dmUserId);
         if (existing && existing.ts >= dmMessage.timestamp.getTime()) return prev;
@@ -269,7 +252,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
 
     client.on(RoomEvent.Timeline, onTimeline);
     updateStatus('chat', { state: 'connecting', error: undefined });
-    client.startClient({ initialSyncLimit: 20 });
+    client.startClient({ initialSyncLimit: 5 });
     clientRef.current = client;
     setClient(client);
 
@@ -363,23 +346,6 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       roomIdToDMUserIdRef.current = new Map(roomIdToDMUserIdRef.current).set(room.roomId, otherUserId);
 
       const timelineEvents = room.getLiveTimeline().getEvents();
-      const backfillMsgs: ChatMessage[] = [];
-      for (const ev of timelineEvents) {
-        const msg = transformEventToChatMessage(ev, room, otherUserId, clientRef.current);
-        if (msg) backfillMsgs.push(msg);
-      }
-
-      if (backfillMsgs.length > 0) {
-        setDmMessages(prev => {
-          const existing = prev.get(otherUserId) ?? [];
-          let merged = existing;
-          for (const msg of backfillMsgs) {
-            merged = insertMessage(merged, msg);
-          }
-          if (merged === existing) return prev;
-          return new Map(prev).set(otherUserId, merged);
-        });
-      }
 
       if (activeDmContactIdRef.current === otherUserId) {
         activeDmVersionRef.current += 1;
@@ -724,9 +690,9 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
     return urls;
   }, [client, dmRoomMap]);
 
-  return { messages, lastMessages, activeMessages, setActiveChannel,
+  return { lastMessages, activeMessages, setActiveChannel,
            sendMessage, sendImageMessage, uploadContent, fetchHistory,
-           dmMessages, dmLastMessages, activeDmMessages, setActiveDmContact, dmRoomMap,
+           dmLastMessages, activeDmMessages, setActiveDmContact, dmRoomMap,
            dmUserDisplayNames, dmUserAvatarUrls, sendDMMessage, fetchDMHistory,
            fetchAvatarUrl, client };
 }

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -91,6 +91,28 @@ function transformEventToChatMessage(
   };
 }
 
+/**
+ * Read all `m.room.message` events from a room's live timeline and transform
+ * them into ChatMessages. Pure helper for active-message loading.
+ *
+ * Returns `[]` when the room cannot be resolved (caller's responsibility to
+ * setState on the returned value).
+ */
+function loadMessagesFromTimeline(
+  client: MatrixClient,
+  roomId: string,
+  targetId: string,
+): ChatMessage[] {
+  const room = client.getRoom(roomId);
+  if (!room) return [];
+  const out: ChatMessage[] = [];
+  for (const ev of room.getLiveTimeline().getEvents()) {
+    const m = transformEventToChatMessage(ev, room, targetId, client);
+    if (m) out.push(m);
+  }
+  return out;
+}
+
 export interface MatrixCredentials {
   homeserverUrl: string;
   accessToken: string;
@@ -358,6 +380,19 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
           return new Map(prev).set(otherUserId, merged);
         });
       }
+
+      if (activeDmContactIdRef.current === otherUserId) {
+        activeDmVersionRef.current += 1;
+        const myVersion = activeDmVersionRef.current;
+        const messages: ChatMessage[] = [];
+        for (const ev of timelineEvents) {
+          const m = transformEventToChatMessage(ev, room, otherUserId, clientRef.current);
+          if (m) messages.push(m);
+        }
+        if (activeDmVersionRef.current === myVersion) {
+          setActiveDmMessages(messages);
+        }
+      }
     };
 
     const onMyMembership = (room: Room, membership: string) => {
@@ -609,24 +644,14 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       setActiveMessages([]);
       return;
     }
-    const room = client.getRoom(roomId);
-    if (!room) {
-      setActiveMessages([]);
-      return;
-    }
-
-    const events = room.getLiveTimeline().getEvents();
-    const messages: ChatMessage[] = [];
-    for (const ev of events) {
-      const m = transformEventToChatMessage(ev, room, channelId, client);
-      if (m) messages.push(m);
-    }
+    const messages = loadMessagesFromTimeline(client, roomId, channelId);
 
     if (activeRoomVersionRef.current === myVersion) {
       setActiveMessages(messages);
     }
   }, [credentials]);
 
+  // No deps: dmRoomMapRef is mutable and always reflects the latest map.
   const setActiveDmContact = useCallback((matrixUserId: string | null) => {
     activeDmVersionRef.current += 1;
     const myVersion = activeDmVersionRef.current;
@@ -646,18 +671,7 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       setActiveDmMessages([]);
       return;
     }
-    const room = client.getRoom(roomId);
-    if (!room) {
-      setActiveDmMessages([]);
-      return;
-    }
-
-    const events = room.getLiveTimeline().getEvents();
-    const messages: ChatMessage[] = [];
-    for (const ev of events) {
-      const m = transformEventToChatMessage(ev, room, matrixUserId, client);
-      if (m) messages.push(m);
-    }
+    const messages = loadMessagesFromTimeline(client, roomId, matrixUserId);
 
     if (activeDmVersionRef.current === myVersion) {
       setActiveDmMessages(messages);

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -24,6 +24,73 @@ function insertMessage(existing: ChatMessage[], msg: ChatMessage): ChatMessage[]
   return updated;
 }
 
+/**
+ * Transform a Matrix `m.room.message` event into a ChatMessage.
+ * Pure: only depends on its arguments. No SDK calls beyond what's
+ * passed in via `client` (used for mxc → http URL resolution).
+ *
+ * Returns null for non-message events.
+ */
+function transformEventToChatMessage(
+  event: MatrixEvent,
+  room: Room | undefined,
+  channelId: string,
+  client: MatrixClient | null,
+): ChatMessage | null {
+  if (event.getType() !== EventType.RoomMessage) return null;
+
+  const senderId = event.getSender() ?? 'Unknown';
+  const senderMember = room?.getMember(senderId);
+  const displayName = senderMember?.rawDisplayName || senderMember?.name || senderId;
+
+  const content = event.getContent() as {
+    body?: string;
+    msgtype?: string;
+    url?: string;
+    info?: { thumbnail_url?: string; w?: number; h?: number; mimetype?: string; size?: number };
+    'm.relates_to'?: { 'm.in_reply_to'?: { event_id: string } };
+  };
+
+  let media: MediaAttachment[] | undefined;
+  if (content.msgtype === 'm.image' && content.url) {
+    const fullUrl = client?.mxcUrlToHttp(content.url) ?? content.url;
+    media = [{
+      type: content.info?.mimetype?.toLowerCase() === 'image/gif' ? 'gif' : 'image',
+      url: fullUrl,
+      width: content.info?.w,
+      height: content.info?.h,
+      mimetype: content.info?.mimetype,
+      size: content.info?.size,
+    }];
+  }
+
+  const rawBody = content.body ?? '';
+  const isBridgeBotSender = /^@brmble[_-]?/.test(senderId);
+  const bridgeMatch = isBridgeBotSender ? rawBody.match(/^\[(.+?)\]:\s*/) : null;
+  const messageSender = bridgeMatch ? bridgeMatch[1] : displayName;
+  let messageContent = bridgeMatch ? rawBody.slice(bridgeMatch[0].length) : rawBody;
+
+  // Strip reply fallback from body (lines starting with > )
+  messageContent = messageContent.split('\n').filter(line => !/^> ?/.test(line)).join('\n').trim();
+
+  // For image-only messages, body is just the filename — don't show it as text
+  const displayContent = media ? '' : messageContent;
+
+  const relatesTo = content['m.relates_to'] as { 'm.in_reply_to'?: { event_id: string } } | undefined;
+  const replyToEventId = relatesTo?.['m.in_reply_to']?.event_id;
+
+  return {
+    id: event.getId() ?? crypto.randomUUID(),
+    channelId,
+    sender: messageSender,
+    senderMatrixUserId: senderId,
+    content: displayContent,
+    timestamp: new Date(event.getTs()),
+    ...(media && { media }),
+    ...(replyToEventId && { replyToEventId }),
+  };
+}
+
 export interface MatrixCredentials {
   homeserverUrl: string;
   accessToken: string;
@@ -88,60 +155,8 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       if (event.getType() !== EventType.RoomMessage) return;
       const channelId = roomIdToChannelId.get(room?.roomId ?? '');
       if (channelId) {
-        const senderId = event.getSender() ?? 'Unknown';
-        const senderMember = room?.getMember(senderId);
-        const displayName = senderMember?.rawDisplayName || senderMember?.name || senderId;
-
-        const content = event.getContent() as {
-          body?: string;
-          msgtype?: string;
-          url?: string;
-          info?: { thumbnail_url?: string; w?: number; h?: number; mimetype?: string; size?: number };
-          'm.relates_to'?: { 'm.in_reply_to'?: { event_id: string } };
-        };
-
-        let media: MediaAttachment[] | undefined;
-        if (content.msgtype === 'm.image' && content.url) {
-          const cl = clientRef.current;
-          const fullUrl = cl?.mxcUrlToHttp(content.url) ?? content.url;
-
-          media = [{
-            type: content.info?.mimetype?.toLowerCase() === 'image/gif' ? 'gif' : 'image',
-            url: fullUrl,
-            width: content.info?.w,
-            height: content.info?.h,
-            mimetype: content.info?.mimetype,
-            size: content.info?.size,
-          }];
-        }
-
-        const rawBody = content.body ?? '';
-        // Only parse bridged "[Name]: " prefixes for events sent by the bridge bot
-        const isBridgeBotSender = /^@brmble[_-]?/.test(senderId);
-        const bridgeMatch = isBridgeBotSender ? rawBody.match(/^\[(.+?)\]:\s*/) : null;
-        const messageSender = bridgeMatch ? bridgeMatch[1] : displayName;
-        let messageContent = bridgeMatch ? rawBody.slice(bridgeMatch[0].length) : rawBody;
-
-        // Strip reply fallback from body (lines starting with > )
-        messageContent = messageContent.split('\n').filter(line => !/^> ?/.test(line)).join('\n').trim();
-
-        // For image-only messages, body is just the filename — don't show it as text
-        const displayContent = media ? '' : messageContent;
-
-        // Extract reply relation from Matrix event
-        const relatesTo = content['m.relates_to'] as { 'm.in_reply_to'?: { event_id: string } } | undefined;
-        const replyToEventId = relatesTo?.['m.in_reply_to']?.event_id;
-
-        const message: ChatMessage = {
-          id: event.getId() ?? crypto.randomUUID(),
-          channelId,
-          sender: messageSender,
-          senderMatrixUserId: senderId,
-          content: displayContent,
-          timestamp: new Date(event.getTs()),
-          ...(media && { media }),
-          ...(replyToEventId && { replyToEventId }),
-        };
+        const message = transformEventToChatMessage(event, room, channelId, clientRef.current);
+        if (!message) return;
 
         setMessages(prev => {
           const existing = prev.get(channelId) ?? [];
@@ -161,60 +176,8 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
         return;
       }
 
-      const dmSenderId = event.getSender() ?? 'Unknown';
-      const dmSenderMember = room?.getMember(dmSenderId);
-      const dmDisplayName = dmSenderMember?.rawDisplayName || dmSenderMember?.name || dmSenderId;
-
-      const dmContent = event.getContent() as {
-        body?: string;
-        msgtype?: string;
-        url?: string;
-        info?: { thumbnail_url?: string; w?: number; h?: number; mimetype?: string; size?: number };
-        'm.relates_to'?: { 'm.in_reply_to'?: { event_id: string } };
-      };
-
-      let dmMedia: MediaAttachment[] | undefined;
-      if (dmContent.msgtype === 'm.image' && dmContent.url) {
-        const cl = clientRef.current;
-        const fullUrl = cl?.mxcUrlToHttp(dmContent.url) ?? dmContent.url;
-
-        dmMedia = [{
-          type: dmContent.info?.mimetype?.toLowerCase() === 'image/gif' ? 'gif' : 'image',
-          url: fullUrl,
-          width: dmContent.info?.w,
-          height: dmContent.info?.h,
-          mimetype: dmContent.info?.mimetype,
-          size: dmContent.info?.size,
-        }];
-      }
-
-      const dmRawBody = dmContent.body ?? '';
-      // Only parse bridged "[Name]: " prefixes for events sent by the bridge bot
-      const isDmBridgeBotSender = /^@brmble[_-]?/.test(dmSenderId);
-      const dmBridgeMatch = isDmBridgeBotSender ? dmRawBody.match(/^\[(.+?)\]:\s*/) : null;
-      const dmSender = dmBridgeMatch ? dmBridgeMatch[1] : dmDisplayName;
-      let dmMessageContent = dmBridgeMatch ? dmRawBody.slice(dmBridgeMatch[0].length) : dmRawBody;
-
-      // Strip reply fallback from body (lines starting with > )
-      dmMessageContent = dmMessageContent.split('\n').filter(line => !/^> ?/.test(line)).join('\n').trim();
-
-      // For image-only messages, body is just the filename — don't show it as text
-      const dmDisplayContent = dmMedia ? '' : dmMessageContent;
-
-      // Extract reply relation from Matrix event
-      const dmRelatesTo = dmContent['m.relates_to'] as { 'm.in_reply_to'?: { event_id: string } } | undefined;
-      const dmReplyToEventId = dmRelatesTo?.['m.in_reply_to']?.event_id;
-
-      const dmMessage: ChatMessage = {
-        id: event.getId() ?? crypto.randomUUID(),
-        channelId: dmUserId,
-        sender: dmSender,
-        senderMatrixUserId: dmSenderId,
-        content: dmDisplayContent,
-        timestamp: new Date(event.getTs()),
-        ...(dmMedia && { media: dmMedia }),
-        ...(dmReplyToEventId && { replyToEventId: dmReplyToEventId }),
-      };
+      const dmMessage = transformEventToChatMessage(event, room, dmUserId, clientRef.current);
+      if (!dmMessage) return;
 
       setDmMessages(prev => {
         const existing = prev.get(dmUserId) ?? [];
@@ -283,58 +246,17 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
     /** Register a newly-discovered DM room in local maps and backfill any messages
      *  that onTimeline may have dropped before the mapping existed. */
     const registerDMRoom = (room: Room, otherUserId: string) => {
-      if (roomIdToDMUserIdRef.current.has(room.roomId)) return; // already tracked
+      if (roomIdToDMUserIdRef.current.has(room.roomId)) return;
 
       setDmRoomMap(prev => new Map(prev).set(otherUserId, room.roomId));
       dmRoomMapRef.current = new Map(dmRoomMapRef.current).set(otherUserId, room.roomId);
       roomIdToDMUserIdRef.current = new Map(roomIdToDMUserIdRef.current).set(room.roomId, otherUserId);
 
-      // Backfill: the SDK already has timeline events for this room that onTimeline
-      // dropped because the room wasn't in roomIdToDMUserIdRef at the time.
       const timelineEvents = room.getLiveTimeline().getEvents();
       const backfillMsgs: ChatMessage[] = [];
       for (const ev of timelineEvents) {
-        if (ev.getType() !== EventType.RoomMessage) continue;
-        const senderId = ev.getSender() ?? 'Unknown';
-        const senderMember = room.getMember(senderId);
-        const displayName = senderMember?.rawDisplayName || senderMember?.name || senderId;
-
-        const content = ev.getContent() as {
-          body?: string;
-          msgtype?: string;
-          url?: string;
-          info?: { thumbnail_url?: string; w?: number; h?: number; mimetype?: string; size?: number };
-        };
-
-        let media: MediaAttachment[] | undefined;
-        if (content.msgtype === 'm.image' && content.url) {
-          const cl = clientRef.current;
-          const fullUrl = cl?.mxcUrlToHttp(content.url) ?? content.url;
-          media = [{
-            type: content.info?.mimetype?.toLowerCase() === 'image/gif' ? 'gif' : 'image',
-            url: fullUrl,
-            width: content.info?.w,
-            height: content.info?.h,
-            mimetype: content.info?.mimetype,
-            size: content.info?.size,
-          }];
-        }
-
-        const rawBody = content.body ?? '';
-        const isBridgeBotSender = /^@brmble[_-]?/.test(senderId);
-        const bridgeMatch = isBridgeBotSender ? rawBody.match(/^\[(.+?)\]:\s*/) : null;
-        const messageSender = bridgeMatch ? bridgeMatch[1] : displayName;
-        const messageContent = bridgeMatch ? rawBody.slice(bridgeMatch[0].length) : rawBody;
-
-        backfillMsgs.push({
-          id: ev.getId() ?? crypto.randomUUID(),
-          channelId: otherUserId,
-          sender: messageSender,
-          senderMatrixUserId: senderId,
-          content: media ? '' : messageContent,
-          timestamp: new Date(ev.getTs()),
-          ...(media && { media }),
-        });
+        const msg = transformEventToChatMessage(ev, room, otherUserId, clientRef.current);
+        if (msg) backfillMsgs.push(msg);
       }
 
       if (backfillMsgs.length > 0) {

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -120,6 +120,14 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
   const [lastMessages, setLastMessages] = useState<Map<string, MessagePreview>>(new Map());
   const [dmLastMessages, setDmLastMessages] = useState<Map<string, MessagePreview>>(new Map());
 
+  // Active-only message state: only the currently-viewed channel/DM is loaded
+  const [activeMessages, setActiveMessages] = useState<ChatMessage[]>([]);
+  const [activeDmMessages, setActiveDmMessages] = useState<ChatMessage[]>([]);
+  const activeChannelIdRef = useRef<string | null>(null);
+  const activeDmContactIdRef = useRef<string | null>(null);
+  const activeRoomVersionRef = useRef(0);
+  const activeDmVersionRef = useRef(0);
+
   const dmRoomMapRef = useRef<Map<string, string>>(new Map());
   // Keep ref in sync
   useEffect(() => { dmRoomMapRef.current = dmRoomMap; }, [dmRoomMap]);
@@ -146,6 +154,10 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
       setLastMessages(new Map());
       setDmMessages(new Map());
       setDmLastMessages(new Map());
+      setActiveMessages([]);
+      setActiveDmMessages([]);
+      activeChannelIdRef.current = null;
+      activeDmContactIdRef.current = null;
       setDmRoomMap(new Map());
       dmRoomMapRef.current = new Map();
       roomIdToDMUserIdRef.current = new Map();
@@ -187,6 +199,12 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
           });
           return next;
         });
+        if (activeChannelIdRef.current === channelId) {
+          setActiveMessages(prev => {
+            const updated = insertMessage(prev, message);
+            return updated === prev ? prev : updated;
+          });
+        }
         return;
       }
 
@@ -219,6 +237,12 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
         });
         return next;
       });
+      if (activeDmContactIdRef.current === dmUserId) {
+        setActiveDmMessages(prev => {
+          const updated = insertMessage(prev, dmMessage);
+          return updated === prev ? prev : updated;
+        });
+      }
     };
 
     client.on(RoomEvent.Timeline, onTimeline);
@@ -566,6 +590,80 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
     return null;
   }, []);
 
+  const setActiveChannel = useCallback((channelId: string | null) => {
+    activeRoomVersionRef.current += 1;
+    const myVersion = activeRoomVersionRef.current;
+    activeChannelIdRef.current = channelId;
+
+    if (!channelId) {
+      setActiveMessages([]);
+      return;
+    }
+    const client = clientRef.current;
+    if (!credentials || !client) {
+      setActiveMessages([]);
+      return;
+    }
+    const roomId = credentials.roomMap[channelId];
+    if (!roomId) {
+      setActiveMessages([]);
+      return;
+    }
+    const room = client.getRoom(roomId);
+    if (!room) {
+      setActiveMessages([]);
+      return;
+    }
+
+    const events = room.getLiveTimeline().getEvents();
+    const messages: ChatMessage[] = [];
+    for (const ev of events) {
+      const m = transformEventToChatMessage(ev, room, channelId, client);
+      if (m) messages.push(m);
+    }
+
+    if (activeRoomVersionRef.current === myVersion) {
+      setActiveMessages(messages);
+    }
+  }, [credentials]);
+
+  const setActiveDmContact = useCallback((matrixUserId: string | null) => {
+    activeDmVersionRef.current += 1;
+    const myVersion = activeDmVersionRef.current;
+    activeDmContactIdRef.current = matrixUserId;
+
+    if (!matrixUserId) {
+      setActiveDmMessages([]);
+      return;
+    }
+    const client = clientRef.current;
+    if (!client) {
+      setActiveDmMessages([]);
+      return;
+    }
+    const roomId = dmRoomMapRef.current.get(matrixUserId);
+    if (!roomId) {
+      setActiveDmMessages([]);
+      return;
+    }
+    const room = client.getRoom(roomId);
+    if (!room) {
+      setActiveDmMessages([]);
+      return;
+    }
+
+    const events = room.getLiveTimeline().getEvents();
+    const messages: ChatMessage[] = [];
+    for (const ev of events) {
+      const m = transformEventToChatMessage(ev, room, matrixUserId, client);
+      if (m) messages.push(m);
+    }
+
+    if (activeDmVersionRef.current === myVersion) {
+      setActiveDmMessages(messages);
+    }
+  }, []);
+
   // Resolve display names for DM partners from Matrix room membership.
   // This works even when the other user isn't connected to Mumble.
   const dmUserDisplayNames = useMemo(() => {
@@ -612,8 +710,9 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
     return urls;
   }, [client, dmRoomMap]);
 
-  return { messages, lastMessages, sendMessage, sendImageMessage, uploadContent, fetchHistory,
-           dmMessages, dmLastMessages, dmRoomMap,
+  return { messages, lastMessages, activeMessages, setActiveChannel,
+           sendMessage, sendImageMessage, uploadContent, fetchHistory,
+           dmMessages, dmLastMessages, activeDmMessages, setActiveDmContact, dmRoomMap,
            dmUserDisplayNames, dmUserAvatarUrls, sendDMMessage, fetchDMHistory,
            fetchAvatarUrl, client };
 }

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -377,6 +377,21 @@ export function useMatrixClient(credentials: MatrixCredentials | null) {
 
       const timelineEvents = room.getLiveTimeline().getEvents();
 
+      for (let i = timelineEvents.length - 1; i >= 0; i--) {
+        const ev = timelineEvents[i];
+        if (ev.getType() !== EventType.RoomMessage) continue;
+        const msg = transformEventToChatMessage(ev, room, otherUserId, clientRef.current);
+        if (!msg) continue;
+        setDmLastMessages(prev => {
+          const existing = prev.get(otherUserId);
+          if (existing && existing.ts >= msg.timestamp.getTime()) return prev;
+          const next = new Map(prev);
+          next.set(otherUserId, { content: msg.content, ts: msg.timestamp.getTime(), sender: msg.sender });
+          return next;
+        });
+        break;
+      }
+
       if (activeDmContactIdRef.current === otherUserId) {
         activeDmVersionRef.current += 1;
         const myVersion = activeDmVersionRef.current;

--- a/src/Brmble.Web/src/hooks/useNotificationQueue.ts
+++ b/src/Brmble.Web/src/hooks/useNotificationQueue.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import type { NotificationStatus } from '../components/Notification/Notification';
 
 const MAX_VISIBLE = 3;
@@ -53,12 +53,18 @@ export function useNotificationQueue() {
   }, []);
 
   const unregister = useCallback((id: string) => {
-    setEntries(prev => prev.filter(e => e.id !== id));
+    setEntries(prev => {
+      const next = prev.filter(e => e.id !== id);
+      return next.length === prev.length ? prev : next;
+    });
   }, []);
 
-  const visibleSet = getVisible(entries);
+  const visibleSet = useMemo(() => getVisible(entries), [getVisible, entries]);
 
   const isVisible = useCallback((id: string) => visibleSet.has(id), [visibleSet]);
 
-  return { register, unregister, isVisible, visibleCount: visibleSet.size, totalCount: entries.length };
+  return useMemo(
+    () => ({ register, unregister, isVisible, visibleCount: visibleSet.size, totalCount: entries.length }),
+    [register, unregister, isVisible, visibleSet, entries.length],
+  );
 }

--- a/src/Brmble.Web/src/test-setup.ts
+++ b/src/Brmble.Web/src/test-setup.ts
@@ -1,13 +1,9 @@
 import '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 
-// Node 25 introduces a native localStorage global that lacks .clear() and conflicts with
-// jsdom's implementation. vitest's populateGlobal skips localStorage because it exists
-// on the Node global, so jsdom's localStorage never overrides it.
-// We restore proper behaviour by delegating to document.defaultView which IS the real
-// jsdom Window object (vitest patches document.defaultView to point to itself but that
-// still gives us access to jsdom's Window prototype chain).
-// Fallback: a fully-functional in-memory shim.
+// Node 25 ships a native localStorage on globalThis that lacks .clear(), and vitest's
+// populateGlobal skips the slot because it's already populated, so jsdom's Storage
+// never installs. We feature-detect on .clear and replace with a Map-backed shim.
 (function patchLocalStorage() {
   // Check if localStorage already has .clear — if it does, nothing to do.
   if (typeof globalThis.localStorage?.clear === 'function') return;

--- a/src/Brmble.Web/src/test-setup.ts
+++ b/src/Brmble.Web/src/test-setup.ts
@@ -1,2 +1,44 @@
 import '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+
+// Node 25 introduces a native localStorage global that lacks .clear() and conflicts with
+// jsdom's implementation. vitest's populateGlobal skips localStorage because it exists
+// on the Node global, so jsdom's localStorage never overrides it.
+// We restore proper behaviour by delegating to document.defaultView which IS the real
+// jsdom Window object (vitest patches document.defaultView to point to itself but that
+// still gives us access to jsdom's Window prototype chain).
+// Fallback: a fully-functional in-memory shim.
+(function patchLocalStorage() {
+  // Check if localStorage already has .clear — if it does, nothing to do.
+  if (typeof globalThis.localStorage?.clear === 'function') return;
+
+  // Build a Map-backed localStorage shim.
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string): string | null {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    key(index: number): string | null {
+      return [...store.keys()][index] ?? null;
+    },
+  };
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: shim,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+})();

--- a/src/Brmble.Web/src/test-setup.ts
+++ b/src/Brmble.Web/src/test-setup.ts
@@ -8,28 +8,21 @@ import '@testing-library/jest-dom/vitest';
   // Check if localStorage already has .clear — if it does, nothing to do.
   if (typeof globalThis.localStorage?.clear === 'function') return;
 
-  // Build a Map-backed localStorage shim.
+  // Build a Map-backed localStorage shim with proper key enumeration.
+  // Methods live on the prototype so Object.keys() only returns stored keys.
   const store = new Map<string, string>();
-  const shim: Storage = {
-    get length() {
-      return store.size;
-    },
-    clear() {
-      store.clear();
-    },
-    getItem(key: string): string | null {
-      return store.has(key) ? store.get(key)! : null;
-    },
-    setItem(key: string, value: string) {
-      store.set(key, String(value));
-    },
-    removeItem(key: string) {
-      store.delete(key);
-    },
-    key(index: number): string | null {
-      return [...store.keys()][index] ?? null;
-    },
-  };
+
+  class StorageShim implements Storage {
+    get length() { return store.size; }
+    clear() { store.clear(); for (const k of Object.keys(this)) delete (this as Record<string, unknown>)[k]; }
+    getItem(key: string): string | null { return store.has(key) ? store.get(key)! : null; }
+    setItem(key: string, value: string) { store.set(key, String(value)); Object.defineProperty(this, key, { value: String(value), writable: true, enumerable: true, configurable: true }); }
+    removeItem(key: string) { store.delete(key); delete (this as Record<string, unknown>)[key]; }
+    key(index: number): string | null { return [...store.keys()][index] ?? null; }
+    [name: string]: unknown;
+  }
+
+  const shim = new StorageShim();
 
   Object.defineProperty(globalThis, 'localStorage', {
     value: shim,


### PR DESCRIPTION
## Summary

- React-state holds only the active chat (Matrix channel, Matrix DM, Mumble channel-root, Mumble session DM); matrix-js-sdk's internal timeline is the source of truth, with a bounded `lastMessages` map (one entry per room) for sidebar previews.
- `initialSyncLimit` lowered 20 → 5 — cuts cold-start payload by ~75% (fewer events on the wire and zero eager `MatrixEvent → ChatMessage` transformations for inactive rooms).
- Three collateral unbounded-growth paths fixed: `useChatStore` non-server-root cap (200 msgs/channel), `useDMStore.mumbleMessages` cap per contact, and `useDMStore.pendingMessages` cleanup on Matrix DM send failure.

Closes the WebView2 *page out of memory* symptom from commit `94cc38c` (the throttle-rerenders fix removed sustained churn but explicitly didn't fix the underlying leak). Spec: [`docs/superpowers/specs/2026-05-03-lazy-chat-loading-design.md`](docs/superpowers/specs/2026-05-03-lazy-chat-loading-design.md). Plan: [`docs/superpowers/plans/2026-05-03-lazy-chat-loading.md`](docs/superpowers/plans/2026-05-03-lazy-chat-loading.md).

## Architecture notes

- New helpers in `useMatrixClient`: pure module-scope `transformEventToChatMessage(event, room, channelId, client)` and `loadMessagesFromTimeline(client, roomId, targetId)` — both used by the new `setActiveChannel` / `setActiveDmContact` callbacks.
- Race protection via monotonic `activeRoomVersionRef` / `activeDmVersionRef`: rapid channel switches cannot commit a stale load on top of a newer one.
- PREPARED-time reload: if the user has a channel/DM selected before initial sync completes, the active load runs again once the SDK has the room — otherwise the chat could render empty until the first new message arrives.
- `registerDMRoom` rebuilds `activeDmMessages` when the freshly registered room belongs to the currently active contact (covers the spec's "DM first-time flow" edge case).

## Test plan

- [x] `(cd src/Brmble.Web && npm test -- --run)` — 320/321 pass; the 1 failure (`replyHelpers.test.ts`) is pre-existing and untouched by this branch.
- [x] `(cd src/Brmble.Web && npm run build)` — clean.
- [x] `dotnet build` — clean (3 pre-existing warnings in `MumbleVoiceEngine`, 0 errors).
- [x] Smoke test via wpf-cli: app launches cleanly, auto-connects to a saved server, channel sidebar populated, active channel renders messages from history, no entries in `%TEMP%/brmble-tls.log`, graceful close.
- [ ] Manual smoke test — channel-switching (rapid + slow), DM contact switching, scrollback, send message in channel + DM.
- [ ] 30-minute idle test (the original repro from commit `94cc38c`): private bytes / V8 heap before vs. after — expectation: flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)