### PR TITLE
Harden LiveKit token refresh and revocation

### DIFF
--- a/docs/superpowers/plans/2026-05-11-livekit-token-refresh-revocation.md
+++ b/docs/superpowers/plans/2026-05-11-livekit-token-refresh-revocation.md
@@ -1,0 +1,1030 @@
+# LiveKit Token Refresh Revocation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh active LiveKit authorization before expiry and promptly remove affected LiveKit participants when voice/channel access changes.
+
+**Architecture:** Add a focused in-memory participant tracker on the server, record participants on successful token issuance, and use lifecycle helpers to revoke only affected participant identities. Add a client-side refresh lease in `useScreenShare` that reuses the existing token endpoint before `expiresAt` and disconnects/cleans up on refresh failure.
+
+**Tech Stack:** ASP.NET Core minimal APIs, MSTest, Moq, React 19, TypeScript, Vitest, LiveKit client SDK.
+
+---
+
+## File Structure
+
+- Create: `src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs`
+  - Owns in-memory active LiveKit participant bookkeeping.
+  - Does not authorize requests and does not call LiveKit.
+- Create: `tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs`
+  - Unit-tests tracker upsert, removal, channel filtering, and pruning.
+- Create: `src/Brmble.Server/LiveKit/ILiveKitParticipantRemover.cs`
+  - Testable abstraction for removing LiveKit participant identities.
+- Modify: `src/Brmble.Server/LiveKit/LiveKitService.cs`
+  - Implement `ILiveKitParticipantRemover` on existing service.
+- Modify: `src/Brmble.Server/LiveKit/LiveKitExtensions.cs`
+  - Register `LiveKitParticipantTracker` and `ILiveKitParticipantRemover`.
+- Modify: `src/Brmble.Server/LiveKit/LiveKitEndpoints.cs`
+  - Record participant tracker entries on successful `/livekit/token` responses.
+- Modify: `tests/Brmble.Server.Tests/LiveKit/LiveKitEndpointsTests.cs`
+  - Assert successful token issuance records participant bookkeeping.
+- Modify: `src/Brmble.Server/Mumble/MumbleServerCallback.cs`
+  - Revoke tracked participant records on disconnect and channel move.
+  - Keep existing screen-share stop broadcasts for publishers.
+- Modify: `tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs`
+  - Assert disconnect and move revoke publishers/viewers correctly.
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.ts`
+  - Add refresh scheduling and cleanup around active room leases.
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.test.ts`
+  - Add Vitest coverage for refresh scheduling, success, failure, and timer cleanup.
+
+---
+
+### Task 1: Server Participant Tracker
+
+**Files:**
+- Create: `tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs`
+- Create: `src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs`
+- Modify: `src/Brmble.Server/LiveKit/LiveKitExtensions.cs`
+
+- [ ] **Step 1: Write failing tracker tests**
+
+Create `tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs` with:
+
+```csharp
+using Brmble.Server.LiveKit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.LiveKit;
+
+[TestClass]
+public class LiveKitParticipantTrackerTests
+{
+    [TestMethod]
+    public void Upsert_ReplacesExistingParticipantRecord()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var firstExpiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        var secondExpiry = DateTimeOffset.UtcNow.AddMinutes(10);
+
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, firstExpiry));
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Publish, secondExpiry));
+
+        var records = tracker.GetSnapshot();
+
+        Assert.AreEqual(1, records.Count);
+        Assert.AreEqual(LiveKitAccessMode.Publish, records[0].AccessMode);
+        Assert.AreEqual(secondExpiry, records[0].ExpiresAt);
+    }
+
+    [TestMethod]
+    public void RemoveBySession_RemovesOnlyThatSession()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry));
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@bob:test", 20, 8, LiveKitAccessMode.Subscribe, expiry));
+
+        var removed = tracker.RemoveBySession(7);
+
+        Assert.AreEqual(1, removed.Count);
+        Assert.AreEqual("@alice:test", removed[0].MatrixUserId);
+        CollectionAssert.AreEquivalent(new[] { "@bob:test" }, tracker.GetSnapshot().Select(r => r.MatrixUserId).ToArray());
+    }
+
+    [TestMethod]
+    public void RemoveRoomsOtherThan_RemovesOldRoomsAndKeepsCurrentRoom()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Publish, expiry));
+        tracker.Upsert(new LiveKitParticipantRecord("channel-2", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry));
+
+        var removed = tracker.RemoveBySessionExceptRoom(7, "channel-2");
+
+        Assert.AreEqual(1, removed.Count);
+        Assert.AreEqual("channel-1", removed[0].RoomName);
+        Assert.AreEqual("channel-2", tracker.GetSnapshot().Single().RoomName);
+    }
+
+    [TestMethod]
+    public void PruneExpired_RemovesExpiredRecords()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var now = DateTimeOffset.UtcNow;
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@old:test", 10, 7, LiveKitAccessMode.Subscribe, now.AddSeconds(-1)));
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@fresh:test", 20, 8, LiveKitAccessMode.Subscribe, now.AddMinutes(5)));
+
+        var removed = tracker.PruneExpired(now);
+
+        Assert.AreEqual(1, removed.Count);
+        Assert.AreEqual("@old:test", removed[0].MatrixUserId);
+        Assert.AreEqual("@fresh:test", tracker.GetSnapshot().Single().MatrixUserId);
+    }
+
+    [TestMethod]
+    public void Remove_RemovesByRoomAndIdentity()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry));
+
+        var removed = tracker.Remove("channel-1", "@alice:test");
+
+        Assert.IsNotNull(removed);
+        Assert.AreEqual("@alice:test", removed.MatrixUserId);
+        Assert.AreEqual(0, tracker.GetSnapshot().Count);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter LiveKitParticipantTrackerTests`
+
+Expected: FAIL because `LiveKitParticipantTracker` and `LiveKitParticipantRecord` do not exist.
+
+- [ ] **Step 3: Implement tracker**
+
+Create `src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs` with:
+
+```csharp
+using System.Collections.Concurrent;
+
+namespace Brmble.Server.LiveKit;
+
+public sealed record LiveKitParticipantRecord(
+    string RoomName,
+    string MatrixUserId,
+    long UserId,
+    int SessionId,
+    LiveKitAccessMode AccessMode,
+    DateTimeOffset ExpiresAt);
+
+public sealed class LiveKitParticipantTracker
+{
+    private readonly ConcurrentDictionary<(string RoomName, string MatrixUserId), LiveKitParticipantRecord> _participants = new();
+
+    public void Upsert(LiveKitParticipantRecord record)
+        => _participants[(record.RoomName, record.MatrixUserId)] = record;
+
+    public LiveKitParticipantRecord? Remove(string roomName, string matrixUserId)
+    {
+        return _participants.TryRemove((roomName, matrixUserId), out var record)
+            ? record
+            : null;
+    }
+
+    public IReadOnlyList<LiveKitParticipantRecord> RemoveBySession(int sessionId)
+        => RemoveWhere(record => record.SessionId == sessionId);
+
+    public IReadOnlyList<LiveKitParticipantRecord> RemoveBySessionExceptRoom(int sessionId, string roomName)
+        => RemoveWhere(record => record.SessionId == sessionId && !string.Equals(record.RoomName, roomName, StringComparison.Ordinal));
+
+    public IReadOnlyList<LiveKitParticipantRecord> PruneExpired(DateTimeOffset now)
+        => RemoveWhere(record => record.ExpiresAt <= now);
+
+    public IReadOnlyList<LiveKitParticipantRecord> GetSnapshot()
+        => _participants.Values.ToList();
+
+    private IReadOnlyList<LiveKitParticipantRecord> RemoveWhere(Func<LiveKitParticipantRecord, bool> predicate)
+    {
+        var removed = new List<LiveKitParticipantRecord>();
+        foreach (var pair in _participants)
+        {
+            if (predicate(pair.Value) && _participants.TryRemove(pair.Key, out var record))
+            {
+                removed.Add(record);
+            }
+        }
+
+        return removed;
+    }
+}
+```
+
+Modify `src/Brmble.Server/LiveKit/LiveKitExtensions.cs`:
+
+```csharp
+namespace Brmble.Server.LiveKit;
+
+public static class LiveKitExtensions
+{
+    public static IServiceCollection AddLiveKit(this IServiceCollection services)
+    {
+        services.AddOptions<LiveKitSettings>()
+            .BindConfiguration("LiveKit");
+        services.AddSingleton<LiveKitService>();
+        services.AddSingleton<ILiveKitRoomQuery>(sp => sp.GetRequiredService<LiveKitService>());
+        services.AddSingleton<ScreenShareTracker>();
+        services.AddSingleton<LiveKitParticipantTracker>();
+        services.AddSingleton<IUserIdMapper, SessionMappingUserIdMapper>();
+        services.AddHostedService<ScreenShareReconciliationService>();
+        return services;
+    }
+}
+```
+
+- [ ] **Step 4: Run tracker tests**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter LiveKitParticipantTrackerTests`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit tracker**
+
+```powershell
+git add "src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs" "src/Brmble.Server/LiveKit/LiveKitExtensions.cs" "tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs"
+git commit -m "feat: track active livekit participants"
+```
+
+---
+
+### Task 2: Token Endpoint Participant Recording
+
+**Files:**
+- Modify: `tests/Brmble.Server.Tests/LiveKit/LiveKitEndpointsTests.cs`
+- Modify: `src/Brmble.Server/LiveKit/LiveKitEndpoints.cs`
+
+- [ ] **Step 1: Write failing endpoint test**
+
+Add this test to `tests/Brmble.Server.Tests/LiveKit/LiveKitEndpointsTests.cs` before the private records:
+
+```csharp
+[TestMethod]
+public async Task TokenRequest_WithCurrentChannelAccess_RecordsParticipant()
+{
+    using var factory = new BrmbleServerFactory();
+    using var client = factory.CreateClient();
+
+    var sessionMapping = factory.Services.GetRequiredService<ISessionMappingService>();
+    var channelMembership = factory.Services.GetRequiredService<IChannelMembershipService>();
+    var participantTracker = factory.Services.GetRequiredService<LiveKitParticipantTracker>();
+
+    sessionMapping.SetNameForSession("TestUser", 7);
+    await client.PostAsJsonAsync("/auth/token", new { mumbleUsername = "TestUser" });
+    channelMembership.Update(7, 1);
+
+    var response = await client.PostAsJsonAsync("/livekit/token", new { roomName = "channel-1", accessMode = "subscribe" });
+
+    Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+    var record = participantTracker.GetSnapshot().Single();
+    Assert.AreEqual("channel-1", record.RoomName);
+    Assert.AreEqual("@testuser:localhost", record.MatrixUserId);
+    Assert.AreEqual(1L, record.UserId);
+    Assert.AreEqual(7, record.SessionId);
+    Assert.AreEqual(LiveKitAccessMode.Subscribe, record.AccessMode);
+    Assert.IsTrue(record.ExpiresAt > DateTimeOffset.UtcNow);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter TokenRequest_WithCurrentChannelAccess_RecordsParticipant`
+
+Expected: FAIL because no participant is recorded yet.
+
+- [ ] **Step 3: Record participant after token issuance**
+
+Modify the `/livekit/token` endpoint signature in `src/Brmble.Server/LiveKit/LiveKitEndpoints.cs` to accept `LiveKitParticipantTracker participantTracker` after `IChannelMembershipService channelMembership`:
+
+```csharp
+IChannelMembershipService channelMembership,
+LiveKitParticipantTracker participantTracker,
+ILogger<LiveKitService> logger) =>
+```
+
+Replace the current `isInRequestedRoom` block with code that also captures the session id:
+
+```csharp
+var hasSession = sessionMapping.TryGetSessionByUserId(user.Id, out var sessionId);
+var isInRequestedRoom = hasSession
+    && channelMembership.TryGetChannel(sessionId, out var channelId)
+    && string.Equals(roomName, $"channel-{channelId}", StringComparison.Ordinal);
+```
+
+After `metadata is null` handling and before URL construction, add:
+
+```csharp
+if (hasSession)
+{
+    participantTracker.PruneExpired(issuedAt);
+    participantTracker.Upsert(new LiveKitParticipantRecord(
+        roomName,
+        user.MatrixUserId,
+        user.Id,
+        sessionId,
+        accessMode.Value,
+        metadata.ExpiresAt));
+}
+```
+
+- [ ] **Step 4: Run endpoint tests**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter LiveKitEndpointsTests`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit endpoint recording**
+
+```powershell
+git add "src/Brmble.Server/LiveKit/LiveKitEndpoints.cs" "tests/Brmble.Server.Tests/LiveKit/LiveKitEndpointsTests.cs"
+git commit -m "feat: record livekit participants on token issuance"
+```
+
+---
+
+### Task 3: Testable LiveKit Participant Removal Interface
+
+**Files:**
+- Create: `src/Brmble.Server/LiveKit/ILiveKitParticipantRemover.cs`
+- Modify: `src/Brmble.Server/LiveKit/LiveKitService.cs`
+- Modify: `src/Brmble.Server/LiveKit/LiveKitExtensions.cs`
+- Modify: `src/Brmble.Server/Mumble/MumbleServerCallback.cs`
+- Modify: `tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs`
+
+- [ ] **Step 1: Add interface and wire callback to it**
+
+Create `src/Brmble.Server/LiveKit/ILiveKitParticipantRemover.cs`:
+
+```csharp
+namespace Brmble.Server.LiveKit;
+
+public interface ILiveKitParticipantRemover
+{
+    Task RemoveParticipant(string roomName, string participantIdentity);
+}
+```
+
+Modify `src/Brmble.Server/LiveKit/LiveKitService.cs` class declaration:
+
+```csharp
+public class LiveKitService : ILiveKitRoomQuery, ILiveKitParticipantRemover
+```
+
+Modify `src/Brmble.Server/LiveKit/LiveKitExtensions.cs` registrations:
+
+```csharp
+services.AddSingleton<ILiveKitRoomQuery>(sp => sp.GetRequiredService<LiveKitService>());
+services.AddSingleton<ILiveKitParticipantRemover>(sp => sp.GetRequiredService<LiveKitService>());
+```
+
+Modify `src/Brmble.Server/Mumble/MumbleServerCallback.cs` field and constructor parameter from `LiveKitService liveKitService` to:
+
+```csharp
+private readonly ILiveKitParticipantRemover _liveKitParticipantRemover;
+```
+
+Constructor parameter:
+
+```csharp
+ILiveKitParticipantRemover liveKitParticipantRemover,
+```
+
+Constructor assignment:
+
+```csharp
+_liveKitParticipantRemover = liveKitParticipantRemover;
+```
+
+Replace existing `_liveKitService.RemoveParticipant(...)` calls with:
+
+```csharp
+await _liveKitParticipantRemover.RemoveParticipant(roomName, mapping.MatrixUserId);
+```
+
+Modify `CreateCallback` in `tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs` to accept the interface:
+
+```csharp
+ILiveKitParticipantRemover? liveKitParticipantRemover = null,
+```
+
+And pass this default to the callback constructor:
+
+```csharp
+liveKitParticipantRemover ?? new Mock<ILiveKitParticipantRemover>().Object,
+```
+
+- [ ] **Step 2: Run server tests**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "MumbleServerCallbackTests|LiveKitServiceRemoveParticipantTests"`
+
+Expected: PASS. This is a refactor to make the next task testable.
+
+- [ ] **Step 3: Commit interface refactor**
+
+```powershell
+git add "src/Brmble.Server/LiveKit/ILiveKitParticipantRemover.cs" "src/Brmble.Server/LiveKit/LiveKitService.cs" "src/Brmble.Server/LiveKit/LiveKitExtensions.cs" "src/Brmble.Server/Mumble/MumbleServerCallback.cs" "tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs"
+git commit -m "refactor: abstract livekit participant removal"
+```
+
+---
+
+### Task 4: Server Lifecycle Revocation
+
+**Files:**
+- Modify: `tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs`
+- Modify: `src/Brmble.Server/Mumble/MumbleServerCallback.cs`
+
+- [ ] **Step 1: Write failing disconnect revocation tests**
+
+Add these tests to `tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs`:
+
+```csharp
+[TestMethod]
+public async Task DispatchUserDisconnected_RevokesViewerOnlyParticipantWithoutShareStopped()
+{
+    var bus = new Mock<IBrmbleEventBus>();
+    var capturedMessages = new List<object>();
+    bus.Setup(b => b.BroadcastAsync(It.IsAny<object>()))
+        .Callback<object>(msg => capturedMessages.Add(msg))
+        .Returns(Task.CompletedTask);
+
+    var mapping = new Mock<ISessionMappingService>();
+    mapping.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
+    {
+        { 42, new SessionMapping("@alice:test", "Alice", 100L) }
+    });
+
+    var participantTracker = new LiveKitParticipantTracker();
+    participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
+
+    var remover = new Mock<ILiveKitParticipantRemover>();
+    remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+
+    var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
+
+    await callback.DispatchUserDisconnected(new MumbleUser("Alice", "abc", 42));
+
+    remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Once);
+    Assert.AreEqual(0, participantTracker.GetSnapshot().Count);
+    Assert.IsFalse(capturedMessages.Any(m => JsonSerializer.Serialize(m).Contains("screenShare.stopped")));
+}
+
+[TestMethod]
+public async Task DispatchUserDisconnected_RevokesPublisherAndViewerRecords()
+{
+    var bus = new Mock<IBrmbleEventBus>();
+    bus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
+    var mapping = new Mock<ISessionMappingService>();
+    mapping.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
+    {
+        { 42, new SessionMapping("@alice:test", "Alice", 100L) }
+    });
+
+    var tracker = new ScreenShareTracker();
+    tracker.Start("channel-5", "Alice", 100L, "@alice:test");
+    var participantTracker = new LiveKitParticipantTracker();
+    participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Publish, DateTimeOffset.UtcNow.AddMinutes(5)));
+    participantTracker.Upsert(new LiveKitParticipantRecord("channel-9", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
+
+    var remover = new Mock<ILiveKitParticipantRemover>();
+    remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+    var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, screenShareTracker: tracker, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
+
+    await callback.DispatchUserDisconnected(new MumbleUser("Alice", "abc", 42));
+
+    remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Once);
+    remover.Verify(r => r.RemoveParticipant("channel-9", "@alice:test"), Times.Once);
+    Assert.IsNull(tracker.GetActive("channel-5"));
+    Assert.AreEqual(0, participantTracker.GetSnapshot().Count);
+}
+```
+
+Update `CreateCallback` parameters in the test file to include:
+
+```csharp
+LiveKitParticipantTracker? liveKitParticipantTracker = null,
+```
+
+Pass the tracker to `new MumbleServerCallback(...)` after the participant remover argument:
+
+```csharp
+liveKitParticipantTracker ?? new LiveKitParticipantTracker(),
+```
+
+- [ ] **Step 2: Run disconnect tests to verify they fail**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "DispatchUserDisconnected_RevokesViewerOnlyParticipantWithoutShareStopped|DispatchUserDisconnected_RevokesPublisherAndViewerRecords"`
+
+Expected: FAIL because `MumbleServerCallback` does not accept or use `LiveKitParticipantTracker` yet.
+
+- [ ] **Step 3: Implement disconnect revocation helper**
+
+Modify `src/Brmble.Server/Mumble/MumbleServerCallback.cs` constructor dependencies by adding:
+
+```csharp
+private readonly LiveKitParticipantTracker _liveKitParticipantTracker;
+```
+
+Constructor parameter after `ILiveKitParticipantRemover liveKitParticipantRemover`:
+
+```csharp
+LiveKitParticipantTracker liveKitParticipantTracker,
+```
+
+Constructor assignment:
+
+```csharp
+_liveKitParticipantTracker = liveKitParticipantTracker;
+```
+
+Add this private helper inside the class:
+
+```csharp
+private async Task RevokeParticipants(IReadOnlyList<LiveKitParticipantRecord> records)
+{
+    foreach (var record in records)
+    {
+        await _liveKitParticipantRemover.RemoveParticipant(record.RoomName, record.MatrixUserId);
+    }
+}
+```
+
+In `DispatchUserDisconnected`, after the existing share stop loop and before `_sessionMapping.RemoveSession(...)`, add:
+
+```csharp
+var revokedRecords = _liveKitParticipantTracker.RemoveBySession(user.SessionId);
+await RevokeParticipants(revokedRecords);
+```
+
+- [ ] **Step 4: Run disconnect revocation tests**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "DispatchUserDisconnected_RevokesViewerOnlyParticipantWithoutShareStopped|DispatchUserDisconnected_RevokesPublisherAndViewerRecords"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing channel move revocation tests**
+
+Add this test to `tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs`:
+
+```csharp
+[TestMethod]
+public async Task DispatchUserStateChanged_RevokesOldRoomParticipantAndKeepsNewRoomParticipant()
+{
+    var bus = new Mock<IBrmbleEventBus>();
+    bus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
+    var channelMembership = new Mock<IChannelMembershipService>();
+    var mapping = new Mock<ISessionMappingService>();
+    mapping.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
+    {
+        { 42, new SessionMapping("@alice:test", "Alice", 100L) }
+    });
+
+    var screenShareTracker = new ScreenShareTracker();
+    screenShareTracker.Start("channel-5", "Alice", 100L, "@alice:test");
+    var participantTracker = new LiveKitParticipantTracker();
+    participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Publish, DateTimeOffset.UtcNow.AddMinutes(5)));
+    participantTracker.Upsert(new LiveKitParticipantRecord("channel-10", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
+
+    var remover = new Mock<ILiveKitParticipantRemover>();
+    remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+    var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, channelMembership: channelMembership.Object, screenShareTracker: screenShareTracker, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
+
+    await callback.DispatchUserStateChanged(new MumbleUser("Alice", "abc", 42), 10);
+
+    remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Once);
+    remover.Verify(r => r.RemoveParticipant("channel-10", "@alice:test"), Times.Never);
+    Assert.IsNull(screenShareTracker.GetActive("channel-5"));
+    Assert.AreEqual("channel-10", participantTracker.GetSnapshot().Single().RoomName);
+}
+```
+
+- [ ] **Step 6: Run channel move test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter DispatchUserStateChanged_RevokesOldRoomParticipantAndKeepsNewRoomParticipant`
+
+Expected: FAIL because channel move currently removes publisher share participants but not viewer-only tracker records.
+
+- [ ] **Step 7: Implement channel move revocation**
+
+In `DispatchUserStateChanged`, keep `_channelMembership.Update(user.SessionId, channelId);` and existing share-stop behavior. After the share room loop, add:
+
+```csharp
+var revokedRecords = _liveKitParticipantTracker.RemoveBySessionExceptRoom(user.SessionId, currentRoom);
+await RevokeParticipants(revokedRecords);
+```
+
+When updating existing `_liveKitParticipantRemover.RemoveParticipant` calls in this method, call through the same participant remover field:
+
+```csharp
+await _liveKitParticipantRemover.RemoveParticipant(roomName, mapping.MatrixUserId);
+```
+
+If this causes duplicate removal for publisher records, remove the direct call inside the share loop and let `RevokeParticipants(revokedRecords)` remove tracked participants once. Keep the screen-share tracker stop and event broadcast inside the share loop.
+
+- [ ] **Step 8: Run lifecycle tests**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter MumbleServerCallbackTests`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit lifecycle revocation**
+
+```powershell
+git add "src/Brmble.Server/Mumble/MumbleServerCallback.cs" "tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs"
+git commit -m "feat: revoke livekit participants on voice changes"
+```
+
+---
+
+### Task 5: Client Refresh Scheduling Tests
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.test.ts`
+
+- [ ] **Step 1: Add fake timer cleanup to test setup**
+
+Modify the import line in `src/Brmble.Web/src/hooks/useScreenShare.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+```
+
+Add this after the existing `beforeEach` block:
+
+```ts
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+```
+
+- [ ] **Step 2: Write failing refresh success test**
+
+Add this test inside the `describe('useScreenShare', () => { ... })` block:
+
+```ts
+  it('refreshes token before expiry and keeps the room connected on success', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
+    const tokenHandlers: Array<(data: unknown) => void> = [];
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandlers.push(handler);
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandlers[0]?.({ token: 'viewer-jwt', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:10:00.000Z', requestId: 1 });
+      await promise;
+    });
+
+    expect(bridge.send).toHaveBeenCalledWith('livekit.requestToken', { roomName: 'channel-1', accessMode: 'subscribe', requestId: 1 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+    });
+
+    expect(bridge.send).toHaveBeenCalledWith('livekit.requestToken', { roomName: 'channel-1', accessMode: 'subscribe', requestId: 2 });
+
+    await act(async () => {
+      tokenHandlers[1]?.({ token: 'viewer-jwt-2', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:20:00.000Z', requestId: 2 });
+      await Promise.resolve();
+    });
+
+    expect(mockRoom.disconnect).not.toHaveBeenCalled();
+    expect(result.current.watchingShares).toHaveLength(1);
+  });
+```
+
+- [ ] **Step 3: Write failing refresh failure test**
+
+Add this test inside the same `describe` block:
+
+```ts
+  it('disconnects and clears watching state when token refresh fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
+    const tokenHandlers: Array<(data: unknown) => void> = [];
+    const tokenErrorHandlers: Array<(data: unknown) => void> = [];
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandlers.push(handler);
+      if (type === 'livekit.tokenError') tokenErrorHandlers.push(handler);
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandlers[0]?.({ token: 'viewer-jwt', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:10:00.000Z', requestId: 1 });
+      await promise;
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+      tokenErrorHandlers[1]?.({ error: 'forbidden', requestId: 2 });
+      await Promise.resolve();
+    });
+
+    expect(mockRoom.disconnect).toHaveBeenCalled();
+    expect(result.current.watchingShares).toEqual([]);
+    expect(result.current.error).toBe('LiveKit access could not be renewed');
+  });
+```
+
+- [ ] **Step 4: Write failing timer cleanup test**
+
+Add this test inside the same `describe` block:
+
+```ts
+  it('cancels pending token refresh when viewer disconnects', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
+    const tokenHandlers: Array<(data: unknown) => void> = [];
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandlers.push(handler);
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandlers[0]?.({ token: 'viewer-jwt', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:10:00.000Z', requestId: 1 });
+      await promise;
+    });
+
+    await act(async () => {
+      await result.current.disconnectViewer();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+    });
+
+    const tokenRequests = (bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.requestToken');
+    expect(tokenRequests).toHaveLength(1);
+  });
+```
+
+- [ ] **Step 5: Run tests to verify they fail**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts` from `src/Brmble.Web`.
+
+Expected: FAIL because refresh scheduling is not implemented.
+
+- [ ] **Step 6: Commit failing client tests only after confirming failure is expected**
+
+Do not commit failing tests yet. Continue to Task 6 in the same working tree state.
+
+---
+
+### Task 6: Client Refresh Implementation
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.ts`
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.test.ts`
+
+- [ ] **Step 1: Add refresh state refs and helpers**
+
+In `src/Brmble.Web/src/hooks/useScreenShare.ts`, add these near the other type definitions:
+
+```ts
+type ActiveTokenLease = {
+  roomName: string;
+  accessMode: LiveKitAccessMode;
+  url: string;
+  expiresAt: string;
+  generation: number;
+};
+
+const TOKEN_REFRESH_SAFETY_WINDOW_MS = 2 * 60 * 1000;
+const MIN_TOKEN_REFRESH_DELAY_MS = 5 * 1000;
+```
+
+Inside `useScreenShare`, add refs near `pendingTokenRequestRef`:
+
+```ts
+  const activeTokenLeaseRef = useRef<ActiveTokenLease | null>(null);
+  const tokenRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+```
+
+Add helper callbacks after `requestToken`:
+
+```ts
+  const clearTokenRefreshTimer = useCallback(() => {
+    if (tokenRefreshTimerRef.current) {
+      clearTimeout(tokenRefreshTimerRef.current);
+      tokenRefreshTimerRef.current = null;
+    }
+  }, []);
+
+  const clearTokenLease = useCallback(() => {
+    clearTokenRefreshTimer();
+    activeTokenLeaseRef.current = null;
+  }, [clearTokenRefreshTimer]);
+```
+
+- [ ] **Step 2: Add refresh scheduling callback**
+
+Add this callback after `clearTokenLease`:
+
+```ts
+  const scheduleTokenRefresh = useCallback((lease: ActiveTokenLease) => {
+    clearTokenRefreshTimer();
+
+    const expiresAtMs = Date.parse(lease.expiresAt);
+    if (!Number.isFinite(expiresAtMs)) {
+      return;
+    }
+
+    const delayMs = Math.max(MIN_TOKEN_REFRESH_DELAY_MS, expiresAtMs - Date.now() - TOKEN_REFRESH_SAFETY_WINDOW_MS);
+    tokenRefreshTimerRef.current = setTimeout(() => {
+      void (async () => {
+        const currentLease = activeTokenLeaseRef.current;
+        if (!currentLease || currentLease.generation !== lease.generation) {
+          return;
+        }
+
+        try {
+          const refreshed = await requestToken(currentLease.roomName, currentLease.accessMode);
+          if (!refreshed.expiresAt || activeTokenLeaseRef.current?.generation !== currentLease.generation) {
+            return;
+          }
+
+          const nextLease = { ...currentLease, url: refreshed.url, expiresAt: refreshed.expiresAt };
+          activeTokenLeaseRef.current = nextLease;
+          scheduleTokenRefresh(nextLease);
+        } catch {
+          if (activeTokenLeaseRef.current?.generation !== currentLease.generation) {
+            return;
+          }
+
+          setError('LiveKit access could not be renewed');
+          const room = roomRef.current;
+          roomRef.current = null;
+          roomAccessModeRef.current = null;
+          roomReconnectUpgradeRef.current = false;
+          clearTokenLease();
+          invalidateRoomLifecycle();
+          cancelPendingViewerAttempts();
+          clearWatchingState();
+          if (isSharingRef.current) {
+            await stopLocalShare('interrupted', room);
+          }
+          try { await room?.disconnect(); } catch { /* ignore */ }
+        }
+      })();
+    }, delayMs);
+  }, [cancelPendingViewerAttempts, clearTokenLease, clearTokenRefreshTimer, clearWatchingState, invalidateRoomLifecycle, requestToken, stopLocalShare]);
+```
+
+If TypeScript reports use-before-declaration because `stopLocalShare`, `cancelPendingViewerAttempts`, or `clearWatchingState` are declared later, move this callback below those callback declarations and keep the same body.
+
+- [ ] **Step 3: Store lease after initial room token**
+
+In `ensureRoom`, replace:
+
+```ts
+const { token, url } = await requestToken(roomName, accessMode);
+```
+
+With:
+
+```ts
+const tokenResponse = await requestToken(roomName, accessMode);
+const { token, url } = tokenResponse;
+```
+
+After `await room.connect(url, token);` and after the lifecycle generation check succeeds, add:
+
+```ts
+      if (tokenResponse.expiresAt) {
+        const lease = {
+          roomName,
+          accessMode,
+          url,
+          expiresAt: tokenResponse.expiresAt,
+          generation: roomLifecycleGenerationRef.current,
+        };
+        activeTokenLeaseRef.current = lease;
+        scheduleTokenRefresh(lease);
+      } else {
+        clearTokenLease();
+      }
+```
+
+Add `scheduleTokenRefresh` and `clearTokenLease` to the `ensureRoom` dependency array.
+
+- [ ] **Step 4: Clear lease on all disconnect paths**
+
+In `maybeDisconnectRoom`, after setting `roomReconnectUpgradeRef.current = false;`, add:
+
+```ts
+      clearTokenLease();
+```
+
+In `RoomEvent.Disconnected`, after `roomAccessModeRef.current = null;`, add:
+
+```ts
+        clearTokenLease();
+```
+
+In the `room.connect` catch block, after `roomReconnectUpgradeRef.current = false;`, add:
+
+```ts
+          clearTokenLease();
+```
+
+In `disconnectViewer`, before `await maybeDisconnectRoom();` in the no-user-id cleanup path, add:
+
+```ts
+    clearTokenLease();
+```
+
+In the unmount cleanup effect, before `invalidateRoomLifecycle();`, add:
+
+```ts
+      clearTokenLease();
+```
+
+Add `clearTokenLease` to dependency arrays for callbacks/effects that use it.
+
+- [ ] **Step 5: Run client tests**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts` from `src/Brmble.Web`.
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit client refresh**
+
+```powershell
+git add "src/Brmble.Web/src/hooks/useScreenShare.ts" "src/Brmble.Web/src/hooks/useScreenShare.test.ts"
+git commit -m "feat: refresh livekit tokens before expiry"
+```
+
+---
+
+### Task 7: Final Verification
+
+**Files:**
+- Verify all modified server and frontend files.
+
+- [ ] **Step 1: Run server test suite**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend hook tests**
+
+Run: `npm run test -- src/hooks/useScreenShare.test.ts` from `src/Brmble.Web`.
+
+Expected: PASS.
+
+- [ ] **Step 3: Build frontend**
+
+Run: `npm run build` from `src/Brmble.Web`.
+
+Expected: PASS with Vite production build output.
+
+- [ ] **Step 4: Build solution**
+
+Run: `dotnet build`
+
+Expected: PASS.
+
+- [ ] **Step 5: Check working tree**
+
+Run: `git status --short --branch`
+
+Expected: branch is `fix/livekit-token-refresh-revocation`; only unrelated pre-existing untracked files may remain (`%USERPROFILE%/`, `.opencode/plans/`, `nul`, `src/Brmble.Web/nul`).
+
+- [ ] **Step 6: Commit verification fixes if any were required**
+
+If verification required code changes, commit them:
+
+```powershell
+git add "src/Brmble.Server" "tests/Brmble.Server.Tests" "src/Brmble.Web/src/hooks/useScreenShare.ts" "src/Brmble.Web/src/hooks/useScreenShare.test.ts"
+git commit -m "fix: stabilize livekit token revocation"
+```
+
+If no changes were required, do not create an empty commit.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: participant tracking, token endpoint recording, disconnect/move revocation, viewer-only revocation, refresh before expiry, refresh failure cleanup, and verification are each covered by a task.
+- Scope: permission-loss without a concrete event source is covered by reuse of the revocation helper when such events exist; current implementation enforces future denial through the existing token endpoint and early removal through observed disconnect/move events.
+- Type consistency: `LiveKitParticipantRecord`, `LiveKitParticipantTracker`, and `ILiveKitParticipantRemover` are introduced before use in later tasks.

--- a/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
@@ -1,7 +1,7 @@
 # LiveKit & Screen Sharing Feature Roadmap
 
 **Date:** 2026-04-17
-**Status:** Active roadmap. Foundation, recent follow-up fixes, and the first E. Token & Security hardening pass are implemented; remaining E/F work should focus on token rotation/revocation and connection reliability.
+**Status:** Active roadmap. Foundation, recent follow-up fixes, and E. Token & Security are implemented; next recommended phase is F. Connection & Reliability.
 
 This is the master feature list for LiveKit and screen sharing work. Completed sub-projects and shipped follow-up fixes are tracked here, while future work should continue through design -> plan -> implementation cycles.
 
@@ -14,7 +14,7 @@ This is the master feature list for LiveKit and screen sharing work. Completed s
 | B | Broadcaster Controls | Not started | -- |
 | C | Viewing Experience | Not started | -- |
 | D | Game Overlay | Not started | -- |
-| E | Token & Security | Partially implemented | `2026-04-30-livekit-token-security-phase-design.md` |
+| E | Token & Security | Implemented | `2026-04-30-livekit-token-security-phase-design.md`, `2026-05-11-livekit-token-refresh-revocation-design.md` |
 | F | Connection & Reliability | Not started | -- |
 | G | UI/UX Polish | Not started | -- |
 | H | Clips & Screenshots | Not started | -- |
@@ -86,15 +86,15 @@ See full spec: `2026-04-17-multi-share-foundation-design.md`
 > Hardening the LiveKit auth layer.
 
 28. Token scoping (publish vs. subscribe-only tokens for viewers) -- implemented in E1
-29. Token rotation (auto-refresh before expiry without interrupting stream) -- future
-30. Token revocation (server-side, tied to channel kick via RemoveParticipant) -- future
+29. Token rotation (auto-refresh before expiry without interrupting stream) -- implemented in E2
+30. Token revocation (server-side, tied to channel kick via RemoveParticipant) -- implemented in E2
 31. Auth on `/livekit/active-share` endpoint (issue #349) -- implemented in E1
 32. Rate limiting on LiveKit endpoints (issue #351) -- implemented in E2 for token and active-share endpoints
 33. Room-level permissions tied to channel permissions
 
-**Implemented E-pass behavior:** authenticated active-share discovery, explicit publish/subscribe token access modes, server-side channel permission checks for token issuance, 1-hour token expiry metadata, targeted LiveKit endpoint rate limiting, duplicate share-start suppression, and idle/leave-voice screenshare cleanup.
+**Implemented E-pass behavior:** authenticated active-share discovery, explicit publish/subscribe token access modes, server-side channel permission checks for token issuance, 1-hour token expiry metadata, targeted LiveKit endpoint rate limiting, duplicate share-start suppression, idle/leave-voice screenshare cleanup, client token refresh before expiry, active LiveKit participant tracking, participant-scoped early revocation on observed voice lifecycle changes, and retrying participant removal to cover join-after-revoke timing windows.
 
-**Remaining E work:** token refresh/rotation before expiry, early revocation on kick/permission loss, and any deeper room-level permission model beyond current channel membership checks.
+**E completion note:** Issue `#354` is addressed by the current E2 work and is ready to close after PR review. Fine-grained permission-loss events beyond the current Mumble disconnect/move lifecycle remain reusable future hardening if the Mumble integration exposes additional ACL event sources, but they are not blocking for the E phase.
 
 **Deferred:** Share passwords -- not needed, channel membership is the access boundary.
 
