### PR TITLE
Add chat reactions design specification

### DIFF
--- a/docs/superpowers/specs/2026-05-14-chat-reactions-design.md
+++ b/docs/superpowers/specs/2026-05-14-chat-reactions-design.md
@@ -1,0 +1,77 @@
+# Chat Reactions Design
+
+## Summary
+
+Add emoji reactions to chat messages using Matrix's native `m.reaction` event type. Users can react with a predefined set of 6 emojis via the message context menu. No backend changes needed.
+
+## Predefined Emoji Set
+
+👍 ❤️ 😂 😮 😢 😡
+
+## Data Model
+
+Add a `reactions` field to `ChatMessage` in `types/index.ts`:
+
+```typescript
+interface ChatMessage {
+  // ... existing fields
+  reactions?: Record<string, string[]>  // emoji → sender IDs
+}
+```
+
+Example: `{ "👍": ["@alice:server", "@bob:server"], "😂": ["@alice:server"] }`
+
+Empty arrays are pruned — a reaction entry with no users is removed from the map.
+
+## Matrix Event Processing
+
+In `useMatrixClient.ts`:
+
+- **Timeline filter relaxed**: process `m.reaction` events in addition to `m.room.message`
+- **Reaction events**: parse `event.getContent()` → extract `m.relates_to.event_id`, `m.relates_to.key` (emoji), and sender. Update target message's `reactions` map in `activeMessages`/`lastMessages` state
+- **Redaction handling**: when a reaction is redacted, remove the sender from that emoji's array; if array becomes empty, prune the entry
+- **Initial sync**: when loading timeline (channel or DM), aggregate `m.reaction` events into their target messages
+
+## Sending/Removing Reactions
+
+Two functions exposed from `useMatrixClient`:
+
+- **`sendReaction(roomId, eventId, emoji)`**: sends `m.reaction` via Matrix SDK. Optimistically adds current user to the reactions map.
+- **`removeReaction(roomId, reactionEventId)`**: calls `client.redactEvent()` to remove own reaction. Optimistically removes current user.
+
+A local cache `Map<messageEventId, Map<emoji, reactionEventId>>` tracks reaction event IDs for quick redaction lookup.
+
+## Context Menu
+
+In `ChatPanel.tsx`, add "React" to the message context menu. Opens an inline submenu with the 6 emojis. Each emoji shows:
+
+- The emoji character
+- Visual indication if already applied by current user
+- Clicking toggles: add (sendReaction) or remove (removeReaction)
+
+Context menu passes `messageId` (event ID) and `channelId` (room ID) to handlers.
+
+## Reaction Display
+
+In `MessageBubble.tsx`, render reactions as a row of badges below message content, above the timestamp:
+
+- Each badge: emoji + count (e.g., "👍 2")
+- If current user reacted: filled/highlighted background (`--accent`/`--accent-hover`)
+- Clicking a badge toggles the reaction
+- Entire row absent when `reactions` is undefined or empty
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `src/Brmble.Web/src/types/index.ts` | Add `reactions` to `ChatMessage` |
+| `src/Brmble.Web/src/hooks/useMatrixClient.ts` | Process `m.reaction`/redaction, add `sendReaction`/`removeReaction`, reaction event ID cache |
+| `src/Brmble.Web/src/components/chat/MessageBubble.tsx` | Render reaction badges with toggle |
+| `src/Brmble.Web/src/components/chat/MessageBubble.css` | Reaction badge styles |
+| `src/Brmble.Web/src/components/chat/ChatPanel.tsx` | Add "React" submenu to context menu |
+| `src/Brmble.Web/src/components/chat/ChatPanel.css` | Context menu reaction styles |
+| `src/Brmble.Web/src/hooks/useMatrixClient.test.ts` | Tests for reaction send/remove/timeline processing |
+
+## No Backend Changes
+
+Reactions use standard Matrix CS API `m.reaction` events sent directly from the client. The Matrix homeserver handles persistence and sync. Mumble has no reaction concept, so no relay is needed.

