### PR TITLE
fix: prevent WebView2 from serving stale cached HTML

### DIFF
--- a/src/Brmble.Client/Overlay/CompanionOverlayHost.cs
+++ b/src/Brmble.Client/Overlay/CompanionOverlayHost.cs
@@ -53,6 +53,8 @@ internal sealed class CompanionOverlayHost : IDisposable
                 "brmble.local",
                 _webRoot,
                 CoreWebView2HostResourceAccessKind.Allow);
+            WebViewCacheConfig.DisableHtmlCacheForVirtualHost(
+                _controller.CoreWebView2, _environment, _webRoot);
         }
 
         _controller.CoreWebView2.NavigationStarting += (_, args) =>

--- a/src/Brmble.Client/Overlay/CompanionOverlayHost.cs
+++ b/src/Brmble.Client/Overlay/CompanionOverlayHost.cs
@@ -50,7 +50,7 @@ internal sealed class CompanionOverlayHost : IDisposable
         if (!_useDevServer)
         {
             _controller.CoreWebView2.SetVirtualHostNameToFolderMapping(
-                "brmble.local",
+                WebViewCacheConfig.VirtualHost,
                 _webRoot,
                 CoreWebView2HostResourceAccessKind.Allow);
             WebViewCacheConfig.DisableHtmlCacheForVirtualHost(

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -257,6 +257,8 @@ static class Program
             var webRoot = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "web");
             _controller.CoreWebView2.SetVirtualHostNameToFolderMapping(
                 "brmble.local", webRoot, CoreWebView2HostResourceAccessKind.Allow);
+            WebViewCacheConfig.DisableHtmlCacheForVirtualHost(
+                _controller.CoreWebView2, env, webRoot);
 
             _bridge = new NativeBridge(_controller.CoreWebView2, hwnd);
             _overlayRelay = new CompanionOverlayRelay();

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -256,7 +256,7 @@ static class Program
 
             var webRoot = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "web");
             _controller.CoreWebView2.SetVirtualHostNameToFolderMapping(
-                "brmble.local", webRoot, CoreWebView2HostResourceAccessKind.Allow);
+                WebViewCacheConfig.VirtualHost, webRoot, CoreWebView2HostResourceAccessKind.Allow);
             WebViewCacheConfig.DisableHtmlCacheForVirtualHost(
                 _controller.CoreWebView2, env, webRoot);
 

--- a/src/Brmble.Client/WebViewCacheConfig.cs
+++ b/src/Brmble.Client/WebViewCacheConfig.cs
@@ -1,0 +1,60 @@
+using Microsoft.Web.WebView2.Core;
+
+namespace Brmble.Client;
+
+internal static class WebViewCacheConfig
+{
+    private const string VirtualHost = "brmble.local";
+
+    // Vite content-hashes JS/CSS bundle filenames, so those are safe to cache
+    // normally. index.html and overlay.html keep their names across releases,
+    // and WebView2 persists its HTTP cache in the user data folder between
+    // sessions. Without this, a stale cached HTML can keep referencing
+    // hashed bundles that no longer exist after an update, breaking the app.
+    public static void DisableHtmlCacheForVirtualHost(
+        CoreWebView2 webView,
+        CoreWebView2Environment env,
+        string webRoot)
+    {
+        webView.AddWebResourceRequestedFilter(
+            $"https://{VirtualHost}/*.html",
+            CoreWebView2WebResourceContext.Document);
+
+        var rootFull = Path.GetFullPath(webRoot);
+
+        webView.WebResourceRequested += (_, args) =>
+        {
+            try
+            {
+                var uri = new Uri(args.Request.Uri);
+                var relativePath = uri.AbsolutePath.TrimStart('/');
+                var fullPath = Path.GetFullPath(Path.Combine(rootFull, relativePath));
+
+                if (!fullPath.StartsWith(rootFull + Path.DirectorySeparatorChar,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                if (!File.Exists(fullPath))
+                {
+                    return;
+                }
+
+                var stream = File.OpenRead(fullPath);
+                args.Response = env.CreateWebResourceResponse(
+                    stream,
+                    200,
+                    "OK",
+                    "Content-Type: text/html; charset=utf-8\r\n" +
+                    "Cache-Control: no-store, must-revalidate\r\n" +
+                    "Pragma: no-cache\r\n" +
+                    "Expires: 0");
+            }
+            catch
+            {
+                // Fall back to WebView2's default virtual-host handler on any error.
+            }
+        };
+    }
+}

--- a/src/Brmble.Client/WebViewCacheConfig.cs
+++ b/src/Brmble.Client/WebViewCacheConfig.cs
@@ -4,7 +4,7 @@ namespace Brmble.Client;
 
 internal static class WebViewCacheConfig
 {
-    private const string VirtualHost = "brmble.local";
+    public const string VirtualHost = "brmble.local";
 
     // Vite content-hashes JS/CSS bundle filenames, so those are safe to cache
     // normally. index.html and overlay.html keep their names across releases,
@@ -42,14 +42,22 @@ internal static class WebViewCacheConfig
                 }
 
                 var stream = File.OpenRead(fullPath);
-                args.Response = env.CreateWebResourceResponse(
-                    stream,
-                    200,
-                    "OK",
-                    "Content-Type: text/html; charset=utf-8\r\n" +
-                    "Cache-Control: no-store, must-revalidate\r\n" +
-                    "Pragma: no-cache\r\n" +
-                    "Expires: 0");
+                try
+                {
+                    args.Response = env.CreateWebResourceResponse(
+                        stream,
+                        200,
+                        "OK",
+                        "Content-Type: text/html; charset=utf-8\r\n" +
+                        "Cache-Control: no-store, must-revalidate\r\n" +
+                        "Pragma: no-cache\r\n" +
+                        "Expires: 0");
+                }
+                catch
+                {
+                    stream.Dispose();
+                    throw;
+                }
             }
             catch
             {


### PR DESCRIPTION
## Summary
- WebView2 persists its HTTP cache across sessions in the user data folder. Vite content-hashes JS/CSS bundles so those are safe to cache, but `index.html` and `overlay.html` keep their names across releases.
- After an update, a stale cached HTML can keep referencing hashed bundles that no longer exist on disk — silently breaking the app.
- Fix: intercept HTML requests on the `brmble.local` virtual host via `WebResourceRequested` and serve them from disk with `Cache-Control: no-store, must-revalidate`. Hashed assets continue to cache normally.
- Applied to both the main window (`Program.cs`) and the companion overlay (`CompanionOverlayHost.cs`) via a shared `WebViewCacheConfig` helper. Path-traversal guarded by verifying the resolved path stays under `webRoot`.

## Test plan
- [ ] Build a release, install, capture the JS bundle filenames the app loads.
- [ ] Ship a new release with different bundle hashes, install on top, verify the app loads the new bundles on first launch (no manual cache clear).
- [ ] Verify hashed JS/CSS assets are still served with normal caching (DevTools Network panel shows 200 from cache on reload, but `index.html` shows `no-store`).
- [ ] Verify the companion overlay also picks up new HTML/bundles after an update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)