@@ -180,22 +180,19 @@ These items were discussed and explicitly parked:
 
 ## Next-Phase Issue Shortlist
 
-The remaining priority work around E/F should start with these still-open or partially completed issues:
+The remaining priority work moves to phase F and should start with:
 
-- `#354` `[SECURITY] LiveKit tokens have no early revocation`
 - `#380` `feat: Reconnect non-voice services independently when Mumble stays connected`
 
 Implemented by the current E-pass:
 
 - `#349` `[SECURITY] /livekit/active-share endpoint has no authentication`
 - `#351` `[SECURITY] No rate limiting on any endpoint` for LiveKit token/active-share paths
+- `#354` `[SECURITY] LiveKit tokens have no early revocation`
 - `#359` `Disable Screenshare button and keybinding while LiveKit is connecting` for duplicate in-flight share starts
 
-Known roadmap gaps with no dedicated issue yet:
+Known phase-F roadmap gaps with no dedicated issue yet:
 
-- token scoping for publish vs subscribe-only tokens
-- token rotation / refresh before expiry
-- room-level permissions tied to channel permissions
 - auto-reconnect on drop
 - share state recovery after crash
 - connection quality indicator and graceful degradation
@@ -206,8 +203,8 @@ The recommended next sequence is:
 
 1. **A. Multi-Share Foundation** -- implemented
 2. **A2. Multi-Share Layouts** -- implemented
