### PR TITLE
fix(config): strip legacy voice-stack keys from config.json on load

### DIFF
--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -396,7 +396,14 @@ internal sealed class AppConfigService : IAppConfigService
                 _profileRegistrations = data?.ProfileRegistrations ?? new();
                 _isFirstLaunch = false;
                 MigrateIdentityPfx();
-                if (HasLegacySettingsKeys(json)) Save();
+                if (HasLegacySettingsKeys(json))
+                {
+                    // Isolate the cleanup write — a failure here (read-only file,
+                    // locked, perms) must not bubble up and trigger the outer
+                    // catch, which would reset all state to defaults.
+                    try { Save(); }
+                    catch { /* leave legacy keys in place; we'll try again next launch */ }
+                }
                 return;
             }
 
@@ -561,9 +568,13 @@ internal sealed class AppConfigService : IAppConfigService
         // Detect keys from the pre-WebRTC-only voice refactor (5dbd3b6).
         // Deserialization silently drops them, but the file keeps the dead keys
         // until something else triggers a Save — clean them up on next launch.
-        try
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(rawJson); }
+        catch (JsonException) { return false; }
+        catch (ArgumentException) { return false; }
+
+        using (doc)
         {
-            using var doc = JsonDocument.Parse(rawJson);
             if (!doc.RootElement.TryGetProperty("settings", out var settings)
                 || settings.ValueKind != JsonValueKind.Object) return false;
             if (settings.TryGetProperty("speechDenoise", out _)) return true;
@@ -572,7 +583,6 @@ internal sealed class AppConfigService : IAppConfigService
                 && audio.ValueKind == JsonValueKind.Object
                 && audio.TryGetProperty("processingStack", out _)) return true;
         }
-        catch { /* malformed JSON — Load already handled the broken-file path */ }
         return false;
     }
 

--- a/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppConfigService.cs
@@ -396,6 +396,7 @@ internal sealed class AppConfigService : IAppConfigService
                 _profileRegistrations = data?.ProfileRegistrations ?? new();
                 _isFirstLaunch = false;
                 MigrateIdentityPfx();
+                if (HasLegacySettingsKeys(json)) Save();
                 return;
             }
 
@@ -553,6 +554,26 @@ internal sealed class AppConfigService : IAppConfigService
             _profiles.RemoveAll(p => p.Id == id);
             _activeProfileId = null;
         }
+    }
+
+    private static bool HasLegacySettingsKeys(string rawJson)
+    {
+        // Detect keys from the pre-WebRTC-only voice refactor (5dbd3b6).
+        // Deserialization silently drops them, but the file keeps the dead keys
+        // until something else triggers a Save — clean them up on next launch.
+        try
+        {
+            using var doc = JsonDocument.Parse(rawJson);
+            if (!doc.RootElement.TryGetProperty("settings", out var settings)
+                || settings.ValueKind != JsonValueKind.Object) return false;
+            if (settings.TryGetProperty("speechDenoise", out _)) return true;
+            if (settings.TryGetProperty("speechEnhancement", out _)) return true;
+            if (settings.TryGetProperty("audio", out var audio)
+                && audio.ValueKind == JsonValueKind.Object
+                && audio.TryGetProperty("processingStack", out _)) return true;
+        }
+        catch { /* malformed JSON — Load already handled the broken-file path */ }
+        return false;
     }
 
     private record LegacyServerlistData

--- a/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
@@ -438,5 +438,29 @@ public class AppConfigServiceTests
         Assert.AreEqual(96000, settings.Audio.OpusBitrate);
         // Removed fields are gone — but the new NS setting takes its default
         Assert.AreEqual(NoiseSuppressionLevel.High, settings.NoiseSuppression.Level);
