### PR TITLE
fix: harden LiveKit move and leave voice flows

### DIFF
--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -751,6 +751,7 @@ The `status` prop drives icon, color, ARIA role, and auto-dismiss behavior:
 4. **Does it need a dismiss button?** Persistent notifications: yes. Blocking with no fallback: no dismiss.
 5. **What actions does it need?** Max 1 primary action. Action must be reachable elsewhere in UI since notifications can be missed.
 6. **What title + detail?** Title = what happened (short, one line). Detail = context or next step (optional).
+7. **What lifecycle model?** Choose one: stable singleton, replacement, or historical/multi-entry. This determines the ID and cleanup strategy.
 
 ### Props
 
@@ -818,6 +819,21 @@ Top-right notifications are managed by the `useNotificationQueue` hook (`src/Brm
 - `unregister(id)` — call from `onExited` (after exit animation), not from `onDismiss`. This ensures the exit animation completes before the slot is freed.
 - `isVisible(id)` — pass as the `visible` prop to `<Notification>`.
 - Bottom-center notifications (`Toast`) bypass the queue — they position independently.
+
+### Queue Lifecycle Checklist
+
+Before adding a top-right notification, decide and document the lifecycle model:
+
+- **Stable singleton:** One logical notification exists at a time. Use a stable ID (`update`, `copy`, `idle-auto-leave`) and unregister that same ID when it is no longer relevant.
+- **Replacement:** Repeated events should overwrite the previous notification. Use generated IDs only if you unregister the previous ID before registering the next one. Example: repeated channel-move notifications should replace the last move notification, not accumulate forever.
+- **Historical/multi-entry:** Repeated events should remain separate because each entry matters. Use generated IDs, but prove every generated ID is eventually unregistered. Example: imported server notifications may show one notification per imported server.
+
+Generated IDs require extra care:
+
+- Matching title/detail/status does **not** deduplicate notifications; only the `id` matters.
+- If a notification clears React state in `onDismiss`, do not assume `onExited` will run afterward. Either keep the component mounted with `visible={false}` until exit, or explicitly unregister the queue ID in the same dismissal path.
+- For replacement notifications, unregister the previous ID before setting/registering the next generated ID.
+- Add a repeated-event test for any generated-ID top-right notification. The test must emit at least **4** events, or otherwise prove stale entries cannot fill the max-3 queue and block future notifications.
 
 **Integration pattern in App.tsx:**
 ```tsx

--- a/docs/superpowers/plans/2026-05-09-admin-move-notifications.md
+++ b/docs/superpowers/plans/2026-05-09-admin-move-notifications.md
@@ -1,0 +1,234 @@
+# Admin Move Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a clear top-right notification when the local user is moved by another user/server, including when screen sharing is stopped by that move.
+
+**Architecture:** Extend the existing `voice.channelChanged` bridge event with move metadata from Mumble `UserState.Actor`. The React app consumes that metadata, generates a queued `<Notification>`, and marks share teardown as an intentional channel-move reason so the generic technical failure is suppressed.
+
+**Tech Stack:** C# Mumble client bridge, React/TypeScript, MSTest, Vitest.
+
+---
+
+### Task 1: Backend Move Metadata
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`
+- Test: `tests/Brmble.Client.Tests/Services/MumbleAdapterMoveEventTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create a focused test around a small formatter/helper that turns self-channel-change data into a payload with actor metadata:
+
+```csharp
+using Brmble.Client.Services.Voice;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class MumbleAdapterMoveEventTests
+{
+    [TestMethod]
+    public void CreateChannelChangedPayload_WithActor_ReturnsMoveMetadata()
+    {
+        var payload = MumbleAdapter.CreateChannelChangedPayload(
+            previousChannelId: 5,
+            currentChannelId: 7,
+            actorSession: 99,
+            actorName: "Moderator",
+            movedByOtherUser: true);
+
+        Assert.AreEqual(7u, payload.ChannelId);
+        Assert.AreEqual(5u, payload.PreviousChannelId);
+        Assert.AreEqual(99u, payload.ActorSession);
+        Assert.AreEqual("Moderator", payload.ActorName);
+        Assert.AreEqual("moved", payload.Reason);
+    }
+
+    [TestMethod]
+    public void CreateChannelChangedPayload_WithoutActor_ReturnsUnknownReason()
+    {
+        var payload = MumbleAdapter.CreateChannelChangedPayload(
+            previousChannelId: 5,
+            currentChannelId: 7,
+            actorSession: null,
+            actorName: null,
+            movedByOtherUser: false);
+
+        Assert.AreEqual(7u, payload.ChannelId);
+        Assert.AreEqual(5u, payload.PreviousChannelId);
+        Assert.IsNull(payload.ActorSession);
+        Assert.IsNull(payload.ActorName);
+        Assert.AreEqual("unknown", payload.Reason);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~MumbleAdapterMoveEventTests"`
+
+Expected: FAIL because `MumbleAdapterMoveEventTests.cs` or `CreateChannelChangedPayload` does not exist.
+
+- [ ] **Step 3: Implement minimal backend helper and event payload**
+
+Add an internal payload record and helper in `MumbleAdapter.cs`:
+
+```csharp
+internal sealed record ChannelChangedPayload(
+    uint ChannelId,
+    uint? PreviousChannelId,
+    uint? ActorSession,
+    string? ActorName,
+    string Reason);
+
+internal static ChannelChangedPayload CreateChannelChangedPayload(
+    uint? previousChannelId,
+    uint currentChannelId,
+    uint? actorSession,
+    string? actorName,
+    bool movedByOtherUser)
+{
+    return new ChannelChangedPayload(
+        currentChannelId,
+        previousChannelId,
+        actorSession,
+        string.IsNullOrWhiteSpace(actorName) ? null : actorName,
+        movedByOtherUser ? "moved" : "unknown");
+}
+```
+
+Update the local-user channel change send path to call this helper and pass actor metadata from `userState.Actor` when available and not the local user.
+
+- [ ] **Step 4: Run backend tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~MumbleAdapterMoveEventTests|FullyQualifiedName~MumbleAdapterCredentialsTests"`
+
+Expected: PASS.
+
+### Task 2: Frontend Move Notification Utilities
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Test: `src/Brmble.Web/src/App.test.tsx`
+
+- [ ] **Step 1: Write failing utility tests**
+
+Add tests for `getMovedChannelNotification`:
+
+```ts
+expect(getMovedChannelNotification({ actorName: 'Moderator', previousChannelName: 'General', channelName: 'Raid', wasSharing: true })).toEqual({
+  status: 'info',
+  title: 'Moved to Raid',
+  detail: 'Moderator moved you from General to Raid. Screen sharing was stopped.',
+});
+
+expect(getMovedChannelNotification({ actorName: undefined, previousChannelName: undefined, channelName: 'Raid', wasSharing: false })).toEqual({
+  status: 'info',
+  title: 'Moved to Raid',
+  detail: 'You were moved to Raid.',
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- App.test.tsx --runInBand` from `src/Brmble.Web` if supported by the repo test runner, otherwise run the existing frontend test command for `App.test.tsx`.
+
+Expected: FAIL because `getMovedChannelNotification` does not exist.
+
+- [ ] **Step 3: Implement utility and share stop reason**
+
+Add:
+
+```ts
+export interface MovedChannelNotificationInput {
+  actorName?: string;
+  previousChannelName?: string;
+  channelName: string;
+  wasSharing: boolean;
+}
+
+export function getMovedChannelNotification(input: MovedChannelNotificationInput): ScreenShareEndedNotification {
+  const movedBy = input.actorName || 'You were';
+  const route = input.previousChannelName
+    ? `${movedBy} moved you from ${input.previousChannelName} to ${input.channelName}`
+    : input.actorName
+      ? `${input.actorName} moved you to ${input.channelName}`
+      : `You were moved to ${input.channelName}`;
+
+  return {
+    status: 'info',
+    title: `Moved to ${input.channelName}`,
+    detail: `${route}.${input.wasSharing ? ' Screen sharing was stopped.' : ''}`,
+  };
+}
+```
+
+Extend `LocalShareStopReason` in `useScreenShare.ts` with `'moved-channel'`, and make `getScreenShareEndedNotification('moved-channel')` return `null` because the move notification owns the message.
+
+- [ ] **Step 4: Run utility tests**
+
+Run the same frontend test command from Step 2.
+
+Expected: PASS.
+
+### Task 3: Frontend Event Wiring
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+
+- [ ] **Step 1: Add move notification state**
+
+Add a queued notification state similar to `screenShareEndedNotification`, with IDs like `channel-moved-${sequence}`.
+
+- [ ] **Step 2: Wire `voice.channelChanged` metadata**
+
+Update the event data type to include:
+
+```ts
+{ channelId: number; previousChannelId?: number; actorName?: string; reason?: 'moved' | 'unknown' }
+```
+
+When `reason === 'moved'` or `actorName` exists:
+- Resolve destination and previous channel names from `channelsRef.current`.
+- Read `const wasSharing = isSharingRef.current` before any share cleanup.
+- If sharing, call `markLocalShareTeardownIntent('moved-channel')`.
+- Set/register the move notification.
+
+- [ ] **Step 3: Render the notification**
+
+Render a top-right `<Notification>` using the shared stack and `notifQueue`.
+
+- [ ] **Step 4: Verify no Toast usage**
+
+Search for the new move code and confirm it renders `<Notification position="top-right" ...>` and does not use `Toast`.
+
+### Task 4: Verification
+
+**Files:**
+- Build/test only.
+
+- [ ] **Step 1: Run client tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~MumbleAdapterMoveEventTests|FullyQualifiedName~MumbleAdapterCredentialsTests"`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend tests**
+
+Run the repo frontend test command for `App.test.tsx` from `src/Brmble.Web`.
+
+Expected: PASS.
+
+- [ ] **Step 3: Build frontend**
+
+Run: `npm run build` from `src/Brmble.Web`.
+
+Expected: PASS.
+
+- [ ] **Step 4: Build client**
+
+Run: `dotnet build --no-incremental` from `src/Brmble.Client` after closing running clients.
+
+Expected: PASS with 0 warnings.

--- a/docs/superpowers/plans/2026-05-09-kick-ban-notifications.md
+++ b/docs/superpowers/plans/2026-05-09-kick-ban-notifications.md
@@ -1,0 +1,150 @@
+# Kick Ban Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show clear top-right notifications when the local user is kicked or banned from a Mumble server.
+
+**Architecture:** Extend the existing `voice.disconnected` bridge payload from self `UserRemove` with kick/ban metadata. The React app consumes that metadata and renders one stable replacement notification with ID `server-removal`.
+
+**Tech Stack:** C# Mumble client bridge, React/TypeScript, MSTest, Vitest.
+
+---
+
+### Task 1: Backend Removal Payload
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`
+- Test: `tests/Brmble.Client.Tests/Services/MumbleAdapterRemovalEventTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Brmble.Client.Tests/Services/MumbleAdapterRemovalEventTests.cs`:
+
+```csharp
+using Brmble.Client.Services.Voice;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class MumbleAdapterRemovalEventTests
+{
+    [TestMethod]
+    public void CreateServerRemovalPayload_ForKick_ReturnsWarningMetadata()
+    {
+        var payload = MumbleAdapter.CreateServerRemovalPayload(
+            banned: false,
+            actorName: "Moderator",
+            reason: "Too loud");
+
+        Assert.AreEqual("kicked", payload.Reason);
+        Assert.AreEqual("Moderator", payload.ActorName);
+        Assert.AreEqual("Too loud", payload.Message);
+    }
+
+    [TestMethod]
+    public void CreateServerRemovalPayload_ForBan_ReturnsBanMetadata()
+    {
+        var payload = MumbleAdapter.CreateServerRemovalPayload(
+            banned: true,
+            actorName: "Admin",
+            reason: "Spam");
+
+        Assert.AreEqual("banned", payload.Reason);
+        Assert.AreEqual("Admin", payload.ActorName);
+        Assert.AreEqual("Spam", payload.Message);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~MumbleAdapterRemovalEventTests"`
+
+Expected: FAIL because `CreateServerRemovalPayload` does not exist.
+
+- [ ] **Step 3: Implement helper and emit payload**
+
+In `MumbleAdapter.cs`, add an internal record and helper:
+
+```csharp
+internal sealed record ServerRemovalPayload(string Reason, string ActorName, string? Message, bool ReconnectAvailable);
+
+internal static ServerRemovalPayload CreateServerRemovalPayload(bool banned, string? actorName, string? reason)
+{
+    return new ServerRemovalPayload(
+        banned ? "banned" : "kicked",
+        string.IsNullOrWhiteSpace(actorName) ? "the server" : actorName,
+        string.IsNullOrWhiteSpace(reason) ? null : reason,
+        true);
+}
+```
+
+In `UserRemove`, when `isSelf`, send `voice.disconnected` with this payload after the existing system message.
+
+- [ ] **Step 4: Run backend tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~MumbleAdapterRemovalEventTests|FullyQualifiedName~MumbleAdapterMoveEventTests"`
+
+Expected: PASS.
+
+### Task 2: Frontend Notification
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Test: `src/Brmble.Web/src/App.screenShareStart.test.ts`
+
+- [ ] **Step 1: Write failing frontend tests**
+
+Add tests that emit `voice.disconnected` with kick and ban payloads, then assert `notifQueue.register('server-removal', ...)` and notification copy appears.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- App.screenShareStart.test.ts` from `src/Brmble.Web`.
+
+Expected: FAIL because no server-removal notification exists.
+
+- [ ] **Step 3: Implement server-removal notification**
+
+In `App.tsx`, add `getServerRemovalNotification()` helper:
+
+```ts
+export function getServerRemovalNotification(input: { reason: 'kicked' | 'banned'; actorName?: string; message?: string }) {
+  const actorName = input.actorName || 'the server';
+  const action = input.reason === 'banned' ? 'banned' : 'kicked';
+  return {
+    status: input.reason === 'banned' ? 'error' as const : 'warning' as const,
+    title: input.reason === 'banned' ? 'Banned from server' : 'Kicked from server',
+    detail: `${actorName} ${action} you from the server.${input.message ? ` Reason: ${input.message}` : ''}`,
+  };
+}
+```
+
+Use stable ID `server-removal`, register it when disconnect payload reason is `kicked` or `banned`, and render it as top-right `<Notification>`.
+
+- [ ] **Step 4: Run frontend tests**
+
+Run: `npm test -- App.screenShareStart.test.ts` from `src/Brmble.Web`.
+
+Expected: PASS.
+
+### Task 3: Verification
+
+**Files:**
+- Build/test only.
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+`dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~MumbleAdapterRemovalEventTests|FullyQualifiedName~MumbleAdapterMoveEventTests|FullyQualifiedName~MumbleAdapterCredentialsTests"`
+`npm test -- App.screenShareEnded.test.ts App.screenShareStart.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Build frontend and client**
+
+Run:
+`npm run build` from `src/Brmble.Web`
+`dotnet build --no-incremental` from `src/Brmble.Client`
+
+Expected: PASS with 0 C# warnings.

--- a/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
+++ b/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
@@ -126,6 +126,9 @@ namespace MumbleSharp
 
         public void SendControl<T>(PacketType type, T packet)
         {
+            if (_tcp == null)
+                return;
+
             _tcp.Send<T>(type, packet);
         }
 

--- a/lib/MumbleVoiceEngine/Codec/OpusDecoder.cs
+++ b/lib/MumbleVoiceEngine/Codec/OpusDecoder.cs
@@ -94,7 +94,7 @@ namespace MumbleVoiceEngine.Codec
         /// <param name="dstOffset">The zero-based byte offset in dstBuffer at which to begin writing decoded audio samples.</param>
         /// <returns>The number of bytes decoded and written to dstBuffer.</returns>
         /// <remarks>Set srcEncodedBuffer to null to instruct the decoder that a packet was dropped.</remarks>
-        public unsafe int Decode(byte[] srcEncodedBuffer, int srcOffset, int srcLength, byte[] dstBuffer, int dstOffset)
+        public unsafe int Decode(byte[]? srcEncodedBuffer, int srcOffset, int srcLength, byte[] dstBuffer, int dstOffset)
         {
             var availableBytes = dstBuffer.Length - dstOffset;
             var frameCount = availableBytes / _sampleSize;

--- a/lib/MumbleVoiceEngine/VoiceEngine.cs
+++ b/lib/MumbleVoiceEngine/VoiceEngine.cs
@@ -68,17 +68,20 @@ public class VoiceEngine : IDisposable
             return;
 
         var p = parsed.Value;
-        UserAudioPipeline pipeline;
-        if (!_users.TryGetValue(p.Session, out pipeline))
+        if (!_users.TryGetValue(p.Session, out var pipeline))
         {
-            pipeline = new UserAudioPipeline();
-            OnUserPipelineCreated(pipeline);
+            var newPipeline = new UserAudioPipeline();
+            OnUserPipelineCreated(newPipeline);
 
-            if (!_users.TryAdd(p.Session, pipeline))
+            if (!_users.TryAdd(p.Session, newPipeline))
             {
-                pipeline.Dispose();
+                newPipeline.Dispose();
                 if (!_users.TryGetValue(p.Session, out pipeline))
                     return;
+            }
+            else
+            {
+                pipeline = newPipeline;
             }
         }
         pipeline.FeedEncodedPacket(p.OpusData, p.Sequence);

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -2937,6 +2937,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             if (_leaveVoiceInProgress)
             {
                 _leaveVoiceInProgress = false;
+                if (_pendingLocalJoinChannelId == currentChannelId)
+                    _pendingLocalJoinChannelId = null;
             }
             else if (_pendingLocalJoinChannelId == currentChannelId)
             {

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using Org.BouncyCastle.Tls;
@@ -34,6 +35,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private string? _lastWelcomeText;
     private readonly CertificateService? _certService;
     private uint? _previousChannelId;
+    private uint? _pendingLocalJoinChannelId;
     private bool _leftVoice;
     private bool _leaveVoiceInProgress;
     private bool _canRejoin;
@@ -41,6 +43,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private volatile bool _intentionalDisconnect = false;
     private volatile bool _rejected = false;
     private volatile bool _isReconnect = false;
+    private volatile bool _serverRemovalDisconnect = false;
     private volatile CancellationTokenSource? _reconnectCts;
     private string? _reconnectHost;
     private int _reconnectPort;
@@ -287,7 +290,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     {
         _isReconnect = false;
         _cts?.Cancel();
-        _processThread?.Join(2000);
+        var processThread = _processThread;
+        if (processThread != null && processThread != Thread.CurrentThread)
+            processThread.Join(2000);
         _processThread = null;
 
         StopVoiceIdlePolling();
@@ -326,6 +331,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         ChannelDictionary.Clear();
         _lastWelcomeText = null;
         _previousChannelId = null;
+        _pendingLocalJoinChannelId = null;
         if (_intentionalDisconnect || _reconnectHost == null)
         {
             _apiUrl = null;
@@ -338,7 +344,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         // Only emit voice.disconnected for intentional disconnects or when no reconnect is possible.
         // When _intentionalDisconnect is false and we have reconnect params, ReconnectLoop will take over.
-        if (_intentionalDisconnect || _reconnectHost == null)
+        if (_serverRemovalDisconnect)
+        {
+            _serverRemovalDisconnect = false;
+        }
+        else if (_intentionalDisconnect || _reconnectHost == null)
         {
             _bridge?.Send("voice.disconnected", null);
             _bridge?.NotifyUiThread();
@@ -602,6 +612,25 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         EmitCanRejoin(_previousChannelId != null);
     }
 
+    private void ClearLeaveVoiceState()
+    {
+        if (LocalUser == null) return;
+
+        _leftVoice = false;
+        _previousChannelId = null;
+
+        LocalUser.SelfMuted = false;
+        LocalUser.SelfDeaf = false;
+        LocalUser.SendMuteDeaf();
+        _audioManager?.SetMuted(false);
+        _audioManager?.SetDeafened(false);
+
+        _bridge?.Send("voice.selfMuteChanged", new { muted = false });
+        _bridge?.Send("voice.selfDeafChanged", new { deafened = false });
+        _bridge?.Send("voice.leftVoiceChanged", new { leftVoice = false });
+        EmitCanRejoin(false);
+    }
+
     /// <summary>
     /// Updates <see cref="_canRejoin"/> and emits <c>voice.canRejoinChanged</c>.
     /// Call whenever <see cref="_previousChannelId"/> is assigned or cleared.
@@ -763,6 +792,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         if (Connection is not { State: ConnectionStates.Connected })
             return;
 
+        _pendingLocalJoinChannelId = channelId;
         Connection.SendControl(PacketType.UserState, new UserState { ChannelId = channelId });
         SendPermissionQuery(new PermissionQuery { ChannelId = channelId });
     }
@@ -1147,7 +1177,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         return System.Text.Json.JsonSerializer.Serialize(new { roomName, accessMode = normalizedAccessMode });
     }
 
-    internal static bool TryGetLiveKitAccessMode(System.Text.Json.JsonElement data, out string? accessMode)
+    internal static bool TryGetLiveKitAccessMode(System.Text.Json.JsonElement data, [NotNullWhen(true)] out string? accessMode)
     {
         accessMode = null;
 
@@ -1156,6 +1186,43 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         accessMode = modeElement.GetString();
         return !string.IsNullOrWhiteSpace(accessMode);
+    }
+
+    internal sealed record ChannelChangedPayload(
+        uint ChannelId,
+        uint? PreviousChannelId,
+        uint? ActorSession,
+        string? ActorName,
+        string Reason);
+
+    internal static ChannelChangedPayload CreateChannelChangedPayload(
+        uint? previousChannelId,
+        uint currentChannelId,
+        uint? actorSession,
+        string? actorName,
+        bool movedByOtherUser)
+    {
+        return new ChannelChangedPayload(
+            currentChannelId,
+            previousChannelId,
+            actorSession,
+            string.IsNullOrWhiteSpace(actorName) ? null : actorName,
+            movedByOtherUser ? "moved" : "unknown");
+    }
+
+    internal sealed record ServerRemovalPayload(
+        string Reason,
+        string ActorName,
+        string? Message,
+        bool ReconnectAvailable);
+
+    internal static ServerRemovalPayload CreateServerRemovalPayload(bool banned, string? actorName, string? reason)
+    {
+        return new ServerRemovalPayload(
+            banned ? "banned" : "kicked",
+            string.IsNullOrWhiteSpace(actorName) ? "the server" : actorName,
+            string.IsNullOrWhiteSpace(reason) ? null : reason,
+            true);
     }
 
     private static async Task<TlsResult> GetViaBcTls(X509Certificate2 cert, Uri uri)
@@ -2247,7 +2314,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         bridge.RegisterHandler("livekit.requestToken", async data =>
         {
             var roomName = data.TryGetProperty("roomName", out var rn) ? rn.GetString() : null;
-            var hasAccessMode = TryGetLiveKitAccessMode(data, out var accessMode);
             var requestId = data.TryGetProperty("requestId", out var requestIdProp) && requestIdProp.ValueKind == System.Text.Json.JsonValueKind.Number
                 ? requestIdProp.GetInt32()
                 : (int?)null;
@@ -2258,7 +2324,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 return;
             }
 
-            if (!hasAccessMode)
+            if (!TryGetLiveKitAccessMode(data, out var accessMode))
             {
                 _bridge?.Send("livekit.tokenError", new { error = "Missing or invalid accessMode", requestId });
                 _bridge?.NotifyUiThread();
@@ -2843,29 +2909,47 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         if (previousChannel.HasValue && currentChannelId != previousChannel && isSelf)
         {
-            _bridge?.Send("voice.channelChanged", new { channelId = currentChannelId });
+            uint? actorSession = null;
+            string? actorName = null;
+            var movedByOtherUser = false;
+            if (userState.ShouldSerializeActor() && userState.Actor != userState.Session)
+            {
+                actorSession = userState.Actor;
+                movedByOtherUser = true;
+                if (UserDictionary.TryGetValue(userState.Actor, out var actor))
+                    actorName = actor.Name;
+            }
+
+            var isExpectedLocalJoin = _pendingLocalJoinChannelId == currentChannelId;
+            if (!movedByOtherUser && !isExpectedLocalJoin && !_leaveVoiceInProgress)
+            {
+                movedByOtherUser = true;
+            }
+
+            _bridge?.Send("voice.channelChanged", CreateChannelChangedPayload(
+                previousChannel,
+                currentChannelId,
+                actorSession,
+                actorName,
+                movedByOtherUser));
 
             // If this channel change was initiated by LeaveVoice toggle, just clear the flag
             if (_leaveVoiceInProgress)
             {
                 _leaveVoiceInProgress = false;
             }
+            else if (_pendingLocalJoinChannelId == currentChannelId)
+            {
+                _pendingLocalJoinChannelId = null;
+                if (_leftVoice && LocalUser != null)
+                {
+                    ClearLeaveVoiceState();
+                }
+            }
             // If user manually joins a channel while in left-voice mode, clear it
             else if (_leftVoice && LocalUser != null)
             {
-                _leftVoice = false;
-                _previousChannelId = null;
-
-                LocalUser.SelfMuted = false;
-                LocalUser.SelfDeaf = false;
-                LocalUser.SendMuteDeaf();
-                _audioManager?.SetMuted(false);
-                _audioManager?.SetDeafened(false);
-
-                _bridge?.Send("voice.selfMuteChanged", new { muted = false });
-                _bridge?.Send("voice.selfDeafChanged", new { deafened = false });
-                _bridge?.Send("voice.leftVoiceChanged", new { leftVoice = false });
-                EmitCanRejoin(false);
+                ClearLeaveVoiceState();
             }
             // If the user moves to root while not in leave-voice, treat it as activating leave-voice.
             // Store the channel they came from so they can rejoin.
@@ -3010,6 +3094,13 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 actorName = actor.Name ?? "Unknown";
             }
             var reason = !string.IsNullOrEmpty(userRemove.Reason) ? $": {userRemove.Reason}" : "";
+            _intentionalDisconnect = true;
+            _serverRemovalDisconnect = true;
+            _reconnectCts?.Cancel();
+            _reconnectCts = null;
+            _reconnectHost = null;
+            _reconnectUsername = null;
+            _reconnectPassword = null;
 
             if (userRemove.Ban == true)
             {
@@ -3019,6 +3110,13 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             {
                 SendSystemMessage($"You were kicked by {actorName}{reason}", "kicked");
             }
+
+            _bridge?.Send("voice.disconnected", CreateServerRemovalPayload(
+                userRemove.Ban == true,
+                actorName,
+                userRemove.Reason));
+            _bridge?.NotifyUiThread();
+            Disconnect();
         }
         else if (userName != null)
         {

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -56,7 +56,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
     {
         var user = ToMumbleUser(state);
         _logger.LogDebug("ICE callback: user connected {User}", user.Name);
-        Task.Run(() => SafeDispatch(() => DispatchUserConnected(user), nameof(userConnected)));
+        Task.Run(() => SafeDispatch(() => DispatchUserConnected(user, state.channel), nameof(userConnected)));
     }
 
     public override void userDisconnected(MumbleServer.User state, Ice.Current current)
@@ -114,9 +114,12 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
     public Task DispatchTextMessage(MumbleUser sender, string text, int channelId)
         => Task.WhenAll(_handlers.Select(h => h.OnUserTextMessage(sender, text, channelId)));
 
-    public async Task DispatchUserConnected(MumbleUser user)
+    public async Task DispatchUserConnected(MumbleUser user, int? initialChannelId = null)
     {
         _sessionMapping.SetNameForSession(user.Name, user.SessionId);
+
+        if (initialChannelId.HasValue)
+            _channelMembership.Update(user.SessionId, initialChannelId.Value);
 
         // Try cert-based resolution — await so handlers see the cert hash
         var enriched = await TryResolveCertAsync(user);

--- a/src/Brmble.Web/src/App.screenShareEnded.test.ts
+++ b/src/Brmble.Web/src/App.screenShareEnded.test.ts
@@ -4,14 +4,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as AppModule from './App';
 import {
   createQueuedScreenShareEndedNotification,
+  getMovedChannelNotification,
   getScreenShareEndedNotification,
   runIntentionalDisconnect,
+  shouldTreatMoveAsSharingRelated,
 } from './App';
 import { useNotificationQueue } from './hooks/useNotificationQueue';
 
 type ReplaceScreenShareEndedNotification = (
   current: ReturnType<typeof createQueuedScreenShareEndedNotification>,
-  reason: 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture',
+  reason: 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel',
   sequence: number,
   notifQueue: { unregister: (id: string) => void },
 ) => ReturnType<typeof createQueuedScreenShareEndedNotification>;
@@ -23,6 +25,10 @@ describe('getScreenShareEndedNotification', () => {
 
   it('keeps manual share endings silent', () => {
     expect(getScreenShareEndedNotification('manual')).toBeNull();
+  });
+
+  it('keeps moved-channel share endings silent because the move notification owns the message', () => {
+    expect(getScreenShareEndedNotification('moved-channel')).toBeNull();
   });
 
   it('returns null notification for manual share stop', () => {
@@ -114,6 +120,72 @@ describe('getScreenShareEndedNotification', () => {
 
   it('does not create a queued notification for manual share stop', () => {
     expect(createQueuedScreenShareEndedNotification('manual', 1)).toBeNull();
+  });
+});
+
+describe('getMovedChannelNotification', () => {
+  it('mentions actor and stopped sharing when a move interrupts sharing', () => {
+    expect(getMovedChannelNotification({
+      actorName: 'Moderator',
+      previousChannelName: 'General',
+      channelName: 'Raid',
+      wasSharing: true,
+    })).toEqual({
+      status: 'info',
+      title: 'Moved to Raid',
+      detail: 'Moderator moved you from General to Raid. Screen sharing was stopped.',
+    });
+  });
+
+  it('uses generic wording when actor and previous channel are unknown', () => {
+    expect(getMovedChannelNotification({
+      actorName: undefined,
+      previousChannelName: undefined,
+      channelName: 'Raid',
+      wasSharing: false,
+    })).toEqual({
+      status: 'info',
+      title: 'Moved to Raid',
+      detail: 'You were moved to Raid.',
+    });
+  });
+});
+
+describe('shouldTreatMoveAsSharingRelated', () => {
+  it('treats a move as sharing-related when the sharing channel ref is still set', () => {
+    expect(shouldTreatMoveAsSharingRelated({
+      isSharing: false,
+      isLocalShareStartPending: false,
+      sharingChannelId: '2',
+      currentShareEndedNotification: null,
+    })).toBe(true);
+  });
+
+  it('treats a move as sharing-related while a local share start is pending', () => {
+    expect(shouldTreatMoveAsSharingRelated({
+      isSharing: false,
+      isLocalShareStartPending: true,
+      sharingChannelId: undefined,
+      currentShareEndedNotification: null,
+    })).toBe(true);
+  });
+
+  it('treats a move as sharing-related when a share-ended notification already exists', () => {
+    expect(shouldTreatMoveAsSharingRelated({
+      isSharing: false,
+      isLocalShareStartPending: false,
+      sharingChannelId: undefined,
+      currentShareEndedNotification: createQueuedScreenShareEndedNotification('error', 1),
+    })).toBe(true);
+  });
+
+  it('does not treat a move as sharing-related when no share signal exists', () => {
+    expect(shouldTreatMoveAsSharingRelated({
+      isSharing: false,
+      isLocalShareStartPending: false,
+      sharingChannelId: undefined,
+      currentShareEndedNotification: null,
+    })).toBe(false);
   });
 });
 

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -1144,6 +1144,46 @@ describe('active share discovery', () => {
     });
   });
 
+  it('manual share stop does not make a later admin move look sharing-related', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id.startsWith('channel-moved-'));
+    screenShareState.isSharing = true;
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    act(() => {
+      getLocalShareEndedHandler()?.('manual');
+    });
+    screenShareState.isSharing = false;
+
+    act(() => {
+      bridge.emit('voice.channelChanged', {
+        channelId: 2,
+        previousChannelId: 1,
+        actorName: 'Moderator',
+        reason: 'moved',
+      });
+    });
+
+    await waitFor(() => {
+      expect(notifQueue.register).toHaveBeenCalledWith('channel-moved-0', 'info');
+      expect(document.body.textContent).toContain('Moved to Gaming');
+      expect(document.body.textContent).not.toContain('Screen sharing was stopped.');
+    });
+    expect(markLocalShareTeardownIntent).not.toHaveBeenCalledWith('moved-channel');
+    expect(stopSharing).not.toHaveBeenCalled();
+  });
+
   it('admin move while not sharing does not set moved-channel teardown intent', async () => {
     screenShareState.isSharing = false;
     render(React.createElement(App));

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -19,6 +19,9 @@ const {
   getIdleActionsArgs,
   clearIdleActionsArgs,
   captureIdleActionsArgs,
+  getLocalShareEndedHandler,
+  clearLocalShareEndedHandler,
+  captureLocalShareEndedHandler,
 } = vi.hoisted(() => {
   const handlers = new Map<string, Set<BridgeHandler>>();
   const disconnect = vi.fn();
@@ -50,6 +53,7 @@ const {
     dismissPreLeaveCancelled: vi.fn(),
   };
   let idleActionsArgs: { onBeforeAutoLeave?: () => void | Promise<void> } | null = null;
+  let localShareEndedHandler: ((reason: 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel') => void) | null = null;
   const mockBridge = {
     send: vi.fn(),
     on: vi.fn((type: string, handler: BridgeHandler) => {
@@ -92,6 +96,13 @@ const {
     captureIdleActionsArgs: (args: { onBeforeAutoLeave?: () => void | Promise<void> }) => {
       idleActionsArgs = args;
     },
+    getLocalShareEndedHandler: () => localShareEndedHandler,
+    clearLocalShareEndedHandler: () => {
+      localShareEndedHandler = null;
+    },
+    captureLocalShareEndedHandler: (handler?: (reason: 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel') => void) => {
+      localShareEndedHandler = handler ?? null;
+    },
     notifQueue: {
       register: vi.fn(),
       unregister: vi.fn(),
@@ -119,9 +130,11 @@ vi.mock('./hooks/useMatrixClient', () => ({
 }));
 
 vi.mock('./hooks/useScreenShare', () => ({
-  useScreenShare: () => ({
+  useScreenShare: (_onDisconnected?: () => void, _settings?: unknown, onLocalShareEnded?: (reason: 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel') => void) => {
+    captureLocalShareEndedHandler(onLocalShareEnded);
+    return {
     isSharing: screenShareState.isSharing,
-    startSharing: vi.fn(),
+    startSharing: vi.fn().mockResolvedValue(true),
     stopSharing,
     markLocalShareTeardownIntent,
     error: screenShareState.error,
@@ -135,7 +148,8 @@ vi.mock('./hooks/useScreenShare', () => ({
     disconnectViewer,
     connectAsViewer,
     isViewerConnectPending: screenShareState.isViewerConnectPending,
-  }),
+    };
+  },
 }));
 
 vi.mock('./hooks/useLeaveVoiceCooldown', () => ({
@@ -305,9 +319,10 @@ import App, { canWatchShareFromChannel, getNextLiveKitStatusUpdate, shouldClearL
 
 describe('toggleLocalScreenShare', () => {
   it('starts sharing in the current voice channel without changing LiveKit status first', async () => {
-    const startSharing = vi.fn().mockResolvedValue(undefined);
+    const startSharing = vi.fn().mockResolvedValue(true);
     const stopSharing = vi.fn();
     const setSharingChannelId = vi.fn();
+    const onSharingChannelIdChanged = vi.fn();
 
     await toggleLocalScreenShare({
       isSharing: false,
@@ -316,11 +331,34 @@ describe('toggleLocalScreenShare', () => {
       startSharing,
       stopSharing,
       setSharingChannelId,
+      onSharingChannelIdChanged,
     });
 
     expect(startSharing).toHaveBeenCalledWith('channel-7');
     expect(setSharingChannelId).toHaveBeenCalledWith('7');
+    expect(onSharingChannelIdChanged).toHaveBeenCalledWith('7');
     expect(stopSharing).not.toHaveBeenCalled();
+  });
+
+  it('does not set sharing channel when startSharing returns false after cancellation', async () => {
+    const startSharing = vi.fn().mockResolvedValue(false);
+    const stopSharing = vi.fn();
+    const setSharingChannelId = vi.fn();
+    const onSharingChannelIdChanged = vi.fn();
+
+    await toggleLocalScreenShare({
+      isSharing: false,
+      selfLeftVoice: false,
+      voiceChannelId: 7,
+      startSharing,
+      stopSharing,
+      setSharingChannelId,
+      onSharingChannelIdChanged,
+    });
+
+    expect(startSharing).toHaveBeenCalledWith('channel-7');
+    expect(setSharingChannelId).not.toHaveBeenCalled();
+    expect(onSharingChannelIdChanged).not.toHaveBeenCalled();
   });
 
   it('ignores local share start while LiveKit is already connecting', async () => {
@@ -425,6 +463,7 @@ describe('active share discovery', () => {
     idleActionsState.preLeaveStartedAt = null;
     idleActionsState.preLeaveCancelledAt = null;
     clearIdleActionsArgs();
+    clearLocalShareEndedHandler();
     vi.mocked(notifQueue.isVisible).mockReturnValue(false);
   });
 
@@ -909,6 +948,368 @@ describe('active share discovery', () => {
       ['livekit.checkActiveShare', expect.objectContaining({ roomName: 'channel-1' })],
       ['livekit.checkActiveShare', expect.objectContaining({ roomName: 'channel-2' })],
     ]);
+  });
+
+  it('unregisters previous moved-channel notification before registering a replacement', async () => {
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming' },
+          { id: 3, name: 'Raid' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    act(() => {
+      bridge.emit('voice.channelChanged', {
+        channelId: 2,
+        previousChannelId: 1,
+        actorName: 'Moderator',
+        reason: 'moved',
+      });
+    });
+
+    await waitFor(() => {
+      expect(notifQueue.register).toHaveBeenCalledWith('channel-moved-0', 'info');
+    });
+
+    act(() => {
+      bridge.emit('voice.channelChanged', {
+        channelId: 3,
+        previousChannelId: 2,
+        actorName: 'Moderator',
+        reason: 'moved',
+      });
+    });
+
+    await waitFor(() => {
+      expect(notifQueue.unregister).toHaveBeenCalledWith('channel-moved-0');
+      expect(notifQueue.register).toHaveBeenCalledWith('channel-moved-1', 'info');
+    });
+  });
+
+  it('keeps showing moved notifications after many replacements', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id.startsWith('channel-moved-'));
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming' },
+          { id: 3, name: 'Raid' },
+          { id: 4, name: 'Ops' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    for (let i = 0; i < 25; i++) {
+      const previousChannelId = (i % 4) + 1;
+      const channelId = ((i + 1) % 4) + 1;
+      act(() => {
+        bridge.emit('voice.channelChanged', {
+          channelId,
+          previousChannelId,
+          actorName: 'Moderator',
+          reason: 'moved',
+        });
+      });
+    }
+
+    await waitFor(() => {
+      expect(notifQueue.register).toHaveBeenCalledWith('channel-moved-24', 'info');
+      expect(document.body.textContent).toContain('Moved to');
+    });
+    expect(notifQueue.unregister).toHaveBeenCalledWith('channel-moved-23');
+  });
+
+  it('treats repeated admin moves as sharing-related when user resumes sharing after each move', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id.startsWith('channel-moved-'));
+    const view = render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming' },
+          { id: 3, name: 'Raid' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    for (let i = 0; i < 6; i++) {
+      await act(async () => {
+        view.getByTestId('header-toggle-screen-share').click();
+        await Promise.resolve();
+      });
+      act(() => {
+        bridge.emit('voice.channelChanged', {
+          channelId: i % 2 === 0 ? 2 : 3,
+          previousChannelId: i % 2 === 0 ? 1 : 2,
+          actorName: 'Moderator',
+          reason: 'moved',
+        });
+      });
+      await waitFor(() => {
+        expect(document.body.textContent).toContain('Screen sharing was stopped.');
+      });
+      screenShareState.isSharing = false;
+    }
+
+    expect(markLocalShareTeardownIntent).toHaveBeenCalledTimes(6);
+    expect(stopSharing).toHaveBeenCalledTimes(6);
+  });
+
+  it('admin move while sharing stops local publishing with moved-channel intent', async () => {
+    screenShareState.isSharing = true;
+    vi.mocked(stopSharing).mockResolvedValueOnce(undefined);
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    act(() => {
+      bridge.emit('voice.channelChanged', {
+        channelId: 2,
+        previousChannelId: 1,
+        actorName: 'Moderator',
+        reason: 'moved',
+      });
+    });
+
+    await waitFor(() => {
+      expect(markLocalShareTeardownIntent).toHaveBeenCalledWith('moved-channel');
+      expect(stopSharing).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('admin move after a LiveKit interruption replaces the technical share warning with moved sharing notification', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id.startsWith('screen-share-ended-') || id.startsWith('channel-moved-'));
+    screenShareState.isSharing = true;
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    act(() => {
+      getLocalShareEndedHandler()?.('interrupted');
+    });
+    screenShareState.isSharing = false;
+
+    act(() => {
+      bridge.emit('voice.channelChanged', {
+        channelId: 2,
+        previousChannelId: 1,
+        actorName: 'Moderator',
+        reason: 'moved',
+      });
+    });
+
+    await waitFor(() => {
+      expect(notifQueue.unregister).toHaveBeenCalledWith('screen-share-ended-0');
+      expect(notifQueue.register).toHaveBeenCalledWith('channel-moved-0', 'info');
+      expect(document.body.textContent).toContain('Moved to Gaming');
+      expect(document.body.textContent).toContain('Screen sharing was stopped.');
+      expect(document.body.textContent).not.toContain('technical issue');
+    });
+  });
+
+  it('admin move while not sharing does not set moved-channel teardown intent', async () => {
+    screenShareState.isSharing = false;
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    act(() => {
+      bridge.emit('voice.channelChanged', {
+        channelId: 2,
+        previousChannelId: 1,
+        actorName: 'Moderator',
+        reason: 'moved',
+      });
+    });
+
+    await waitFor(() => {
+      expect(notifQueue.register).toHaveBeenCalledWith('channel-moved-0', 'info');
+    });
+    expect(markLocalShareTeardownIntent).not.toHaveBeenCalledWith('moved-channel');
+    expect(stopSharing).not.toHaveBeenCalled();
+  });
+
+  it('describes admin move to root as moved out of voice', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id.startsWith('channel-moved-'));
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 0, name: 'Connected', parent: 0 },
+          { id: 1, name: 'General' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    act(() => {
+      bridge.emit('voice.channelChanged', {
+        channelId: 0,
+        previousChannelId: 1,
+        actorName: 'Moderator',
+        reason: 'moved',
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('Moved out of voice');
+      expect(document.body.textContent).toContain('Moderator moved you out of General.');
+      expect(document.body.textContent).not.toContain('Moved to Connected');
+    });
+  });
+
+  it('describes admin move to root while sharing as moved out of voice and stopped sharing', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id.startsWith('channel-moved-'));
+    screenShareState.isSharing = true;
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 0, name: 'Connected', parent: 0 },
+          { id: 1, name: 'General' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    act(() => {
+      bridge.emit('voice.channelChanged', {
+        channelId: 0,
+        previousChannelId: 1,
+        actorName: 'Moderator',
+        reason: 'moved',
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('Moved out of voice');
+      expect(document.body.textContent).toContain('Moderator moved you out of General. Screen sharing was stopped.');
+    });
+  });
+
+  it('shows a warning notification when kicked from the server', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'server-removal');
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.disconnected', {
+        reason: 'kicked',
+        actorName: 'Moderator',
+        message: 'Too loud',
+        reconnectAvailable: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(notifQueue.register).toHaveBeenCalledWith('server-removal', 'warning');
+      expect(document.body.textContent).toContain('Kicked from server');
+      expect(document.body.textContent).toContain('Moderator kicked you from the server. Reason: Too loud');
+    });
+  });
+
+  it('shows an error notification when banned from the server', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'server-removal');
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.disconnected', {
+        reason: 'banned',
+        actorName: 'Admin',
+        message: 'Spam',
+        reconnectAvailable: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(notifQueue.register).toHaveBeenCalledWith('server-removal', 'error');
+      expect(document.body.textContent).toContain('Banned from server');
+      expect(document.body.textContent).toContain('Admin banned you from the server. Reason: Spam');
+    });
+  });
+
+  it('clears server removal notification after reconnecting successfully', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'server-removal');
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.disconnected', {
+        reason: 'kicked',
+        actorName: 'Moderator',
+        reconnectAvailable: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(notifQueue.register).toHaveBeenCalledWith('server-removal', 'warning');
+      expect(document.body.textContent).toContain('Kicked from server');
+    });
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [{ id: 1, name: 'General' }],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(notifQueue.unregister).toHaveBeenCalledWith('server-removal');
+      expect(document.body.textContent).not.toContain('Kicked from server');
+    });
   });
 
   it('screen share active channel switch cancel keeps sharing and does not join the new channel', async () => {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -56,9 +56,19 @@ export interface QueuedScreenShareEndedNotification extends ScreenShareEndedNoti
   id: string;
 }
 
+export interface MovedChannelNotificationInput {
+  actorName?: string;
+  previousChannelName?: string;
+  channelName: string;
+  movedToRoot?: boolean;
+  wasSharing: boolean;
+}
+
 export function getScreenShareEndedNotification(reason: LocalShareStopReason): ScreenShareEndedNotification | null {
   switch (reason) {
     case 'manual':
+      return null;
+    case 'moved-channel':
       return null;
     case 'source-closed':
       return {
@@ -91,6 +101,35 @@ export function getScreenShareEndedNotification(reason: LocalShareStopReason): S
   }
 }
 
+export function getMovedChannelNotification(input: MovedChannelNotificationInput): ScreenShareEndedNotification {
+  if (input.movedToRoot) {
+    const actor = input.actorName || 'Someone';
+    const route = input.previousChannelName
+      ? `${actor} moved you out of ${input.previousChannelName}`
+      : input.actorName
+        ? `${input.actorName} moved you out of voice`
+        : 'You were moved out of voice';
+
+    return {
+      status: 'info',
+      title: 'Moved out of voice',
+      detail: `${route}.${input.wasSharing ? ' Screen sharing was stopped.' : ''}`,
+    };
+  }
+
+  const route = input.previousChannelName
+    ? `${input.actorName || 'Someone'} moved you from ${input.previousChannelName} to ${input.channelName}`
+    : input.actorName
+      ? `${input.actorName} moved you to ${input.channelName}`
+      : `You were moved to ${input.channelName}`;
+
+  return {
+    status: 'info',
+    title: `Moved to ${input.channelName}`,
+    detail: `${route}.${input.wasSharing ? ' Screen sharing was stopped.' : ''}`,
+  };
+}
+
 export function createQueuedScreenShareEndedNotification(
   reason: LocalShareStopReason,
   sequence: number,
@@ -119,15 +158,38 @@ export function replaceScreenShareEndedNotification(
   return createQueuedScreenShareEndedNotification(reason, sequence);
 }
 
+export function shouldTreatMoveAsSharingRelated(options: {
+  isSharing: boolean;
+  isLocalShareStartPending: boolean;
+  sharingChannelId: string | undefined;
+  currentShareEndedNotification: QueuedScreenShareEndedNotification | null;
+}) {
+  return options.isSharing
+    || options.isLocalShareStartPending
+    || options.sharingChannelId !== undefined
+    || options.currentShareEndedNotification !== null;
+}
+
+export function getServerRemovalNotification(input: { reason: 'kicked' | 'banned'; actorName?: string; message?: string }): ScreenShareEndedNotification {
+  const actorName = input.actorName || 'the server';
+  const action = input.reason === 'banned' ? 'banned' : 'kicked';
+  return {
+    status: input.reason === 'banned' ? 'error' : 'warning',
+    title: input.reason === 'banned' ? 'Banned from server' : 'Kicked from server',
+    detail: `${actorName} ${action} you from the server.${input.message ? ` Reason: ${input.message}` : ''}`,
+  };
+}
+
 interface ToggleLocalScreenShareOptions {
   isSharing: boolean;
   selfLeftVoice: boolean;
   voiceChannelId?: number;
   liveKitState?: ServiceStatus['state'];
-  startSharing: (roomName: string) => Promise<void>;
+  startSharing: (roomName: string) => Promise<boolean>;
   stopSharing: () => Promise<void>;
   markLocalShareTeardownIntent?: (reason: LocalShareStopReason) => void;
   setSharingChannelId: (channelId: string | undefined) => void;
+  onSharingChannelIdChanged?: (channelId: string | undefined) => void;
 }
 
 interface NextLiveKitStatusOptions {
@@ -216,10 +278,12 @@ export async function toggleLocalScreenShare({
   startSharing,
   stopSharing,
   setSharingChannelId,
+  onSharingChannelIdChanged,
 }: ToggleLocalScreenShareOptions) {
   if (isSharing) {
     await stopSharing();
     setSharingChannelId(undefined);
+    onSharingChannelIdChanged?.(undefined);
     return;
   }
 
@@ -232,8 +296,13 @@ export async function toggleLocalScreenShare({
   }
 
   try {
-    await startSharing(`channel-${voiceChannelId}`);
-    setSharingChannelId(String(voiceChannelId));
+    const started = await startSharing(`channel-${voiceChannelId}`);
+    if (!started) {
+      return;
+    }
+    const nextSharingChannelId = String(voiceChannelId);
+    setSharingChannelId(nextSharingChannelId);
+    onSharingChannelIdChanged?.(nextSharingChannelId);
   } catch {
     // startSharing sets error state internally; App effects handle status updates.
   }
@@ -329,6 +398,14 @@ interface User {
   avatarUrl?: string;
   certHash?: string;
   isBrmbleClient?: boolean;
+}
+
+interface QueuedMovedChannelNotification extends ScreenShareEndedNotification {
+  id: string;
+}
+
+interface ServerRemovalNotification extends ScreenShareEndedNotification {
+  id: 'server-removal';
 }
 
 
@@ -912,6 +989,8 @@ function App() {
     const onVoiceConnected = ((data: unknown) => {
       setConnectionStatus('connected');
       updateStatus('voice', { state: 'connected', error: undefined });
+      notifQueue.unregister('server-removal');
+      setServerRemovalNotification(null);
       const d = data as { username?: string; channelId?: number; channels?: Channel[]; users?: User[] } | undefined;
 
       // Use actual channel from server instead of assuming root.
@@ -983,7 +1062,19 @@ function App() {
     const onVoiceDisconnected = (data: unknown) => {
       clearPendingAction();
       purgeEphemeralMessages('server-root');
-      const d = data as { reconnectAvailable?: boolean } | null;
+      const d = data as { reconnectAvailable?: boolean; reason?: 'kicked' | 'banned' | string; actorName?: string; message?: string } | null;
+
+      if (d?.reason === 'kicked' || d?.reason === 'banned') {
+        const notification = {
+          id: 'server-removal' as const,
+          ...getServerRemovalNotification({
+            reason: d.reason,
+            actorName: d.actorName,
+            message: d.message,
+          }),
+        };
+        setServerRemovalNotification(notification);
+      }
 
       if (d?.reconnectAvailable && userSawConnectedRef.current) {
         // User was connected and saw the UI, then lost connection
@@ -1174,10 +1265,55 @@ function App() {
       }
     });
 
-    const onVoiceChannelChanged = ((data: unknown) => {
+  const onVoiceChannelChanged = ((data: unknown) => {
       clearPendingAction();
-      const d = data as { channelId: number; name?: string } | undefined;
+      const d = data as { channelId: number; name?: string; previousChannelId?: number; actorName?: string; reason?: 'moved' | 'unknown' } | undefined;
       if (d?.channelId !== undefined && d?.channelId !== null) {
+        const wasSharing = shouldTreatMoveAsSharingRelated({
+          isSharing: isSharingRef.current || wasLocalShareRecentlyActiveRef.current,
+          isLocalShareStartPending: isLocalShareStartPendingRef.current,
+          sharingChannelId: sharingChannelIdRef.current,
+          currentShareEndedNotification: screenShareEndedNotificationRef.current,
+        });
+        if (d.reason === 'moved') {
+          if (movedChannelNotificationRef.current) {
+            notifQueue.unregister(movedChannelNotificationRef.current.id);
+            movedChannelNotificationRef.current = null;
+          }
+
+          if (wasSharing) {
+            markLocalShareTeardownIntent('moved-channel');
+            void stopSharingRef.current?.();
+          }
+          if (screenShareEndedNotificationRef.current) {
+            notifQueue.unregister(screenShareEndedNotificationRef.current.id);
+            screenShareEndedNotificationRef.current = null;
+            setScreenShareEndedNotification(null);
+          }
+
+          const channelName = d.name
+            || channelsRef.current.find(c => c.id === d.channelId)?.name
+            || (d.channelId === 0 ? (serverLabel || 'Server') : `Channel ${d.channelId}`);
+          const previousChannelName = d.previousChannelId !== undefined
+            ? channelsRef.current.find(c => c.id === d.previousChannelId)?.name
+            : undefined;
+          const notification = {
+            id: `channel-moved-${nextMovedChannelNotificationIdRef.current++}`,
+            ...getMovedChannelNotification({
+              actorName: d.actorName,
+              previousChannelName,
+              channelName,
+              movedToRoot: d.channelId === 0,
+              wasSharing,
+            }),
+          };
+          movedChannelNotificationRef.current = notification;
+          setMovedChannelNotification(notification);
+          sharingChannelIdRef.current = undefined;
+          setSharingChannelId(undefined);
+          wasLocalShareRecentlyActiveRef.current = false;
+        }
+
         if (d.channelId === 0) {
           setCurrentChannelId('server-root');
           setCurrentChannelName('');
@@ -2140,14 +2276,21 @@ const handleConnect = (serverData: SavedServer) => {
   }, []);
 
   const [sharingChannelId, setSharingChannelId] = useState<string | undefined>();
+  const sharingChannelIdRef = useRef<string | undefined>(undefined);
+  const wasLocalShareRecentlyActiveRef = useRef(false);
   const [isLocalShareStartPending, setIsLocalShareStartPending] = useState(false);
+  const isLocalShareStartPendingRef = useRef(false);
   const [screenShareToast, setScreenShareToast] = useState<{
     userName: string; roomName: string; userId?: number; matrixUserId?: string;
   } | null>(null);
   const [screenShareEndedNotification, setScreenShareEndedNotification] = useState<QueuedScreenShareEndedNotification | null>(null);
+  const [movedChannelNotification, setMovedChannelNotification] = useState<QueuedMovedChannelNotification | null>(null);
+  const [serverRemovalNotification, setServerRemovalNotification] = useState<ServerRemovalNotification | null>(null);
   const nextScreenShareEndedNotificationIdRef = useRef(0);
+  const nextMovedChannelNotificationIdRef = useRef(0);
   const nextActiveShareDiscoveryRequestIdRef = useRef(0);
   const screenShareEndedNotificationRef = useRef<QueuedScreenShareEndedNotification | null>(null);
+  const movedChannelNotificationRef = useRef<QueuedMovedChannelNotification | null>(null);
   const [copyToast, setCopyToast] = useState<{ message: string } | null>(null);
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null);
   const [updateProgress, setUpdateProgress] = useState<number | null>(null);
@@ -2163,6 +2306,8 @@ const handleConnect = (serverData: SavedServer) => {
 
   const handleLocalScreenShareEnded = useCallback((reason: LocalShareStopReason) => {
     setSharingChannelId(undefined);
+    sharingChannelIdRef.current = undefined;
+    wasLocalShareRecentlyActiveRef.current = true;
 
     const notification = replaceScreenShareEndedNotification(
       screenShareEndedNotificationRef.current,
@@ -2176,8 +2321,12 @@ const handleConnect = (serverData: SavedServer) => {
 
   const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, disconnectViewer, connectAsViewer, isViewerConnectPending } = useScreenShare(() => {
     setSharingChannelId(undefined);
+    sharingChannelIdRef.current = undefined;
   }, screenShareSettings, handleLocalScreenShareEnded);
   isSharingRef.current = isSharing;
+  if (isSharing) {
+    wasLocalShareRecentlyActiveRef.current = true;
+  }
   stopSharingRef.current = stopSharing;
   disconnectViewerRef.current = disconnectViewer;
 
@@ -2220,6 +2369,18 @@ const handleConnect = (serverData: SavedServer) => {
       // from dismissal/exit handlers so a replacement event gets fresh metadata.
     }
   }, [screenShareEndedNotification, notifQueue]);
+
+  useEffect(() => {
+    if (movedChannelNotification) {
+      notifQueue.register(movedChannelNotification.id, movedChannelNotification.status);
+    }
+  }, [movedChannelNotification, notifQueue]);
+
+  useEffect(() => {
+    if (serverRemovalNotification) {
+      notifQueue.register(serverRemovalNotification.id, serverRemovalNotification.status);
+    }
+  }, [serverRemovalNotification, notifQueue]);
 
   const { isOnCooldown: leaveVoiceOnCooldown, trigger: triggerLeaveVoiceCooldown } = useLeaveVoiceCooldown(1000);
   const { isOnCooldown: muteOnCooldown, trigger: triggerMuteCooldown } = useLeaveVoiceCooldown(1000);
@@ -2311,6 +2472,7 @@ const handleConnect = (serverData: SavedServer) => {
       selfLeftVoice,
       voiceChannelId: selfVoiceChannelId,
     })) {
+      isLocalShareStartPendingRef.current = false;
       setIsLocalShareStartPending(false);
     }
   }, [isLocalShareStartPending, selfLeftVoice, selfVoiceChannelId]);
@@ -2390,6 +2552,7 @@ const handleConnect = (serverData: SavedServer) => {
 
     if (shouldStartSharing) {
       setIsLocalShareStartPending(true);
+      isLocalShareStartPendingRef.current = true;
     }
 
     await toggleLocalScreenShare({
@@ -2400,10 +2563,15 @@ const handleConnect = (serverData: SavedServer) => {
       startSharing,
       stopSharing,
       setSharingChannelId,
+      onSharingChannelIdChanged: (channelId) => {
+        sharingChannelIdRef.current = channelId;
+        wasLocalShareRecentlyActiveRef.current = channelId !== undefined;
+      },
     });
 
     if (shouldStartSharing) {
       setIsLocalShareStartPending(false);
+      isLocalShareStartPendingRef.current = false;
     }
   }, [isSharing, startSharing, stopSharing, selfLeftVoice]);
   handleToggleScreenShareRef.current = handleToggleScreenShare;
@@ -2839,6 +3007,43 @@ const handleConnect = (serverData: SavedServer) => {
               if (screenShareEndedNotificationRef.current?.id === screenShareEndedNotification.id) {
                 screenShareEndedNotificationRef.current = null;
               }
+            }}
+          />
+        )}
+        {movedChannelNotification && notifQueue.isVisible(movedChannelNotification.id) && (
+          <Notification
+            key={movedChannelNotification.id}
+            status={movedChannelNotification.status}
+            position="top-right"
+            visible={!!movedChannelNotification}
+            title={movedChannelNotification.title}
+            detail={movedChannelNotification.detail}
+            onDismiss={() => {
+              notifQueue.unregister(movedChannelNotification.id);
+              movedChannelNotificationRef.current = null;
+              setMovedChannelNotification(null);
+            }}
+            onExited={() => {
+              notifQueue.unregister(movedChannelNotification.id);
+              if (movedChannelNotificationRef.current?.id === movedChannelNotification.id) {
+                movedChannelNotificationRef.current = null;
+              }
+            }}
+          />
+        )}
+        {serverRemovalNotification && notifQueue.isVisible(serverRemovalNotification.id) && (
+          <Notification
+            status={serverRemovalNotification.status}
+            position="top-right"
+            visible={!!serverRemovalNotification}
+            title={serverRemovalNotification.title}
+            detail={serverRemovalNotification.detail}
+            onDismiss={() => {
+              notifQueue.unregister(serverRemovalNotification.id);
+              setServerRemovalNotification(null);
+            }}
+            onExited={() => {
+              notifQueue.unregister(serverRemovalNotification.id);
             }}
           />
         )}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2307,7 +2307,14 @@ const handleConnect = (serverData: SavedServer) => {
   const handleLocalScreenShareEnded = useCallback((reason: LocalShareStopReason) => {
     setSharingChannelId(undefined);
     sharingChannelIdRef.current = undefined;
-    wasLocalShareRecentlyActiveRef.current = true;
+    isSharingRef.current = false;
+    if (reason === 'manual') {
+      wasLocalShareRecentlyActiveRef.current = false;
+      screenShareEndedNotificationRef.current = null;
+      setScreenShareEndedNotification(null);
+    } else {
+      wasLocalShareRecentlyActiveRef.current = true;
+    }
 
     const notification = replaceScreenShareEndedNotification(
       screenShareEndedNotificationRef.current,

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
@@ -10,7 +10,7 @@ const { bridgeMock, usePermissionsMock } = vi.hoisted(() => ({
     send: vi.fn(),
   },
   usePermissionsMock: vi.fn(() => ({
-    hasPermission: vi.fn(() => false),
+    hasPermission: vi.fn((_channelId: number, _permission: number) => false),
     Permission: {
       Move: 0x20,
       MakeChannel: 0x40,
@@ -252,6 +252,57 @@ describe('ChannelTree screen share behavior', () => {
     const indicator = screen.getByText('Sharing').closest('.sharing-indicator');
     expect(indicator).not.toBeNull();
     expect(indicator?.firstElementChild).toHaveTextContent('Sharing');
+  });
+});
+
+describe('ChannelTree user move drag and drop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows admin drag and drop while self is in root', () => {
+    const onMoveUser = vi.fn();
+    usePermissionsMock.mockReturnValue({
+      hasPermission: vi.fn((channelId: number, permission: number) => channelId === 0 && permission === 0x20),
+      Permission: {
+        Move: 0x20,
+        MakeChannel: 0x40,
+        Write: 0x1,
+        Kick: 0x10000,
+        Ban: 0x20000,
+        MuteDeafen: 0x10,
+      },
+      requestPermissions: vi.fn(),
+    });
+
+    render(
+      <ChannelTree
+        channels={[{ id: 1, name: 'General' }, { id: 2, name: 'Gaming' }]}
+        users={[{ session: 7, name: 'Alice', channelId: 1 }]}
+        currentChannelId={0}
+        onJoinChannel={vi.fn()}
+        onMoveUser={onMoveUser}
+      />
+    );
+
+    const userRow = screen.getByText('Alice').closest('.user-row')!;
+    const targetChannel = screen.getByText('Gaming').closest('.channel-row')!;
+    const dragData = new Map<string, string>();
+    const dataTransfer = {
+      effectAllowed: '',
+      setData: vi.fn((type: string, value: string) => dragData.set(type, value)),
+      getData: vi.fn((type: string) => dragData.get(type) ?? ''),
+    };
+
+    expect(userRow).toHaveAttribute('draggable', 'true');
+
+    fireEvent.dragStart(userRow, { dataTransfer });
+    expect(dataTransfer.setData).toHaveBeenCalledWith('text/plain', '7');
+    fireEvent.dragOver(targetChannel, { dataTransfer });
+    fireEvent.drop(targetChannel, { dataTransfer });
+    expect(dataTransfer.getData).toHaveBeenCalledWith('text/plain');
+
+    expect(onMoveUser).toHaveBeenCalledWith(7, 2);
   });
 });
 

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -94,7 +94,8 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     return ids;
   }, [activeShares, sharingChannelId]);
 
-  const canDragUsers = currentChannelId != null && hasPermission(currentChannelId, Permission.Move);
+  const canDragUsers = hasPermission(0, Permission.Move)
+    || (currentChannelId != null && hasPermission(currentChannelId, Permission.Move));
 
   useEffect(() => {
     if (currentChannelId) {
@@ -260,7 +261,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
           }}
           onDragLeave={() => setDropTargetChannel(null)}
           onDrop={(e) => {
-            if (!canDragUsers || draggedUser === null) return;
+            if (!canDragUsers) return;
             e.preventDefault();
             const session = parseInt(e.dataTransfer.getData('text/plain'));
             if (!isNaN(session) && onMoveUser) {

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.css
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.css
@@ -45,6 +45,11 @@
   color: var(--accent-secondary);
 }
 
+.root-drop-target {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary-ghost);
+}
+
 .server-integrated-stats {
   margin: var(--space-xs) 0 var(--space-md);
   display: flex;

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
@@ -8,7 +8,7 @@ const { bridgeMock, usePermissionsMock, useServiceStatusMock, useResizableMock }
     send: vi.fn(),
   },
   usePermissionsMock: vi.fn(() => ({
-    hasPermission: vi.fn(() => false),
+    hasPermission: vi.fn((_channelId: number, _permission: number) => false),
     Permission: {
       Kick: 0x10000,
       Ban: 0x20000,
@@ -258,5 +258,70 @@ describe('Sidebar root user idle (moon) icon', () => {
     });
     const row = screen.getByText('Bob').closest('.root-user-row');
     expect(row?.querySelector('.user-status-area [data-icon="moon"]')).not.toBeNull();
+  });
+});
+
+describe('Sidebar root move drop targets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePermissionsMock.mockReturnValue({
+      hasPermission: vi.fn((channelId: number, permission: number) => channelId === 0 && permission === 0x20),
+      Permission: {
+        Kick: 0x10000,
+        Ban: 0x20000,
+        MuteDeafen: 0x10,
+        Move: 0x20,
+        MakeChannel: 0x40,
+        Write: 0x1,
+      },
+      requestPermissions: vi.fn(),
+    });
+  });
+
+  const dragPayload = (session: string) => ({
+    dataTransfer: {
+      getData: vi.fn((type: string) => type === 'text/plain' ? session : ''),
+      setData: vi.fn(),
+      effectAllowed: 'move',
+    },
+  });
+
+  it('moves a dragged user to root when dropped on the server info panel', () => {
+    renderSidebar({
+      channels: [
+        { id: 0, name: 'Connected', parent: 0 },
+        { id: 1, name: 'General' },
+      ],
+      users: [{ session: 7, name: 'Alice', channelId: 1 }],
+      serverLabel: 'Test Server',
+    });
+
+    const panel = screen.getByText('Test Server').closest('.server-info-panel')!;
+    const event = dragPayload('7');
+    fireEvent.dragOver(panel, event);
+    fireEvent.drop(panel, event);
+
+    expect(bridgeMock.send).toHaveBeenCalledWith('voice.move', { session: 7, channelId: 0 });
+  });
+
+  it('moves a dragged user to root when dropped on the Connected users panel', () => {
+    renderSidebar({
+      channels: [
+        { id: 0, name: 'Connected', parent: 0 },
+        { id: 1, name: 'General' },
+      ],
+      users: [
+        { session: 7, name: 'Alice', channelId: 1 },
+        { session: 8, name: 'RootUser', channelId: 0 },
+      ],
+      serverLabel: 'Test Server',
+    });
+
+    const panel = screen.getByText('RootUser').closest('.root-users-panel')!;
+    const event = dragPayload('7');
+    fireEvent.dragOver(panel, event);
+    fireEvent.drop(panel, event);
+
+    expect(bridgeMock.send).toHaveBeenCalledWith('voice.move', { session: 7, channelId: 0 });
   });
 });

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -147,8 +147,26 @@ export function Sidebar({
   const [requestChannelDialog, setRequestChannelDialog] = useState(false);
   const [newChannelName, setNewChannelName] = useState('');
   const [newChannelDescription, setNewChannelDescription] = useState('');
+  const [rootDropTarget, setRootDropTarget] = useState<'server' | 'connected' | null>(null);
 
   const { hasPermission, Permission, requestPermissions } = usePermissions();
+  const canDropToRoot = connected && hasPermission(0, Permission.Move);
+
+  const moveDroppedUserToRoot = (e: React.DragEvent) => {
+    if (!canDropToRoot) return;
+    e.preventDefault();
+    const session = parseInt(e.dataTransfer.getData('text/plain'));
+    if (!isNaN(session)) {
+      bridge.send('voice.move', { session, channelId: 0 });
+    }
+    setRootDropTarget(null);
+  };
+
+  const allowRootDrop = (target: 'server' | 'connected') => (e: React.DragEvent) => {
+    if (!canDropToRoot) return;
+    e.preventDefault();
+    setRootDropTarget(target);
+  };
 
   useEffect(() => {
     if (connected) {
@@ -158,7 +176,12 @@ export function Sidebar({
 
   return (
     <aside className={`sidebar${isDragging ? ' sidebar--resizing' : ''}`} style={{ width }}>
-      <div className={`server-info-panel${isServerChatActive ? ' server-info-active' : ''}`}>
+      <div
+        className={`server-info-panel${isServerChatActive ? ' server-info-active' : ''}${rootDropTarget === 'server' ? ' root-drop-target' : ''}`}
+        onDragOver={allowRootDrop('server')}
+        onDragLeave={() => setRootDropTarget(null)}
+        onDrop={moveDroppedUserToRoot}
+      >
         {serverLabel ? (
           <div 
             className={`server-info-header${onSelectServer ? ' server-info-clickable' : ''}`}
@@ -272,7 +295,12 @@ export function Sidebar({
       </div>
       
       {connected && rootUsers.length > 0 && (
-        <div className="root-users-panel">
+        <div
+          className={`root-users-panel${rootDropTarget === 'connected' ? ' root-drop-target' : ''}`}
+          onDragOver={allowRootDrop('connected')}
+          onDragLeave={() => setRootDropTarget(null)}
+          onDrop={moveDroppedUserToRoot}
+        >
           <div className="root-users-header">
             <h4 className="heading-label">Connected</h4>
             <span className="root-users-count">{rootUsers.length}</span>

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -147,6 +147,57 @@ describe('useScreenShare', () => {
     expect(result.current.isSharing).toBe(true);
   });
 
+  it('stopSharing cancels a pending share start before token resolution', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    const sharePromise = result.current.startSharing('channel-1');
+    await act(async () => {
+      await result.current.stopSharing();
+      tokenHandler?.(liveKitToken('test-jwt'));
+      await sharePromise;
+    });
+
+    expect(mockRoom.connect).not.toHaveBeenCalled();
+    expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalled();
+    expect(result.current.isSharing).toBe(false);
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStarted')).toHaveLength(0);
+  });
+
+  it('stopSharing cancels a pending share start after room connect before capture publishes', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let resolveCapture: (() => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+    mockRoom.localParticipant.setScreenShareEnabled.mockImplementationOnce(() => new Promise<void>(resolve => {
+      resolveCapture = resolve;
+    }));
+
+    const { result } = renderHook(() => useScreenShare());
+
+    const sharePromise = result.current.startSharing('channel-1');
+    await act(async () => {
+      tokenHandler?.(liveKitToken('test-jwt'));
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.stopSharing();
+      resolveCapture?.();
+      await sharePromise;
+    });
+
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, undefined);
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(false);
+    expect(result.current.isSharing).toBe(false);
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStarted')).toHaveLength(0);
+  });
+
   it('requests subscribe token via bridge when connecting as viewer', async () => {
     let tokenHandler: ((data: unknown) => void) | null = null;
     let shareStartedHandler: ((data: unknown) => void) | null = null;
@@ -1316,7 +1367,7 @@ describe('useScreenShare', () => {
       resolveDisconnect = resolve;
     }));
 
-    let startPromise: Promise<void> | null = null;
+    let startPromise: Promise<boolean> | null = null;
     act(() => {
       startPromise = result.current.startSharing('channel-1');
     });
@@ -1820,7 +1871,7 @@ describe('useScreenShare', () => {
     });
 
     let viewerPromise: Promise<void> | null = null;
-    let sharePromise: Promise<void> | null = null;
+    let sharePromise: Promise<boolean> | null = null;
     act(() => {
       viewerPromise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
       sharePromise = result.current.startSharing('channel-1');
@@ -1854,7 +1905,7 @@ describe('useScreenShare', () => {
     });
 
     let viewerPromise: Promise<void> | null = null;
-    let sharePromise: Promise<void> | null = null;
+    let sharePromise: Promise<boolean> | null = null;
     act(() => {
       viewerPromise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
       sharePromise = result.current.startSharing('channel-1');
@@ -1886,7 +1937,7 @@ describe('useScreenShare', () => {
 
     const { result } = renderHook(() => useScreenShare());
 
-    let sharePromise: Promise<void> | null = null;
+    let sharePromise: Promise<boolean> | null = null;
     act(() => {
       sharePromise = result.current.startSharing('channel-1');
     });
@@ -1923,7 +1974,7 @@ describe('useScreenShare', () => {
       shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
     });
 
-    let sharePromise: Promise<void> | null = null;
+    let sharePromise: Promise<boolean> | null = null;
     let viewerPromise: Promise<void> | null = null;
     act(() => {
       sharePromise = result.current.startSharing('channel-1');

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -24,7 +24,7 @@ export interface ScreenShareSettings {
   systemAudio: boolean;
 }
 
-export type LocalShareStopReason = 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture';
+export type LocalShareStopReason = 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel';
 
 type LocalTrackLike = {
   addEventListener?: (event: string, handler: () => void) => void;
@@ -346,6 +346,7 @@ export function useScreenShare(
   const roomAccessModeRef = useRef<LiveKitAccessMode | null>(null);
   const roomReconnectUpgradeRef = useRef(false);
   const roomLifecycleGenerationRef = useRef(0);
+  const shareStartCancelGenerationRef = useRef(0);
   const pendingRoomRequestRef = useRef<PendingRoomRequest | null>(null);
 
   const cancelPendingRoomRequest = useCallback(() => {
@@ -619,14 +620,15 @@ export function useScreenShare(
     }
   }, [requestToken, stopLocalShare, removeWatchingShare, clearWatchingState, invalidateRoomLifecycle]);
 
-  const startSharing = useCallback(async (roomName: string) => {
+  const startSharing = useCallback(async (roomName: string): Promise<boolean> => {
     if (isStartingShareRef.current) {
-      return;
+      return false;
     }
 
     isStartingShareRef.current = true;
     setError(null);
     localShareStopHandledRef.current = false;
+    const shareStartCancelGeneration = shareStartCancelGenerationRef.current;
 
     try {
       const room = await ensureRoom(roomName, 'publish');
@@ -676,21 +678,28 @@ export function useScreenShare(
 
       await room.localParticipant.setScreenShareEnabled(true, captureOptions);
 
+      if (shareStartCancelGenerationRef.current !== shareStartCancelGeneration || roomRef.current !== room) {
+        try { await room.localParticipant.setScreenShareEnabled(false); } catch { /* ignore */ }
+        try { await maybeDisconnectRoom(); } catch { /* ignore */ }
+        return false;
+      }
+
       isSharingRef.current = true;
       setIsSharing(true);
       bindLocalShareEndListener(room);
 
       bridge.send('livekit.shareStarted', { roomName });
+      return true;
     } catch (err) {
       clearLocalShareEndListener();
 
       if (isSupersededRoomRequestError(err)) {
-        return;
+        return false;
       }
 
       if (isScreenSharePickerCancel(err)) {
         await maybeDisconnectRoom();
-        return;
+        return false;
       }
 
       if (isBlockedWindowCaptureError(err)) {
@@ -702,14 +711,19 @@ export function useScreenShare(
       }
       // Disconnect room if we're not watching anyone either
       await maybeDisconnectRoom();
+      return false;
     } finally {
       isStartingShareRef.current = false;
     }
   }, [screenShareSettings, ensureRoom, bindLocalShareEndListener, clearLocalShareEndListener, maybeDisconnectRoom, stopLocalShare]);
 
   const stopSharing = useCallback(async () => {
+    if (isStartingShareRef.current) {
+      shareStartCancelGenerationRef.current += 1;
+      invalidateRoomLifecycle();
+    }
     await stopLocalShare('manual');
-  }, [stopLocalShare]);
+  }, [invalidateRoomLifecycle, stopLocalShare]);
 
   // --- Viewer logic ---
 

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterMoveEventTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterMoveEventTests.cs
@@ -1,0 +1,165 @@
+using Brmble.Client.Services.Voice;
+using MumbleProto;
+using MumbleSharp;
+using MumbleSharp.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text.Json;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class MumbleAdapterMoveEventTests
+{
+    [TestMethod]
+    public void CreateChannelChangedPayload_WithActor_ReturnsMoveMetadata()
+    {
+        var payload = MumbleAdapter.CreateChannelChangedPayload(
+            previousChannelId: 5,
+            currentChannelId: 7,
+            actorSession: 99,
+            actorName: "Moderator",
+            movedByOtherUser: true);
+
+        Assert.AreEqual(7u, payload.ChannelId);
+        Assert.AreEqual(5u, payload.PreviousChannelId);
+        Assert.AreEqual(99u, payload.ActorSession);
+        Assert.AreEqual("Moderator", payload.ActorName);
+        Assert.AreEqual("moved", payload.Reason);
+    }
+
+    [TestMethod]
+    public void CreateChannelChangedPayload_WithoutActor_ReturnsUnknownReason()
+    {
+        var payload = MumbleAdapter.CreateChannelChangedPayload(
+            previousChannelId: 5,
+            currentChannelId: 7,
+            actorSession: null,
+            actorName: null,
+            movedByOtherUser: false);
+
+        Assert.AreEqual(7u, payload.ChannelId);
+        Assert.AreEqual(5u, payload.PreviousChannelId);
+        Assert.IsNull(payload.ActorSession);
+        Assert.IsNull(payload.ActorName);
+        Assert.AreEqual("unknown", payload.Reason);
+    }
+
+    [TestMethod]
+    public void CreateChannelChangedPayload_WithSelfSessionFromServerMove_ReturnsMoveReasonEvenWithoutActor()
+    {
+        var payload = MumbleAdapter.CreateChannelChangedPayload(
+            previousChannelId: 5,
+            currentChannelId: 7,
+            actorSession: null,
+            actorName: null,
+            movedByOtherUser: true);
+
+        Assert.AreEqual(7u, payload.ChannelId);
+        Assert.AreEqual(5u, payload.PreviousChannelId);
+        Assert.IsNull(payload.ActorSession);
+        Assert.IsNull(payload.ActorName);
+        Assert.AreEqual("moved", payload.Reason);
+    }
+
+    [TestMethod]
+    public void UserState_ForSelfMoveWithSessionButNoActor_EmitsMovedReason()
+    {
+        var bridge = NativeBridgeTestHarness.Create();
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var connection = new MumbleConnection(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 64738), adapter, voiceSupport: false);
+        adapter.Initialise(connection);
+        typeof(MumbleConnection)
+            .GetProperty(nameof(MumbleConnection.State))!
+            .SetValue(connection, ConnectionStates.Connected);
+        adapter.ChannelState(new ChannelState { ChannelId = 0, Name = "Root" });
+        adapter.ChannelState(new ChannelState { ChannelId = 5, Name = "General", Parent = 0 });
+        adapter.ChannelState(new ChannelState { ChannelId = 7, Name = "Gaming", Parent = 0 });
+        adapter.UserState(new UserState { Session = 42, Name = "TestUser", ChannelId = 5 });
+        adapter.ServerSync(new ServerSync { Session = 42 });
+        _ = NativeBridgeTestHarness.DrainMessages(bridge);
+
+        adapter.UserState(new UserState { Session = 42, ChannelId = 7 });
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        var channelChanged = sent.Single(m => m.Type == "voice.channelChanged");
+        using var doc = JsonDocument.Parse(channelChanged.DataJson);
+        Assert.AreEqual("moved", doc.RootElement.GetProperty("reason").GetString());
+        Assert.AreEqual(5u, doc.RootElement.GetProperty("previousChannelId").GetUInt32());
+        Assert.AreEqual(7u, doc.RootElement.GetProperty("channelId").GetUInt32());
+    }
+
+    [TestMethod]
+    public void UserState_ForLeaveVoiceEcho_KeepsLeftVoiceMuteAndDeafenActive()
+    {
+        var bridge = NativeBridgeTestHarness.Create();
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var connection = new MumbleConnection(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 64738), adapter, voiceSupport: false);
+        adapter.Initialise(connection);
+        typeof(MumbleConnection)
+            .GetProperty(nameof(MumbleConnection.State))!
+            .SetValue(connection, ConnectionStates.Connected);
+        adapter.ChannelState(new ChannelState { ChannelId = 0, Name = "Root" });
+        adapter.ChannelState(new ChannelState { ChannelId = 5, Name = "General", Parent = 0 });
+        adapter.UserState(new UserState { Session = 42, Name = "TestUser", ChannelId = 5 });
+        adapter.ServerSync(new ServerSync { Session = 42 });
+        _ = NativeBridgeTestHarness.DrainMessages(bridge);
+
+        SetField(adapter, "_leftVoice", true);
+        SetField(adapter, "_leaveVoiceInProgress", true);
+        adapter.LocalUser!.SelfMuted = true;
+        adapter.LocalUser!.SelfDeaf = true;
+        adapter.UserState(new UserState { Session = 42, ChannelId = 0 });
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        Assert.IsTrue(adapter.LocalUser!.SelfMuted);
+        Assert.IsTrue(adapter.LocalUser!.SelfDeaf);
+        Assert.IsFalse(sent.Any(m => m.Type == "voice.leftVoiceChanged" && m.DataJson.Contains("\"leftVoice\":false")));
+    }
+
+    [TestMethod]
+    public void UserState_ForLocalJoinFromRootWhileLeftVoice_ClearsLeftVoiceMuteAndDeafen()
+    {
+        var bridge = NativeBridgeTestHarness.Create();
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var connection = new MumbleConnection(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 64738), adapter, voiceSupport: false);
+        adapter.Initialise(connection);
+        typeof(MumbleConnection)
+            .GetProperty(nameof(MumbleConnection.State))!
+            .SetValue(connection, ConnectionStates.Connected);
+        adapter.ChannelState(new ChannelState { ChannelId = 0, Name = "Root" });
+        adapter.ChannelState(new ChannelState { ChannelId = 5, Name = "General", Parent = 0 });
+        var root = adapter.Channels.Single(c => c.Id == 0);
+        var user = new User(adapter, 42) { Name = "TestUser", Channel = root };
+        SetBaseField(adapter, "UserDictionary", new ConcurrentDictionary<uint, User>([
+            new KeyValuePair<uint, User>(42, user),
+        ]));
+        SetBaseProperty(adapter, "LocalUser", user);
+        SetBaseProperty(adapter, "ReceivedServerSync", true);
+        _ = NativeBridgeTestHarness.DrainMessages(bridge);
+
+        SetField(adapter, "_leftVoice", true);
+        SetField(adapter, "_leaveVoiceInProgress", false);
+        SetField(adapter, "_pendingLocalJoinChannelId", 5u);
+        adapter.LocalUser!.SelfMuted = true;
+        adapter.LocalUser!.SelfDeaf = true;
+        adapter.UserState(new UserState { Session = 42, ChannelId = 5 });
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        Assert.IsFalse(adapter.LocalUser!.SelfMuted);
+        Assert.IsFalse(adapter.LocalUser!.SelfDeaf);
+        Assert.IsTrue(sent.Any(m => m.Type == "voice.leftVoiceChanged" && m.DataJson.Contains("\"leftVoice\":false")));
+        Assert.IsTrue(sent.Any(m => m.Type == "voice.selfMuteChanged" && m.DataJson.Contains("\"muted\":false")));
+        Assert.IsTrue(sent.Any(m => m.Type == "voice.selfDeafChanged" && m.DataJson.Contains("\"deafened\":false")));
+    }
+
+    private static void SetField(object instance, string name, object? value)
+        => instance.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
+
+    private static void SetBaseField(object instance, string name, object? value)
+        => instance.GetType().BaseType!.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
+
+    private static void SetBaseProperty(object instance, string name, object? value)
+        => instance.GetType().BaseType!.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.SetValue(instance, value);
+}

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterMoveEventTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterMoveEventTests.cs
@@ -115,6 +115,7 @@ public class MumbleAdapterMoveEventTests
         var sent = NativeBridgeTestHarness.DrainMessages(bridge);
         Assert.IsTrue(adapter.LocalUser!.SelfMuted);
         Assert.IsTrue(adapter.LocalUser!.SelfDeaf);
+        Assert.IsNull(GetField<uint?>(adapter, "_pendingLocalJoinChannelId"));
         Assert.IsFalse(sent.Any(m => m.Type == "voice.leftVoiceChanged" && m.DataJson.Contains("\"leftVoice\":false")));
     }
 
@@ -156,6 +157,9 @@ public class MumbleAdapterMoveEventTests
 
     private static void SetField(object instance, string name, object? value)
         => instance.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
+
+    private static T? GetField<T>(object instance, string name)
+        => (T?)instance.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(instance);
 
     private static void SetBaseField(object instance, string name, object? value)
         => instance.GetType().BaseType!.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -12,6 +12,7 @@ using Brmble.Client.Services.AppConfig;
 using Brmble.Client.Services.Certificate;
 using Brmble.Client.Services.Serverlist;
 using Brmble.Client.Services.Voice;
+using MumbleSharp.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Brmble.Client.Tests.Services;
@@ -61,14 +62,21 @@ internal static class MumbleAdapterTestHarness
     public static MumbleAdapter CreateWithBridge(NativeBridge bridge, string? apiUrl = null, CertificateService? certService = null)
     {
         var adapter = (MumbleAdapter)RuntimeHelpers.GetUninitializedObject(typeof(MumbleAdapter));
+        SetBaseField(adapter, "UserDictionary", new ConcurrentDictionary<uint, User>());
+        SetBaseField(adapter, "ChannelDictionary", new ConcurrentDictionary<uint, Channel>());
         SetField(adapter, "_bridge", bridge);
         SetField(adapter, "_apiUrl", apiUrl);
         SetField(adapter, "_certService", certService);
+        SetField(adapter, "_userMappings", new Dictionary<string, string>());
+        SetField(adapter, "_sessionMappings", new ConcurrentDictionary<uint, MumbleAdapter.SessionMappingEntry>());
         return adapter;
     }
 
     private static void SetField(object instance, string name, object? value)
         => instance.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
+
+    private static void SetBaseField(object instance, string name, object? value)
+        => instance.GetType().BaseType!.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
 }
 
 internal sealed class TestAppConfigService : IAppConfigService

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterRemovalEventTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterRemovalEventTests.cs
@@ -1,0 +1,64 @@
+using Brmble.Client.Services.Voice;
+using MumbleProto;
+using MumbleSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class MumbleAdapterRemovalEventTests
+{
+    [TestMethod]
+    public void CreateServerRemovalPayload_ForKick_ReturnsWarningMetadata()
+    {
+        var payload = MumbleAdapter.CreateServerRemovalPayload(
+            banned: false,
+            actorName: "Moderator",
+            reason: "Too loud");
+
+        Assert.AreEqual("kicked", payload.Reason);
+        Assert.AreEqual("Moderator", payload.ActorName);
+        Assert.AreEqual("Too loud", payload.Message);
+        Assert.IsTrue(payload.ReconnectAvailable);
+    }
+
+    [TestMethod]
+    public void CreateServerRemovalPayload_ForBan_ReturnsBanMetadata()
+    {
+        var payload = MumbleAdapter.CreateServerRemovalPayload(
+            banned: true,
+            actorName: "Admin",
+            reason: "Spam");
+
+        Assert.AreEqual("banned", payload.Reason);
+        Assert.AreEqual("Admin", payload.ActorName);
+        Assert.AreEqual("Spam", payload.Message);
+        Assert.IsTrue(payload.ReconnectAvailable);
+    }
+
+    [TestMethod]
+    public void UserRemove_ForSelfKick_ClosesConnectionAndSuppressesGenericDisconnect()
+    {
+        var bridge = NativeBridgeTestHarness.Create();
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var connection = new MumbleConnection(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 64738), adapter, voiceSupport: false);
+        adapter.Initialise(connection);
+        typeof(MumbleConnection)
+            .GetProperty(nameof(MumbleConnection.State))!
+            .SetValue(connection, ConnectionStates.Connected);
+        adapter.ChannelState(new ChannelState { ChannelId = 0, Name = "Root" });
+        adapter.ChannelState(new ChannelState { ChannelId = 1, Name = "General", Parent = 0 });
+        adapter.UserState(new UserState { Session = 7, Name = "TestUser", ChannelId = 1 });
+        adapter.UserState(new UserState { Session = 8, Name = "Moderator", ChannelId = 1 });
+        adapter.ServerSync(new ServerSync { Session = 7 });
+
+        adapter.UserRemove(new UserRemove { Session = 7, Actor = 8, Reason = "Too loud" });
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge).FindAll(m => m.Type == "voice.disconnected");
+        Assert.AreEqual(ConnectionStates.Disconnected, connection.State);
+        Assert.IsNull(adapter.LocalUser);
+        Assert.AreEqual(1, sent.Count);
+        StringAssert.Contains(sent[0].DataJson, "\"reason\":\"kicked\"");
+        StringAssert.Contains(sent[0].DataJson, "\"actorName\":\"Moderator\"");
+    }
+}

--- a/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
@@ -200,6 +200,19 @@ public class MumbleServerCallbackTests
     }
 
     [TestMethod]
+    public async Task DispatchUserConnected_WithInitialChannel_UpdatesChannelMembership()
+    {
+        var handler = new Mock<IMumbleEventHandler>();
+        handler.Setup(h => h.OnUserConnected(It.IsAny<MumbleUser>())).Returns(Task.CompletedTask);
+        var channelMembership = new Mock<IChannelMembershipService>();
+        var callback = CreateCallback([handler.Object], channelMembership: channelMembership.Object);
+
+        await callback.DispatchUserConnected(new MumbleUser("Alice", "abc", 42), initialChannelId: 5);
+
+        channelMembership.Verify(cm => cm.Update(42, 5), Times.Once);
+    }
+
+    [TestMethod]
     public async Task DispatchUserStateChanged_StopsShareWhenUserChangesChannel()
     {
         var bus = new Mock<IBrmbleEventBus>();


### PR DESCRIPTION
## Summary
- Fix LiveKit access-mode/nullability warnings and harden pending screen-share cancellation so admin moves cannot leave publishing in an old room.
- Add structured admin move, move-to-root, kick, and ban notifications, including replacement lifecycle handling for repeated move events.
- Fix leave-voice state transitions, root drag/drop user moves, and initial Mumble channel membership sync for LiveKit channel checks.

## Details
- Admin moves now include previous channel, actor metadata, and reason so the UI can show move-specific notifications instead of generic technical share errors.
- Moving a user to root is shown as "Moved out of voice" instead of "Moved to Connected".
- Kick/ban emits structured voice.disconnected metadata, suppresses duplicate generic disconnects, and cleans adapter state.
- Leave Voice now keeps mute/deafen/left-voice active when moving to root, and clears that state when the user rejoins a channel from root.
- Sidebar drag/drop now works for admins while they are in root, and users can be dropped into root via the server info panel or Connected panel.
- Server membership now records the initial channel on user connect, covering last-channel auto-join cases.
- Notification lifecycle guidance was documented in docs/UI_GUIDE.md.

## Tests
- Targeted client adapter tests for move metadata, kick/ban cleanup, and leave-voice state transitions.
- Frontend tests for pending share cancellation, repeated move notifications, move-to-root wording, and sidebar root drag/drop.
- Server callback regression for initial channel membership on user connect.
- Manual retesting covered multi-client admin move/share/leave-voice/root drag-drop flows.