-3. **E. Token & Security remaining work** -- token rotation, early revocation, and deeper permission lifecycle hardening
-4. **F. Connection & Reliability** -- address reconnect, recovery, and connection-state behavior after the current E-pass
+3. **E. Token & Security** -- implemented
+4. **F. Connection & Reliability** -- next priority; address reconnect, recovery, and connection-state behavior
 5. **C. Viewing Experience** -- pop-out, PiP, fullscreen (needed before overlay)
 6. **B. Broadcaster Controls** -- window picker, audio, quality presets
 7. **D. Game Overlay** -- depends on C (PiP/pop-out patterns) and voice system

--- a/docs/superpowers/specs/2026-04-30-livekit-token-security-phase-design.md
+++ b/docs/superpowers/specs/2026-04-30-livekit-token-security-phase-design.md
@@ -1,7 +1,7 @@
 # LiveKit Token & Security Phase Design
 
 **Date:** 2026-04-30
-**Status:** Partially implemented. E1 and the first E2 hardening pass have landed; token rotation and early revocation remain future work.
+**Status:** Implemented. E1 and E2 have landed, including token refresh before expiry and participant-scoped early revocation for observed voice lifecycle changes.
 **Scope:** Historical design for the LiveKit security phase split into `E1: Access Control Foundation` and `E2: Token Lifecycle Hardening`.
 
 ## Overview
@@ -17,7 +17,7 @@ One product clarification is important: share discovery metadata and share watch
 - Make the server the single authority for LiveKit publish and subscribe permissions while keeping share discovery as authenticated visibility metadata.
 - Separate publisher and viewer access through explicit token scoping.
 - Tie actual LiveKit watch/publish access to actual channel membership and permission state rather than room-name knowledge.
-- Add short-lived token lifecycle controls and abuse resistance. The landed E2 pass includes shorter token expiry metadata, targeted rate limiting, and duplicate-start suppression; token rotation and early revocation remain future work.
+- Add short-lived token lifecycle controls and abuse resistance. E2 includes shorter token expiry metadata, targeted rate limiting, duplicate-start suppression, token refresh before expiry, and participant-scoped early revocation.
 - Include one tiny client-side guardrail that prevents duplicate share-start attempts during the token/connect path.
 
 ## Non-Goals
@@ -43,16 +43,13 @@ Deliverables:
 
 ### E2. Token Lifecycle Hardening
 
-`E2` builds on `E1` by controlling duration and abuse resistance first, then leaving full revocation/rotation for follow-up work. It does not invent new authorization rules; it only enforces and maintains the access model established in `E1`.
+`E2` builds on `E1` by controlling duration, abuse resistance, token rotation, and active-session revocation. It does not invent new authorization rules; it only enforces and maintains the access model established in `E1`.
 
 Deliverables:
 
 - short-lived token expiry metadata
 - rate limiting on relevant LiveKit endpoints
 - one tiny duplicate-start guardrail during the LiveKit auth/connect path
-
-Deferred E2 deliverables:
-
 - token rotation before expiry
 - early revocation on kick, leave, or permission loss
 
@@ -111,7 +108,9 @@ This means share discovery remains visible product metadata, while publish and s
 2. Server returns expiry metadata so the client flow is rotation-ready
 3. Rate limiting constrains repeated token/discovery abuse
 4. The duplicate-start guard prevents overlapping share-start/token-connect attempts on the client
-5. Future work adds token refresh before expiry and early revocation on kick, leave, or permission loss
+5. The client refreshes tokens before expiry for active share/watch sessions
+6. The server tracks active LiveKit participants and removes affected identities when observed voice lifecycle events revoke access
+7. Revocation uses retrying participant removal to cover transient LiveKit API failures and join-after-revoke timing windows
 
 The lifecycle layer should not create a second set of rules. It only maintains and enforces the access model defined by `E1`.
 
@@ -155,14 +154,16 @@ The rate limiter should be scoped narrowly enough to protect these endpoints wit
 ### Token rotation
 
 - Tokens should become short-lived enough that long-lived unauthorized access is materially reduced.
-- The landed client flow accepts expiry metadata so token refresh can be added without changing the response contract again.
-- Full refresh before expiry remains future E work.
+- The client uses expiry metadata to refresh active LiveKit authorization before expiry.
+- Refresh failure is treated as access loss and tears down the affected share/watch session.
 
 ### Early revocation
 
 - Access should end early when the user is kicked, leaves the channel, or loses the relevant permission.
 - Revocation should be tied to the same server-side source of truth used for token issuance.
 - A revoked session should be treated as access loss, not as a generic network failure.
+- Active participant identities should be removed without tearing down unrelated valid participants in the same LiveKit room.
+- Revocation attempts should be retried briefly because a token can be issued just before voice lifecycle revocation and the participant may join after the first removal attempt.
 
 ## Tiny Guardrail
 
@@ -239,12 +240,12 @@ Keeping those separate prevents future `F`-phase reconnect work from being pollu
 - short-lived token metadata is returned with an expiry timestamp
 - rate limiting blocks repeated token/discovery abuse
 - duplicate-start guard suppresses a second in-flight share-start request
-
-Future E tests:
-
 - token refresh occurs before expiry without dropping a valid session
 - expired token without refresh ends access cleanly
 - kick, leave, or permission loss revokes active access
+- viewer-only revocation removes only the affected participant and does not broadcast share stop
+- publisher revocation stops tracker state and broadcasts share stop
+- failed or early participant removal is retried
 
 ### Manual verification
 

--- a/docs/superpowers/specs/2026-05-11-livekit-token-refresh-revocation-design.md
+++ b/docs/superpowers/specs/2026-05-11-livekit-token-refresh-revocation-design.md
@@ -1,10 +1,15 @@
 # LiveKit Token Refresh And Revocation Design
 
+**Date:** 2026-05-11
+**Status:** Implemented. This completes the remaining E2 token lifecycle hardening scope for issue `#354`; phase F is the next LiveKit roadmap focus.
+
 ## Context
 
 Issue #354 tracks the remaining E2 token lifecycle hardening work. The E1 access-control foundation is already in place: LiveKit token requests are scoped by access mode and authorized against the caller's current Mumble channel membership. The first E2 pass added shorter expiry metadata, rate limiting, and duplicate-start protection.
 
 The remaining gap is active access. A user who already joined a LiveKit room should be removed promptly when their voice/channel authorization changes, and valid users should refresh access before token expiry without dropping an active share or watch session.
+
+This design has landed. Manual two-client validation covered share/watch, viewer leave, sharer leave, viewer move, sharer move, reconnect after viewer disconnect, reconnect after sharer disconnect, and preservation of valid share sessions. The untested manual scenario is the three-client case where one viewer is revoked while another viewer continues watching; this is covered by the design and automated tests and remains useful for broader manual regression passes.
 
 ## Goals
 

--- a/docs/superpowers/specs/2026-05-11-livekit-token-refresh-revocation-design.md
+++ b/docs/superpowers/specs/2026-05-11-livekit-token-refresh-revocation-design.md
@@ -1,0 +1,147 @@
+# LiveKit Token Refresh And Revocation Design
+
+## Context
+
+Issue #354 tracks the remaining E2 token lifecycle hardening work. The E1 access-control foundation is already in place: LiveKit token requests are scoped by access mode and authorized against the caller's current Mumble channel membership. The first E2 pass added shorter expiry metadata, rate limiting, and duplicate-start protection.
+
+The remaining gap is active access. A user who already joined a LiveKit room should be removed promptly when their voice/channel authorization changes, and valid users should refresh access before token expiry without dropping an active share or watch session.
+
+## Goals
+
+- Refresh LiveKit tokens before expiry for active share/watch sessions.
+- Keep valid active sessions alive across token rotation.
+- Remove affected LiveKit participants early when they disconnect, leave voice, move channel, are kicked/banned, or lose channel permission.
+- Re-authorize refresh/token requests using current Mumble session and channel membership.
+- Preserve other valid participants in the same LiveKit room.
+- Add tests for refresh timing, refresh failure cleanup, and revocation events.
+
+## Non-Goals
+
+- Do not tear down an entire LiveKit room when only one participant loses access.
+- Do not add persisted LiveKit session state; in-memory bookkeeping is sufficient for active server process state.
+- Do not attempt to cryptographically revoke an already-issued JWT. LiveKit JWTs remain bearer tokens until expiry; early revocation is implemented by removing active participants and denying future tokens.
+- Do not automatically restart browser screen capture after a disconnect. A reconnect creates a fresh authorization path, but sharing requires client-side capture to be started again intentionally.
+
+## Chosen Approach
+
+Use participant-scoped revocation plus client token refresh.
+
+The server records active LiveKit participant bookkeeping when it issues a token. This record is not an authorization source; it only answers, "which LiveKit identities may need to be removed if this Mumble session or user loses access?" Authorization continues to come from `ISessionMappingService` and `IChannelMembershipService`.
+
+When Mumble lifecycle events show that a user no longer belongs in a voice channel, the server removes only that user's LiveKit participant identity from affected rooms. If that user was publishing, the existing screen-share tracker is stopped and `screenShare.stopped` is broadcast. If the user was only watching, no share stop event is emitted; the affected client is disconnected from LiveKit while publishers and other valid viewers continue.
+
+The React screen-share hook stores the active room, access mode, and `expiresAt` from token responses. It schedules a refresh before expiry. A successful refresh keeps the authorization lease current. A failed refresh means the current LiveKit session is no longer safely authorized, so the hook disconnects from the room and cleans local share/watch state using the existing interruption paths.
+
+## Server Components
+
+### LiveKit Participant Tracker
+
+Add a small singleton service for active participant bookkeeping. Each record should include:
+
+- `roomName`
+- `matrixUserId`
+- `userId`
+- `sessionId`
+- `accessMode`
+- `expiresAt`
+
+The tracker should support:
+
+- Upsert on token issuance.
+- Remove by room and participant identity when a local client disconnects cleanly.
+- Find and remove all records for a session when the Mumble session disconnects.
+- Find and remove records for a session that no longer match the current channel room after a move.
+- Prune expired records opportunistically.
+
+This tracker should be deliberately small and in-memory. If the server restarts, existing LiveKit participants may remain until token expiry or LiveKit detects disconnects; this is acceptable for the current hardening phase because token TTL remains short.
+
+### Token Endpoint
+
+`/livekit/token` already validates the certificate, resolves the user, parses `roomName` and `accessMode`, and authorizes against current Mumble channel membership. After successful token metadata generation, it should record the active participant in the tracker using the current session id and returned `expiresAt`.
+
+Refresh requests should use the same endpoint and same authorization rules. No special refresh endpoint is required.
+
+### Mumble Lifecycle Revocation
+
+On user disconnect:
+
+- Look up the old session mapping before removing it.
+- Stop and broadcast active shares for that user, as current code already does.
+- Remove the user's LiveKit participant identity from every tracked room for that session, including viewer-only records.
+- Remove session and channel membership after revocation bookkeeping is captured.
+
+On user channel move:
+
+- Capture the previous channel before updating membership.
+- Update the membership to the new channel.
+- For tracked LiveKit participant records on that session, keep records matching the new `channel-<id>` room and revoke records for any other room.
+- For revoked publish records, stop and broadcast the screen share.
+- For revoked subscribe records, only remove the LiveKit participant.
+
+On kick/ban/leave voice:
+
+- These flow through Mumble disconnect/session removal in the current server callback path, so they should use the same session revocation path.
+
+On permission loss without a move/disconnect:
+
+- If the server receives a channel/user state event that makes current channel authorization false, revoke the affected participant records using the same helper as channel move.
+- If the current Mumble integration cannot observe fine-grained ACL changes yet, the token endpoint still denies future refreshes once membership/permission checks fail. Early participant removal for ACL-only changes can be added where that event source becomes available.
+
+## Client Refresh Flow
+
+`useScreenShare` should treat `expiresAt` as an authorization lease for the current LiveKit room connection.
+
+After connecting with a token:
+
+- Store the active `roomName`, effective `accessMode`, and `expiresAt`.
+- Schedule refresh before expiry, with a safety window rather than waiting until the last moment.
+- If the room is upgraded from subscribe to publish, replace the stored lease with the publish lease.
+- Clear the timer on room disconnect, local cleanup, component unmount, and superseded room requests.
+
+On refresh success:
+
+- Update the stored expiry and schedule the next refresh.
+- Keep the existing LiveKit room connected.
+
+On refresh failure:
+
+- Invalidate the room lifecycle.
+- Disconnect the LiveKit room.
+- If sharing, stop local share with an interruption/error reason.
+- Clear watched shares and pending viewer attempts.
+- Surface a concise error so the UI can indicate that LiveKit access could not be renewed.
+
+The LiveKit client SDK may not need the new token injected into an already-connected room for the immediate connection to stay alive, but the refresh is still useful because it revalidates authorization before expiry and detects permission loss promptly. If the SDK exposes a supported token-update API in the installed version, the implementation can use it; otherwise, the refreshed token is treated as a renewed server-side authorization lease.
+
+## Reconnect Behavior
+
+A reconnect is a fresh authorization path.
+
+If a user disconnects while sharing, the server removes their old LiveKit participant, stops their tracked share, and broadcasts `screenShare.stopped`. When the user auto-reconnects to Mumble, they receive a new session id. If they land back in the same voice channel, future token requests are valid again, but the old screen capture is not automatically resumed.
+
+If a user disconnects while watching, the server removes only their LiveKit participant. The publisher and other viewers remain connected. When the user reconnects and is back in the same voice channel, discovery can find the existing share and the client can request a fresh subscribe token to watch again.
+
+## Testing
+
+Server tests should cover:
+
+- Token issuance records participant bookkeeping with room, identity, session, mode, and expiry.
+- Disconnect revokes all tracked participant records for the old session, including viewer-only records.
+- Channel move revokes records for the previous channel but preserves records for the new channel.
+- Publishing revocation stops tracker state and broadcasts `screenShare.stopped`.
+- Viewer revocation removes the participant without broadcasting a share stop.
+- Expired tracker records are pruned and are not revoked repeatedly.
+
+Client tests should cover:
+
+- Refresh is scheduled before `expiresAt`.
+- Refresh success schedules the next refresh without disconnecting the room.
+- Refresh failure disconnects and clears share/watch state.
+- Pending refresh timers are canceled when the room disconnects or a room request is superseded.
+
+## Risks And Constraints
+
+- LiveKit JWTs cannot be revoked after issuance, so short TTL plus participant removal is the practical enforcement model.
+- In-memory participant tracking is process-local. A server restart may lose revocation bookkeeping for already-connected participants, but short token TTL and LiveKit disconnect behavior limit exposure.
+- Browser capture should not be auto-restarted after revocation or reconnect because that would surprise users and may violate browser capture expectations.
+- Permission-loss events are only as complete as the Mumble event sources available to the server. Future ACL event integration can reuse the same participant revocation helper.

--- a/src/Brmble.Server/LiveKit/ILiveKitParticipantRemover.cs
+++ b/src/Brmble.Server/LiveKit/ILiveKitParticipantRemover.cs
@@ -1,0 +1,6 @@
+namespace Brmble.Server.LiveKit;
+
+public interface ILiveKitParticipantRemover
+{
+    Task RemoveParticipant(string roomName, string participantIdentity);
+}

--- a/src/Brmble.Server/LiveKit/ILiveKitParticipantRemover.cs
+++ b/src/Brmble.Server/LiveKit/ILiveKitParticipantRemover.cs
@@ -2,5 +2,5 @@ namespace Brmble.Server.LiveKit;
 
 public interface ILiveKitParticipantRemover
 {
-    Task RemoveParticipant(string roomName, string participantIdentity);
+    Task<bool> RemoveParticipant(string roomName, string participantIdentity);
 }

--- a/src/Brmble.Server/LiveKit/ILiveKitParticipantRevocationScheduler.cs
+++ b/src/Brmble.Server/LiveKit/ILiveKitParticipantRevocationScheduler.cs
@@ -1,0 +1,6 @@
+namespace Brmble.Server.LiveKit;
+
+public interface ILiveKitParticipantRevocationScheduler
+{
+    Task RevokeParticipants(IReadOnlyList<LiveKitParticipantRecord> records);
+}

--- a/src/Brmble.Server/LiveKit/LiveKitEndpoints.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitEndpoints.cs
@@ -31,6 +31,7 @@ public static class LiveKitEndpoints
             UserRepository userRepo,
             ISessionMappingService sessionMapping,
             IChannelMembershipService channelMembership,