+
+        // The on-disk file should be rewritten without the legacy keys.
+        var rewritten = File.ReadAllText(Path.Combine(_tempDir, "config.json"));
+        StringAssert.DoesNotMatch(rewritten, new System.Text.RegularExpressions.Regex("processingStack", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
+        StringAssert.DoesNotMatch(rewritten, new System.Text.RegularExpressions.Regex("speechDenoise", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
+        StringAssert.DoesNotMatch(rewritten, new System.Text.RegularExpressions.Regex("speechEnhancement", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
+    }
+
+    [TestMethod]
+    public void LoadsCleanSettings_DoesNotRewriteFile()
+    {
+        // A clean config should not be needlessly rewritten on every launch.
+        var svc1 = new AppConfigService(_tempDir, null);
+        svc1.SetSettings(svc1.GetSettings()); // ensure file exists in canonical form
+
+        var path = Path.Combine(_tempDir, "config.json");
+        var before = File.GetLastWriteTimeUtc(path);
+        System.Threading.Thread.Sleep(50);
+
+        // Re-load: no legacy keys → no rewrite
+        _ = new AppConfigService(_tempDir, null);
+        var after = File.GetLastWriteTimeUtc(path);
+
+        Assert.AreEqual(before, after, "Clean config.json should not be rewritten on load");
     }
 }

--- a/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
@@ -440,10 +440,15 @@ public class AppConfigServiceTests
         Assert.AreEqual(NoiseSuppressionLevel.High, settings.NoiseSuppression.Level);
 
         // The on-disk file should be rewritten without the legacy keys.
+        // Parse it back rather than substring-matching the raw text.
         var rewritten = File.ReadAllText(Path.Combine(_tempDir, "config.json"));
-        StringAssert.DoesNotMatch(rewritten, new System.Text.RegularExpressions.Regex("processingStack", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
-        StringAssert.DoesNotMatch(rewritten, new System.Text.RegularExpressions.Regex("speechDenoise", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
-        StringAssert.DoesNotMatch(rewritten, new System.Text.RegularExpressions.Regex("speechEnhancement", System.Text.RegularExpressions.RegexOptions.IgnoreCase));
+        using var doc = System.Text.Json.JsonDocument.Parse(rewritten);
+        var settingsEl = doc.RootElement.GetProperty("settings");
+        Assert.IsFalse(settingsEl.TryGetProperty("speechDenoise", out _), "speechDenoise should be removed");
+        Assert.IsFalse(settingsEl.TryGetProperty("speechEnhancement", out _), "speechEnhancement should be removed");
+        Assert.IsFalse(
+            settingsEl.GetProperty("audio").TryGetProperty("processingStack", out _),
+            "audio.processingStack should be removed");
     }
 
     [TestMethod]
@@ -453,14 +458,15 @@ public class AppConfigServiceTests
         var svc1 = new AppConfigService(_tempDir, null);
         svc1.SetSettings(svc1.GetSettings()); // ensure file exists in canonical form
 
+        // Stamp a known sentinel timestamp; if Load() writes the file, this changes.
+        // (Avoids relying on filesystem clock resolution + Thread.Sleep.)
         var path = Path.Combine(_tempDir, "config.json");
-        var before = File.GetLastWriteTimeUtc(path);
-        System.Threading.Thread.Sleep(50);
+        var sentinel = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(path, sentinel);
 
-        // Re-load: no legacy keys → no rewrite
         _ = new AppConfigService(_tempDir, null);
-        var after = File.GetLastWriteTimeUtc(path);
 
-        Assert.AreEqual(before, after, "Clean config.json should not be rewritten on load");
+        Assert.AreEqual(sentinel, File.GetLastWriteTimeUtc(path),
+            "Clean config.json should not be rewritten on load");
     }
 }


### PR DESCRIPTION
## Summary
- After the WebRTC-only refactor (5dbd3b6) dropped `speechDenoise`, `speechEnhancement` and `audio.processingStack` from `AppSettings`, the deserializer silently ignored them — but `Load()` never re-saves, so users who hadn't touched any setting since still have the dead keys sitting in `%APPDATA%\Brmble\config.json`.
- `AppConfigService.Load()` now detects any of those legacy keys in the raw JSON and forces a single `Save()` to rewrite the file in canonical form. Clean configs are left untouched.

## Test plan
- [x] `dotnet test tests/Brmble.Client.Tests --filter "FullyQualifiedName~AppConfigServiceTests"` — 29/29 pass
- [x] `LoadsLegacySettings_WithSpeechDenoiseAndProcessingStack_ReturnsDefaultNoiseSuppression` extended to assert the on-disk file no longer contains the legacy keys after load
- [x] New `LoadsCleanSettings_DoesNotRewriteFile` verifies clean configs aren't needlessly rewritten on every launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)