--- a/docs/superpowers/specs/2026-05-14-message-deletion-design.md
+++ b/docs/superpowers/specs/2026-05-14-message-deletion-design.md
@@ -1,0 +1,67 @@
+# Design: Own Message Deletion in Matrix Chat
+
+**Date:** 2026-05-14
+**Status:** Approved
+
+## Overview
+
+Allow users to delete (redact) their own messages in Matrix chat. Uses Matrix's built-in `redact` API — no backend changes needed.
+
+## Scope
+
+- Own message deletion only (no admin deletion of other users' messages)
+- Channel messages and DMs both covered (same `redactEvent` SDK call)
+- Confirmation dialog before deletion
+- Redacted messages show as "Message deleted" placeholder
+
+## Behavior
+
+- **Trigger**: Right-click own message → context menu → click "Delete"
+- **Confirmation**: "Delete this message?" dialog with Cancel/Delete buttons
+- **Result**: Matrix redaction is sent; the event is replaced with a placeholder in all clients
+- **Availability**: Only the sender's own messages; other users' messages have no delete option
+
+## Technical Implementation
+
+### Files Modified
+
+1. **types/index.ts** — add `redacted?: boolean` field to `ChatMessage`
+
+2. **useMatrixClient.ts** — two changes:
+   - Add `deleteMessage(channelId, eventId)` function calling `client.redactEvent(roomId, eventId)`
+   - In `transformEventToChatMessage()`: check `event.isRedacted()` or detect `m.room.redaction` → set `redacted: true`
+   - Expose `deleteMessage` in the hook return
+
+3. **ChatPanel.tsx** — two changes:
+   - Change `onOpenContextMenu` handler: allow own messages to open context menu (currently guarded by `if (s !== currentUsername)`)
+   - Add "Delete" item to context menu for own messages (check `s === currentUsername`)
+   - Wire Delete to confirmation dialog, then call `deleteMessage`
+   - Add a `PromptDialog` or `ConfirmDialog` for the confirmation step — look at the existing `PromptDialog` component used elsewhere
+
+4. **MessageBubble.tsx** — handle `redacted` flag:
+   - When `message.redacted` is true, render a dimmed placeholder: "Message deleted" (italic, gray, same pattern as system messages)
+   - Don't show content, media, reply preview, or link preview for redacted messages
+
+### Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| Delete message with replies | Matrix keeps replies intact; replied-to content shows "Message deleted" |
+| Delete image message | Shows "Message deleted" placeholder (no broken image) |
+| Delete pending message | Can't happen (no eventId yet) — delete option not shown |
+| Delete message in DM | Works same as channel (same `redactEvent` API) |
+| Redaction from another client | Received via timeline sync → shows "Message deleted" |
+| Rapid double-click Delete | First call succeeds, second throws — catch and ignore |
+
+### Open Questions
+
+None — pattern is well-understood and follows existing code conventions.
+
+## Testing
+
+- Right-click own message → context menu shows "Delete"
+- Click Delete → confirmation dialog appears
+- Confirm → message replaced with "Message deleted" placeholder
+- Dismiss → dialog closed, message unchanged
+- Other user's message → no context menu (same as before) or no Delete option
+- Redaction received from sync → placeholder rendered correctly


### PR DESCRIPTION
## Summary
- Adds design specification for chat emoji reactions feature
- Documents Matrix `m.reaction` event integration
- Defines UI/UX patterns for reaction display and interaction
- No code implementation yet — spec only

## Changes
- **New file**: `docs/superpowers/specs/2026-05-14-chat-reactions-design.md`
  - Predefined 6-emoji reaction set (👍 ❤️ 😂 😮 😢 😡)
  - Matrix event processing workflow
  - Context menu interaction design
  - Reaction badge display specifications