+            LiveKitParticipantTracker participantTracker,
             ILogger<LiveKitService> logger) =>
         {
             var certHash = certHashExtractor.GetCertHash(httpContext);
@@ -71,7 +72,10 @@ public static class LiveKitEndpoints
             if (accessMode is null)
                 return Results.BadRequest(new { error = "accessMode must be 'publish' or 'subscribe'" });
 
-            var isInRequestedRoom = IsUserInRoom(user.Id, roomName, sessionMapping, channelMembership);
+            var hasSession = sessionMapping.TryGetSessionByUserId(user.Id, out var sessionId);
+            var isInRequestedRoom = hasSession
+                && channelMembership.TryGetChannel(sessionId, out var channelId)
+                && string.Equals(roomName, $"channel-{channelId}", StringComparison.Ordinal);
 
             var authz = await liveKitService.AuthorizeTokenRequest(
                 certHash,
@@ -95,6 +99,18 @@ public static class LiveKitEndpoints
             var metadata = await liveKitService.GenerateTokenMetadata(certHash, roomName, accessMode.Value, issuedAt);
             if (metadata is null)
                 return Results.Unauthorized();
+
+            if (hasSession)
+            {
+                participantTracker.PruneExpired(issuedAt);
+                participantTracker.Upsert(new LiveKitParticipantRecord(
+                    roomName,
+                    user.MatrixUserId,
+                    user.Id,
+                    sessionId,
+                    accessMode.Value,
+                    metadata.ExpiresAt));
+            }
 
             // Build the LiveKit WebSocket URL relative to the request origin.
             // LiveKit is proxied through YARP at /livekit/, so the client connects

--- a/src/Brmble.Server/LiveKit/LiveKitEndpoints.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitEndpoints.cs
@@ -85,19 +85,18 @@ public static class LiveKitEndpoints
             if (metadata is null)
                 return Results.Unauthorized();
 
-            if (hasSession && participantTracker.IsSessionRevoking(sessionId))
-                return Results.StatusCode(StatusCodes.Status403Forbidden);
-
             if (hasSession)
             {
                 participantTracker.PruneExpired(issuedAt);
-                participantTracker.Upsert(new LiveKitParticipantRecord(
+                var recorded = participantTracker.TryUpsert(new LiveKitParticipantRecord(
                     roomName,
                     user.MatrixUserId,
                     user.Id,
                     sessionId,
                     accessMode.Value,
                     metadata.ExpiresAt));
+                if (!recorded)
+                    return Results.StatusCode(StatusCodes.Status403Forbidden);
             }
 
             // Build the LiveKit WebSocket URL relative to the request origin.

--- a/src/Brmble.Server/LiveKit/LiveKitEndpoints.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitEndpoints.cs
@@ -7,21 +7,6 @@ namespace Brmble.Server.LiveKit;
 
 public static class LiveKitEndpoints
 {
-    private static bool IsUserInRoom(
-        long userId,
-        string roomName,
-        ISessionMappingService sessionMapping,
-        IChannelMembershipService channelMembership)
-    {
-        if (!sessionMapping.TryGetSessionByUserId(userId, out var sessionId)
-            || !channelMembership.TryGetChannel(sessionId, out var channelId))
-        {
-            return false;
-        }
-
-        return string.Equals(roomName, $"channel-{channelId}", StringComparison.Ordinal);
-    }
-
     public static IEndpointRouteBuilder MapLiveKitEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapPost("/livekit/token", async (

--- a/src/Brmble.Server/LiveKit/LiveKitEndpoints.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitEndpoints.cs
@@ -85,6 +85,9 @@ public static class LiveKitEndpoints
             if (metadata is null)
                 return Results.Unauthorized();
 
+            if (hasSession && participantTracker.IsSessionRevoking(sessionId))
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+
             if (hasSession)
             {
                 participantTracker.PruneExpired(issuedAt);

--- a/src/Brmble.Server/LiveKit/LiveKitExtensions.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitExtensions.cs
@@ -8,6 +8,7 @@ public static class LiveKitExtensions
             .BindConfiguration("LiveKit");
         services.AddSingleton<LiveKitService>();
         services.AddSingleton<ILiveKitRoomQuery>(sp => sp.GetRequiredService<LiveKitService>());
+        services.AddSingleton<LiveKitParticipantTracker>();
         services.AddSingleton<ScreenShareTracker>();
         services.AddSingleton<IUserIdMapper, SessionMappingUserIdMapper>();
         services.AddHostedService<ScreenShareReconciliationService>();

--- a/src/Brmble.Server/LiveKit/LiveKitExtensions.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitExtensions.cs
@@ -9,6 +9,7 @@ public static class LiveKitExtensions
         services.AddSingleton<LiveKitService>();
         services.AddSingleton<ILiveKitRoomQuery>(sp => sp.GetRequiredService<LiveKitService>());
         services.AddSingleton<ILiveKitParticipantRemover>(sp => sp.GetRequiredService<LiveKitService>());
+        services.AddSingleton<ILiveKitParticipantRevocationScheduler, LiveKitParticipantRevocationScheduler>();
         services.AddSingleton<LiveKitParticipantTracker>();
         services.AddSingleton<ScreenShareTracker>();
         services.AddSingleton<IUserIdMapper, SessionMappingUserIdMapper>();

--- a/src/Brmble.Server/LiveKit/LiveKitExtensions.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitExtensions.cs
@@ -8,6 +8,7 @@ public static class LiveKitExtensions
             .BindConfiguration("LiveKit");
         services.AddSingleton<LiveKitService>();
         services.AddSingleton<ILiveKitRoomQuery>(sp => sp.GetRequiredService<LiveKitService>());
+        services.AddSingleton<ILiveKitParticipantRemover>(sp => sp.GetRequiredService<LiveKitService>());
         services.AddSingleton<LiveKitParticipantTracker>();
         services.AddSingleton<ScreenShareTracker>();
         services.AddSingleton<IUserIdMapper, SessionMappingUserIdMapper>();

--- a/src/Brmble.Server/LiveKit/LiveKitParticipantRevocationScheduler.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitParticipantRevocationScheduler.cs
@@ -24,13 +24,14 @@ public sealed class LiveKitParticipantRevocationScheduler : ILiveKitParticipantR
             return;
 
         var snapshot = records.ToArray();
-        await RemoveParticipants(snapshot);
+        var removedAll = await RemoveParticipants(snapshot);
 
         foreach (var delay in _retryDelays)
         {
             if (delay == TimeSpan.Zero)
             {
-                await RemoveParticipants(snapshot);
+                if (!removedAll)
+                    removedAll = await RemoveParticipants(snapshot);
             }
             else
             {
@@ -52,11 +53,15 @@ public sealed class LiveKitParticipantRevocationScheduler : ILiveKitParticipantR
         }
     }
 
-    private async Task RemoveParticipants(IReadOnlyList<LiveKitParticipantRecord> records)
+    private async Task<bool> RemoveParticipants(IReadOnlyList<LiveKitParticipantRecord> records)
     {
+        var removedAll = true;
         foreach (var record in records)
         {
-            await _participantRemover.RemoveParticipant(record.RoomName, record.MatrixUserId);
+            var removed = await _participantRemover.RemoveParticipant(record.RoomName, record.MatrixUserId);
+            removedAll &= removed;
         }
+
+        return removedAll;
     }
 }

--- a/src/Brmble.Server/LiveKit/LiveKitParticipantRevocationScheduler.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitParticipantRevocationScheduler.cs
@@ -1,0 +1,62 @@
+namespace Brmble.Server.LiveKit;
+
+public sealed class LiveKitParticipantRevocationScheduler : ILiveKitParticipantRevocationScheduler
+{
+    private static readonly TimeSpan[] DefaultRetryDelays = [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(10)];
+
+    private readonly ILiveKitParticipantRemover _participantRemover;
+    private readonly IReadOnlyList<TimeSpan> _retryDelays;
+    private readonly ILogger<LiveKitParticipantRevocationScheduler> _logger;
+
+    public LiveKitParticipantRevocationScheduler(
+        ILiveKitParticipantRemover participantRemover,
+        ILogger<LiveKitParticipantRevocationScheduler> logger,
+        IReadOnlyList<TimeSpan>? retryDelays = null)
+    {
+        _participantRemover = participantRemover;
+        _retryDelays = retryDelays ?? DefaultRetryDelays;
+        _logger = logger;
+    }
+
+    public async Task RevokeParticipants(IReadOnlyList<LiveKitParticipantRecord> records)
+    {
+        if (records.Count == 0)
+            return;
+
+        var snapshot = records.ToArray();
+        await RemoveParticipants(snapshot);
+
+        foreach (var delay in _retryDelays)
+        {
+            if (delay == TimeSpan.Zero)
+            {
+                await RemoveParticipants(snapshot);
+            }
+            else
+            {
+                _ = RetryAfterDelay(snapshot, delay);
+            }
+        }
+    }
+
+    private async Task RetryAfterDelay(IReadOnlyList<LiveKitParticipantRecord> records, TimeSpan delay)
+    {
+        try
+        {
+            await Task.Delay(delay);
+            await RemoveParticipants(records);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "LiveKit participant revocation retry failed");
+        }
+    }
+
+    private async Task RemoveParticipants(IReadOnlyList<LiveKitParticipantRecord> records)
+    {
+        foreach (var record in records)
+        {
+            await _participantRemover.RemoveParticipant(record.RoomName, record.MatrixUserId);
+        }
+    }
+}

--- a/src/Brmble.Server/LiveKit/LiveKitParticipantRevocationScheduler.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitParticipantRevocationScheduler.cs
@@ -6,15 +6,18 @@ public sealed class LiveKitParticipantRevocationScheduler : ILiveKitParticipantR
 
     private readonly ILiveKitParticipantRemover _participantRemover;
     private readonly IReadOnlyList<TimeSpan> _retryDelays;
+    private readonly Func<TimeSpan, Task> _delay;
     private readonly ILogger<LiveKitParticipantRevocationScheduler> _logger;
 
     public LiveKitParticipantRevocationScheduler(
         ILiveKitParticipantRemover participantRemover,
         ILogger<LiveKitParticipantRevocationScheduler> logger,
-        IReadOnlyList<TimeSpan>? retryDelays = null)
+        IReadOnlyList<TimeSpan>? retryDelays = null,
+        Func<TimeSpan, Task>? delay = null)
     {
         _participantRemover = participantRemover;
         _retryDelays = retryDelays ?? DefaultRetryDelays;
+        _delay = delay ?? Task.Delay;
         _logger = logger;
     }
 
@@ -33,7 +36,7 @@ public sealed class LiveKitParticipantRevocationScheduler : ILiveKitParticipantR
                 if (!removedAll)
                     removedAll = await RemoveParticipants(snapshot);
             }
-            else
+            else if (!removedAll)
             {
                 _ = RetryAfterDelay(snapshot, delay);
             }
@@ -44,7 +47,7 @@ public sealed class LiveKitParticipantRevocationScheduler : ILiveKitParticipantR
     {
         try
         {
-            await Task.Delay(delay);
+            await _delay(delay);
             await RemoveParticipants(records);
         }
         catch (Exception ex)

--- a/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
@@ -13,9 +13,16 @@ public sealed record LiveKitParticipantRecord(
 public sealed class LiveKitParticipantTracker
 {
     private readonly ConcurrentDictionary<(string RoomName, string MatrixUserId), LiveKitParticipantRecord> _participants = new();
+    private readonly ConcurrentDictionary<int, byte> _revokingSessions = new();
 
     public void Upsert(LiveKitParticipantRecord record)
         => _participants[(record.RoomName, record.MatrixUserId)] = record;
+
+    public void MarkSessionRevoking(int sessionId)
+        => _revokingSessions[sessionId] = 0;
+
+    public bool IsSessionRevoking(int sessionId)
+        => _revokingSessions.ContainsKey(sessionId);
 
     public LiveKitParticipantRecord? Remove(string roomName, string matrixUserId)
     {

--- a/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
@@ -1,0 +1,52 @@
+using System.Collections.Concurrent;
+
+namespace Brmble.Server.LiveKit;
+
+public sealed record LiveKitParticipantRecord(
+    string RoomName,
+    string MatrixUserId,
+    long UserId,
+    int SessionId,
+    LiveKitAccessMode AccessMode,
+    DateTimeOffset ExpiresAt);
+
+public sealed class LiveKitParticipantTracker
+{
+    private readonly ConcurrentDictionary<(string RoomName, string MatrixUserId), LiveKitParticipantRecord> _participants = new();
+
+    public void Upsert(LiveKitParticipantRecord record)
+        => _participants[(record.RoomName, record.MatrixUserId)] = record;
+
+    public LiveKitParticipantRecord? Remove(string roomName, string matrixUserId)
+    {
+        return _participants.TryRemove((roomName, matrixUserId), out var record)
+            ? record
+            : null;
+    }
+
+    public IReadOnlyList<LiveKitParticipantRecord> RemoveBySession(int sessionId)
+        => RemoveWhere(record => record.SessionId == sessionId);
+
+    public IReadOnlyList<LiveKitParticipantRecord> RemoveBySessionExceptRoom(int sessionId, string roomName)
+        => RemoveWhere(record => record.SessionId == sessionId && !string.Equals(record.RoomName, roomName, StringComparison.Ordinal));
+
+    public IReadOnlyList<LiveKitParticipantRecord> PruneExpired(DateTimeOffset now)
+        => RemoveWhere(record => record.ExpiresAt <= now);
+
+    public IReadOnlyList<LiveKitParticipantRecord> GetSnapshot()
+        => _participants.Values.ToList();
+
+    private IReadOnlyList<LiveKitParticipantRecord> RemoveWhere(Func<LiveKitParticipantRecord, bool> predicate)
+    {
+        var removed = new List<LiveKitParticipantRecord>();
+        foreach (var pair in _participants)
+        {
+            if (predicate(pair.Value) && _participants.TryRemove(pair.Key, out var record))
+            {
+                removed.Add(record);
+            }
+        }
+
+        return removed;
+    }
+}

--- a/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
@@ -41,12 +41,17 @@ public sealed class LiveKitParticipantTracker
         var removed = new List<LiveKitParticipantRecord>();
         foreach (var pair in _participants)
         {
-            if (predicate(pair.Value) && _participants.TryRemove(pair.Key, out var record))
+            if (predicate(pair.Value) && TryRemoveMatched(_participants, pair))
             {
-                removed.Add(record);
+                removed.Add(pair.Value);
             }
         }
 
         return removed;
     }
+
+    internal static bool TryRemoveMatched(
+        ConcurrentDictionary<(string RoomName, string MatrixUserId), LiveKitParticipantRecord> participants,
+        KeyValuePair<(string RoomName, string MatrixUserId), LiveKitParticipantRecord> participant)
+        => ((ICollection<KeyValuePair<(string RoomName, string MatrixUserId), LiveKitParticipantRecord>>)participants).Remove(participant);
 }

--- a/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
@@ -12,17 +12,55 @@ public sealed record LiveKitParticipantRecord(
 
 public sealed class LiveKitParticipantTracker
 {
+    private readonly object _lock = new();
     private readonly ConcurrentDictionary<(string RoomName, string MatrixUserId), LiveKitParticipantRecord> _participants = new();
     private readonly ConcurrentDictionary<int, byte> _revokingSessions = new();
+    private readonly ConcurrentDictionary<int, string> _sessionRooms = new();
 
     public void Upsert(LiveKitParticipantRecord record)
-        => _participants[(record.RoomName, record.MatrixUserId)] = record;
+        => TryUpsert(record);
+
+    public bool TryUpsert(LiveKitParticipantRecord record)
+    {
+        lock (_lock)
+        {
+            if (_revokingSessions.ContainsKey(record.SessionId))
+                return false;
+
+            if (_sessionRooms.TryGetValue(record.SessionId, out var currentRoom)
+                && !string.Equals(record.RoomName, currentRoom, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            _participants[(record.RoomName, record.MatrixUserId)] = record;
+            return true;
+        }
+    }
 
     public void MarkSessionRevoking(int sessionId)
-        => _revokingSessions[sessionId] = 0;
+    {
+        lock (_lock)
+        {
+            _revokingSessions[sessionId] = 0;
+        }
+    }
+
+    public void MarkSessionRoom(int sessionId, string roomName)
+    {
+        lock (_lock)
+        {
+            _sessionRooms[sessionId] = roomName;
+        }
+    }
 
     public bool IsSessionRevoking(int sessionId)
-        => _revokingSessions.ContainsKey(sessionId);
+    {
+        lock (_lock)
+        {
+            return _revokingSessions.ContainsKey(sessionId);
+        }
+    }
 
     public LiveKitParticipantRecord? Remove(string roomName, string matrixUserId)
     {
@@ -41,20 +79,28 @@ public sealed class LiveKitParticipantTracker
         => RemoveWhere(record => record.ExpiresAt <= now);
 
     public IReadOnlyList<LiveKitParticipantRecord> GetSnapshot()
-        => _participants.Values.ToList();
+    {
+        lock (_lock)
+        {
+            return _participants.Values.ToList();
+        }
+    }
 
     private IReadOnlyList<LiveKitParticipantRecord> RemoveWhere(Func<LiveKitParticipantRecord, bool> predicate)
     {
-        var removed = new List<LiveKitParticipantRecord>();
-        foreach (var pair in _participants)
+        lock (_lock)
         {
-            if (predicate(pair.Value) && TryRemoveMatched(_participants, pair))
+            var removed = new List<LiveKitParticipantRecord>();
+            foreach (var pair in _participants)
             {
-                removed.Add(pair.Value);
+                if (predicate(pair.Value) && TryRemoveMatched(_participants, pair))
+                {
+                    removed.Add(pair.Value);
+                }
             }
-        }
 
-        return removed;
+            return removed;
+        }
     }
 
     internal static bool TryRemoveMatched(

--- a/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitParticipantTracker.cs
@@ -12,23 +12,27 @@ public sealed record LiveKitParticipantRecord(
 
 public sealed class LiveKitParticipantTracker
 {
+    private static readonly TimeSpan MarkerGracePeriod = TimeSpan.FromMinutes(2);
     private readonly object _lock = new();
     private readonly ConcurrentDictionary<(string RoomName, string MatrixUserId), LiveKitParticipantRecord> _participants = new();
-    private readonly ConcurrentDictionary<int, byte> _revokingSessions = new();
-    private readonly ConcurrentDictionary<int, string> _sessionRooms = new();
+    private readonly ConcurrentDictionary<int, DateTimeOffset> _revokingSessions = new();
+    private readonly ConcurrentDictionary<int, SessionRoomMarker> _sessionRooms = new();
 
     public void Upsert(LiveKitParticipantRecord record)
         => TryUpsert(record);
 
-    public bool TryUpsert(LiveKitParticipantRecord record)
+    public bool TryUpsert(LiveKitParticipantRecord record, DateTimeOffset? now = null)
     {
         lock (_lock)
         {
+            var currentTime = now ?? DateTimeOffset.UtcNow;
+            PruneMarkers(currentTime);
+
             if (_revokingSessions.ContainsKey(record.SessionId))
                 return false;
 
             if (_sessionRooms.TryGetValue(record.SessionId, out var currentRoom)
-                && !string.Equals(record.RoomName, currentRoom, StringComparison.Ordinal))
+                && !string.Equals(record.RoomName, currentRoom.RoomName, StringComparison.Ordinal))
             {
                 return false;
             }
@@ -38,19 +42,20 @@ public sealed class LiveKitParticipantTracker
         }
     }
 
-    public void MarkSessionRevoking(int sessionId)
+    public void MarkSessionRevoking(int sessionId, DateTimeOffset? now = null)
     {
         lock (_lock)
         {
-            _revokingSessions[sessionId] = 0;
+            _revokingSessions[sessionId] = (now ?? DateTimeOffset.UtcNow).Add(MarkerGracePeriod);
+            _sessionRooms.TryRemove(sessionId, out _);
         }
     }
 
-    public void MarkSessionRoom(int sessionId, string roomName)
+    public void MarkSessionRoom(int sessionId, string roomName, DateTimeOffset? now = null)
     {
         lock (_lock)
         {
-            _sessionRooms[sessionId] = roomName;
+            _sessionRooms[sessionId] = new SessionRoomMarker(roomName, (now ?? DateTimeOffset.UtcNow).Add(MarkerGracePeriod));
         }
     }
 
@@ -58,6 +63,7 @@ public sealed class LiveKitParticipantTracker
     {
         lock (_lock)
         {
+            PruneMarkers(DateTimeOffset.UtcNow);
             return _revokingSessions.ContainsKey(sessionId);
         }
     }
@@ -76,7 +82,13 @@ public sealed class LiveKitParticipantTracker
         => RemoveWhere(record => record.SessionId == sessionId && !string.Equals(record.RoomName, roomName, StringComparison.Ordinal));
 
     public IReadOnlyList<LiveKitParticipantRecord> PruneExpired(DateTimeOffset now)
-        => RemoveWhere(record => record.ExpiresAt <= now);
+    {
+        lock (_lock)
+        {
+            PruneMarkers(now);
+            return RemoveWhereLocked(record => record.ExpiresAt <= now);
+        }
+    }
 
     public IReadOnlyList<LiveKitParticipantRecord> GetSnapshot()
     {
@@ -90,16 +102,40 @@ public sealed class LiveKitParticipantTracker
     {
         lock (_lock)
         {
-            var removed = new List<LiveKitParticipantRecord>();
-            foreach (var pair in _participants)
-            {
-                if (predicate(pair.Value) && TryRemoveMatched(_participants, pair))
-                {
-                    removed.Add(pair.Value);
-                }
-            }
+            return RemoveWhereLocked(predicate);
+        }
+    }
 
-            return removed;
+    private IReadOnlyList<LiveKitParticipantRecord> RemoveWhereLocked(Func<LiveKitParticipantRecord, bool> predicate)
+    {
+        var removed = new List<LiveKitParticipantRecord>();
+        foreach (var pair in _participants)
+        {
+            if (predicate(pair.Value) && TryRemoveMatched(_participants, pair))
+            {
+                removed.Add(pair.Value);
+            }
+        }
+
+        return removed;
+    }
+
+    private void PruneMarkers(DateTimeOffset now)
+    {
+        foreach (var pair in _revokingSessions)
+        {
+            if (pair.Value <= now)
+            {
+                _revokingSessions.TryRemove(pair.Key, out _);
+            }
+        }
+
+        foreach (var pair in _sessionRooms)
+        {
+            if (pair.Value.ExpiresAt <= now)
+            {
+                _sessionRooms.TryRemove(pair.Key, out _);
+            }
         }
     }
 
@@ -107,4 +143,6 @@ public sealed class LiveKitParticipantTracker
         ConcurrentDictionary<(string RoomName, string MatrixUserId), LiveKitParticipantRecord> participants,
         KeyValuePair<(string RoomName, string MatrixUserId), LiveKitParticipantRecord> participant)
         => ((ICollection<KeyValuePair<(string RoomName, string MatrixUserId), LiveKitParticipantRecord>>)participants).Remove(participant);
+
+    private sealed record SessionRoomMarker(string RoomName, DateTimeOffset ExpiresAt);
 }

--- a/src/Brmble.Server/LiveKit/LiveKitService.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitService.cs
@@ -107,7 +107,7 @@ public class LiveKitService : ILiveKitRoomQuery, ILiveKitParticipantRemover
                 : LiveKitAuthorizationResult.Denied(LiveKitAuthorizationFailure.Forbidden));
     }
 
-    public async Task RemoveParticipant(string roomName, string participantIdentity)
+    public async Task<bool> RemoveParticipant(string roomName, string participantIdentity)
     {
         try
         {
@@ -123,11 +123,13 @@ public class LiveKitService : ILiveKitRoomQuery, ILiveKitParticipantRemover
             });
 
             _logger.LogInformation("Removed participant {Identity} from room {Room}", participantIdentity, roomName);
+            return true;
         }
         catch (Exception ex)
         {
             // Idempotent: if room/participant doesn't exist, that's fine
             _logger.LogDebug(ex, "Could not remove participant {Identity} from room {Room} (may not exist)", participantIdentity, roomName);
+            return false;
         }
     }
 

--- a/src/Brmble.Server/LiveKit/LiveKitService.cs
+++ b/src/Brmble.Server/LiveKit/LiveKitService.cs
@@ -7,7 +7,7 @@ namespace Brmble.Server.LiveKit;
 
 public sealed record LiveKitTokenMetadata(string Token, DateTimeOffset ExpiresAt);
 
-public class LiveKitService : ILiveKitRoomQuery
+public class LiveKitService : ILiveKitRoomQuery, ILiveKitParticipantRemover
 {
     private static readonly TimeSpan DefaultTokenTtl = TimeSpan.FromHours(1);
 

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -11,7 +11,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
     private readonly IBrmbleEventBus _eventBus;
     private readonly IChannelMembershipService _channelMembership;
     private readonly ScreenShareTracker _screenShareTracker;
-    private readonly LiveKitService _liveKitService;
+    private readonly ILiveKitParticipantRemover _liveKitParticipantRemover;
     private readonly ILogger<MumbleServerCallback> _logger;
     private MumbleServer.ServerPrx? _serverProxy;
 
@@ -21,7 +21,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
         IBrmbleEventBus eventBus,
         IChannelMembershipService channelMembership,
         ScreenShareTracker screenShareTracker,
-        LiveKitService liveKitService,
+        ILiveKitParticipantRemover liveKitParticipantRemover,
         ILogger<MumbleServerCallback> logger)
     {
         _handlers = handlers;
@@ -29,7 +29,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
         _eventBus = eventBus;
         _channelMembership = channelMembership;
         _screenShareTracker = screenShareTracker;
-        _liveKitService = liveKitService;
+        _liveKitParticipantRemover = liveKitParticipantRemover;
         _logger = logger;
     }
 
@@ -159,7 +159,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
             foreach (var roomName in stoppedRooms)
             {
                 await _eventBus.BroadcastAsync(new { type = "screenShare.stopped", roomName, userId = mapping.UserId });
-                await _liveKitService.RemoveParticipant(roomName, mapping.MatrixUserId);
+                await _liveKitParticipantRemover.RemoveParticipant(roomName, mapping.MatrixUserId);
             }
         }
 
@@ -184,7 +184,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
                 {
                     _screenShareTracker.StopByUserId(roomName, mapping.UserId);
                     await _eventBus.BroadcastAsync(new { type = "screenShare.stopped", roomName, userId = mapping.UserId });
-                    await _liveKitService.RemoveParticipant(roomName, mapping.MatrixUserId);
+                    await _liveKitParticipantRemover.RemoveParticipant(roomName, mapping.MatrixUserId);
                 }
             }
         }

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -185,11 +185,12 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
     public async Task DispatchUserStateChanged(MumbleUser user, int channelId)
     {
         _channelMembership.Update(user.SessionId, channelId);
+        var currentRoom = $"channel-{channelId}";
+        _liveKitParticipantTracker.MarkSessionRoom(user.SessionId, currentRoom);
 
         var snapshot = _sessionMapping.GetSnapshot();
         if (snapshot.TryGetValue(user.SessionId, out var mapping))
         {
-            var currentRoom = $"channel-{channelId}";
             var shareRooms = _screenShareTracker.GetSharesByUserId(mapping.UserId);
             foreach (var roomName in shareRooms)
             {

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -154,22 +154,29 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
 
     public async Task DispatchUserDisconnected(MumbleUser user)
     {
+        IReadOnlyList<string> stoppedRooms = [];
+
         // Check if user was sharing and stop all shares before removing session
         var snapshot = _sessionMapping.GetSnapshot();
         if (snapshot.TryGetValue(user.SessionId, out var mapping))
         {
-            var stoppedRooms = _screenShareTracker.StopAllByUserId(mapping.UserId);
+            stoppedRooms = _screenShareTracker.StopAllByUserId(mapping.UserId);
+        }
+
+        var revokedRecords = _liveKitParticipantTracker.RemoveBySession(user.SessionId);
+        _sessionMapping.RemoveSession(user.SessionId);
+        _channelMembership.Remove(user.SessionId);
+
+        if (snapshot.TryGetValue(user.SessionId, out mapping))
+        {
             foreach (var roomName in stoppedRooms)
             {
                 await _eventBus.BroadcastAsync(new { type = "screenShare.stopped", roomName, userId = mapping.UserId });
             }
         }
 
-        var revokedRecords = _liveKitParticipantTracker.RemoveBySession(user.SessionId);
         await RevokeParticipants(revokedRecords);
 
-        _sessionMapping.RemoveSession(user.SessionId);
-        _channelMembership.Remove(user.SessionId);
         await _eventBus.BroadcastAsync(new { type = "userMappingRemoved", sessionId = user.SessionId });
         await Task.WhenAll(_handlers.Select(h => h.OnUserDisconnected(user)));
     }

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -163,6 +163,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
             stoppedRooms = _screenShareTracker.StopAllByUserId(mapping.UserId);
         }
 
+        _liveKitParticipantTracker.MarkSessionRevoking(user.SessionId);
         var revokedRecords = _liveKitParticipantTracker.RemoveBySession(user.SessionId);
         _sessionMapping.RemoveSession(user.SessionId);
         _channelMembership.Remove(user.SessionId);

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -12,6 +12,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
     private readonly IChannelMembershipService _channelMembership;
     private readonly ScreenShareTracker _screenShareTracker;
     private readonly ILiveKitParticipantRemover _liveKitParticipantRemover;
+    private readonly LiveKitParticipantTracker _liveKitParticipantTracker;
     private readonly ILogger<MumbleServerCallback> _logger;
     private MumbleServer.ServerPrx? _serverProxy;
 
@@ -22,6 +23,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
         IChannelMembershipService channelMembership,
         ScreenShareTracker screenShareTracker,
         ILiveKitParticipantRemover liveKitParticipantRemover,
+        LiveKitParticipantTracker liveKitParticipantTracker,
         ILogger<MumbleServerCallback> logger)
     {
         _handlers = handlers;
@@ -30,6 +32,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
         _channelMembership = channelMembership;
         _screenShareTracker = screenShareTracker;
         _liveKitParticipantRemover = liveKitParticipantRemover;
+        _liveKitParticipantTracker = liveKitParticipantTracker;
         _logger = logger;
     }
 
@@ -159,9 +162,11 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
             foreach (var roomName in stoppedRooms)
             {
                 await _eventBus.BroadcastAsync(new { type = "screenShare.stopped", roomName, userId = mapping.UserId });
-                await _liveKitParticipantRemover.RemoveParticipant(roomName, mapping.MatrixUserId);
             }
         }
+
+        var revokedRecords = _liveKitParticipantTracker.RemoveBySession(user.SessionId);
+        await RevokeParticipants(revokedRecords);
 
         _sessionMapping.RemoveSession(user.SessionId);
         _channelMembership.Remove(user.SessionId);
@@ -184,9 +189,11 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
                 {
                     _screenShareTracker.StopByUserId(roomName, mapping.UserId);
                     await _eventBus.BroadcastAsync(new { type = "screenShare.stopped", roomName, userId = mapping.UserId });
-                    await _liveKitParticipantRemover.RemoveParticipant(roomName, mapping.MatrixUserId);
                 }
             }
+
+            var revokedRecords = _liveKitParticipantTracker.RemoveBySessionExceptRoom(user.SessionId, currentRoom);
+            await RevokeParticipants(revokedRecords);
         }
     }
 
@@ -198,6 +205,14 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
 
     public Task DispatchChannelRenamed(MumbleChannel channel)
         => Task.WhenAll(_handlers.Select(h => h.OnChannelRenamed(channel)));
+
+    private async Task RevokeParticipants(IReadOnlyList<LiveKitParticipantRecord> records)
+    {
+        foreach (var record in records)
+        {
+            await _liveKitParticipantRemover.RemoveParticipant(record.RoomName, record.MatrixUserId);
+        }
+    }
 
     private async Task<MumbleUser> TryResolveCertAsync(MumbleUser user)
     {

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -11,7 +11,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
     private readonly IBrmbleEventBus _eventBus;
     private readonly IChannelMembershipService _channelMembership;
     private readonly ScreenShareTracker _screenShareTracker;
-    private readonly ILiveKitParticipantRemover _liveKitParticipantRemover;
+    private readonly ILiveKitParticipantRevocationScheduler _liveKitRevocationScheduler;
     private readonly LiveKitParticipantTracker _liveKitParticipantTracker;
     private readonly ILogger<MumbleServerCallback> _logger;
     private MumbleServer.ServerPrx? _serverProxy;
@@ -22,7 +22,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
         IBrmbleEventBus eventBus,
         IChannelMembershipService channelMembership,
         ScreenShareTracker screenShareTracker,
-        ILiveKitParticipantRemover liveKitParticipantRemover,
+        ILiveKitParticipantRevocationScheduler liveKitRevocationScheduler,
         LiveKitParticipantTracker liveKitParticipantTracker,
         ILogger<MumbleServerCallback> logger)
     {
@@ -31,7 +31,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
         _eventBus = eventBus;
         _channelMembership = channelMembership;
         _screenShareTracker = screenShareTracker;
-        _liveKitParticipantRemover = liveKitParticipantRemover;
+        _liveKitRevocationScheduler = liveKitRevocationScheduler;
         _liveKitParticipantTracker = liveKitParticipantTracker;
         _logger = logger;
     }
@@ -176,7 +176,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
             }
         }
 
-        await RevokeParticipants(revokedRecords);
+        await _liveKitRevocationScheduler.RevokeParticipants(revokedRecords);
 
         await _eventBus.BroadcastAsync(new { type = "userMappingRemoved", sessionId = user.SessionId });
         await Task.WhenAll(_handlers.Select(h => h.OnUserDisconnected(user)));
@@ -202,7 +202,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
             }
 
             var revokedRecords = _liveKitParticipantTracker.RemoveBySessionExceptRoom(user.SessionId, currentRoom);
-            await RevokeParticipants(revokedRecords);
+            await _liveKitRevocationScheduler.RevokeParticipants(revokedRecords);
         }
     }
 
@@ -214,14 +214,6 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
 
     public Task DispatchChannelRenamed(MumbleChannel channel)
         => Task.WhenAll(_handlers.Select(h => h.OnChannelRenamed(channel)));
-
-    private async Task RevokeParticipants(IReadOnlyList<LiveKitParticipantRecord> records)
-    {
-        foreach (var record in records)
-        {
-            await _liveKitParticipantRemover.RemoveParticipant(record.RoomName, record.MatrixUserId);
-        }
-    }
 
     private async Task<MumbleUser> TryResolveCertAsync(MumbleUser user)
     {

--- a/src/Brmble.Server/Properties/AssemblyInfo.cs
+++ b/src/Brmble.Server/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Brmble.Server.Tests")]

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -7,6 +7,7 @@ const roomEventHandlers = new Map<string, Set<(...args: unknown[]) => void>>();
 const localTrackEventHandlers = new Map<string, Set<() => void>>();
 let localSharePublicationEnabled = false;
 let mockRoomConstructionCount = 0;
+const mockRoomInstances: Array<{ connect: ReturnType<typeof vi.fn> }> = [];
 
 const mockLocalScreenShareTrack = {
   addEventListener: vi.fn((event: string, handler: () => void) => {
@@ -28,7 +29,7 @@ const mockLocalScreenShareTrack = {
 };
 
 const emitRoomEvent = (event: string, ...args: unknown[]) => {
-  for (const handler of roomEventHandlers.get(event) ?? []) {
+  for (const handler of [...(roomEventHandlers.get(event) ?? [])]) {
     handler(...args);
   }
 };
@@ -71,17 +72,21 @@ const mockRoom = {
 
 vi.mock('livekit-client', () => ({
   Room: class MockRoom {
-    constructor() {
-      mockRoomConstructionCount += 1;
-    }
-
-    connect = mockRoom.connect;
-    disconnect = mockRoom.disconnect;
+    connect = vi.fn((...args: unknown[]) => mockRoom.connect(...args));
+    disconnect = vi.fn((...args: unknown[]) => mockRoom.disconnect(...args));
     name = mockRoom.name;
     get state() { return mockRoom.state; }
     localParticipant = mockRoom.localParticipant;
     remoteParticipants = mockRoom.remoteParticipants;
-    on = mockRoom.on;
+    on = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      mockRoom.on(event, handler);
+      return this;
+    });
+
+    constructor() {
+      mockRoomConstructionCount += 1;
+      mockRoomInstances.push(this);
+    }
   },
   RoomEvent: {
     Disconnected: 'disconnected',
@@ -117,6 +122,7 @@ describe('useScreenShare', () => {
     localTrackEventHandlers.clear();
     localSharePublicationEnabled = false;
     mockRoomConstructionCount = 0;
+    mockRoomInstances.length = 0;
   });
 
   afterEach(() => {
@@ -293,7 +299,7 @@ describe('useScreenShare', () => {
     expect(result.current.watchingShares).toHaveLength(1);
   });
 
-  it('uses refreshed viewer token to recover a disconnected room without clearing watch state', async () => {
+  it('uses a fresh room and refreshed viewer token to recover a disconnected room without clearing watch state', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
     const tokenHandlers: Array<(data: unknown) => void> = [];
@@ -331,8 +337,11 @@ describe('useScreenShare', () => {
       await Promise.resolve();
     });
 
-    expect(mockRoom.connect).toHaveBeenNthCalledWith(1, 'ws://localhost/livekit', 'viewer-jwt');
-    expect(mockRoom.connect).toHaveBeenNthCalledWith(2, 'ws://localhost/livekit', 'viewer-jwt-2');
+    expect(mockRoomConstructionCount).toBe(2);
+    expect(mockRoomInstances[0]?.connect).toHaveBeenCalledTimes(1);
+    expect(mockRoomInstances[0]?.connect).toHaveBeenCalledWith('ws://localhost/livekit', 'viewer-jwt');
+    expect(mockRoomInstances[1]?.connect).toHaveBeenCalledTimes(1);
+    expect(mockRoomInstances[1]?.connect).toHaveBeenCalledWith('ws://localhost/livekit', 'viewer-jwt-2');
     expect(result.current.watchingShares).toEqual([expect.objectContaining({ roomName: 'channel-1', userId: 10 })]);
   });
 

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -364,6 +364,60 @@ describe('useScreenShare', () => {
     expect(tokenRequests).toHaveLength(1);
   });
 
+  it('ignores stale in-flight refresh failure after reconnecting to the same room', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
+    const tokenHandlers: Array<(data: unknown) => void> = [];
+    const tokenErrorHandlers: Array<(data: unknown) => void> = [];
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandlers.push(handler);
+      if (type === 'livekit.tokenError') tokenErrorHandlers.push(handler);
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandlers[0]?.({ token: 'viewer-jwt', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:10:00.000Z', requestId: 1 });
+      await promise;
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+    });
+    expect(bridge.send).toHaveBeenCalledWith('livekit.requestToken', { roomName: 'channel-1', accessMode: 'subscribe', requestId: 2 });
+
+    act(() => {
+      emitRoomEvent('disconnected');
+    });
+    expect(result.current.watchingShares).toEqual([]);
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandlers[2]?.({ token: 'viewer-jwt-3', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:20:00.000Z', requestId: 3 });
+      await promise;
+    });
+
+    expect(result.current.watchingShares).toHaveLength(1);
+    const disconnectCallsAfterReconnect = mockRoom.disconnect.mock.calls.length;
+
+    await act(async () => {
+      tokenErrorHandlers[1]?.({ error: 'forbidden', requestId: 2 });
+      await Promise.resolve();
+    });
+
+    expect(result.current.watchingShares).toHaveLength(1);
+    expect(result.current.error).toBeNull();
+    expect(mockRoom.disconnect).toHaveBeenCalledTimes(disconnectCallsAfterReconnect);
+  });
+
   it('suppresses a second startSharing call while one is already connecting', async () => {
     let tokenHandler: ((data: unknown) => void) | null = null;
 

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -345,6 +345,48 @@ describe('useScreenShare', () => {
     expect(result.current.watchingShares).toEqual([expect.objectContaining({ roomName: 'channel-1', userId: 10 })]);
   });
 
+  it('does not recover a disconnected publisher with a fresh empty room', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
+    const tokenHandlers: Array<(data: unknown) => void> = [];
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandlers.push(handler);
+    });
+
+    const onDisconnected = vi.fn();
+    const onLocalShareEnded = vi.fn();
+    const { result } = renderHook(() => (useScreenShare as any)(onDisconnected, undefined, onLocalShareEnded));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandlers[0]?.({ token: 'publisher-jwt', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:10:00.000Z', requestId: 1 });
+      await promise;
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+    });
+
+    await act(async () => {
+      tokenHandlers[1]?.({ token: 'publisher-jwt-2', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:20:00.000Z', requestId: 2 });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      mockRoom.state = 'disconnected';
+      emitRoomEvent('disconnected');
+      await Promise.resolve();
+    });
+
+    expect(mockRoomConstructionCount).toBe(1);
+    expect(mockRoomInstances[0]?.connect).toHaveBeenCalledTimes(1);
+    expect(result.current.isSharing).toBe(false);
+    expect(onDisconnected).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledTimes(1);
+    expect(onLocalShareEnded).toHaveBeenCalledWith('interrupted');
+    expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStopped')).toHaveLength(1);
+  });
+
   it('disconnects and clears watching state when token refresh fails', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useScreenShare } from './useScreenShare';
 import bridge from '../bridge';
@@ -117,6 +117,10 @@ describe('useScreenShare', () => {
     localTrackEventHandlers.clear();
     localSharePublicationEnabled = false;
     mockRoomConstructionCount = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('starts in idle state with empty activeShares', () => {
@@ -247,6 +251,117 @@ describe('useScreenShare', () => {
     });
 
     expect(mockRoom.connect).toHaveBeenCalledWith('ws://localhost/livekit', 'jwt');
+  });
+
+  it('refreshes token before expiry and keeps the room connected on success', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
+    const tokenHandlers: Array<(data: unknown) => void> = [];
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandlers.push(handler);
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandlers[0]?.({ token: 'viewer-jwt', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:10:00.000Z', requestId: 1 });
+      await promise;
+    });
+
+    expect(bridge.send).toHaveBeenCalledWith('livekit.requestToken', { roomName: 'channel-1', accessMode: 'subscribe', requestId: 1 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+    });
+
+    expect(bridge.send).toHaveBeenCalledWith('livekit.requestToken', { roomName: 'channel-1', accessMode: 'subscribe', requestId: 2 });
+
+    await act(async () => {
+      tokenHandlers[1]?.({ token: 'viewer-jwt-2', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:20:00.000Z', requestId: 2 });
+      await Promise.resolve();
+    });
+
+    expect(mockRoom.disconnect).not.toHaveBeenCalled();
+    expect(result.current.watchingShares).toHaveLength(1);
+  });
+
+  it('disconnects and clears watching state when token refresh fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
+    const tokenHandlers: Array<(data: unknown) => void> = [];
+    const tokenErrorHandlers: Array<(data: unknown) => void> = [];
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandlers.push(handler);
+      if (type === 'livekit.tokenError') tokenErrorHandlers.push(handler);
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandlers[0]?.({ token: 'viewer-jwt', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:10:00.000Z', requestId: 1 });
+      await promise;
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+      tokenErrorHandlers[1]?.({ error: 'forbidden', requestId: 2 });
+      await Promise.resolve();
+    });
+
+    expect(mockRoom.disconnect).toHaveBeenCalled();
+    expect(result.current.watchingShares).toEqual([]);
+    expect(result.current.error).toBe('LiveKit access could not be renewed');
+  });
+
+  it('cancels pending token refresh when viewer disconnects', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
+    const tokenHandlers: Array<(data: unknown) => void> = [];
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandlers.push(handler);
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandlers[0]?.({ token: 'viewer-jwt', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:10:00.000Z', requestId: 1 });
+      await promise;
+    });
+
+    await act(async () => {
+      await result.current.disconnectViewer();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+    });
+
+    const tokenRequests = (bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.requestToken');
+    expect(tokenRequests).toHaveLength(1);
   });
 
   it('suppresses a second startSharing call while one is already connecting', async () => {

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -293,6 +293,49 @@ describe('useScreenShare', () => {
     expect(result.current.watchingShares).toHaveLength(1);
   });
 
+  it('uses refreshed viewer token to recover a disconnected room without clearing watch state', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));
+    const tokenHandlers: Array<(data: unknown) => void> = [];
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandlers.push(handler);
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandlers[0]?.({ token: 'viewer-jwt', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:10:00.000Z', requestId: 1 });
+      await promise;
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8 * 60 * 1000);
+    });
+
+    await act(async () => {
+      tokenHandlers[1]?.({ token: 'viewer-jwt-2', url: 'ws://localhost/livekit', expiresAt: '2026-05-11T12:20:00.000Z', requestId: 2 });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      mockRoom.state = 'disconnected';
+      emitRoomEvent('disconnected');
+      await Promise.resolve();
+    });
+
+    expect(mockRoom.connect).toHaveBeenNthCalledWith(1, 'ws://localhost/livekit', 'viewer-jwt');
+    expect(mockRoom.connect).toHaveBeenNthCalledWith(2, 'ws://localhost/livekit', 'viewer-jwt-2');
+    expect(result.current.watchingShares).toEqual([expect.objectContaining({ roomName: 'channel-1', userId: 10 })]);
+  });
+
   it('disconnects and clears watching state when token refresh fails', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-11T12:00:00.000Z'));

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -605,7 +605,8 @@ export function useScreenShare(
         && lease.roomName === room.name
         && lease.accessMode === currentAccessMode
         && Date.parse(lease.expiresAt) > Date.now()
-        && (watchingSharesRef.current.length > 0 || isSharingRef.current);
+        && watchingSharesRef.current.length > 0
+        && !isSharingRef.current;
 
       if (canRecoverWithLease) {
         const reconnectGeneration = roomLifecycleGenerationRef.current;

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -643,6 +643,7 @@ export function useScreenShare(
         roomRef.current = null;
         roomAccessModeRef.current = null;
         clearTokenLease();
+        invalidateRoomLifecycle();
         clearWatchingState();
         const teardownIntent = localShareTeardownIntentRef.current;
         localShareTeardownIntentRef.current = null;

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -52,8 +52,10 @@ type PendingTokenRequest = {
 type ActiveTokenLease = {
   roomName: string;
   accessMode: LiveKitAccessMode;
+  token: string;
   url: string;
   expiresAt: string;
+  isRefreshed: boolean;
   generation: number;
 };
 
@@ -481,7 +483,7 @@ export function useScreenShare(
             return;
           }
 
-          const nextLease = { ...currentLease, url: refreshed.url, expiresAt: refreshed.expiresAt };
+          const nextLease = { ...currentLease, token: refreshed.token, url: refreshed.url, expiresAt: refreshed.expiresAt, isRefreshed: true };
           activeTokenLeaseRef.current = nextLease;
           scheduleTokenRefresh(nextLease);
         } catch {
@@ -640,6 +642,44 @@ export function useScreenShare(
           return;
         }
 
+        const lease = activeTokenLeaseRef.current;
+        const currentAccessMode = roomAccessModeRef.current;
+        const canRecoverWithLease = lease
+          && lease.isRefreshed
+          && lease.roomName === room.name
+          && lease.accessMode === currentAccessMode
+          && Date.parse(lease.expiresAt) > Date.now()
+          && (watchingSharesRef.current.length > 0 || isSharingRef.current);
+
+        if (canRecoverWithLease) {
+          const reconnectGeneration = roomLifecycleGenerationRef.current;
+          void (async () => {
+            try {
+              await room.connect(lease.url, lease.token);
+              if (roomRef.current !== room || roomLifecycleGenerationRef.current !== reconnectGeneration) {
+                return;
+              }
+              roomAccessModeRef.current = lease.accessMode;
+            } catch {
+              if (roomRef.current !== room || roomLifecycleGenerationRef.current !== reconnectGeneration) {
+                return;
+              }
+
+              roomRef.current = null;
+              roomAccessModeRef.current = null;
+              clearTokenLease();
+              invalidateRoomLifecycle();
+              clearWatchingState();
+              const teardownIntent = localShareTeardownIntentRef.current;
+              localShareTeardownIntentRef.current = null;
+              if (isSharingRef.current) {
+                void stopLocalShare(teardownIntent ?? 'interrupted', room);
+              }
+            }
+          })();
+          return;
+        }
+
         roomRef.current = null;
         roomAccessModeRef.current = null;
         clearTokenLease();
@@ -677,8 +717,10 @@ export function useScreenShare(
         const lease = {
           roomName,
           accessMode,
+          token,
           url,
           expiresAt: tokenResponse.expiresAt,
+          isRefreshed: false,
           generation: roomLifecycleGenerationRef.current,
         };
         activeTokenLeaseRef.current = lease;

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -536,6 +536,125 @@ export function useScreenShare(
     }
   }, [clearLocalShareEndListener, stopLocalShare]);
 
+  const bindRoomEvents = useCallback((room: Room) => {
+    room.on(RoomEvent.TrackSubscribed, (track, _pub, participant) => {
+      if (roomRef.current !== room) {
+        return;
+      }
+
+      const watching = watchingSharesRef.current;
+      const matchedShare = watching.find(s => {
+        const identity = s.matrixUserId ?? String(s.userId);
+        return identity === participant.identity;
+      });
+      if (!matchedShare) return;
+      if (
+        track.kind === Track.Kind.Video &&
+        track.source === Track.Source.ScreenShare
+      ) {
+        const el = track.attach() as HTMLVideoElement;
+        setRemoteVideoEls(prev => new Map(prev).set(matchedShare.userId, el));
+      }
+    });
+
+    room.on(RoomEvent.TrackUnsubscribed, (track, _pub, participant) => {
+      if (roomRef.current !== room) {
+        return;
+      }
+
+      const watching = watchingSharesRef.current;
+      const matchedShare = watching.find(s => {
+        const identity = s.matrixUserId ?? String(s.userId);
+        return identity === participant.identity;
+      });
+      if (!matchedShare) return;
+      if (
+        track.kind === Track.Kind.Video &&
+        track.source === Track.Source.ScreenShare
+      ) {
+        track.detach();
+        const remainingWatchedShares = removeWatchingShare(matchedShare.userId);
+
+        if (remainingWatchedShares.length === 0 && !isSharingRef.current) {
+          const room = roomRef.current;
+          roomRef.current = null;
+          roomAccessModeRef.current = null;
+          roomReconnectUpgradeRef.current = false;
+          clearTokenLease();
+          invalidateRoomLifecycle();
+          room?.disconnect().catch(() => {});
+        }
+      }
+    });
+
+    room.on(RoomEvent.Disconnected, () => {
+      if (roomRef.current !== room) {
+        return;
+      }
+
+      const isUpgradeReconnect = roomReconnectUpgradeRef.current;
+      if (isUpgradeReconnect) {
+        roomReconnectUpgradeRef.current = false;
+        return;
+      }
+
+      const lease = activeTokenLeaseRef.current;
+      const currentAccessMode = roomAccessModeRef.current;
+      const canRecoverWithLease = lease
+        && lease.isRefreshed
+        && lease.roomName === room.name
+        && lease.accessMode === currentAccessMode
+        && Date.parse(lease.expiresAt) > Date.now()
+        && (watchingSharesRef.current.length > 0 || isSharingRef.current);
+
+      if (canRecoverWithLease) {
+        const reconnectGeneration = roomLifecycleGenerationRef.current;
+        const nextRoom = new Room();
+        bindRoomEvents(nextRoom);
+        roomRef.current = nextRoom;
+        roomAccessModeRef.current = lease.accessMode;
+
+        void (async () => {
+          try {
+            await nextRoom.connect(lease.url, lease.token);
+            if (roomRef.current !== nextRoom || roomLifecycleGenerationRef.current !== reconnectGeneration) {
+              return;
+            }
+            roomAccessModeRef.current = lease.accessMode;
+          } catch {
+            if (roomRef.current !== nextRoom || roomLifecycleGenerationRef.current !== reconnectGeneration) {
+              return;
+            }
+
+            roomRef.current = null;
+            roomAccessModeRef.current = null;
+            clearTokenLease();
+            invalidateRoomLifecycle();
+            clearWatchingState();
+            const teardownIntent = localShareTeardownIntentRef.current;
+            localShareTeardownIntentRef.current = null;
+            if (isSharingRef.current) {
+              void stopLocalShare(teardownIntent ?? 'interrupted', room);
+            }
+            try { await nextRoom.disconnect(); } catch { /* ignore */ }
+          }
+        })();
+        return;
+      }
+
+      roomRef.current = null;
+      roomAccessModeRef.current = null;
+      clearTokenLease();
+      invalidateRoomLifecycle();
+      clearWatchingState();
+      const teardownIntent = localShareTeardownIntentRef.current;
+      localShareTeardownIntentRef.current = null;
+      if (isSharingRef.current) {
+        void stopLocalShare(teardownIntent ?? 'interrupted', room);
+      }
+    });
+  }, [clearTokenLease, clearWatchingState, invalidateRoomLifecycle, removeWatchingShare, stopLocalShare]);
+
   // Ensure we have a connected room for the given channel.
   // Returns the existing room if already connected to this channel, otherwise connects.
   const ensureRoom = useCallback(async (roomName: string, accessMode: LiveKitAccessMode): Promise<Room> => {
@@ -580,117 +699,7 @@ export function useScreenShare(
       }
 
       const room = new Room();
-
-      room.on(RoomEvent.TrackSubscribed, (track, _pub, participant) => {
-        if (roomRef.current !== room) {
-          return;
-        }
-
-        const watching = watchingSharesRef.current;
-        const matchedShare = watching.find(s => {
-          const identity = s.matrixUserId ?? String(s.userId);
-          return identity === participant.identity;
-        });
-        if (!matchedShare) return;
-        if (
-          track.kind === Track.Kind.Video &&
-          track.source === Track.Source.ScreenShare
-        ) {
-          const el = track.attach() as HTMLVideoElement;
-          setRemoteVideoEls(prev => new Map(prev).set(matchedShare.userId, el));
-        }
-      });
-
-      room.on(RoomEvent.TrackUnsubscribed, (track, _pub, participant) => {
-        if (roomRef.current !== room) {
-          return;
-        }
-
-        const watching = watchingSharesRef.current;
-        const matchedShare = watching.find(s => {
-          const identity = s.matrixUserId ?? String(s.userId);
-          return identity === participant.identity;
-        });
-        if (!matchedShare) return;
-        if (
-          track.kind === Track.Kind.Video &&
-          track.source === Track.Source.ScreenShare
-        ) {
-          track.detach();
-          const remainingWatchedShares = removeWatchingShare(matchedShare.userId);
-
-          if (remainingWatchedShares.length === 0 && !isSharingRef.current) {
-            const room = roomRef.current;
-            roomRef.current = null;
-            roomAccessModeRef.current = null;
-            roomReconnectUpgradeRef.current = false;
-            clearTokenLease();
-            invalidateRoomLifecycle();
-            room?.disconnect().catch(() => {});
-          }
-        }
-      });
-
-      room.on(RoomEvent.Disconnected, () => {
-        if (roomRef.current !== room) {
-          return;
-        }
-
-        const isUpgradeReconnect = roomReconnectUpgradeRef.current;
-        if (isUpgradeReconnect) {
-          roomReconnectUpgradeRef.current = false;
-          return;
-        }
-
-        const lease = activeTokenLeaseRef.current;
-        const currentAccessMode = roomAccessModeRef.current;
-        const canRecoverWithLease = lease
-          && lease.isRefreshed
-          && lease.roomName === room.name
-          && lease.accessMode === currentAccessMode
-          && Date.parse(lease.expiresAt) > Date.now()
-          && (watchingSharesRef.current.length > 0 || isSharingRef.current);
-
-        if (canRecoverWithLease) {
-          const reconnectGeneration = roomLifecycleGenerationRef.current;
-          void (async () => {
-            try {
-              await room.connect(lease.url, lease.token);
-              if (roomRef.current !== room || roomLifecycleGenerationRef.current !== reconnectGeneration) {
-                return;
-              }
-              roomAccessModeRef.current = lease.accessMode;
-            } catch {
-              if (roomRef.current !== room || roomLifecycleGenerationRef.current !== reconnectGeneration) {
-                return;
-              }
-
-              roomRef.current = null;
-              roomAccessModeRef.current = null;
-              clearTokenLease();
-              invalidateRoomLifecycle();
-              clearWatchingState();
-              const teardownIntent = localShareTeardownIntentRef.current;
-              localShareTeardownIntentRef.current = null;
-              if (isSharingRef.current) {
-                void stopLocalShare(teardownIntent ?? 'interrupted', room);
-              }
-            }
-          })();
-          return;
-        }
-
-        roomRef.current = null;
-        roomAccessModeRef.current = null;
-        clearTokenLease();
-        invalidateRoomLifecycle();
-        clearWatchingState();
-        const teardownIntent = localShareTeardownIntentRef.current;
-        localShareTeardownIntentRef.current = null;
-        if (isSharingRef.current) {
-          void stopLocalShare(teardownIntent ?? 'interrupted', room);
-        }
-      });
+      bindRoomEvents(room);
 
       roomRef.current = room;
       roomAccessModeRef.current = accessMode;
@@ -754,7 +763,7 @@ export function useScreenShare(
         pendingRoomRequestRef.current = null;
       }
     }
-  }, [requestToken, stopLocalShare, removeWatchingShare, clearWatchingState, invalidateRoomLifecycle, clearTokenLease, scheduleTokenRefresh]);
+  }, [requestToken, clearWatchingState, invalidateRoomLifecycle, clearTokenLease, scheduleTokenRefresh, bindRoomEvents]);
 
   const startSharing = useCallback(async (roomName: string): Promise<boolean> => {
     if (isStartingShareRef.current) {

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -49,6 +49,14 @@ type PendingTokenRequest = {
   cancel: () => void;
 };
 
+type ActiveTokenLease = {
+  roomName: string;
+  accessMode: LiveKitAccessMode;
+  url: string;
+  expiresAt: string;
+  generation: number;
+};
+
 type PendingViewerAttempt = {
   id: number;
   roomName: string;
@@ -58,6 +66,9 @@ type PendingViewerAttempt = {
 };
 
 type SupersededRoomRequest = Error & { code: 'LIVEKIT_ROOM_REQUEST_SUPERSEDED' };
+
+const TOKEN_REFRESH_SAFETY_WINDOW_MS = 2 * 60 * 1000;
+const MIN_TOKEN_REFRESH_DELAY_MS = 5 * 1000;
 
 type ErrorLike = {
   name?: unknown;
@@ -167,6 +178,8 @@ export function useScreenShare(
   const shareEventVersionByRoomRef = useRef(new Map<string, number>());
   const nextTokenRequestIdRef = useRef(0);
   const pendingTokenRequestRef = useRef<PendingTokenRequest | null>(null);
+  const activeTokenLeaseRef = useRef<ActiveTokenLease | null>(null);
+  const tokenRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onDisconnectedRef = useRef(onDisconnected);
   const onLocalShareEndedRef = useRef(onLocalShareEnded);
   const localShareEndCleanupRef = useRef<(() => void) | null>(null);
@@ -228,6 +241,18 @@ export function useScreenShare(
     watchingSharesRef.current = shares;
     setWatchingShares(shares);
   }, []);
+
+  const clearTokenRefreshTimer = useCallback(() => {
+    if (tokenRefreshTimerRef.current) {
+      clearTimeout(tokenRefreshTimerRef.current);
+      tokenRefreshTimerRef.current = null;
+    }
+  }, []);
+
+  const clearTokenLease = useCallback(() => {
+    clearTokenRefreshTimer();
+    activeTokenLeaseRef.current = null;
+  }, [clearTokenRefreshTimer]);
 
   const markLocalShareTeardownIntent = useCallback((reason: LocalShareStopReason) => {
     localShareTeardownIntentRef.current = reason;
@@ -390,10 +415,11 @@ export function useScreenShare(
       roomRef.current = null;
       roomAccessModeRef.current = null;
       roomReconnectUpgradeRef.current = false;
+      clearTokenLease();
       invalidateRoomLifecycle();
       try { await room.disconnect(); } catch { /* ignore */ }
     }
-  }, [invalidateRoomLifecycle]);
+  }, [clearTokenLease, invalidateRoomLifecycle]);
 
   const stopLocalShare = useCallback(async (
     reason: LocalShareStopReason,
@@ -432,6 +458,54 @@ export function useScreenShare(
 
     await maybeDisconnectRoom();
   }, [clearLocalShareEndListener, maybeDisconnectRoom]);
+
+  const scheduleTokenRefresh = useCallback((lease: ActiveTokenLease) => {
+    clearTokenRefreshTimer();
+
+    const expiresAtMs = Date.parse(lease.expiresAt);
+    if (!Number.isFinite(expiresAtMs)) {
+      return;
+    }
+
+    const delayMs = Math.max(MIN_TOKEN_REFRESH_DELAY_MS, expiresAtMs - Date.now() - TOKEN_REFRESH_SAFETY_WINDOW_MS);
+    tokenRefreshTimerRef.current = setTimeout(() => {
+      void (async () => {
+        const currentLease = activeTokenLeaseRef.current;
+        if (!currentLease || currentLease.generation !== lease.generation) {
+          return;
+        }
+
+        try {
+          const refreshed = await requestToken(currentLease.roomName, currentLease.accessMode);
+          if (!refreshed.expiresAt || activeTokenLeaseRef.current?.generation !== currentLease.generation) {
+            return;
+          }
+
+          const nextLease = { ...currentLease, url: refreshed.url, expiresAt: refreshed.expiresAt };
+          activeTokenLeaseRef.current = nextLease;
+          scheduleTokenRefresh(nextLease);
+        } catch {
+          if (activeTokenLeaseRef.current?.generation !== currentLease.generation) {
+            return;
+          }
+
+          setError('LiveKit access could not be renewed');
+          const room = roomRef.current;
+          roomRef.current = null;
+          roomAccessModeRef.current = null;
+          roomReconnectUpgradeRef.current = false;
+          clearTokenLease();
+          invalidateRoomLifecycle();
+          cancelPendingViewerAttempts();
+          clearWatchingState();
+          if (isSharingRef.current) {
+            await stopLocalShare('interrupted', room);
+          }
+          try { await room?.disconnect(); } catch { /* ignore */ }
+        }
+      })();
+    }, delayMs);
+  }, [cancelPendingViewerAttempts, clearTokenLease, clearTokenRefreshTimer, clearWatchingState, invalidateRoomLifecycle, requestToken, stopLocalShare]);
 
   const bindLocalShareEndListener = useCallback((room: Room) => {
     clearLocalShareEndListener();
@@ -491,12 +565,14 @@ export function useScreenShare(
         roomReconnectUpgradeRef.current = isUpgradeReconnect;
         roomRef.current = null;
         roomAccessModeRef.current = null;
+        clearTokenLease();
         invalidateRoomLifecycle();
         lifecycleGeneration = roomLifecycleGenerationRef.current;
         try { await existing.disconnect(); } catch { /* ignore */ }
       }
 
-      const { token, url } = await requestToken(roomName, accessMode);
+      const tokenResponse = await requestToken(roomName, accessMode);
+      const { token, url } = tokenResponse;
       if (roomLifecycleGenerationRef.current !== lifecycleGeneration) {
         throw createSupersededRoomRequestError();
       }
@@ -546,6 +622,7 @@ export function useScreenShare(
             roomRef.current = null;
             roomAccessModeRef.current = null;
             roomReconnectUpgradeRef.current = false;
+            clearTokenLease();
             invalidateRoomLifecycle();
             room?.disconnect().catch(() => {});
           }
@@ -565,6 +642,7 @@ export function useScreenShare(
 
         roomRef.current = null;
         roomAccessModeRef.current = null;
+        clearTokenLease();
         clearWatchingState();
         const teardownIntent = localShareTeardownIntentRef.current;
         localShareTeardownIntentRef.current = null;
@@ -583,6 +661,7 @@ export function useScreenShare(
           roomRef.current = null;
           roomAccessModeRef.current = null;
           roomReconnectUpgradeRef.current = false;
+          clearTokenLease();
           roomLifecycleGenerationRef.current += 1;
         }
         try { await room.disconnect(); } catch { /* ignore */ }
@@ -591,6 +670,20 @@ export function useScreenShare(
       if (roomLifecycleGenerationRef.current !== lifecycleGeneration || roomRef.current !== room) {
         try { await room.disconnect(); } catch { /* ignore */ }
         throw createSupersededRoomRequestError();
+      }
+
+      if (tokenResponse.expiresAt) {
+        const lease = {
+          roomName,
+          accessMode,
+          url,
+          expiresAt: tokenResponse.expiresAt,
+          generation: roomLifecycleGenerationRef.current,
+        };
+        activeTokenLeaseRef.current = lease;
+        scheduleTokenRefresh(lease);
+      } else {
+        clearTokenLease();
       }
 
       roomReconnectUpgradeRef.current = false;
@@ -618,7 +711,7 @@ export function useScreenShare(
         pendingRoomRequestRef.current = null;
       }
     }
-  }, [requestToken, stopLocalShare, removeWatchingShare, clearWatchingState, invalidateRoomLifecycle]);
+  }, [requestToken, stopLocalShare, removeWatchingShare, clearWatchingState, invalidateRoomLifecycle, clearTokenLease, scheduleTokenRefresh]);
 
   const startSharing = useCallback(async (roomName: string): Promise<boolean> => {
     if (isStartingShareRef.current) {
@@ -847,9 +940,10 @@ export function useScreenShare(
     setRemoteVideoEls(new Map());
     updateWatchingShares([]);
     setFocusedShare(null);
+    clearTokenLease();
     invalidateRoomLifecycle();
     await maybeDisconnectRoom();
-  }, [removeWatchingShare, updateWatchingShares, maybeDisconnectRoom, invalidateRoomLifecycle, cancelPendingViewerAttempts]);
+  }, [removeWatchingShare, updateWatchingShares, maybeDisconnectRoom, invalidateRoomLifecycle, cancelPendingViewerAttempts, clearTokenLease]);
 
   // Listen for screen share events from bridge
   useEffect(() => {
@@ -895,6 +989,7 @@ export function useScreenShare(
           roomRef.current = null;
           roomAccessModeRef.current = null;
           roomReconnectUpgradeRef.current = false;
+          clearTokenLease();
           invalidateRoomLifecycle();
         }
       }
@@ -973,15 +1068,16 @@ export function useScreenShare(
       bridge.off('livekit.activeShareResult', onActiveShareResult);
       bridge.off('livekit.activeShareError', onActiveShareError);
     };
-  }, [removeWatchingShare, updateActiveShares, invalidateRoomLifecycle, cancelPendingViewerAttempts]);
+  }, [removeWatchingShare, updateActiveShares, invalidateRoomLifecycle, cancelPendingViewerAttempts, clearTokenLease]);
 
   useEffect(() => {
     return () => {
       clearLocalShareEndListener();
       cancelPendingViewerAttempts();
+      clearTokenLease();
       invalidateRoomLifecycle();
     };
-  }, [clearLocalShareEndListener, cancelPendingViewerAttempts, invalidateRoomLifecycle]);
+  }, [clearLocalShareEndListener, cancelPendingViewerAttempts, clearTokenLease, invalidateRoomLifecycle]);
 
   // Backward compat: expose first active share as activeShare
   const activeShare: ActiveShare | null = activeShares.length > 0

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitEndpointsTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitEndpointsTests.cs
@@ -150,6 +150,32 @@ public class LiveKitEndpointsTests
     }
 
     [TestMethod]
+    public async Task TokenRequest_WithCurrentChannelAccess_RecordsParticipant()
+    {
+        using var factory = new BrmbleServerFactory();
+        using var client = factory.CreateClient();
+
+        var sessionMapping = factory.Services.GetRequiredService<ISessionMappingService>();
+        var channelMembership = factory.Services.GetRequiredService<IChannelMembershipService>();
+        var participantTracker = factory.Services.GetRequiredService<LiveKitParticipantTracker>();
+
+        sessionMapping.SetNameForSession("TestUser", 7);
+        await client.PostAsJsonAsync("/auth/token", new { mumbleUsername = "TestUser" });
+        channelMembership.Update(7, 1);
+
+        var response = await client.PostAsJsonAsync("/livekit/token", new { roomName = "channel-1", accessMode = "subscribe" });
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var record = participantTracker.GetSnapshot().Single();
+        Assert.AreEqual("channel-1", record.RoomName);
+        Assert.AreEqual("@1:localhost", record.MatrixUserId);
+        Assert.AreEqual(1L, record.UserId);
+        Assert.AreEqual(7, record.SessionId);
+        Assert.AreEqual(LiveKitAccessMode.Subscribe, record.AccessMode);
+        Assert.IsTrue(record.ExpiresAt > DateTimeOffset.UtcNow);
+    }
+
+    [TestMethod]
     public async Task TokenRequest_RepeatedRapidCalls_EventuallyReturnsTooManyRequests()
     {
         using var factory = new BrmbleServerFactory();

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitEndpointsTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitEndpointsTests.cs
@@ -176,6 +176,27 @@ public class LiveKitEndpointsTests
     }
 
     [TestMethod]
+    public async Task TokenRequest_WhenSessionRevoking_ReturnsForbiddenAndDoesNotRecordParticipant()
+    {
+        using var factory = new BrmbleServerFactory();
+        using var client = factory.CreateClient();
+
+        var sessionMapping = factory.Services.GetRequiredService<ISessionMappingService>();
+        var channelMembership = factory.Services.GetRequiredService<IChannelMembershipService>();
+        var participantTracker = factory.Services.GetRequiredService<LiveKitParticipantTracker>();
+
+        sessionMapping.SetNameForSession("TestUser", 7);
+        await client.PostAsJsonAsync("/auth/token", new { mumbleUsername = "TestUser" });
+        channelMembership.Update(7, 1);
+        participantTracker.MarkSessionRevoking(7);
+
+        var response = await client.PostAsJsonAsync("/livekit/token", new { roomName = "channel-1", accessMode = "subscribe" });
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.AreEqual(0, participantTracker.GetSnapshot().Count);
+    }
+
+    [TestMethod]
     public async Task TokenRequest_RepeatedRapidCalls_EventuallyReturnsTooManyRequests()
     {
         using var factory = new BrmbleServerFactory();

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantRevocationSchedulerTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantRevocationSchedulerTests.cs
@@ -41,4 +41,54 @@ public class LiveKitParticipantRevocationSchedulerTests
             new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5))
         ]);
     }
+
+    [TestMethod]
+    public async Task RevokeParticipants_DoesNotScheduleDelayedRetry_WhenImmediateRemovalSucceeds()
+    {
+        var remover = new Mock<ILiveKitParticipantRemover>();
+        remover.Setup(r => r.RemoveParticipant("channel-5", "@alice:test")).ReturnsAsync(true);
+        var delayCalls = 0;
+        var scheduler = new LiveKitParticipantRevocationScheduler(
+            remover.Object,
+            NullLogger<LiveKitParticipantRevocationScheduler>.Instance,
+            [TimeSpan.FromSeconds(2)],
+            _ =>
+            {
+                delayCalls++;
+                return Task.CompletedTask;
+            });
+
+        await scheduler.RevokeParticipants([
+            new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5))
+        ]);
+
+        Assert.AreEqual(0, delayCalls);
+        remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RevokeParticipants_SchedulesDelayedRetry_WhenImmediateRemovalFails()
+    {
+        var remover = new Mock<ILiveKitParticipantRemover>();
+        remover.SetupSequence(r => r.RemoveParticipant("channel-5", "@alice:test"))
+            .ReturnsAsync(false)
+            .ReturnsAsync(true);
+        var retryStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scheduler = new LiveKitParticipantRevocationScheduler(
+            remover.Object,
+            NullLogger<LiveKitParticipantRevocationScheduler>.Instance,
+            [TimeSpan.FromSeconds(2)],
+            _ =>
+            {
+                retryStarted.SetResult();
+                return Task.CompletedTask;
+            });
+
+        await scheduler.RevokeParticipants([
+            new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5))
+        ]);
+        await retryStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Exactly(2));
+    }
 }

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantRevocationSchedulerTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantRevocationSchedulerTests.cs
@@ -1,0 +1,44 @@
+using Brmble.Server.LiveKit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Brmble.Server.Tests.LiveKit;
+
+[TestClass]
+public class LiveKitParticipantRevocationSchedulerTests
+{
+    [TestMethod]
+    public async Task RevokeParticipants_RetriesParticipantRemoval_WhenImmediateRemovalFails()
+    {
+        var remover = new Mock<ILiveKitParticipantRemover>();
+        remover.SetupSequence(r => r.RemoveParticipant("channel-5", "@alice:test"))
+            .ReturnsAsync(false)
+            .ReturnsAsync(true);
+        var scheduler = new LiveKitParticipantRevocationScheduler(
+            remover.Object,
+            NullLogger<LiveKitParticipantRevocationScheduler>.Instance,
+            [TimeSpan.Zero]);
+
+        await scheduler.RevokeParticipants([
+            new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5))
+        ]);
+
+        remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Exactly(2));
+    }
+
+    [TestMethod]
+    public async Task RevokeParticipants_DoesNotThrow_WhenParticipantRemovalReturnsFalse()
+    {
+        var remover = new Mock<ILiveKitParticipantRemover>();
+        remover.Setup(r => r.RemoveParticipant("channel-5", "@alice:test")).ReturnsAsync(false);
+        var scheduler = new LiveKitParticipantRevocationScheduler(
+            remover.Object,
+            NullLogger<LiveKitParticipantRevocationScheduler>.Instance,
+            []);
+
+        await scheduler.RevokeParticipants([
+            new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5))
+        ]);
+    }
+}

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
@@ -1,4 +1,5 @@
 using Brmble.Server.LiveKit;
+using System.Collections.Concurrent;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Brmble.Server.Tests.LiveKit;
@@ -80,5 +81,21 @@ public class LiveKitParticipantTrackerTests
         Assert.IsNotNull(removed);
         Assert.AreEqual("@alice:test", removed.MatrixUserId);
         Assert.AreEqual(0, tracker.GetSnapshot().Count);
+    }
+
+    [TestMethod]
+    public void TryRemoveMatched_DoesNotRemoveReplacementRecord()
+    {
+        var participants = new ConcurrentDictionary<(string RoomName, string MatrixUserId), LiveKitParticipantRecord>();
+        var key = ("channel-1", "@alice:test");
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        var matched = new LiveKitParticipantRecord(key.Item1, key.Item2, 10, 7, LiveKitAccessMode.Subscribe, expiry);
+        var replacement = new LiveKitParticipantRecord(key.Item1, key.Item2, 10, 8, LiveKitAccessMode.Publish, expiry);
+        participants[key] = replacement;
+
+        var removed = LiveKitParticipantTracker.TryRemoveMatched(participants, new KeyValuePair<(string RoomName, string MatrixUserId), LiveKitParticipantRecord>(key, matched));
+
+        Assert.IsFalse(removed);
+        Assert.AreEqual(replacement, participants[key]);
     }
 }

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
@@ -14,8 +14,8 @@ public class LiveKitParticipantTrackerTests
         var firstExpiry = DateTimeOffset.UtcNow.AddMinutes(5);
         var secondExpiry = DateTimeOffset.UtcNow.AddMinutes(10);
 
-        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, firstExpiry));
-        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Publish, secondExpiry));
+        Assert.IsTrue(tracker.TryUpsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, firstExpiry)));
+        Assert.IsTrue(tracker.TryUpsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Publish, secondExpiry)));
 
         var records = tracker.GetSnapshot();
 
@@ -92,6 +92,31 @@ public class LiveKitParticipantTrackerTests
 
         Assert.IsTrue(tracker.IsSessionRevoking(7));
         Assert.IsFalse(tracker.IsSessionRevoking(8));
+    }
+
+    [TestMethod]
+    public void TryUpsert_ReturnsFalseAfterSessionRevoking()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var record = new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5));
+
+        tracker.MarkSessionRevoking(7);
+
+        Assert.IsFalse(tracker.TryUpsert(record));
+        Assert.AreEqual(0, tracker.GetSnapshot().Count);
+    }
+
+    [TestMethod]
+    public void TryUpsert_ReturnsFalseForStaleRoomAndTrueForCurrentRoom()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(5);
+
+        tracker.MarkSessionRoom(7, "channel-2");
+
+        Assert.IsFalse(tracker.TryUpsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry)));
+        Assert.IsTrue(tracker.TryUpsert(new LiveKitParticipantRecord("channel-2", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry)));
+        Assert.AreEqual("channel-2", tracker.GetSnapshot().Single().RoomName);
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
@@ -107,6 +107,19 @@ public class LiveKitParticipantTrackerTests
     }
 
     [TestMethod]
+    public void TryUpsert_AllowsSessionAfterRevokingGraceExpires()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var now = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+        var record = new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, now.AddMinutes(5));
+
+        tracker.MarkSessionRevoking(7, now);
+
+        Assert.IsTrue(tracker.TryUpsert(record, now.AddMinutes(3)));
+        Assert.AreEqual(1, tracker.GetSnapshot().Count);
+    }
+
+    [TestMethod]
     public void TryUpsert_ReturnsFalseForStaleRoomAndTrueForCurrentRoom()
     {
         var tracker = new LiveKitParticipantTracker();
@@ -117,6 +130,19 @@ public class LiveKitParticipantTrackerTests
         Assert.IsFalse(tracker.TryUpsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry)));
         Assert.IsTrue(tracker.TryUpsert(new LiveKitParticipantRecord("channel-2", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry)));
         Assert.AreEqual("channel-2", tracker.GetSnapshot().Single().RoomName);
+    }
+
+    [TestMethod]
+    public void PruneExpired_RemovesExpiredSessionRoomMarker()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var now = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+        var record = new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, now.AddMinutes(5));
+
+        tracker.MarkSessionRoom(7, "channel-2", now);
+        tracker.PruneExpired(now.AddMinutes(3));
+
+        Assert.IsTrue(tracker.TryUpsert(record, now.AddMinutes(3)));
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
@@ -84,6 +84,17 @@ public class LiveKitParticipantTrackerTests
     }
 
     [TestMethod]
+    public void MarkSessionRevoking_MarksOnlyThatSession()
+    {
+        var tracker = new LiveKitParticipantTracker();
+
+        tracker.MarkSessionRevoking(7);
+
+        Assert.IsTrue(tracker.IsSessionRevoking(7));
+        Assert.IsFalse(tracker.IsSessionRevoking(8));
+    }
+
+    [TestMethod]
     public void TryRemoveMatched_DoesNotRemoveReplacementRecord()
     {
         var participants = new ConcurrentDictionary<(string RoomName, string MatrixUserId), LiveKitParticipantRecord>();

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitParticipantTrackerTests.cs
@@ -1,0 +1,84 @@
+using Brmble.Server.LiveKit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.LiveKit;
+
+[TestClass]
+public class LiveKitParticipantTrackerTests
+{
+    [TestMethod]
+    public void Upsert_ReplacesExistingParticipantRecord()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var firstExpiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        var secondExpiry = DateTimeOffset.UtcNow.AddMinutes(10);
+
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, firstExpiry));
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Publish, secondExpiry));
+
+        var records = tracker.GetSnapshot();
+
+        Assert.AreEqual(1, records.Count);
+        Assert.AreEqual(LiveKitAccessMode.Publish, records[0].AccessMode);
+        Assert.AreEqual(secondExpiry, records[0].ExpiresAt);
+    }
+
+    [TestMethod]
+    public void RemoveBySession_RemovesOnlyThatSession()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry));
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@bob:test", 20, 8, LiveKitAccessMode.Subscribe, expiry));
+
+        var removed = tracker.RemoveBySession(7);
+
+        Assert.AreEqual(1, removed.Count);
+        Assert.AreEqual("@alice:test", removed[0].MatrixUserId);
+        CollectionAssert.AreEquivalent(new[] { "@bob:test" }, tracker.GetSnapshot().Select(r => r.MatrixUserId).ToArray());
+    }
+
+    [TestMethod]
+    public void RemoveRoomsOtherThan_RemovesOldRoomsAndKeepsCurrentRoom()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Publish, expiry));
+        tracker.Upsert(new LiveKitParticipantRecord("channel-2", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry));
+
+        var removed = tracker.RemoveBySessionExceptRoom(7, "channel-2");
+
+        Assert.AreEqual(1, removed.Count);
+        Assert.AreEqual("channel-1", removed[0].RoomName);
+        Assert.AreEqual("channel-2", tracker.GetSnapshot().Single().RoomName);
+    }
+
+    [TestMethod]
+    public void PruneExpired_RemovesExpiredRecords()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var now = DateTimeOffset.UtcNow;
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@old:test", 10, 7, LiveKitAccessMode.Subscribe, now.AddSeconds(-1)));
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@fresh:test", 20, 8, LiveKitAccessMode.Subscribe, now.AddMinutes(5)));
+
+        var removed = tracker.PruneExpired(now);
+
+        Assert.AreEqual(1, removed.Count);
+        Assert.AreEqual("@old:test", removed[0].MatrixUserId);
+        Assert.AreEqual("@fresh:test", tracker.GetSnapshot().Single().MatrixUserId);
+    }
+
+    [TestMethod]
+    public void Remove_RemovesByRoomAndIdentity()
+    {
+        var tracker = new LiveKitParticipantTracker();
+        var expiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        tracker.Upsert(new LiveKitParticipantRecord("channel-1", "@alice:test", 10, 7, LiveKitAccessMode.Subscribe, expiry));
+
+        var removed = tracker.Remove("channel-1", "@alice:test");
+
+        Assert.IsNotNull(removed);
+        Assert.AreEqual("@alice:test", removed.MatrixUserId);
+        Assert.AreEqual(0, tracker.GetSnapshot().Count);
+    }
+}

--- a/tests/Brmble.Server.Tests/LiveKit/LiveKitServiceRemoveParticipantTests.cs
+++ b/tests/Brmble.Server.Tests/LiveKit/LiveKitServiceRemoveParticipantTests.cs
@@ -14,7 +14,7 @@ namespace Brmble.Server.Tests.LiveKit;
 public class LiveKitServiceRemoveParticipantTests
 {
     [TestMethod]
-    public async Task RemoveParticipant_DoesNotThrow_WhenRoomDoesNotExist()
+    public async Task RemoveParticipant_ReturnsFalseAndDoesNotThrow_WhenRoomDoesNotExist()
     {
         var settings = Options.Create(new LiveKitSettings { ApiKey = "test", ApiSecret = "secret-must-be-long-enough-for-hmac", ServerUrl = "http://localhost:7880" });
         var matrixSettings = Options.Create(new MatrixSettings { ServerDomain = "test.local" });
@@ -25,6 +25,8 @@ public class LiveKitServiceRemoveParticipantTests
         var service = new LiveKitService(settings, userRepo.Object, NullLogger<LiveKitService>.Instance);
 
         // Should not throw even if LiveKit server isn't running (we catch the exception)
-        await service.RemoveParticipant("nonexistent-room", "nonexistent-user");
+        var removed = await service.RemoveParticipant("nonexistent-room", "nonexistent-user");
+
+        Assert.IsFalse(removed);
     }
 }

--- a/tests/Brmble.Server.Tests/Mumble/MumbleIceServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleIceServiceTests.cs
@@ -23,6 +23,7 @@ public class MumbleIceServiceTests
             new Mock<IChannelMembershipService>().Object,
             new ScreenShareTracker(),
             new LiveKitService(Options.Create(new LiveKitSettings()), new Mock<UserRepository>(new Mock<Database>("Data Source=:memory:").Object, Options.Create(new MatrixSettings { ServerDomain = "test.local" })).Object, NullLogger<LiveKitService>.Instance),
+            new LiveKitParticipantTracker(),
             NullLogger<MumbleServerCallback>.Instance);
 
         var iceSettings = Options.Create(new IceSettings { Host = host, Port = port, Secret = "test-secret" });

--- a/tests/Brmble.Server.Tests/Mumble/MumbleIceServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleIceServiceTests.cs
@@ -16,13 +16,19 @@ public class MumbleIceServiceTests
 {
     private static MumbleIceService CreateService(string host = "localhost", int port = 9999)
     {
+        var participantRemover = new Mock<ILiveKitParticipantRemover>().Object;
+        var revocationScheduler = new LiveKitParticipantRevocationScheduler(
+            participantRemover,
+            NullLogger<LiveKitParticipantRevocationScheduler>.Instance,
+            []);
+
         var callback = new MumbleServerCallback(
             Enumerable.Empty<IMumbleEventHandler>(),
             new Mock<ISessionMappingService>().Object,
             new Mock<IBrmbleEventBus>().Object,
             new Mock<IChannelMembershipService>().Object,
             new ScreenShareTracker(),
-            new LiveKitService(Options.Create(new LiveKitSettings()), new Mock<UserRepository>(new Mock<Database>("Data Source=:memory:").Object, Options.Create(new MatrixSettings { ServerDomain = "test.local" })).Object, NullLogger<LiveKitService>.Instance),
+            revocationScheduler,
             new LiveKitParticipantTracker(),
             NullLogger<MumbleServerCallback>.Instance);
 

--- a/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
@@ -31,7 +31,17 @@ public class MumbleServerCallbackTests
             mapping = defaultMapping.Object;
         }
 
-        var remover = liveKitParticipantRemover ?? new Mock<ILiveKitParticipantRemover>().Object;
+        ILiveKitParticipantRemover remover;
+        if (liveKitParticipantRemover is not null)
+        {
+            remover = liveKitParticipantRemover;
+        }
+        else
+        {
+            var defaultRemover = new Mock<ILiveKitParticipantRemover>();
+            defaultRemover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
+            remover = defaultRemover.Object;
+        }
         var revocationScheduler = new LiveKitParticipantRevocationScheduler(
             remover,
             NullLogger<LiveKitParticipantRevocationScheduler>.Instance,
@@ -305,7 +315,7 @@ public class MumbleServerCallbackTests
         participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
 
         var remover = new Mock<ILiveKitParticipantRemover>();
-        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
 
         var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
 
@@ -332,7 +342,9 @@ public class MumbleServerCallbackTests
         participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
 
         var remover = new Mock<ILiveKitParticipantRemover>();
-        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        remover.SetupSequence(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(false)
+            .ReturnsAsync(true);
 
         var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, liveKitParticipantRemover: remover.Object, liveKitRevocationRetryDelays: [TimeSpan.Zero], liveKitParticipantTracker: participantTracker);
 
@@ -362,7 +374,7 @@ public class MumbleServerCallbackTests
         participantTracker.Upsert(new LiveKitParticipantRecord("channel-9", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
 
         var remover = new Mock<ILiveKitParticipantRemover>();
-        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
         var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, screenShareTracker: tracker, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
 
         await callback.DispatchUserDisconnected(new MumbleUser("Alice", "abc", 42));
@@ -394,7 +406,7 @@ public class MumbleServerCallbackTests
         var remover = new Mock<ILiveKitParticipantRemover>();
         remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>()))
             .Callback(() => order.Add("remove-participant"))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync(true);
         var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, channelMembership: channelMembership.Object, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
 
         await callback.DispatchUserDisconnected(new MumbleUser("Alice", "abc", 42));
@@ -421,7 +433,7 @@ public class MumbleServerCallbackTests
         participantTracker.Upsert(new LiveKitParticipantRecord("channel-10", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
 
         var remover = new Mock<ILiveKitParticipantRemover>();
-        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
         var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, channelMembership: channelMembership.Object, screenShareTracker: screenShareTracker, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
 
         await callback.DispatchUserStateChanged(new MumbleUser("Alice", "abc", 42), 10);

--- a/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
@@ -1,13 +1,10 @@
 using System.Text.Json;
 using Brmble.Server.Auth;
-using Brmble.Server.Data;
 using Brmble.Server.Events;
 using Brmble.Server.LiveKit;
-using Brmble.Server.Matrix;
 using Brmble.Server.Mumble;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -22,7 +19,7 @@ public class MumbleServerCallbackTests
         IBrmbleEventBus? bus = null,
         IChannelMembershipService? channelMembership = null,
         ScreenShareTracker? screenShareTracker = null,
-        LiveKitService? liveKitService = null,
+        ILiveKitParticipantRemover? liveKitParticipantRemover = null,
         ILogger<MumbleServerCallback>? logger = null)
     {
         if (mapping is null)
@@ -38,7 +35,7 @@ public class MumbleServerCallbackTests
             bus ?? new Mock<IBrmbleEventBus>().Object,
             channelMembership ?? new Mock<IChannelMembershipService>().Object,
             screenShareTracker ?? new ScreenShareTracker(),
-            liveKitService ?? new LiveKitService(Options.Create(new LiveKitSettings()), new Mock<UserRepository>(new Mock<Database>("Data Source=:memory:").Object, Options.Create(new MatrixSettings { ServerDomain = "test.local" })).Object, NullLogger<LiveKitService>.Instance),
+            liveKitParticipantRemover ?? new Mock<ILiveKitParticipantRemover>().Object,
             logger ?? NullLogger<MumbleServerCallback>.Instance);
     }
 

--- a/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
@@ -20,6 +20,7 @@ public class MumbleServerCallbackTests
         IChannelMembershipService? channelMembership = null,
         ScreenShareTracker? screenShareTracker = null,
         ILiveKitParticipantRemover? liveKitParticipantRemover = null,
+        IReadOnlyList<TimeSpan>? liveKitRevocationRetryDelays = null,
         LiveKitParticipantTracker? liveKitParticipantTracker = null,
         ILogger<MumbleServerCallback>? logger = null)
     {
@@ -30,13 +31,19 @@ public class MumbleServerCallbackTests
             mapping = defaultMapping.Object;
         }
 
+        var remover = liveKitParticipantRemover ?? new Mock<ILiveKitParticipantRemover>().Object;
+        var revocationScheduler = new LiveKitParticipantRevocationScheduler(
+            remover,
+            NullLogger<LiveKitParticipantRevocationScheduler>.Instance,
+            liveKitRevocationRetryDelays ?? []);
+
         return new MumbleServerCallback(
             handlers,
             mapping,
             bus ?? new Mock<IBrmbleEventBus>().Object,
             channelMembership ?? new Mock<IChannelMembershipService>().Object,
             screenShareTracker ?? new ScreenShareTracker(),
-            liveKitParticipantRemover ?? new Mock<ILiveKitParticipantRemover>().Object,
+            revocationScheduler,
             liveKitParticipantTracker ?? new LiveKitParticipantTracker(),
             logger ?? NullLogger<MumbleServerCallback>.Instance);
     }
@@ -310,10 +317,38 @@ public class MumbleServerCallbackTests
     }
 
     [TestMethod]
-    public async Task DispatchUserDisconnected_RevokesPublisherAndViewerRecords()
+    public async Task DispatchUserDisconnected_RetriesRevokedParticipantRemoval()
     {
         var bus = new Mock<IBrmbleEventBus>();
         bus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
+
+        var mapping = new Mock<ISessionMappingService>();
+        mapping.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
+        {
+            { 42, new SessionMapping("@alice:test", "Alice", 100L) }
+        });
+
+        var participantTracker = new LiveKitParticipantTracker();
+        participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
+
+        var remover = new Mock<ILiveKitParticipantRemover>();
+        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+
+        var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, liveKitParticipantRemover: remover.Object, liveKitRevocationRetryDelays: [TimeSpan.Zero], liveKitParticipantTracker: participantTracker);
+
+        await callback.DispatchUserDisconnected(new MumbleUser("Alice", "abc", 42));
+
+        remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Exactly(2));
+    }
+
+    [TestMethod]
+    public async Task DispatchUserDisconnected_RevokesPublisherAndViewerRecords()
+    {
+        var bus = new Mock<IBrmbleEventBus>();
+        var capturedMessages = new List<object>();
+        bus.Setup(b => b.BroadcastAsync(It.IsAny<object>()))
+            .Callback<object>(msg => capturedMessages.Add(msg))
+            .Returns(Task.CompletedTask);
         var mapping = new Mock<ISessionMappingService>();
         mapping.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
         {
@@ -336,6 +371,7 @@ public class MumbleServerCallbackTests
         remover.Verify(r => r.RemoveParticipant("channel-9", "@alice:test"), Times.Once);
         Assert.IsNull(tracker.GetActive("channel-5"));
         Assert.AreEqual(0, participantTracker.GetSnapshot().Count);
+        Assert.IsTrue(capturedMessages.Any(m => JsonSerializer.Serialize(m).Contains("screenShare.stopped")));
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
@@ -339,6 +339,34 @@ public class MumbleServerCallbackTests
     }
 
     [TestMethod]
+    public async Task DispatchUserDisconnected_RemovesAuthStateBeforeRevokingParticipants()
+    {
+        var order = new List<string>();
+        var bus = new Mock<IBrmbleEventBus>();
+        bus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
+        var mapping = new Mock<ISessionMappingService>();
+        mapping.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
+        {
+            { 42, new SessionMapping("@alice:test", "Alice", 100L) }
+        });
+        mapping.Setup(m => m.RemoveSession(42)).Callback(() => order.Add("remove-session"));
+        var channelMembership = new Mock<IChannelMembershipService>();
+        channelMembership.Setup(cm => cm.Remove(42)).Callback(() => order.Add("remove-channel"));
+        var participantTracker = new LiveKitParticipantTracker();
+        participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
+
+        var remover = new Mock<ILiveKitParticipantRemover>();
+        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback(() => order.Add("remove-participant"))
+            .Returns(Task.CompletedTask);
+        var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, channelMembership: channelMembership.Object, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
+
+        await callback.DispatchUserDisconnected(new MumbleUser("Alice", "abc", 42));
+
+        CollectionAssert.AreEqual(new[] { "remove-session", "remove-channel", "remove-participant" }, order);
+    }
+
+    [TestMethod]
     public async Task DispatchUserStateChanged_RevokesOldRoomParticipantAndKeepsNewRoomParticipant()
     {
         var bus = new Mock<IBrmbleEventBus>();

--- a/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
@@ -20,6 +20,7 @@ public class MumbleServerCallbackTests
         IChannelMembershipService? channelMembership = null,
         ScreenShareTracker? screenShareTracker = null,
         ILiveKitParticipantRemover? liveKitParticipantRemover = null,
+        LiveKitParticipantTracker? liveKitParticipantTracker = null,
         ILogger<MumbleServerCallback>? logger = null)
     {
         if (mapping is null)
@@ -36,6 +37,7 @@ public class MumbleServerCallbackTests
             channelMembership ?? new Mock<IChannelMembershipService>().Object,
             screenShareTracker ?? new ScreenShareTracker(),
             liveKitParticipantRemover ?? new Mock<ILiveKitParticipantRemover>().Object,
+            liveKitParticipantTracker ?? new LiveKitParticipantTracker(),
             logger ?? NullLogger<MumbleServerCallback>.Instance);
     }
 
@@ -275,5 +277,94 @@ public class MumbleServerCallbackTests
         Assert.AreEqual("channel-5", stopMsg.RootElement.GetProperty("roomName").GetString());
         channelMembership.Verify(cm => cm.Remove(42), Times.Once);
         mapping.Verify(m => m.RemoveSession(42), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DispatchUserDisconnected_RevokesViewerOnlyParticipantWithoutShareStopped()
+    {
+        var bus = new Mock<IBrmbleEventBus>();
+        var capturedMessages = new List<object>();
+        bus.Setup(b => b.BroadcastAsync(It.IsAny<object>()))
+            .Callback<object>(msg => capturedMessages.Add(msg))
+            .Returns(Task.CompletedTask);
+
+        var mapping = new Mock<ISessionMappingService>();
+        mapping.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
+        {
+            { 42, new SessionMapping("@alice:test", "Alice", 100L) }
+        });
+
+        var participantTracker = new LiveKitParticipantTracker();
+        participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
+
+        var remover = new Mock<ILiveKitParticipantRemover>();
+        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+
+        var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
+
+        await callback.DispatchUserDisconnected(new MumbleUser("Alice", "abc", 42));
+
+        remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Once);
+        Assert.AreEqual(0, participantTracker.GetSnapshot().Count);
+        Assert.IsFalse(capturedMessages.Any(m => JsonSerializer.Serialize(m).Contains("screenShare.stopped")));
+    }
+
+    [TestMethod]
+    public async Task DispatchUserDisconnected_RevokesPublisherAndViewerRecords()
+    {
+        var bus = new Mock<IBrmbleEventBus>();
+        bus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
+        var mapping = new Mock<ISessionMappingService>();
+        mapping.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
+        {
+            { 42, new SessionMapping("@alice:test", "Alice", 100L) }
+        });
+
+        var tracker = new ScreenShareTracker();
+        tracker.Start("channel-5", "Alice", 100L, "@alice:test");
+        var participantTracker = new LiveKitParticipantTracker();
+        participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Publish, DateTimeOffset.UtcNow.AddMinutes(5)));
+        participantTracker.Upsert(new LiveKitParticipantRecord("channel-9", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
+
+        var remover = new Mock<ILiveKitParticipantRemover>();
+        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, screenShareTracker: tracker, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
+
+        await callback.DispatchUserDisconnected(new MumbleUser("Alice", "abc", 42));
+
+        remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Once);
+        remover.Verify(r => r.RemoveParticipant("channel-9", "@alice:test"), Times.Once);
+        Assert.IsNull(tracker.GetActive("channel-5"));
+        Assert.AreEqual(0, participantTracker.GetSnapshot().Count);
+    }
+
+    [TestMethod]
+    public async Task DispatchUserStateChanged_RevokesOldRoomParticipantAndKeepsNewRoomParticipant()
+    {
+        var bus = new Mock<IBrmbleEventBus>();
+        bus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
+        var channelMembership = new Mock<IChannelMembershipService>();
+        var mapping = new Mock<ISessionMappingService>();
+        mapping.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
+        {
+            { 42, new SessionMapping("@alice:test", "Alice", 100L) }
+        });
+
+        var screenShareTracker = new ScreenShareTracker();
+        screenShareTracker.Start("channel-5", "Alice", 100L, "@alice:test");
+        var participantTracker = new LiveKitParticipantTracker();
+        participantTracker.Upsert(new LiveKitParticipantRecord("channel-5", "@alice:test", 100L, 42, LiveKitAccessMode.Publish, DateTimeOffset.UtcNow.AddMinutes(5)));
+        participantTracker.Upsert(new LiveKitParticipantRecord("channel-10", "@alice:test", 100L, 42, LiveKitAccessMode.Subscribe, DateTimeOffset.UtcNow.AddMinutes(5)));
+
+        var remover = new Mock<ILiveKitParticipantRemover>();
+        remover.Setup(r => r.RemoveParticipant(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        var callback = CreateCallback([], mapping: mapping.Object, bus: bus.Object, channelMembership: channelMembership.Object, screenShareTracker: screenShareTracker, liveKitParticipantRemover: remover.Object, liveKitParticipantTracker: participantTracker);
+
+        await callback.DispatchUserStateChanged(new MumbleUser("Alice", "abc", 42), 10);
+
+        remover.Verify(r => r.RemoveParticipant("channel-5", "@alice:test"), Times.Once);
+        remover.Verify(r => r.RemoveParticipant("channel-10", "@alice:test"), Times.Never);
+        Assert.IsNull(screenShareTracker.GetActive("channel-5"));
+        Assert.AreEqual("channel-10", participantTracker.GetSnapshot().Single().RoomName);
     }
 }


### PR DESCRIPTION
## Summary
- Add server-side LiveKit participant tracking, revocation-aware token issuance, and retrying participant removal for voice lifecycle changes
- Refresh active LiveKit authorization before expiry and cleanly tear down share/watch state on refresh failure
- Update LiveKit roadmap/security specs to mark E token security complete and phase F as next

## Test Plan
- [x] dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj
- [x] npm run test -- src/hooks/useScreenShare.test.ts
- [x] npm run build
- [x] dotnet build
- [x] Manual two-client scenarios: share/watch, viewer leave, sharer leave, viewer move, sharer move, viewer reconnect, sharer reconnect

Closes #354