### PR TITLE
feat(neon-d): dealer risk system with protection and arrests

### DIFF
--- a/.opencode/plans/2026-05-14-neon-d-street-heat-design.md
+++ b/.opencode/plans/2026-05-14-neon-d-street-heat-design.md
@@ -1,0 +1,205 @@
+# NeonD — "Street Heat" Design Document
+
+**Date:** 2026-05-14
+**Goal:** Add risk, rival gangs, and market events to the NeonD (Brmble Empire) idle game to make it more engaging.
+
+## Overview
+
+Three interconnected layers added on top of the existing NeonD idle game loop:
+
+1. **Heat/Risk System** — dealers accumulate heat from sales; too much heat = arrested
+2. **Rival Gangs & Territory** — fight rival gangs for territory control per product; territory affects sell price
+3. **Market Events** — random timed events that affect prices, heat, and territory
+
+## Architecture
+
+All new state lives in the existing `GameState` interface. The existing `useGameEngine` hook is extended with new actions and tick logic. New UI components are added alongside existing ones.
+
+### Files Modified
+- `src/Brmble.Web/src/components/NeonD/types.ts` — add new types
+- `src/Brmble.Web/src/components/NeonD/constants.ts` — add new constants
+- `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts` — extend tick and actions
+- `src/Brmble.Web/src/components/NeonD/NeonDGame.tsx` — integrate new UI
+- `src/Brmble.Web/src/components/NeonD/NeonD.module.css` — new styles
+
+### Files Created
+- `src/Brmble.Web/src/components/NeonD/components/HeatBar.tsx` — heat visualization
+- `src/Brmble.Web/src/components/NeonD/components/TerritoryPanel.tsx` — territory overview
+- `src/Brmble.Web/src/components/NeonD/components/EventBanner.tsx` — event notifications
+
+### Test Files Created/Modified
+- `src/Brmble.Web/src/components/NeonD/__tests__/constants.test.ts` — new constant tests
+- `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts` — new mechanic tests
+- `src/Brmble.Web/src/components/NeonD/components/__tests__/HeatBar.test.tsx` — new
+- `src/Brmble.Web/src/components/NeonD/components/__tests__/TerritoryPanel.test.tsx` — new
+- `src/Brmble.Web/src/components/NeonD/components/__tests__/EventBanner.test.tsx` — new
+
+## Section 1: Types & Constants
+
+### New Types (in `types.ts`)
+
+```typescript
+export type MarketEventType = 'FESTIVAL' | 'CRASH' | 'CRACKDOWN' | 'HEAT_WAVE' | 'RIVAL_ATTACK' | 'TRUCE';
+
+export interface MarketEvent {
+  type: MarketEventType;
+  description: string;
+  duration: number;
+  productId?: string;
+  startTime: number;
+}
+
+export interface GangTerritory {
+  productId: string;
+  playerControl: number;
+  rivalControl: number;
+}
+```
+
+### Extended `Dealer` interface additions
+```typescript
+heat: number;
+missionStatus: 'idle' | 'on_mission' | 'arrested';
+missionEndTime?: number;
+missionTarget?: string;
+isArrested: boolean;
+bailCost: number;
+```
+
+### New Constants (in `constants.ts`)
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `HEAT_RATE` | 0.02 | Heat generated per gram sold |
+| `HEAT_DECAY` | 0.005 | Heat decay per tick when idle |
+| `PRODUCT_RISK` | Record<string, number> | Risk multiplier per product (Weed=0.5, Mushrooms=0.7, BlueLotus=0.9, Frostbite=1.2, ElectricLace=1.5, Meth=3.0, PharmGrade=3.5, K-Hole=4.0, rest=4.5) |
+| `BAIL_BASE` | 500 | Base bail cost |
+| `BAIL_PER_EQUIP` | 1000 | Bail cost per equipment slot filled |
+| `TERRITORY_MIN` | 8 | Minimum territory % gained per mission |
+| `TERRITORY_MAX` | 12 | Maximum territory % gained per mission |
+| `MISSION_DURATION` | 30 | Duration in seconds for a mission |
+| `MISSION_COST` | 1000 | Cost to send a dealer on mission |
+| `RIVAL_ATTACK_CHANCE` | 0.02 | Probability per tick of rival attack |
+| `RIVAL_ATTACK_MIN` | 5 | Minimum territory % lost on attack |
+| `RIVAL_ATTACK_MAX` | 15 | Maximum territory % lost on attack |
+| `EVENT_COOLDOWN` | 45 | Minimum seconds between events |
+| `EVENT_CHANCE_PER_TICK` | 0.005 | Probability per tick of spawning event |
+
+### Gang Definitions
+```typescript
+export const GANGS = [
+  { id: 'cartel', name: 'The Cartel', color: '#e74c3c' },
+  { id: 'eastside', name: 'Eastside Crew', color: '#9b59b6' },
+  { id: 'purple', name: 'Purple Syndicate', color: '#8e44ad' },
+] as const;
+```
+
+### Market Event Definitions
+```typescript
+export const MARKET_EVENTS = {
+  FESTIVAL:    { description: '🎉 Festival! All prices +50%', duration: 15, priceMultiplier: 1.5 },
+  CRASH:       { description: '📉 Market Crash! All prices -40%', duration: 30, priceMultiplier: 0.6 },
+  CRACKDOWN:   { description: '🚔 Police Crackdown! Heat gain x2', duration: 20, heatMultiplier: 2 },
+  HEAT_WAVE:   { description: '🔥 Heat Wave! Demand x3', duration: 15, productMultiplier: 3 },
+  RIVAL_ATTACK: { description: '💀 Rival Attack! Territory lost', duration: 0, isInstant: true },
+  TRUCE:       { description: '🤝 Truce! No rival attacks', duration: 60, noAttacks: true },
+} as const;
+```
+
+## Section 2: Engine Logic (useGameEngine changes)
+
+### Extended GameState additions
+```typescript
+dealerHeat: Record<string, number>;
+territory: Record<string, GangTerritory>;
+activeEvent: MarketEvent | null;
+lastEventTime: number;
+nextRivalAttackTime: number;
+```
+
+### Tick Loop (extended, runs every 1s)
+
+```
+1. Production: generate stock at rate (unchanged)
+2. Sales: for each active, non-arrested, non-mission dealer:
+   a. Calculate effectivePrice = basePrice × territoryMultiplier × eventMultiplier
+   b. Sell stock, earn money, heat += effectiveVolume × HEAT_RATE × PRODUCT_RISK[product]
+   c. If heat >= 100: dealer.arrested = true
+3. Heat Decay: for idle dealers, heat = max(0, heat - HEAT_DECAY)
+4. Mission Check: if dealer on mission and time expired, grant territory
+5. Rival Attack: if time >= nextRivalAttackTime, reduce territory
+6. Event Check: if cooldown elapsed, roll random event
+7. Event Expiry: clear expired events
+```
+
+### New Actions
+| Action | Implementation |
+|---|---|
+| `payProtection(dealerId)` | Cost = heat × 10. Reset heat to 0. |
+| `payBail(dealerId)` | Cost = BAIL_BASE + BAIL_PER_EQUIP × equipmentCount. Free dealer, heat=50. |
+| `sendOnMission(dealerId, productId)` | Cost = MISSION_COST. Set missionStatus, missionEndTime, missionTarget. |
+| `dismissArrested(dealerId)` | Fire arrested dealer (no bail). |
+
+### Price Calculation
+```typescript
+function getEffectiveSellPrice(productId: string): number {
+  const basePrice = PRODUCT_TIERS[productId] || 1;
+  const territory = state.territory[productId];
+  const territoryMult = territory ? (0.5 + territory.playerControl / 100) : 1.0;
+  const eventMult = state.activeEvent?.type === 'FESTIVAL' ? 1.5
+    : state.activeEvent?.type === 'CRASH' ? 0.6
+    : state.activeEvent?.type === 'HEAT_WAVE' && state.activeEvent?.productId === productId ? 3
+    : 1.0;
+  return basePrice * territoryMult * eventMult;
+}
+```
+
+## Section 3: UI Components
+
+### EventBanner
+- Fixed-position banner below header
+- Colored background per event type
+- Shows icon + description + countdown
+- Auto-fades on expiry
+
+### HeatBar (inside Dealer Card)
+- Horizontal bar (width = heat%), green→yellow→red gradient
+- "Protect" button (cost = heat × 10)
+- Arrested overlay: "🚔 ARRESTED — Pay Bail ($X)" + "Fire"
+- Mission state: "On Mission (Xs remaining)"
+
+### TerritoryPanel (in Distribution column)
+- Compact rows per unlocked product
+- Green bar = player %, red bar = rival %
+- Label: "Product — XX% controlled"
+
+### Dealer Card Additions
+- "Send on Mission" button with product dropdown
+- Disabled while on mission/arrested
+
+## Section 4: Edge Cases
+- Territory clamped to 0-100%
+- Stock still produced when all dealers arrested
+- Mission uses timestamps (works across tab switches)
+- Only one active event at a time
+- RIVAL_ATTACK is instant (duration 0)
+- TRUCE suspends rival attacks for 60s
+- No heat gain while arrested/on mission
+- Protection at 0 heat is no-op
+
+## Section 5: Testing
+- **constants.test.ts:** Product risk for all 18 products, 3 gangs, 6 event types
+- **useGameEngine.test.ts:** Heat accumulation/decay, arrest, protection, bail, mission, territory, events
+- **HeatBar.test.tsx:** Width, color, protect callback
+- **TerritoryPanel.test.tsx:** Renders products, correct percentages
+- **EventBanner.test.tsx:** Renders event, countdown, disappears on expire
+
+## Implementation Order
+1. Types & Constants
+2. Heat System in Engine
+3. Market Events in Engine
+4. Rival Gangs & Territory in Engine
+5. HeatBar component
+6. EventBanner component
+7. TerritoryPanel component
+8. Integration in NeonDGame

--- a/docs/designs/2026-05-14-neon-d-street-heat-review.md
+++ b/docs/designs/2026-05-14-neon-d-street-heat-review.md
@@ -1,0 +1,277 @@
+# Street Heat — Uitbreiding voor Brmble Empire (NeonD)
+
+**Datum:** 14 mei 2026
+**Status:** Concept — klaar voor review
+**Auteur:** AI-assisted design, beoordeeld door het team
+
+---
+
+## 1. Aanleiding & Doel
+
+Brmble Empire (codenaam NeonD) is een idle/incremental game waarin spelers een drugsimperium opbouwen: producten kweken, dealers inhuren en geld verdienen. De huidige versie is functioneel maar mist **spanning en variatie** — de speler kan simpelweg wachten tot het geld binnenkomt zonder ooit echt beslissingen te nemen of risico te lopen.
+
+**Doel van dit ontwerp:** Drie nieuwe spelsystemen toevoegen die de speler dwingen om actieve keuzes te maken, risico af te wegen tegen beloning, en te reageren op een dynamische wereld. Het spel blijft een idle game, maar een die aandacht vraagt.
+
+**Kernvraag:** Wat gebeurt er als je té succesvol wordt? En wie probeert je tegen te houden?
+
+---
+
+## 2. Overzicht — Drie Systemen in één
+
+Het ontwerp bestaat uit drie lagen die op elkaar voortbouwen:
+
+| Systeem | Wat het doet | Waarom |
+|---|---|---|
+| **Heat & Risk** | Dealers lopen hitte op naarmate ze meer verkopen. Te veel hitte = arrestatie. | Creëert spanning en kostenafweging. Succes is niet gratis. |
+| **Rival Gangs & Territory** | Rivaliserende bendes controleren territorium per product. Jouw territorium bepaalt de verkoopprijs. Stuur dealers op missies om meer territory te veroveren. | Strategische laag: waar investeer je je dealers? |
+| **Market Events** | Willekeurige gebeurtenissen die prijzen, hitte en territory beïnvloeden. | Variatie en verrassing. Geen twee speelsessies zijn hetzelfde. |
+
+Deze drie systemen zijn bewust gekozen omdat ze elkaar versterken:
+- Territory veroveren genereert hitte (koppeling laag 1 & 2)
+- Market events kunnen hitte verhogen of territory beschadigen (koppeling laag 3 met 1 & 2)
+- Samen zorgen ze dat de speler constant afwegingen maakt
+
+---
+
+## 3. Systeem 1: Heat & Risk
+
+### Concept
+
+Elke dealer in jouw dienst heeft een **hittemeter** (0-100%). Hoe meer een dealer verkoopt, hoe meer hitte hij oploopt. De snelheid waarmee hitte stijgt, hangt af van **wat** hij verkoopt:
+
+- **Weed** is laag risico → hitte stijgt langzaam
+- **Meth** is hoog risico → hitte stijgt snel
+- **Galactic Core** (late game) is extreem risico → hitte stijgt razendsnel
+
+### Wat gebeurt er bij hoge hitte?
+
+- **0-50%:** Veilig (groene zone). Geen risico.
+- **51-80%:** Risicovol (gele zone). Kans op politie-aandacht neemt toe.
+- **81-100%:** Gevaarlijk (rode zone). Hoge kans op een raid.
+- **100%:** Dealer gearresteerd. Stopt met verkopen tot je actie onderneemt.
+
+### Speler acties
+
+| Actie | Wat het doet | Kosten |
+|---|---|---|
+| **Protection kopen** | Reset hitte naar 0%. | **$10 per hitte-punt** (dus 80 hitte = $800) |
+| **Bail betalen** | Bevrijdt gearresteerde dealer, reset hitte naar 50%. | **$500 + $1000 × aantal equipment slots** |
+| **Dealer ontslaan** | Verliest dealer permanent (incl. equipment). | Gratis, maar je verliest investering |
+
+### Waarom dit systeem?
+
+- Voorkomt dat spelers "gelijk voor eeuwig" door blijven klikken
+- Maakt de afweging: *investeer ik in protection of accepteer ik het risico?*
+- Lage-risico producten (Weed) zijn veiliger maar minder lucratief; hoge-risico producten (Meth) verdienen meer maar geven meer hitte
+- Arrestatie voelt als een natuurlijke setback, niet als een straf
+
+---
+
+## 4. Systeem 2: Rival Gangs & Territory
+
+### Concept
+
+Elk product heeft een **territory percentage** dat aangeeft hoeveel van de markt jij controleert. De rest wordt gecontroleerd door rivaliserende bendes:
+
+- **The Cartel** — agressief, valt vaak aan
+- **Eastside Crew** — stabiel, reageert op veroveringen
+- **Purple Syndicate** — onvoorspelbaar
+
+### Hoe territory werkt
+
+Jouw territory-percentage bepaalt direct de verkoopprijs:
+
+- **0% territory** → product verkoopt voor **50% van de basisprijs**
+- **50% territory** → **100% van de basisprijs**
+- **100% territory** → **150% van de basisprijs**
+
+Dit betekent: als je geen territory hebt in Meth, is het nauwelijks de moeite waard om te produceren. Wil je maximale winst? Dan moet je territory veroveren.
+
+### Territory veroveren — Missies
+
+Spelers kunnen een dealer op **missie** sturen om territory te veroveren in een specifiek product:
+
+1. Kies een dealer die idle is (niet gearresteerd, niet al op missie)
+2. Kies welk product/territory je wilt aanvallen
+3. Betaal **$1.000** missiekosten
+4. Dealer is **30 seconden weg** — verkoopt gedurende die tijd niets
+5. Na 30 seconden: territory stijgt met **8-12%** (willekeurig)
+
+**Afweging:** Een dealer op missie verdient geen geld. Hoe lang kun je het missen?
+
+### Rival aanvallen
+
+Rivalen vallen willekeurig jouw territory aan (gemiddeld elke 30-90 seconden):
+- Een rival kiest een willekeurig product dat jíj hebt unlocked
+- Je verliest **5-15% territory** in dat product
+- Dit gebeurt op de achtergrond; de speler ziet het in het territory overzicht
+
+**Strategische diepgang:** Spelers kunnen hun territorium actief verdedigen door een **Truce** market event af te wachten (zie systeem 3), of door simpelweg te accepteren dat territory fluctueert en continu bij te sturen.
+
+### Waarom dit systeem?
+
+- Geeft de speler een **actieve doelstelling** (territory veroveren) naast het passieve wachten op geld
+- Maakt de keuze: *welk product focus ik me op?* Resources zijn beperkt (3 dealers max)
+- Rivalen zorgen dat het spel **levendig** blijft — je territory staat nooit stil
+- Missies geven dealers **identiteit** en karakter
+
+---
+
+## 5. Systeem 3: Market Events
+
+### Concept
+
+Willekeurig, terwijl je speelt, gebeurt er iets onverwachts. Deze **market events** duren 15-60 seconden en veranderen tijdelijk de spelregels.
+
+### Event types
+
+| Event | Effect | Duur | Frequentie |
+|---|---|---|---|
+| **Festival 🎉** | Alle prijzen +50%. Grote kans om veel te verdienen. | 15s | Zeldzaam |
+| **Market Crash 📉** | Alle prijzen -40%. Minder inkomen. | 30s | Zeldzaam |
+| **Police Crackdown 🚔** | Hitte-opbouw is 2x zo snel, protection kost 2x zoveel. | 20s | Regelmatig |
+| **Heat Wave 🔥** | Een specifiek product heeft 3x vraag (3x prijs). | 15s | Regelmatig |
+| **Rival Attack 💀** | Directe territory loss (instant, geen timer). | — | Regelmatig |
+| **Truce 🤝** | Geen rival aanvallen gedurende 60s. Tijd om veilig territory te veroveren. | 60s | Zeldzaam |
+
+### Hoe events spawnen
+
+- Gemiddeld **elke 45 seconden** kan een nieuw event starten (cooldown)
+- Daarbinnen is er een kleine kans per seconde dat een event echt start
+- Slechts **één event tegelijk** actief
+- Events worden duidelijk getoond aan de speler (banner bovenaan)
+- Na afloop verdwijnt de banner en keren alle effecten terug naar normaal
+
+### Speler reactie
+
+De bedoeling is dat de speler **reageert** op events:
+- Bij een **Festival**: ideale tijd om veel te verkopen (maar let op je hitte)
+- Bij een **Crackdown**: even gas terug, investeer in protection
+- Bij een **Heat Wave**: schakel dealers om naar het gevraagde product
+- Bij een **Truce**: stuur al je dealers op missie zonder angst voor tegenaanvallen
+
+### Waarom dit systeem?
+
+- Voorkomt dat het spel een "set & forget" automatiseringsspel wordt
+- Geeft **pieken en dalen** — spannende momenten afgewisseld met rustige periodes
+- Beloont **oplettendheid**: een speler die reageert op events verdient meer dan iemand die wegloopt
+- Maakt elke speelsessie uniek
+
+---
+
+## 6. Hoe de drie systemen samenwerken
+
+De systemen zijn ontworpen als **communicerende vaten** — ze beïnvloeden elkaar:
+
+```
+Territory veroveren (missie)
+    → genereert hitte (meer verkoop = meer hitte)
+    → hitte kan leiden tot arrestatie
+    → arrestatie kost geld (bail) of verlies van dealer
+
+Market events
+    → beïnvloeden prijzen (Festival = goed moment om te verkopen)
+    → beïnvloeden hitte (Crackdown = oppassen)
+    → beïnvloeden territory (Rival Attack = verlies)
+    → creëren kansen (Truce = veilig veroveren)
+
+Rivalen vallen aan
+    → verlies territory
+    → moet op missie om terug te winnen
+    → missie kost tijd én verkoopcapaciteit
+```
+
+**Voorbeeld speelverloop:**
+1. Speler heeft 3 dealers actief op Meth (hoge winst, hoog risico)
+2. Market event: **Police Crackdown** — hitte stijgt dubbel zo snel
+3. Speler ziet hitte oplopen naar 80% en besluit protection te kopen voor dealer 1
+4. Ondertussen valt **The Cartel** aan — verliest 12% Meth territory
+5. Speler stuurt dealer 2 op missie om territory terug te winnen (30s geen inkomsten)
+6. Net voor de missie begint: **Truce** event — speler heeft 60s veilig de tijd
+7. Na 30s keert dealer 2 terug met +10% territory. Speler stuurt dealer 3 óók op missie
+8. Truce loopt af. Het spel gaat door. De speler heeft actief staan spelen.
+
+Dit soort **emergente verhalen** is precies wat het huidige Brmble Empire mist.
+
+---
+
+## 7. Wat de speler ziet (UI, beschrijvend)
+
+De bestaande layout blijft grotendeels intact. Alleen toevoegingen:
+
+### Event Banner (bovenaan, onder de header)
+Een opvallende balk in kleur die het actieve event toont. Bijvoorbeeld:
+- Groene balk: "🎉 Festival! Alle prijzen +50% — nog 12 sec"
+- Rode balk: "🚔 Police Crackdown! Hitte 2x — nog 8 sec"
+- Blauwe balk: "🤝 Truce! 43 sec zonder rival aanvallen"
+De balk verdwijnt vanzelf als het event afloopt.
+
+### Hittebalk (in elke dealer kaart)
+Elke dealer heeft een horizontale balk die de hitte weergeeft (0-100%):
+- **Groen** (0-50%): veilig
+- **Geel** (51-80%): voorzichtig
+- **Rood** (81-100%): gevaarlijk
+- Naast de balk: de tekst "Hitte: 65%" en een knop "Protect ($650)"
+
+Als een dealer gearresteerd is, vervangt een rode banner de kaart:
+"🚔 GEARRESTEERD — Bail betalen ($2.500) of Ontslaan"
+
+Als een dealer op missie is:
+"Op Missie — Nog 18 sec"
+
+### Territory Overzicht (nieuw paneel in de rechterkolom)
+Onder of boven de dealerlijst staat een compact overzicht per product:
+- "Weed — ████░░░░ 40% gecontroleerd" (groen balkje voor speler, rood voor rivalen)
+- "Meth — ████████ 80% gecontroleerd"
+Het paneel toont alleen producten die de speler heeft unlocked.
+
+### Missie-knop (in dealer kaart)
+Bij elke idle dealer: een knop "Stuur op Missie" met een dropdown om het doelproduct te kiezen. Uitgeschakeld als de dealer op missie of gearresteerd is.
+
+---
+
+## 8. Balans & Ontwerpfilosofie
+
+### Uitgangspunten
+
+1. **Het blijft een idle game.** Een speler moet kunnen wegwandelen en progressie maken. De systemen zijn bedoeld om *extra* diepgang te bieden voor actieve spelers, niet om idle spelers te straffen. Zelfs met 100% hitte wordt een dealer niet direct gearresteerd — je krijgt tijd om te reageren.
+
+2. **Risico = beloning.** De cijfers zijn zo gekozen dat risicovolle strategieën (veel Meth verkopen) meer opleveren dan veilige strategieën, maar ook meer aandacht vragen. Een speler die alleen Weed verkoopt hoeft nauwelijks protection te kopen maar verdient ook minder.
+
+3. **Verlies voelt eerlijk.** Arrestatie kost geld, niet progressie. De productie gaat door, je inventory blijft intact. Alleen de dealer staat even stil. Dit voelt als een setback, niet als een reset.
+
+4. **Variatie zonder complexiteit.** Drie systemen klinkt veel, maar elk systeem heeft precies één knop/actie: Protection kopen, Missie sturen, Event bekijken. De complexiteit zit in de interactie tussen de systemen, niet in de bediening.
+
+### Balans getallen (indicatief)
+
+| Scenario | Hitte per minuut | Tijd tot arrestatie | Protection kosten/min |
+|---|---|---|---|
+| 1 dealer, 4g/s Weed | ~2.4/min | ~41 minuten | ~$24/min |
+| 1 dealer, 4g/s Meth | ~14.4/min | ~7 minuten | ~$144/min |
+| 3 dealers, 4g/s Meth (late game) | ~43.2/min | ~2.3 minuten | ~$432/min |
+
+Late-game spelers moeten dus continu investeren in protection of hun dealers rouleren. Dit creëert een **resource drain** die voorkomt dat geld oneindig groeit.
+
+---
+
+## 9. Implementatie volgorde
+
+De systemen worden in deze volgorde gebouwd:
+
+1. **Types en constanten** — de data modellen (geen gameplay)
+2. **Heat systeem** — hitte, arrestatie, protection, bail
+3. **Market events** — random events, effecten op prijs/hitte
+4. **Rival gangs & territory** — missies, territory, rival aanvallen
+5. **UI componenten** — heat bar, territory panel, event banner
+6. **Integratie** — alles samenvoegen in het bestaande spel
+
+---
+
+## 10. Open vragen voor review
+
+1. Zijn de **kostenbalans** (protection $10/heat, bail $500 + equipment) realistisch?
+2. **Drie rival gangs** — is dat genoeg, of moeten het er meer/minder zijn?
+3. **Missieduur 30 seconden** — is dat lang genoeg om een afweging te voelen maar kort genoeg om niet frustrerend te zijn?
+4. **Event frequentie** — elke 45 seconden een nieuw event. Is dat te veel of te weinig?
+5. Moeten gearresteerde dealers een **tijdslimiet** hebben (automatisch vrij na X minuten) of alleen via bail?
+6. Zijn er **ontbrekende event types** die het spel leuker zouden maken?

--- a/docs/superpowers/plans/2026-05-15-neon-d-dealer-risk.md
+++ b/docs/superpowers/plans/2026-05-15-neon-d-dealer-risk.md
@@ -1,0 +1,841 @@
+# Neon-D Dealer Risk Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add dealer arrest risk, a per-dealer `Pay off cops` toggle with a 15% income penalty, and income-scaled bail recovery to Neon-D.
+
+**Architecture:** Extend the persisted dealer model with protection and arrest state, move arrest and bail math into Neon-D constants plus the game engine hook, and update the dealer card UI to expose risk, protection, and bail actions. Implement the behavior test-first in the existing `useGameEngine` hook tests, then add minimal UI coverage for arrested/protected rendering.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library, Vite
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/Brmble.Web/src/components/NeonD/types.ts`
+  Adds dealer protection/arrest fields and any small helper types needed for risk labels.
+- `src/Brmble.Web/src/components/NeonD/constants.ts`
+  Adds product arrest-risk config, bail constants, helper labels, and updates `INITIAL_GAME_STATE` compatibility.
+- `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`
+  Implements protection toggling, arrest scheduling, bail, and zero-income arrested behavior.
+- `src/Brmble.Web/src/components/NeonD/NeonDGame.tsx`
+  Renders `Pay off cops`, risk labels, and arrested-state actions.
+- `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`
+  Adds TDD coverage for protection, arrest, bail, and persistence-facing behavior.
+
+**Create:**
+- `src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx`
+  Verifies the dealer card renders protection and arrested states correctly.
+
+## Task 1: Extend Dealer Types And Constants
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/NeonD/types.ts`
+- Modify: `src/Brmble.Web/src/components/NeonD/constants.ts`
+- Test: `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`
+
+- [ ] **Step 1: Write the failing type-and-constant test**
+
+Add a new test block near the top of `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`:
+
+```ts
+it('newly hired dealers start unprotected, unarrested, and with a scheduled risk check', () => {
+  const { result } = renderHook(() => useGameEngine());
+
+  act(() => {
+    result.current.hireDealer(makeDealer({ id: 'dealer-state' }), 0);
+  });
+
+  const dealer = result.current.state.activeDealers[0];
+  expect(dealer?.isProtected).toBe(false);
+  expect(dealer?.isArrested).toBe(false);
+  expect(typeof dealer?.nextArrestCheckAt).toBe('number');
+  expect((dealer?.nextArrestCheckAt ?? 0)).toBeGreaterThan(Date.now());
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: FAIL with TypeScript or runtime errors because `isProtected`, `isArrested`, and `nextArrestCheckAt` do not exist yet.
+
+- [ ] **Step 3: Add minimal dealer state and risk constants**
+
+Update `src/Brmble.Web/src/components/NeonD/types.ts`:
+
+```ts
+export type DealerRiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
+
+export interface Dealer {
+  id: string;
+  name: string;
+  selling: string;
+  volume: number;
+  margin: number;
+  volumeBonus: number;
+  marginBonus: number;
+  sideVolume: number;
+  equipmentCount: number;
+  baseVolumeGps: number;
+  baseMarginMult: number;
+  volumeStars: number;
+  marginStars: number;
+  isProtected: boolean;
+  isArrested: boolean;
+  nextArrestCheckAt: number;
+}
+```
+
+Update `src/Brmble.Web/src/components/NeonD/constants.ts` with focused config:
+
+```ts
+export const DEALER_PROTECTION_INCOME_MULTIPLIER = 0.85;
+export const ARREST_CHECK_INTERVAL_MS = {
+  min: 300_000,
+  max: 600_000,
+} as const;
+
+export const BAIL_BASE_FLOOR = 500;
+export const BAIL_INCOME_MULTIPLIER = 45;
+
+export const PRODUCT_ARREST_RISK: Record<string, { chance: number; label: 'LOW' | 'MEDIUM' | 'HIGH' }> = {
+  weed: { chance: 0.10, label: 'LOW' },
+  mushrooms: { chance: 0.12, label: 'LOW' },
+  blueLotus: { chance: 0.15, label: 'MEDIUM' },
+  frostBite: { chance: 0.17, label: 'MEDIUM' },
+  electricLace: { chance: 0.20, label: 'MEDIUM' },
+  meth: { chance: 0.25, label: 'HIGH' },
+  pharmGrade: { chance: 0.28, label: 'HIGH' },
+  khole: { chance: 0.30, label: 'HIGH' },
+  lunarRegolith: { chance: 0.33, label: 'HIGH' },
+  martianSpores: { chance: 0.36, label: 'HIGH' },
+  nebulaMist: { chance: 0.40, label: 'HIGH' },
+  voidCrystals: { chance: 0.45, label: 'HIGH' },
+  chronoSalt: { chance: 0.50, label: 'HIGH' },
+  stardustResin: { chance: 0.55, label: 'HIGH' },
+  darkMatterInk: { chance: 0.60, label: 'HIGH' },
+  singularityShards: { chance: 0.65, label: 'HIGH' },
+  neutronFlakes: { chance: 0.70, label: 'HIGH' },
+  galacticCore: { chance: 0.75, label: 'HIGH' },
+};
+```
+
+- [ ] **Step 4: Seed generated dealers with the new fields**
+
+Update the object returned by `generateRandomDealer` in `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`:
+
+```ts
+return {
+  id: crypto.randomUUID(),
+  name: `${fName} "${lName}"`,
+  selling: drug,
+  volume: baseVolumeGps,
+  margin: baseMarginMult,
+  volumeBonus: 0,
+  marginBonus: 0,
+  sideVolume: 0,
+  equipmentCount: 0,
+  baseVolumeGps,
+  baseMarginMult,
+  volumeStars,
+  marginStars,
+  isProtected: false,
+  isArrested: false,
+  nextArrestCheckAt: Date.now() + ARREST_CHECK_INTERVAL_MS.min,
+};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+
+```bash
+npm run test -- src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: PASS for the new initialization test, with old tests either still passing or exposing the next engine changes needed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/NeonD/types.ts src/Brmble.Web/src/components/NeonD/constants.ts src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+git commit -m "feat: add neon-d dealer risk state"
+```
+
+## Task 2: Implement Protection Toggle And Arrested Income Stop
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`
+
+- [ ] **Step 1: Write failing engine tests for protection and arrested income**
+
+Add these tests to `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`:
+
+```ts
+it('protected dealers earn 15 percent less than unprotected dealers', () => {
+  const { result } = renderHook(() => useGameEngine());
+
+  act(() => {
+    result.current.upgrade('weed');
+    result.current.hireDealer(makeDealer({ id: 'protected-check', margin: 10, volume: 1, sideVolume: 0 }), 0);
+  });
+
+  act(() => {
+    vi.advanceTimersByTime(1_000);
+  });
+  const baseline = result.current.state.lastEarningsPerDealer['protected-check'];
+
+  act(() => {
+    result.current.toggleDealerProtection('protected-check');
+    vi.advanceTimersByTime(1_000);
+  });
+
+  const protectedIncome = result.current.state.lastEarningsPerDealer['protected-check'];
+  expect(protectedIncome).toBeCloseTo(baseline * 0.85, 5);
+});
+
+it('arrested dealers generate zero earnings per tick', () => {
+  const { result } = renderHook(() => useGameEngine());
+
+  act(() => {
+    result.current.upgrade('weed');
+    result.current.hireDealer(makeDealer({ id: 'arrested-check', isArrested: true, nextArrestCheckAt: Date.now() + 999999 }), 0);
+  });
+
+  act(() => {
+    vi.advanceTimersByTime(1_000);
+  });
+
+  expect(result.current.state.lastEarningsPerDealer['arrested-check']).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: FAIL because `toggleDealerProtection` does not exist and the tick loop still pays arrested dealers.
+
+- [ ] **Step 3: Add a protection toggle action**
+
+Add this action to `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`:
+
+```ts
+const scheduleNextArrestCheck = (now: number) =>
+  now + ARREST_CHECK_INTERVAL_MS.min + Math.floor(Math.random() * (ARREST_CHECK_INTERVAL_MS.max - ARREST_CHECK_INTERVAL_MS.min));
+
+const toggleDealerProtection = (dealerId: string) => {
+  setState(prev => ({
+    ...prev,
+    activeDealers: prev.activeDealers.map(dealer => {
+      if (!dealer || dealer.id !== dealerId || dealer.isArrested) return dealer;
+      const nextProtected = !dealer.isProtected;
+      return {
+        ...dealer,
+        isProtected: nextProtected,
+        nextArrestCheckAt: nextProtected ? dealer.nextArrestCheckAt : scheduleNextArrestCheck(Date.now()),
+      };
+    }),
+  }));
+};
+```
+
+- [ ] **Step 4: Apply the protection penalty and arrest skip in the tick**
+
+Update the dealer loop in `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`:
+
+```ts
+prev.activeDealers.forEach((dealer) => {
+  if (!dealer) return;
+  if (dealer.isArrested) {
+    nextEarnings[dealer.id] = 0;
+    return;
+  }
+
+  let dealerGross = 0;
+  // existing primary + side-hustle sale math
+
+  if (dealer.isProtected) {
+    dealerGross *= DEALER_PROTECTION_INCOME_MULTIPLIER;
+  }
+
+  nextEarnings[dealer.id] = dealerGross;
+  totalEarnedThisTick += dealerGross;
+});
+```
+
+- [ ] **Step 5: Export the new action from the hook**
+
+Update the return object in `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`:
+
+```ts
+return {
+  state,
+  upgrade,
+  unlockProduction,
+  hireDealer,
+  fireDealer,
+  refreshPool,
+  resetGame,
+  unlockSlot,
+  setDealerSelling,
+  buyEquipment,
+  toggleDealerProtection,
+};
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run:
+
+```bash
+npm run test -- src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: PASS for the new protection and arrested-income tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+git commit -m "feat: add neon-d dealer protection toggle"
+```
+
+## Task 3: Implement Arrest Checks And Bail Recovery
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`
+- Modify: `src/Brmble.Web/src/components/NeonD/constants.ts`
+
+- [ ] **Step 1: Write failing engine tests for arrest checks and bail**
+
+Add these tests to `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`:
+
+```ts
+it('unprotected dealers use current product risk when the arrest timer expires', () => {
+  vi.spyOn(Math, 'random').mockReturnValue(0);
+
+  const { result } = renderHook(() => useGameEngine());
+  act(() => {
+    result.current.hireDealer(makeDealer({
+      id: 'risk-check',
+      selling: 'meth',
+      isProtected: false,
+      isArrested: false,
+      nextArrestCheckAt: Date.now() - 1,
+    }), 0);
+  });
+
+  act(() => {
+    vi.advanceTimersByTime(1_000);
+  });
+
+  expect(result.current.state.activeDealers[0]?.isArrested).toBe(true);
+});
+
+it('protected dealers never get arrested when the timer expires', () => {
+  vi.spyOn(Math, 'random').mockReturnValue(0);
+
+  const { result } = renderHook(() => useGameEngine());
+  act(() => {
+    result.current.hireDealer(makeDealer({
+      id: 'safe-check',
+      selling: 'meth',
+      isProtected: true,
+      isArrested: false,
+      nextArrestCheckAt: Date.now() - 1,
+    }), 0);
+  });
+
+  act(() => {
+    vi.advanceTimersByTime(1_000);
+  });
+
+  expect(result.current.state.activeDealers[0]?.isArrested).toBe(false);
+});
+
+it('payBail uses current total income per second with a minimum floor', () => {
+  const { result } = renderHook(() => useGameEngine());
+  act(() => {
+    result.current.upgrade('weed');
+    result.current.hireDealer(makeDealer({ id: 'earner', margin: 10, volume: 1, sideVolume: 0 }), 0);
+    vi.advanceTimersByTime(1_000);
+  });
+
+  const dealerIncome = result.current.state.lastEarningsPerDealer['earner'];
+  const expectedCost = Math.max(500, dealerIncome * 45);
+
+  act(() => {
+    result.current.forceArrestDealer('earner');
+  });
+
+  const moneyBefore = result.current.state.money;
+  act(() => {
+    result.current.payDealerBail('earner');
+  });
+
+  expect(result.current.state.money).toBeCloseTo(moneyBefore - expectedCost, 5);
+  expect(result.current.state.activeDealers[0]?.isArrested).toBe(false);
+  expect(result.current.state.activeDealers[0]?.isProtected).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: FAIL because arrest evaluation and bail actions are not implemented.
+
+- [ ] **Step 3: Add engine helpers for risk, bail, and scheduling**
+
+At the top of `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`, add:
+
+```ts
+const scheduleNextArrestCheck = (now: number) =>
+  now + ARREST_CHECK_INTERVAL_MS.min + Math.floor(Math.random() * (ARREST_CHECK_INTERVAL_MS.max - ARREST_CHECK_INTERVAL_MS.min));
+
+const getDealerRisk = (productId: string) =>
+  PRODUCT_ARREST_RISK[productId] ?? { chance: 0.10, label: 'LOW' as const };
+
+const getCurrentTotalIncomePerSecond = (earnings: Record<string, number>) =>
+  Object.values(earnings).reduce((sum, value) => sum + value, 0);
+
+const getBailCost = (earnings: Record<string, number>) =>
+  Math.max(BAIL_BASE_FLOOR, getCurrentTotalIncomePerSecond(earnings) * BAIL_INCOME_MULTIPLIER);
+```
+
+- [ ] **Step 4: Evaluate arrest checks during the tick**
+
+In the state update inside `tick`, compute `now` once and update dealer state after earnings:
+
+```ts
+const now = Date.now();
+let nextDealers = prev.activeDealers.map(dealer => dealer ? { ...dealer } : null);
+
+nextDealers = nextDealers.map(dealer => {
+  if (!dealer || dealer.isArrested || dealer.isProtected) return dealer;
+  if (dealer.nextArrestCheckAt > now) return dealer;
+
+  const risk = getDealerRisk(dealer.selling);
+  const rolledArrest = Math.random() < risk.chance;
+
+  if (rolledArrest) {
+    return {
+      ...dealer,
+      isArrested: true,
+      isProtected: false,
+    };
+  }
+
+  return {
+    ...dealer,
+    nextArrestCheckAt: scheduleNextArrestCheck(now),
+  };
+});
+
+return {
+  ...prev,
+  money: prev.money + totalEarnedThisTick,
+  totalEarned: prev.totalEarned + totalEarnedThisTick,
+  production: nextProduction,
+  activeDealers: nextDealers,
+  lastEarningsPerDealer: nextEarnings,
+};
+```
+
+- [ ] **Step 5: Add bail and force-arrest actions**
+
+Add these actions to `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`:
+
+```ts
+const forceArrestDealer = (dealerId: string) => {
+  setState(prev => ({
+    ...prev,
+    activeDealers: prev.activeDealers.map(dealer =>
+      dealer?.id === dealerId
+        ? { ...dealer, isArrested: true, isProtected: false }
+        : dealer
+    ),
+  }));
+};
+
+const payDealerBail = (dealerId: string) => {
+  setState(prev => {
+    const bailCost = getBailCost(prev.lastEarningsPerDealer);
+    if (prev.money < bailCost) return prev;
+
+    return {
+      ...prev,
+      money: prev.money - bailCost,
+      activeDealers: prev.activeDealers.map(dealer =>
+        dealer?.id === dealerId
+          ? {
+              ...dealer,
+              isArrested: false,
+              isProtected: false,
+              nextArrestCheckAt: scheduleNextArrestCheck(Date.now()),
+            }
+          : dealer
+      ),
+    };
+  });
+};
+```
+
+Expose both methods in the returned hook API so they can be used by the UI and targeted tests.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run:
+
+```bash
+npm run test -- src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: PASS for arrest timing, protection immunity, and bail scaling tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/NeonD/constants.ts src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+git commit -m "feat: add neon-d dealer arrests and bail"
+```
+
+## Task 4: Update Dealer Card UI For Protection, Risk, And Arrested State
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/NeonD/NeonDGame.tsx`
+- Create: `src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx`
+
+- [ ] **Step 1: Write the failing UI test**
+
+Create `src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx` with:
+
+```ts
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { NeonDGame } from '../NeonDGame';
+
+vi.mock('../hooks/useGameEngine', () => ({
+  useGameEngine: () => ({
+    state: {
+      money: 10_000,
+      totalEarned: 0,
+      researchSpeed: 1,
+      production: {
+        weed: { id: 'weed', name: 'Weed', stock: 100, rate: 1, yieldPerLevel: 0.2, costMultiplier: 1.12, level: 1, upgradeCost: 16 },
+      },
+      unlockedProduction: ['weed'],
+      activeDealers: [{
+        id: 'dealer-ui',
+        name: 'Test Dealer',
+        selling: 'weed',
+        volume: 1,
+        margin: 10,
+        volumeBonus: 0,
+        marginBonus: 0,
+        sideVolume: 0,
+        equipmentCount: 0,
+        baseVolumeGps: 1,
+        baseMarginMult: 10,
+        volumeStars: 3,
+        marginStars: 3,
+        isProtected: true,
+        isArrested: false,
+        nextArrestCheckAt: Date.now() + 60_000,
+      }],
+      availableDealers: [],
+      unlockedSlots: 1,
+      lastRefreshTime: 0,
+      lastEarningsPerDealer: { 'dealer-ui': 8.5 },
+    },
+    upgrade: vi.fn(),
+    unlockProduction: vi.fn(),
+    hireDealer: vi.fn(),
+    fireDealer: vi.fn(),
+    refreshPool: vi.fn(),
+    resetGame: vi.fn(),
+    unlockSlot: vi.fn(),
+    setDealerSelling: vi.fn(),
+    buyEquipment: vi.fn(),
+    toggleDealerProtection: vi.fn(),
+    payDealerBail: vi.fn(),
+  }),
+}));
+
+it('shows protection state and risk label on an active dealer card', () => {
+  render(<NeonDGame />);
+  expect(screen.getByText(/protected/i)).toBeInTheDocument();
+  expect(screen.getByText(/low risk/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /pay off cops/i })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npm run test -- src/components/NeonD/__tests__/NeonDGame.test.tsx
+```
+
+Expected: FAIL because the UI does not yet render protection labels or a payoff toggle.
+
+- [ ] **Step 3: Wire the new hook actions into the component**
+
+Update the hook destructuring in `src/Brmble.Web/src/components/NeonD/NeonDGame.tsx`:
+
+```ts
+const {
+  state,
+  upgrade,
+  unlockProduction,
+  hireDealer,
+  fireDealer,
+  refreshPool,
+  resetGame,
+  unlockSlot,
+  setDealerSelling,
+  buyEquipment,
+  toggleDealerProtection,
+  payDealerBail,
+} = useGameEngine();
+```
+
+- [ ] **Step 4: Render risk and protection for active dealers**
+
+In the active dealer card block, add:
+
+```tsx
+<div className={styles.statRow}>
+  <span className={styles.label}>Risk:</span>
+  <span style={{ color: 'var(--accent-secondary)' }}>
+    {PRODUCT_ARREST_RISK[slot.selling]?.label ?? 'LOW'} Risk
+  </span>
+</div>
+
+{slot.isProtected && (
+  <div className={styles.statRow}>
+    <span className={styles.label}>Status:</span>
+    <span style={{ color: 'var(--accent-success)' }}>Protected</span>
+  </div>
+)}
+
+<button
+  className={styles.buyButton}
+  onClick={() => toggleDealerProtection(slot.id)}
+  disabled={slot.isArrested}
+>
+  {slot.isProtected ? 'Pay off cops: On (-15%)' : 'Pay off cops: Off'}
+</button>
+```
+
+- [ ] **Step 5: Render arrested-state controls**
+
+Replace the normal body for arrested dealers with:
+
+```tsx
+if (slot.isArrested) {
+  return (
+    <div key={slot.id} className={`glass-panel ${styles.distributionCard}`} style={{ padding: 0, overflow: 'hidden', marginBottom: 'var(--space-md)' }}>
+      <div className={styles.dealerHeader}>
+        {slot.name} ({state.production[slot.selling]?.name})
+      </div>
+      <div style={{ padding: 'var(--space-md)' }}>
+        <div className={styles.statRow}>
+          <span className={styles.label}>Status:</span>
+          <span style={{ color: 'var(--accent-secondary)' }}>Arrested</span>
+        </div>
+        <div className={styles.statRow}>
+          <span className={styles.label}>Earnings:</span>
+          <span>$0.00/s</span>
+        </div>
+        <div style={{ display: 'grid', gap: 'var(--space-xs)', marginTop: 'var(--space-md)' }}>
+          <button className={styles.buyButton} onClick={() => payDealerBail(slot.id)}>
+            Pay Bail
+          </button>
+          <button className={styles.dangerButton} onClick={() => fireDealer(slot.id)}>
+            Fire Dealer
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run:
+
+```bash
+npm run test -- src/components/NeonD/__tests__/NeonDGame.test.tsx
+```
+
+Expected: PASS for the active protected dealer rendering test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/NeonD/NeonDGame.tsx src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+git commit -m "feat: show neon-d dealer risk controls"
+```
+
+## Task 5: Regression And Persistence Verification
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`
+- Modify: `src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx`
+- Test: `src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts`
+
+- [ ] **Step 1: Add a save-migration regression test**
+
+Append this test to `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`:
+
+```ts
+it('restores older saves by filling in missing dealer risk fields', () => {
+  localStorage.setItem('brmble_neon_d_save', JSON.stringify({
+    activeDealers: [{
+      id: 'legacy',
+      name: 'Legacy Dealer',
+      selling: 'weed',
+      volume: 1,
+      margin: 1,
+      volumeBonus: 0,
+      marginBonus: 0,
+      sideVolume: 0,
+      equipmentCount: 0,
+      baseVolumeGps: 1,
+      baseMarginMult: 1,
+      volumeStars: 1,
+      marginStars: 1,
+    }],
+  }));
+
+  const { result } = renderHook(() => useGameEngine());
+  const dealer = result.current.state.activeDealers[0];
+
+  expect(dealer?.isProtected).toBe(false);
+  expect(dealer?.isArrested).toBe(false);
+  expect(typeof dealer?.nextArrestCheckAt).toBe('number');
+});
+```
+
+- [ ] **Step 2: Add an arrested UI regression test**
+
+Add this second case to `src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx`:
+
+```ts
+it('shows bail and fire actions for arrested dealers', async () => {
+  vi.resetModules();
+  vi.doMock('../hooks/useGameEngine', () => ({
+    useGameEngine: () => ({
+      state: {
+        money: 10_000,
+        totalEarned: 0,
+        researchSpeed: 1,
+        production: {
+          weed: { id: 'weed', name: 'Weed', stock: 100, rate: 1, yieldPerLevel: 0.2, costMultiplier: 1.12, level: 1, upgradeCost: 16 },
+        },
+        unlockedProduction: ['weed'],
+        activeDealers: [{
+          id: 'dealer-arrested',
+          name: 'Arrested Dealer',
+          selling: 'weed',
+          volume: 1,
+          margin: 10,
+          volumeBonus: 0,
+          marginBonus: 0,
+          sideVolume: 0,
+          equipmentCount: 1,
+          baseVolumeGps: 1,
+          baseMarginMult: 10,
+          volumeStars: 3,
+          marginStars: 3,
+          isProtected: false,
+          isArrested: true,
+          nextArrestCheckAt: Date.now() + 60_000,
+        }],
+        availableDealers: [],
+        unlockedSlots: 1,
+        lastRefreshTime: 0,
+        lastEarningsPerDealer: { 'dealer-arrested': 0 },
+      },
+      upgrade: vi.fn(),
+      unlockProduction: vi.fn(),
+      hireDealer: vi.fn(),
+      fireDealer: vi.fn(),
+      refreshPool: vi.fn(),
+      resetGame: vi.fn(),
+      unlockSlot: vi.fn(),
+      setDealerSelling: vi.fn(),
+      buyEquipment: vi.fn(),
+      toggleDealerProtection: vi.fn(),
+      payDealerBail: vi.fn(),
+    }),
+  }));
+
+  const { NeonDGame: ArrestedNeonDGame } = await import('../NeonDGame');
+  render(<ArrestedNeonDGame />);
+
+  expect(screen.getByText(/arrested/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /pay bail/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /fire dealer/i })).toBeInTheDocument();
+  vi.resetModules();
+  vi.doUnmock('../hooks/useGameEngine');
+});
+```
+
+- [ ] **Step 3: Run focused Neon-D tests**
+
+Run:
+
+```bash
+npm run test -- src/components/NeonD/hooks/__tests__/useGameEngine.test.ts src/components/NeonD/__tests__/NeonDGame.test.tsx
+```
+
+Expected: PASS for all new Neon-D risk tests.
+
+- [ ] **Step 4: Run the broader web test suite**
+
+Run:
+
+```bash
+npm run test
+```
+
+Expected: PASS with no regressions outside Neon-D.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+git commit -m "test: cover neon-d dealer risk regression cases"
+```
+
+## Self-Review
+
+**Spec coverage:**  
+The plan covers product-only arrest checks, per-dealer protection toggles, the 15% income penalty, bail scaling from current income per second, arrested dealer recovery/removal, UI exposure of risk/protection/arrest state, and save compatibility.
+
+**Placeholder scan:**  
+No `TBD`, `TODO`, or “handle appropriately” placeholders remain. Each task names exact files, concrete tests, commands, and implementation targets.
+
+**Type consistency:**  
+The plan consistently uses `isProtected`, `isArrested`, `nextArrestCheckAt`, `toggleDealerProtection`, `payDealerBail`, and `forceArrestDealer`. Bail constants and protection constants are named consistently across tasks.

--- a/docs/superpowers/plans/2026-05-15-neon-d-pending-dealer-upgrade.md
+++ b/docs/superpowers/plans/2026-05-15-neon-d-pending-dealer-upgrade.md
@@ -1,0 +1,661 @@
+# Neon-D Pending Dealer Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make dealer equipment upgrades spend money immediately, persist the dealer's three upgrade options, and prevent rerolling by closing and reopening the modal.
+
+**Architecture:** Persist pending dealer upgrade choices on the `Dealer` model and move upgrade-roll ownership into `useGameEngine` so the same state drives autosave, UI reopening, and upgrade resolution. Keep `NeonDGame` as a thin view layer that opens a dealer's stored pending options and removes the cancel path that currently behaves like a reroll.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library
+
+---
+
+## File Structure
+
+- Modify: `src/Brmble.Web/src/components/NeonD/types.ts`
+  - Extend `Dealer` with persisted pending-upgrade fields.
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`
+  - Normalize legacy saves, add a "start equipment upgrade" action, make "resolve equipment upgrade" consume pending dealer options, and clear pending choices when a dealer is fired.
+- Modify: `src/Brmble.Web/src/components/NeonD/NeonDGame.tsx`
+  - Stop generating transient modal options in component state and render the modal from dealer state instead.
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`
+  - Add engine-level TDD coverage for pending choice persistence, charging behavior, resolution, cleanup on fire, and migration defaults.
+- Modify: `src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx`
+  - Add UI coverage that reopening the modal reuses stored dealer options and that the dismiss reroll path is gone.
+
+### Task 1: Persist Pending Upgrade State On Dealers
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`
+- Modify: `src/Brmble.Web/src/components/NeonD/types.ts`
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`
+
+- [ ] **Step 1: Write the failing migration test**
+
+Add this test near the existing legacy-save migration coverage in `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`:
+
+```ts
+  it('restores older saves by filling in missing pending dealer upgrade fields', () => {
+    localStorage.setItem('brmble_neon_d_save', JSON.stringify({
+      activeDealers: [{
+        id: 'legacy',
+        name: 'Legacy Dealer',
+        selling: 'weed',
+        volume: 1,
+        margin: 1,
+        volumeBonus: 0,
+        marginBonus: 0,
+        sideVolume: 0,
+        equipmentCount: 0,
+        baseVolumeGps: 1,
+        baseMarginMult: 1,
+        volumeStars: 1,
+        marginStars: 1,
+        isProtected: false,
+        isArrested: false,
+        nextArrestCheckAt: Date.now() + 10_000,
+      }],
+    }));
+
+    const { result } = renderHook(() => useGameEngine());
+    const dealer = result.current.state.activeDealers[0];
+
+    expect(dealer?.hasPendingUpgrade).toBe(false);
+    expect(dealer?.pendingUpgradeOptions).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```powershell
+npm run test -- src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: FAIL because `hasPendingUpgrade` and `pendingUpgradeOptions` do not exist yet on `Dealer`.
+
+- [ ] **Step 3: Add the new dealer fields and normalize them**
+
+Update `src/Brmble.Web/src/components/NeonD/types.ts`:
+
+```ts
+export interface Dealer {
+  id: string;
+  name: string;
+  selling: string;
+  volume: number;
+  margin: number;
+  volumeBonus: number;
+  marginBonus: number;
+  sideVolume: number;
+  equipmentCount: number;
+  baseVolumeGps: number;
+  baseMarginMult: number;
+  volumeStars: number;
+  marginStars: number;
+  isProtected: boolean;
+  isArrested: boolean;
+  nextArrestCheckAt: number;
+  hasPendingUpgrade: boolean;
+  pendingUpgradeOptions: DealerUpgrade[];
+}
+```
+
+Update `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts` in `generateRandomDealer` and `normalizeDealerRiskState`:
+
+```ts
+  return {
+    id: crypto.randomUUID(),
+    name: `${fName} "${lName}"`,
+    selling: drug,
+    volume: baseVolumeGps,
+    margin: baseMarginMult,
+    volumeBonus: 0,
+    marginBonus: 0,
+    sideVolume: 0,
+    equipmentCount: 0,
+    baseVolumeGps,
+    baseMarginMult,
+    volumeStars,
+    marginStars,
+    isProtected: false,
+    isArrested: false,
+    nextArrestCheckAt: Date.now() + ARREST_CHECK_INTERVAL_MS.min,
+    hasPendingUpgrade: false,
+    pendingUpgradeOptions: [],
+  };
+```
+
+```ts
+const normalizeDealerRiskState = (dealer: Dealer): Dealer => ({
+  ...dealer,
+  isProtected: dealer.isProtected ?? false,
+  isArrested: dealer.isArrested ?? false,
+  nextArrestCheckAt: dealer.nextArrestCheckAt ?? (Date.now() + ARREST_CHECK_INTERVAL_MS.min),
+  hasPendingUpgrade: dealer.hasPendingUpgrade ?? false,
+  pendingUpgradeOptions: dealer.pendingUpgradeOptions ?? [],
+});
+```
+
+Also extend the migration check:
+
+```ts
+        dealer.nextArrestCheckAt === undefined ||
+        dealer.hasPendingUpgrade === undefined ||
+        dealer.pendingUpgradeOptions === undefined
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run:
+
+```powershell
+npm run test -- src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: PASS for the new migration test and no regression in existing hook tests.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- src/Brmble.Web/src/components/NeonD/types.ts src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+git commit -m "feat: persist pending neon-d dealer upgrades"
+```
+
+### Task 2: Move Upgrade Roll Ownership Into The Game Engine
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`
+- Modify: `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`
+
+- [ ] **Step 1: Write the failing behavior tests for starting and resolving dealer upgrades**
+
+Add these tests inside the existing `equipment upgrades` describe block in `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`:
+
+```ts
+    it('startDealerUpgrade charges once and stores three pending options', () => {
+      vi.spyOn(Math, 'random')
+        .mockReturnValueOnce(0.9)
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0.9)
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0.9)
+        .mockReturnValueOnce(0);
+
+      const { result } = setupWithMoney();
+      const moneyBefore = result.current.state.money;
+
+      act(() => {
+        result.current.startDealerUpgrade('test-dealer');
+      });
+
+      const dealer = result.current.state.activeDealers[0];
+      expect(result.current.state.money).toBeCloseTo(moneyBefore - 500, 1);
+      expect(dealer?.hasPendingUpgrade).toBe(true);
+      expect(dealer?.pendingUpgradeOptions).toHaveLength(3);
+    });
+
+    it('startDealerUpgrade reuses an existing pending roll without charging twice', () => {
+      vi.spyOn(Math, 'random')
+        .mockReturnValueOnce(0.9)
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0.9)
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(0.9)
+        .mockReturnValueOnce(0);
+
+      const { result } = setupWithMoney();
+
+      act(() => {
+        result.current.startDealerUpgrade('test-dealer');
+      });
+
+      const moneyAfterFirstRoll = result.current.state.money;
+      const firstOptions = result.current.state.activeDealers[0]?.pendingUpgradeOptions;
+
+      act(() => {
+        result.current.startDealerUpgrade('test-dealer');
+      });
+
+      expect(result.current.state.money).toBeCloseTo(moneyAfterFirstRoll, 1);
+      expect(result.current.state.activeDealers[0]?.pendingUpgradeOptions).toEqual(firstOptions);
+    });
+
+    it('buyEquipment applies the chosen pending upgrade and clears it', () => {
+      const { result } = setupWithMoney();
+
+      act(() => {
+        result.current.startDealerUpgrade('test-dealer');
+      });
+
+      const chosen = result.current.state.activeDealers[0]!.pendingUpgradeOptions[0];
+
+      act(() => {
+        result.current.buyEquipment('test-dealer', chosen);
+      });
+
+      const dealer = result.current.state.activeDealers[0];
+      expect(dealer?.equipmentCount).toBe(1);
+      expect(dealer?.hasPendingUpgrade).toBe(false);
+      expect(dealer?.pendingUpgradeOptions).toEqual([]);
+    });
+
+    it('fireDealer clears any pending equipment choice with the dealer', () => {
+      const { result } = setupWithMoney();
+
+      act(() => {
+        result.current.startDealerUpgrade('test-dealer');
+      });
+
+      act(() => {
+        result.current.fireDealer('test-dealer');
+      });
+
+      expect(result.current.state.activeDealers[0]).toBeNull();
+    });
+```
+
+- [ ] **Step 2: Run the targeted hook test to verify it fails**
+
+Run:
+
+```powershell
+npm run test -- src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: FAIL because `startDealerUpgrade` does not exist and `buyEquipment` still charges money directly instead of resolving a stored pending upgrade.
+
+- [ ] **Step 3: Implement the engine-owned pending upgrade flow**
+
+In `src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts`, extract the current weighted option logic into a helper near the other helper functions:
+
+```ts
+const generateDealerUpgradeOptions = (dealer: Dealer, unlockedProduction: string[]): DealerUpgrade[] => {
+  const options: DealerUpgrade[] = [];
+  const sideHustleProducts = unlockedProduction.filter(id => id !== dealer.selling);
+
+  const commonUpgrades: DealerUpgrade[] = [
+    { type: 'VOLUME', label: 'Armed Gang', description: 'Volume +15%', value: 0.15 },
+    { type: 'MARGIN', label: 'Ferrari', description: 'Margin +15%', value: 0.15 },
+    { type: 'ALL_AROUNDER', label: 'Copter', description: 'Volume & Margin +5%', value: 0.05 },
+  ];
+
+  const uncommonUpgrades: DealerUpgrade[] = [
+    { type: 'BULK', label: 'The Crew', description: 'Volume +35%, Margin -10%', value: 0.35, marginPenalty: 0.1 },
+  ];
+
+  for (let i = 0; i < 3; i++) {
+    const roll = Math.random();
+    if (roll < 0.10 && sideHustleProducts.length > 0) {
+      options.push({
+        type: 'SIDE_HUSTLE',
+        label: 'JACKPOT: Side Hustle',
+        description: 'Add 10% side volume bleed',
+        value: 0.1,
+        sideVolumeValue: 0.1,
+      });
+      continue;
+    }
+
+    if (roll < 0.30) {
+      const upgrade = uncommonUpgrades[Math.floor(Math.random() * uncommonUpgrades.length)];
+      options.push({ ...upgrade });
+      continue;
+    }
+
+    const upgrade = commonUpgrades[Math.floor(Math.random() * commonUpgrades.length)];
+    options.push({ ...upgrade });
+  }
+
+  return options;
+};
+```
+
+Add a new action:
+
+```ts
+  const startDealerUpgrade = (dealerId: string) => {
+    setState(prev => {
+      const dealer = prev.activeDealers.find(d => d?.id === dealerId);
+      if (!dealer || dealer.equipmentCount >= 3) return prev;
+
+      if (dealer.hasPendingUpgrade && dealer.pendingUpgradeOptions.length === 3) {
+        return prev;
+      }
+
+      const upgradeCost = 500 * Math.pow(2.5, dealer.equipmentCount);
+      if (prev.money < upgradeCost) return prev;
+
+      const pendingUpgradeOptions = generateDealerUpgradeOptions(dealer, prev.unlockedProduction);
+
+      return {
+        ...prev,
+        money: prev.money - upgradeCost,
+        activeDealers: prev.activeDealers.map(current =>
+          current?.id === dealerId
+            ? {
+                ...current,
+                hasPendingUpgrade: true,
+                pendingUpgradeOptions,
+              }
+            : current
+        ),
+      };
+    });
+  };
+```
+
+Update `buyEquipment` so it resolves only a stored pending choice and no longer charges again:
+
+```ts
+  const buyEquipment = (dealerId: string, upgrade: DealerUpgrade) => {
+    setState(prev => {
+      const dealer = prev.activeDealers.find(d => d?.id === dealerId);
+      if (!dealer || dealer.equipmentCount >= 3) return prev;
+      if (!dealer.hasPendingUpgrade || dealer.pendingUpgradeOptions.length !== 3) return prev;
+
+      const matchedUpgrade = dealer.pendingUpgradeOptions.find(option =>
+        option.type === upgrade.type &&
+        option.label === upgrade.label &&
+        option.description === upgrade.description &&
+        option.value === upgrade.value &&
+        option.marginPenalty === upgrade.marginPenalty &&
+        option.sideVolumeValue === upgrade.sideVolumeValue
+      );
+
+      if (!matchedUpgrade) return prev;
+
+      const nextDealers = prev.activeDealers.map(d => {
+        if (d?.id !== dealerId) return d;
+
+        const newDealer = {
+          ...d,
+          equipmentCount: d.equipmentCount + 1,
+          hasPendingUpgrade: false,
+          pendingUpgradeOptions: [],
+        };
+
+        if (matchedUpgrade.type === 'VOLUME') newDealer.volumeBonus += matchedUpgrade.value;
+        if (matchedUpgrade.type === 'MARGIN') newDealer.marginBonus += matchedUpgrade.value;
+        if (matchedUpgrade.type === 'ALL_AROUNDER') {
+          newDealer.volumeBonus += matchedUpgrade.value;
+          newDealer.marginBonus += matchedUpgrade.value;
+        }
+        if (matchedUpgrade.type === 'BULK') {
+          newDealer.volumeBonus += matchedUpgrade.value;
+          newDealer.marginBonus -= matchedUpgrade.marginPenalty || 0.1;
+        }
+        if (matchedUpgrade.type === 'SIDE_HUSTLE') {
+          newDealer.sideVolume = (newDealer.sideVolume ?? 0) + (matchedUpgrade.sideVolumeValue ?? 0.10);
+        }
+
+        return newDealer;
+      });
+
+      return { ...prev, activeDealers: nextDealers };
+    });
+  };
+```
+
+Return the new action from the hook:
+
+```ts
+    startDealerUpgrade,
+```
+
+- [ ] **Step 4: Run the targeted hook test to verify it passes**
+
+Run:
+
+```powershell
+npm run test -- src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: PASS for the new start/reopen/resolve/fire behavior plus the existing upgrade tests after adjusting the old "cost deducts" assertion to call `startDealerUpgrade` before `buyEquipment`.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+git commit -m "feat: move neon-d dealer upgrade rolls into game state"
+```
+
+### Task 3: Update The UI To Reopen Stored Dealer Choices Without Rerolling
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx`
+- Modify: `src/Brmble.Web/src/components/NeonD/NeonDGame.tsx`
+
+- [ ] **Step 1: Write the failing UI test for reopening the same stored options**
+
+Add a focused UI test in `src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx` using `render`, `screen`, and `fireEvent`:
+
+```ts
+it('reopens the same pending dealer upgrade options instead of rerolling', async () => {
+  const startDealerUpgrade = vi.fn();
+  const buyEquipment = vi.fn();
+
+  vi.resetModules();
+  vi.doMock('../hooks/useGameEngine', () => ({
+    useGameEngine: () => ({
+      state: {
+        money: 10_000,
+        totalEarned: 0,
+        researchSpeed: 1,
+        production: {
+          weed: { id: 'weed', name: 'Weed', stock: 100, rate: 1, yieldPerLevel: 0.2, costMultiplier: 1.12, level: 1, upgradeCost: 16 },
+        },
+        unlockedProduction: ['weed'],
+        activeDealers: [{
+          id: 'dealer-ui',
+          name: 'Test Dealer',
+          selling: 'weed',
+          volume: 1,
+          margin: 10,
+          volumeBonus: 0,
+          marginBonus: 0,
+          sideVolume: 0,
+          equipmentCount: 0,
+          baseVolumeGps: 1,
+          baseMarginMult: 10,
+          volumeStars: 3,
+          marginStars: 3,
+          isProtected: false,
+          isArrested: false,
+          nextArrestCheckAt: Date.now() + 60_000,
+          hasPendingUpgrade: true,
+          pendingUpgradeOptions: [
+            { type: 'VOLUME', label: 'Armed Gang', description: 'Volume +15%', value: 0.15 },
+            { type: 'MARGIN', label: 'Ferrari', description: 'Margin +15%', value: 0.15 },
+            { type: 'ALL_AROUNDER', label: 'Copter', description: 'Volume & Margin +5%', value: 0.05 },
+          ],
+        }],
+        availableDealers: [],
+        unlockedSlots: 1,
+        lastRefreshTime: 0,
+        lastEarningsPerDealer: { 'dealer-ui': 8.5 },
+      },
+      upgrade: vi.fn(),
+      unlockProduction: vi.fn(),
+      hireDealer: vi.fn(),
+      fireDealer: vi.fn(),
+      refreshPool: vi.fn(),
+      resetGame: vi.fn(),
+      unlockSlot: vi.fn(),
+      setDealerSelling: vi.fn(),
+      startDealerUpgrade,
+      buyEquipment,
+      toggleDealerProtection: vi.fn(),
+      payDealerBail: vi.fn(),
+      forceArrestDealer: vi.fn(),
+    }),
+  }));
+
+  const { NeonDGame: PendingNeonDGame } = await import('../NeonDGame');
+  render(<PendingNeonDGame />);
+
+  fireEvent.click(screen.getByRole('button', { name: /upgrade/i }));
+  expect(screen.getByText('Armed Gang')).toBeInTheDocument();
+  expect(screen.getByText('Ferrari')).toBeInTheDocument();
+  expect(screen.getByText('Copter')).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+  expect(startDealerUpgrade).toHaveBeenCalledWith('dealer-ui');
+});
+```
+
+- [ ] **Step 2: Run the UI test to verify it fails**
+
+Run:
+
+```powershell
+npm run test -- src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+```
+
+Expected: FAIL because the component still generates modal options locally and still shows a cancel button.
+
+- [ ] **Step 3: Make `NeonDGame` read pending dealer choices from the hook**
+
+In `src/Brmble.Web/src/components/NeonD/NeonDGame.tsx`:
+
+- Remove the `Dealer` import if it becomes unused.
+- Replace the local state shape so it tracks only the open dealer id:
+
+```ts
+  const [upgradingDealerId, setUpgradingDealerId] = useState<string | null>(null);
+```
+
+- Read the new hook action:
+
+```ts
+    startDealerUpgrade,
+```
+
+- Delete the local `generateUpgradeOptions` helper entirely.
+
+- Derive the open dealer from state:
+
+```ts
+  const upgradingDealer = upgradingDealerId
+    ? state.activeDealers.find(dealer => dealer?.id === upgradingDealerId) ?? null
+    : null;
+```
+
+- Update the dealer upgrade button:
+
+```ts
+                        <button
+                          className={styles.buyButton}
+                          disabled={isMaxed || state.money < upgradeCost}
+                          onClick={() => {
+                            if (isMaxed) return;
+                            startDealerUpgrade(dealer.id);
+                            setUpgradingDealerId(dealer.id);
+                          }}
+                        >
+```
+
+- Render the modal from persisted options:
+
+```ts
+      {upgradingDealer && upgradingDealer.hasPendingUpgrade && (
+        <div style={{
+          position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+          background: 'rgba(0,0,0,0.85)', display: 'flex',
+          alignItems: 'center', justifyContent: 'center', zIndex: 1000
+        }}>
+          <div className="glass-panel" style={{ padding: 'var(--space-xl)', maxWidth: '500px' }}>
+            <h3 className={styles.columnHeader}>Select Equipment</h3>
+            <div style={{ display: 'grid', gap: '10px', marginTop: '20px' }}>
+              {upgradingDealer.pendingUpgradeOptions.map((opt, i) => (
+                <button
+                  key={`${opt.label}-${i}`}
+                  className={opt.type === 'SIDE_HUSTLE' ? styles.dangerButton : styles.buyButton}
+                  style={opt.type === 'SIDE_HUSTLE'
+                    ? { border: '2px solid gold', boxShadow: '0 0 20px rgba(255, 215, 0, 0.5)' }
+                    : {}}
+                  onClick={() => {
+                    buyEquipment(upgradingDealer.id, opt);
+                    setUpgradingDealerId(null);
+                  }}
+                >
+                  <div style={{ fontWeight: 'bold' }}>{opt.label}</div>
+                  <div style={{ fontSize: '10px', opacity: 0.8 }}>{opt.description}</div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+```
+
+- Add a tiny effect so the modal closes itself if the pending upgrade gets consumed or the dealer disappears:
+
+```ts
+  if (upgradingDealerId && (!upgradingDealer || !upgradingDealer.hasPendingUpgrade)) {
+    setUpgradingDealerId(null);
+  }
+```
+
+If you prefer to avoid a render-time state update, implement that same logic with `useEffect`.
+
+- [ ] **Step 4: Run the UI tests to verify they pass**
+
+Run:
+
+```powershell
+npm run test -- src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+```
+
+Expected: PASS for the new reopening test and the existing dealer card UI tests.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- src/Brmble.Web/src/components/NeonD/NeonDGame.tsx src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+git commit -m "feat: reuse pending neon-d dealer upgrade choices in ui"
+```
+
+### Task 4: Final Verification
+
+**Files:**
+- Modify: none
+- Test: `src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts`
+- Test: `src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx`
+
+- [ ] **Step 1: Run the hook test file**
+
+Run:
+
+```powershell
+npm run test -- src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run the UI test file**
+
+Run:
+
+```powershell
+npm run test -- src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Run both targeted test files together**
+
+Run:
+
+```powershell
+npm run test -- src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+```
+
+Expected: PASS with no new warnings or errors.
+
+- [ ] **Step 4: Commit the verification checkpoint**
+
+```powershell
+git add -- docs/superpowers/plans/2026-05-15-neon-d-pending-dealer-upgrade.md
+git commit -m "docs: add neon-d pending dealer upgrade plan"
+```

--- a/docs/superpowers/specs/2026-05-15-neon-d-dealer-risk-design.md
+++ b/docs/superpowers/specs/2026-05-15-neon-d-dealer-risk-design.md
@@ -1,0 +1,259 @@
+# Neon-D Dealer Risk Design
+
+**Date:** 2026-05-15
+**Status:** Draft for review
+
+## Goal
+
+Add a lightweight dealer arrest system to Neon-D that creates meaningful tradeoffs without breaking the idle flow. The player should choose between higher profits and safer operation on a per-dealer basis.
+
+## Summary
+
+Each active dealer can be in one of three states:
+
+- `active`
+- `protected`
+- `arrested`
+
+Arrest risk is determined only by the product the dealer is currently selling. The game performs a periodic arrest check for each non-protected dealer. If the check succeeds, that dealer becomes arrested and stops generating income until the player either pays bail or fires them.
+
+The player can toggle `Pay off cops` for each dealer. While enabled, that dealer is fully immune to arrest checks but earns 15% less income.
+
+## Design Principles
+
+- Keep the system easy to understand at a glance.
+- Preserve idle progress by using infrequent risk checks instead of constant punishment.
+- Make high-risk products more profitable but harder to run safely.
+- Ensure bail remains a live economic choice throughout early, mid, and late game.
+
+## Dealer States
+
+### Active
+
+The dealer operates normally:
+
+- sells their assigned product
+- generates full income
+- is eligible for arrest checks
+
+### Protected
+
+The dealer operates under `Pay off cops`:
+
+- sells their assigned product
+- generates 85% of normal income
+- is completely immune to arrest checks
+- can be toggled back to normal by the player at any time
+
+Protection is not permanent. It is a live toggle on the dealer card.
+
+### Arrested
+
+The dealer stops operating:
+
+- generates no income
+- cannot switch products
+- cannot buy additional equipment
+- can only be recovered through `Pay Bail` or removed through `Fire Dealer`
+
+Arrested dealers keep their existing equipment unless the player fires them.
+
+## Arrest Check Model
+
+The game performs arrest checks on a schedule per dealer instead of using a visible heat meter.
+
+### Timing
+
+- Each eligible dealer gets checked on a repeating timer.
+- The timer should use a randomized interval window, with the first implementation targeting roughly every 300-600 seconds per dealer.
+- The interval should be independent per dealer so multiple arrests do not feel synchronized or scripted.
+
+### Eligibility
+
+A dealer is eligible for a check only when all of the following are true:
+
+- the slot contains a dealer
+- the dealer is not arrested
+- `Pay off cops` is disabled
+
+### Risk Source
+
+The arrest chance comes only from the product the dealer is actively selling at the moment of the check.
+
+This design intentionally avoids extra hidden math from:
+
+- accumulated heat
+- total money earned
+- equipment count
+- number of dealers
+
+That keeps the system legible and lets players reason directly from product choice.
+
+### Product Risk Tiers
+
+The first implementation should use a simple per-product configuration, for example:
+
+- early products: low arrest chance
+- midgame products: medium arrest chance
+- late-game products: high arrest chance
+
+Exact percentages are balancing values and should live in constants rather than being hardcoded in UI components.
+
+## Pay Off Cops
+
+`Pay off cops` is a per-dealer toggle.
+
+### Effect
+
+- While enabled, the dealer is fully immune to arrest.
+- While enabled, the dealer earns 15% less income.
+
+### Income Handling
+
+The 15% penalty should apply to the dealer's realized earnings, after normal product sale math is calculated for that dealer. This keeps the feature compatible with current volume, margin, side-volume, and equipment systems.
+
+### UX Rules
+
+- The toggle must clearly show whether protection is on or off.
+- The earnings shown on the dealer card should already reflect the current protected or unprotected income.
+- Protected dealers should have a visible status label such as `Protected` or `Cops Paid Off`.
+
+## Bail
+
+When a dealer is arrested, the primary recovery action is `Pay Bail`.
+
+### Bail Formula Direction
+
+Bail must scale with the player's current economy, specifically their current total income per second rather than their cash on hand.
+
+Recommended formula shape:
+
+`bailCost = max(baseFloor, totalIncomePerSecond * bailMultiplier)`
+
+### Requirements
+
+- use current total income per second
+- include a minimum floor so bail never becomes trivial
+- update dynamically as the player's run becomes stronger
+
+This keeps bail meaningful at every stage of the game and prevents it from becoming either irrelevant or impossible.
+
+### Bail Result
+
+After bail is paid:
+
+- the dealer returns to normal operation
+- the dealer is no longer arrested
+- the dealer keeps their existing equipment
+- `Pay off cops` should return in the off state unless later balancing shows a reason to restore the previous setting
+
+Defaulting protection back to off keeps the state transition simple and preserves player choice.
+
+## Fire Dealer
+
+The player may permanently remove an arrested dealer instead of paying bail.
+
+### Effect
+
+- removes the dealer from the slot
+- destroys all equipment and upgrades attached to that dealer
+- does not refund prior investment
+
+This serves as the low-cash escape valve when bail is too expensive or the dealer is no longer worth saving.
+
+## UI Design
+
+The system should stay compact and readable on each dealer card.
+
+### Dealer Card Content
+
+For an active or protected dealer, show:
+
+- current product
+- current earnings per second
+- `Pay off cops` toggle
+- simple risk label for the current product, such as `Low Risk`, `Medium Risk`, or `High Risk`
+
+For a protected dealer, also show:
+
+- explicit protected status text
+- earnings already displayed with the 15% penalty applied
+
+For an arrested dealer, replace normal controls with:
+
+- arrested state messaging
+- `Pay Bail ($X)` button
+- `Fire Dealer` button
+
+### What We Do Not Show
+
+- no heat bar
+- no hidden-risk explanation panel
+- no arrest probability countdown in the main dealer UI
+
+The player-facing model should stay simple: risky products are dangerous, protection costs income, bail fixes arrests.
+
+## Data Model Changes
+
+The current dealer model needs explicit arrest/protection state.
+
+Add fields to dealer state for:
+
+- whether `Pay off cops` is enabled
+- whether the dealer is arrested
+- when the next arrest check should occur
+
+These fields should be persisted with the save state so the system survives refreshes and idle sessions consistently.
+
+## Game Loop Changes
+
+The game tick should gain arrest handling in addition to the existing production and sales logic.
+
+### Per Tick Responsibilities
+
+- continue production updates
+- continue sales updates for active and protected dealers
+- skip sales for arrested dealers
+- check whether a dealer has reached their next arrest-check timestamp
+- if so, evaluate the current product risk and either arrest the dealer or schedule the next check
+
+Protected dealers should never enter the arrest branch.
+
+## Error Handling and Edge Cases
+
+- If a dealer becomes arrested, income for that dealer must stop immediately on the next tick.
+- If a player changes a dealer's product before a risk check fires, the new product determines the risk.
+- If total income per second is zero when bail is calculated, the minimum bail floor still applies.
+- If a protected dealer is toggled off, they become eligible for future arrest checks again using a newly scheduled interval rather than an immediate surprise check.
+- Save migration should safely initialize new dealer state for older saves.
+
+## Testing
+
+Add automated coverage for:
+
+- protected dealers receiving the 15% income penalty
+- protected dealers never getting arrested
+- unprotected dealers using current product risk at check time
+- arrested dealers producing zero dealer income
+- bail cost scaling from current total income per second with a minimum floor
+- firing an arrested dealer removing them and their equipment
+- persisted state restoring arrest/protection fields correctly
+
+## Recommended Implementation Order
+
+1. Extend types and persisted dealer state.
+2. Add configurable product risk constants and bail constants.
+3. Update the game engine to support dealer protection, arrest checks, and bail recovery.
+4. Update dealer card UI for toggle, risk label, and arrested actions.
+5. Add or update tests for engine behavior and persistence.
+
+## Open Balancing Decisions
+
+The following should be tuned during implementation:
+
+- exact arrest percentages per product
+- exact arrest interval window
+- minimum bail floor
+- bail multiplier against total income per second
+
+These values should be easy to iterate on without changing the system design.

--- a/docs/superpowers/specs/2026-05-15-neon-d-pending-dealer-upgrade-design.md
+++ b/docs/superpowers/specs/2026-05-15-neon-d-pending-dealer-upgrade-design.md
@@ -1,0 +1,92 @@
+# Neon-D Pending Dealer Upgrade Design
+
+## Summary
+
+Adjust the Neon-D dealer equipment upgrade flow so that pressing `Upgrade` immediately spends the money and creates a mandatory three-choice upgrade selection for that specific dealer. The player must resolve that selection by choosing one of the offered upgrades or by firing that dealer later. Closing and reopening the upgrade UI must never reroll the choices.
+
+## Desired Player Experience
+
+When the player presses `Upgrade` on a dealer card:
+
+- the upgrade cost is charged immediately
+- exactly three upgrade options are generated
+- those three options become locked to that dealer
+- the player cannot dismiss the choice as a way to get a new roll
+
+If the player reopens the upgrade flow for that same dealer before choosing, they must see the exact same three options again.
+
+If the dealer is fired before a choice is made, the pending upgrade choice disappears together with the dealer.
+
+## State Model
+
+The dealer state should carry its own pending upgrade choice data instead of keeping the offer only in component-local UI state.
+
+Add persistent dealer fields for:
+
+- whether the dealer currently has a pending equipment choice
+- the exact three generated options tied to that dealer
+
+This keeps the flow consistent with autosave and prevents rerolling by closing the modal or refreshing the page.
+
+## Flow Changes
+
+### Start Upgrade
+
+Pressing `Upgrade` should:
+
+- verify the dealer exists
+- verify the dealer is not already maxed out
+- verify the player has enough money
+- immediately subtract the upgrade cost
+- generate three equipment options using the current weighted logic
+- save those three options on the dealer if none are already pending
+- open the upgrade modal for that dealer
+
+If the dealer already has a pending set of options, pressing `Upgrade` again should not charge again and should simply reopen the modal with the existing set.
+
+### Resolve Upgrade
+
+Choosing one option should:
+
+- apply only the selected upgrade
+- increment the dealer equipment count
+- clear the pending option set from that dealer
+- close the modal
+
+### Fire Dealer
+
+Firing a dealer should also discard any pending equipment choice stored on that dealer.
+
+## UI Behavior
+
+The upgrade modal remains the presentation layer for choosing from the dealer's pending options.
+
+Behavior requirements:
+
+- the modal must read its options from dealer state, not from newly generated component state
+- the close button or dismiss action must not create a reroll path
+- reopening the modal for a dealer with pending options must show the same three choices
+- once a choice is made, the modal closes normally
+
+Implementation detail:
+
+The UI may still allow the modal to visually close, but only if the pending options remain stored on the dealer and reopening returns the same set. The important rule is that closing the modal must not regenerate or discard the unpaid choice state.
+
+## Testing
+
+Add or update tests for:
+
+- starting an upgrade immediately charging money and storing three pending options
+- reopening the upgrade flow for the same dealer reusing the same options
+- resolving one option applying the effect and clearing pending options
+- firing a dealer clearing pending options
+- existing dealers from older saves safely defaulting to no pending upgrade data
+
+## Scope
+
+This change is intentionally narrow:
+
+- no change to upgrade weighting rules
+- no increase to the three-equipment cap
+- no new dealer progression system
+- no extra confirmation step before paying for an upgrade roll

--- a/src/Brmble.Web/package.json
+++ b/src/Brmble.Web/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "type-check": "tsc -b tsconfig.test.json --force"
   },
   "dependencies": {
     "livekit-client": "^2.17.2",

--- a/src/Brmble.Web/src/components/NeonD/NeonD.module.css
+++ b/src/Brmble.Web/src/components/NeonD/NeonD.module.css
@@ -124,6 +124,39 @@
   font-size: var(--text-xs);
 }
 
+.flowIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.flowUp {
+  color: var(--accent-success);
+}
+
+.flowDown {
+  color: var(--accent-secondary);
+}
+
+.flowArrow {
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+}
+
+.flowArrowUp {
+  border-bottom: 8px solid var(--accent-success);
+}
+
+.flowArrowDown {
+  border-top: 8px solid var(--accent-secondary);
+}
+
 .upgradeButton {
   flex: 1;
   display: flex;
@@ -246,4 +279,74 @@
   padding: var(--space-xs);
   text-align: center;
   font-weight: bold;
+}
+
+.toggleRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+.toggleLabel {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.toggleHint {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.toggleButton {
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+}
+
+.toggleTrack {
+  width: 34px;
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--glass-border);
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.toggleTrack[data-active='true'] {
+  background: rgba(0, 255, 150, 0.2);
+  border-color: rgba(0, 255, 150, 0.5);
+}
+
+.toggleThumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.toggleThumb[data-active='true'] {
+  transform: translateX(16px);
+  background: var(--accent-success);
+}
+
+.toggleButton:hover .toggleTrack {
+  border-color: var(--accent-success);
+}
+
+.toggleButton:focus-visible {
+  outline: 2px solid var(--accent-success);
+  outline-offset: 4px;
+  border-radius: 999px;
 }

--- a/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
+++ b/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
@@ -328,7 +328,11 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                       <span>$0.00/s</span>
                     </div>
                     <div style={{ display: 'grid', gap: 'var(--space-xs)', marginTop: 'var(--space-md)' }}>
-                      <button className={styles.buyButton} onClick={() => payDealerBail(slot.id)}>
+                      <button 
+                        className={styles.buyButton} 
+                        onClick={() => payDealerBail(slot.id)}
+                        disabled={state.money < bailCost}
+                      >
                         Pay Bail ({formatMoney(bailCost)})
                       </button>
                       <button className={styles.dangerButton} onClick={() => fireDealer(slot.id)}>
@@ -471,7 +475,7 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
         </section>
       </div>
 
-      {upgradingDealer?.hasPendingUpgrade && upgradingDealer.pendingUpgradeOptions.length === 3 && (
+      {upgradingDealer?.hasPendingUpgrade && upgradingDealer.pendingUpgradeOptions.length === 3 && !upgradingDealer.isArrested && (
         <div style={{
           position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
           background: 'rgba(0,0,0,0.85)', display: 'flex', 

--- a/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
+++ b/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useGameEngine } from './hooks/useGameEngine';
-import type { Dealer, DealerUpgrade } from './types';
 import { UNLOCK_COSTS, PRODUCT_TIERS, SLOT_UNLOCK_COSTS, PRODUCT_ARREST_RISK } from './constants';
+import { getBailCost } from './economy';
 import { confirm } from '../../hooks/usePrompt';
 import { Tooltip } from '../Tooltip/Tooltip';
 import styles from './NeonD.module.css';
@@ -49,6 +49,35 @@ function getUpgradeName(id: string): string {
   return names[id] || 'Lab';
 }
 
+function getProductSalesRates(state: ReturnType<typeof useGameEngine>['state']) {
+  const salesRates: Record<string, number> = {};
+
+  Object.keys(state.production).forEach(productId => {
+    salesRates[productId] = 0;
+  });
+
+  state.activeDealers.forEach(dealer => {
+    if (!dealer || dealer.isArrested) return;
+
+    const effectiveVolume = dealer.volume * (1 + dealer.volumeBonus);
+    salesRates[dealer.selling] = (salesRates[dealer.selling] ?? 0) + effectiveVolume;
+
+    if (dealer.sideVolume > 0) {
+      const bleedAmount = effectiveVolume * dealer.sideVolume;
+      state.unlockedProduction.forEach(productId => {
+        if (productId === dealer.selling) return;
+        salesRates[productId] = (salesRates[productId] ?? 0) + bleedAmount;
+      });
+    }
+  });
+
+  return salesRates;
+}
+
+function formatMoney(value: number) {
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
 export function NeonDGame({ onClose }: { onClose?: () => void }) {
   const {
     state,
@@ -60,47 +89,23 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
     resetGame,
     unlockSlot,
     setDealerSelling,
+    startDealerUpgrade,
     buyEquipment,
     toggleDealerProtection,
     payDealerBail,
   } = useGameEngine();
-  const [upgradingDealer, setUpgradingDealer] = useState<{ dealerId: string; options: DealerUpgrade[] } | null>(null);
+  const [upgradingDealerId, setUpgradingDealerId] = useState<string | null>(null);
 
-  const generateUpgradeOptions = (dealer: Dealer): DealerUpgrade[] => {
-    const options: DealerUpgrade[] = [];
-    const sideHustleProducts = state.unlockedProduction.filter(id => id !== dealer.selling);
+  const upgradingDealer = upgradingDealerId
+    ? state.activeDealers.find(dealer => dealer?.id === upgradingDealerId) ?? null
+    : null;
 
-    const commonUpgrades: DealerUpgrade[] = [
-      { type: 'VOLUME', label: 'Armed Gang', description: 'Volume +15%', value: 0.15 },
-      { type: 'MARGIN', label: 'Ferrari', description: 'Margin +15%', value: 0.15 },
-      { type: 'ALL_AROUNDER', label: 'Copter', description: 'Volume & Margin +5%', value: 0.05 },
-    ];
-
-    const uncommonUpgrades: DealerUpgrade[] = [
-      { type: 'BULK', label: 'The Crew', description: 'Volume +35%, Margin -10%', value: 0.35, marginPenalty: 0.1 },
-    ];
-
-    for (let i = 0; i < 3; i++) {
-      const roll = Math.random();
-      if (roll < 0.10 && sideHustleProducts.length > 0) {
-        options.push({
-          type: 'SIDE_HUSTLE',
-          label: 'JACKPOT: Side Hustle',
-          description: `Add 10% side volume bleed`,
-          value: 0.1,
-          sideVolumeValue: 0.1
-        });
-      } else if (roll < 0.30) {
-        const upgrade = uncommonUpgrades[Math.floor(Math.random() * uncommonUpgrades.length)];
-        options.push({ ...upgrade });
-      } else {
-        const upgrade = commonUpgrades[Math.floor(Math.random() * commonUpgrades.length)];
-        options.push({ ...upgrade });
-      }
+  useEffect(() => {
+    if (!upgradingDealerId) return;
+    if (!upgradingDealer || !upgradingDealer.hasPendingUpgrade || upgradingDealer.pendingUpgradeOptions.length === 0) {
+      setUpgradingDealerId(null);
     }
-
-    return options;
-  };
+  }, [upgradingDealer, upgradingDealerId]);
 
   const getRefreshCooldown = () => {
     const now = Date.now();
@@ -124,6 +129,8 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
   const refreshCooldown = getRefreshCooldown();
   const allIds = Object.keys(state.production);
   const nextUnlockIndex = state.unlockedProduction.length;
+  const productSalesRates = getProductSalesRates(state);
+  const bailCost = getBailCost(state.lastEarningsPerDealer);
   const visibleProduction = Object.values(state.production).filter(prod => {
     const isUnlocked = state.unlockedProduction.includes(prod.id);
     const prodIndex = allIds.indexOf(prod.id);
@@ -170,6 +177,11 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
           
           {visibleProduction.map(prod => {
             const isUnlocked = state.unlockedProduction.includes(prod.id);
+            const dealerSalesRate = productSalesRates[prod.id] ?? 0;
+            const salesDelta = prod.rate - dealerSalesRate;
+            const isProductionAhead = salesDelta > 0.001;
+            const isSalesAhead = salesDelta < -0.001;
+
             return (
               <div key={prod.id} className={`glass-panel ${styles.productionCard}`}>
                 <div className={styles.statRow}>
@@ -186,6 +198,26 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                         Yield: <strong>+{prod.rate.toFixed(2)}g/s</strong>
                       </span>
                       <span className={styles.label}>Level {prod.level}</span>
+                    </div>
+
+                    <div className={styles.statRow}>
+                      <span className={styles.salesRate} aria-hidden="true" />
+                      <span
+                        className={`${styles.flowIndicator} ${isProductionAhead ? styles.flowUp : ''} ${isSalesAhead ? styles.flowDown : ''}`}
+                        aria-label={
+                          isProductionAhead
+                            ? 'Production is ahead of dealer sales'
+                            : isSalesAhead
+                              ? 'Dealer sales are ahead of production'
+                              : 'Production and dealer sales are balanced'
+                        }
+                      >
+                        <span
+                          className={`${styles.flowArrow} ${isProductionAhead ? styles.flowArrowUp : ''} ${isSalesAhead ? styles.flowArrowDown : ''}`}
+                          aria-hidden="true"
+                        />
+                        <span>{Math.abs(salesDelta).toFixed(2)}g/s</span>
+                      </span>
                     </div>
 
                     <div style={{ marginTop: 'var(--space-sm)' }}>
@@ -297,7 +329,7 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                     </div>
                     <div style={{ display: 'grid', gap: 'var(--space-xs)', marginTop: 'var(--space-md)' }}>
                       <button className={styles.buyButton} onClick={() => payDealerBail(slot.id)}>
-                        Pay Bail
+                        Pay Bail ({formatMoney(bailCost)})
                       </button>
                       <button className={styles.dangerButton} onClick={() => fireDealer(slot.id)}>
                         Fire Dealer
@@ -311,6 +343,8 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
             const dealer = slot;
                 const upgradeCost = 500 * Math.pow(2.5, dealer.equipmentCount);
                 const isMaxed = dealer.equipmentCount >= 3;
+                const hasStoredPendingUpgrade = dealer.hasPendingUpgrade && dealer.pendingUpgradeOptions.length > 0;
+                const isInsufficientFunds = !hasStoredPendingUpgrade && state.money < upgradeCost;
                 
                 return (
                   <div key={slot.id} className={`glass-panel ${styles.distributionCard}`} style={{ padding: 0, overflow: 'hidden', marginBottom: 'var(--space-md)' }}>
@@ -346,12 +380,14 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                         <StarRating rating={slot.marginStars} label="Margin" tooltipText={`sells 1g of ${state.production[slot.selling]?.name || 'Weed'} for $${(slot.margin * (1 + slot.marginBonus) * (PRODUCT_TIERS[slot.selling] || 1)).toFixed(2)}`} />
                         <span style={{ color: 'var(--accent-primary)', fontSize: '0.85rem' }}>({(1 + slot.marginBonus).toFixed(1)}x)</span>
                       </div>
-                      <div className={styles.statRow}>
-                        <span className={styles.label}>Risk:</span>
-                        <span style={{ color: 'var(--accent-secondary)' }}>
-                          {PRODUCT_ARREST_RISK[slot.selling]?.label ?? 'LOW'} Risk
-                        </span>
-                      </div>
+                      {!slot.isProtected && (
+                        <div className={styles.statRow}>
+                          <span className={styles.label}>Risk:</span>
+                          <span style={{ color: 'var(--accent-secondary)' }}>
+                            {PRODUCT_ARREST_RISK[slot.selling]?.label ?? 'LOW'} Risk
+                          </span>
+                        </div>
+                      )}
                       {slot.isProtected && (
                         <div className={styles.statRow}>
                           <span className={styles.label}>Status:</span>
@@ -365,6 +401,24 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                           <span style={{ color: 'var(--accent-primary)' }}>{(slot.sideVolume * 100).toFixed(1)}%</span>
                         </div>
                       )}
+
+                      <div className={styles.toggleRow}>
+                        <div>
+                          <div className={styles.toggleLabel}>Pay off cops</div>
+                          <div className={styles.toggleHint}>-15% income</div>
+                        </div>
+                        <button
+                          type="button"
+                          className={styles.toggleButton}
+                          aria-label="Pay off cops"
+                          aria-pressed={slot.isProtected}
+                          onClick={() => toggleDealerProtection(slot.id)}
+                        >
+                          <span className={styles.toggleTrack} data-active={slot.isProtected}>
+                            <span className={styles.toggleThumb} data-active={slot.isProtected} />
+                          </span>
+                        </button>
+                      </div>
 
                       <div className={styles.statRow} style={{ marginTop: 'var(--space-xs)', borderTop: '1px solid var(--glass-border)', paddingTop: 'var(--space-xs)' }}>
                         <span className={styles.label}>Earnings:</span>
@@ -384,18 +438,11 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                       <div style={{ marginTop: 'var(--space-sm)', display: 'grid', gap: 'var(--space-xs)' }}>
                         <button
                           className={styles.buyButton}
-                          onClick={() => toggleDealerProtection(slot.id)}
-                          disabled={slot.isArrested}
-                        >
-                          {slot.isProtected ? 'Pay off cops: On (-15%)' : 'Pay off cops: Off'}
-                        </button>
-                        <button
-                          className={styles.buyButton}
-                          disabled={isMaxed || state.money < upgradeCost}
+                          disabled={isMaxed || isInsufficientFunds}
                           onClick={() => {
                             if (isMaxed) return;
-                            const options = generateUpgradeOptions(dealer);
-                            setUpgradingDealer({ dealerId: dealer.id, options });
+                            startDealerUpgrade(dealer.id);
+                            setUpgradingDealerId(dealer.id);
                           }}
                         >
                           {isMaxed ? 'MAXED OUT' : `Upgrade ($${Math.floor(upgradeCost).toLocaleString()})`}
@@ -424,7 +471,7 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
         </section>
       </div>
 
-      {upgradingDealer && (
+      {upgradingDealer?.hasPendingUpgrade && upgradingDealer.pendingUpgradeOptions.length === 3 && (
         <div style={{
           position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
           background: 'rgba(0,0,0,0.85)', display: 'flex', 
@@ -433,7 +480,7 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
           <div className="glass-panel" style={{ padding: 'var(--space-xl)', maxWidth: '500px' }}>
             <h3 className={styles.columnHeader}>Select Equipment</h3>
             <div style={{ display: 'grid', gap: '10px', marginTop: '20px' }}>
-              {upgradingDealer.options.map((opt, i) => (
+              {upgradingDealer.pendingUpgradeOptions.map((opt, i) => (
                 <button 
                   key={i} 
                   className={opt.type === 'SIDE_HUSTLE' ? styles.dangerButton : styles.buyButton}
@@ -442,8 +489,8 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                     boxShadow: '0 0 20px rgba(255, 215, 0, 0.5)'
                   } : {}}
                   onClick={() => {
-                    buyEquipment(upgradingDealer.dealerId, opt);
-                    setUpgradingDealer(null);
+                    buyEquipment(upgradingDealer.id, opt);
+                    setUpgradingDealerId(null);
                   }}
                 >
                   <div style={{ fontWeight: 'bold' }}>{opt.label}</div>
@@ -451,13 +498,6 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                 </button>
               ))}
             </div>
-            <button 
-              className={styles.dangerButton} 
-              style={{ marginTop: '20px', width: '100%' }}
-              onClick={() => setUpgradingDealer(null)}
-            >
-              Cancel
-            </button>
           </div>
         </div>
       )}

--- a/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
+++ b/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useGameEngine } from './hooks/useGameEngine';
 import type { Dealer, DealerUpgrade } from './types';
-import { UNLOCK_COSTS, PRODUCT_TIERS, SLOT_UNLOCK_COSTS } from './constants';
+import { UNLOCK_COSTS, PRODUCT_TIERS, SLOT_UNLOCK_COSTS, PRODUCT_ARREST_RISK } from './constants';
 import { confirm } from '../../hooks/usePrompt';
 import { Tooltip } from '../Tooltip/Tooltip';
 import styles from './NeonD.module.css';
@@ -50,7 +50,20 @@ function getUpgradeName(id: string): string {
 }
 
 export function NeonDGame({ onClose }: { onClose?: () => void }) {
-  const { state, upgrade, unlockProduction, hireDealer, fireDealer, refreshPool, resetGame, unlockSlot, setDealerSelling, buyEquipment } = useGameEngine();
+  const {
+    state,
+    upgrade,
+    unlockProduction,
+    hireDealer,
+    fireDealer,
+    refreshPool,
+    resetGame,
+    unlockSlot,
+    setDealerSelling,
+    buyEquipment,
+    toggleDealerProtection,
+    payDealerBail,
+  } = useGameEngine();
   const [upgradingDealer, setUpgradingDealer] = useState<{ dealerId: string; options: DealerUpgrade[] } | null>(null);
 
   const generateUpgradeOptions = (dealer: Dealer): DealerUpgrade[] => {
@@ -267,6 +280,34 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
               );
             }
             
+            if (slot.isArrested) {
+              return (
+                <div key={slot.id} className={`glass-panel ${styles.distributionCard}`} style={{ padding: 0, overflow: 'hidden', marginBottom: 'var(--space-md)' }}>
+                  <div className={styles.dealerHeader}>
+                    {slot.name} ({state.production[slot.selling]?.name})
+                  </div>
+                  <div style={{ padding: 'var(--space-md)' }}>
+                    <div className={styles.statRow}>
+                      <span className={styles.label}>Status:</span>
+                      <span style={{ color: 'var(--accent-secondary)' }}>Arrested</span>
+                    </div>
+                    <div className={styles.statRow}>
+                      <span className={styles.label}>Earnings:</span>
+                      <span>$0.00/s</span>
+                    </div>
+                    <div style={{ display: 'grid', gap: 'var(--space-xs)', marginTop: 'var(--space-md)' }}>
+                      <button className={styles.buyButton} onClick={() => payDealerBail(slot.id)}>
+                        Pay Bail
+                      </button>
+                      <button className={styles.dangerButton} onClick={() => fireDealer(slot.id)}>
+                        Fire Dealer
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            }
+
             const dealer = slot;
                 const upgradeCost = 500 * Math.pow(2.5, dealer.equipmentCount);
                 const isMaxed = dealer.equipmentCount >= 3;
@@ -305,6 +346,18 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                         <StarRating rating={slot.marginStars} label="Margin" tooltipText={`sells 1g of ${state.production[slot.selling]?.name || 'Weed'} for $${(slot.margin * (1 + slot.marginBonus) * (PRODUCT_TIERS[slot.selling] || 1)).toFixed(2)}`} />
                         <span style={{ color: 'var(--accent-primary)', fontSize: '0.85rem' }}>({(1 + slot.marginBonus).toFixed(1)}x)</span>
                       </div>
+                      <div className={styles.statRow}>
+                        <span className={styles.label}>Risk:</span>
+                        <span style={{ color: 'var(--accent-secondary)' }}>
+                          {PRODUCT_ARREST_RISK[slot.selling]?.label ?? 'LOW'} Risk
+                        </span>
+                      </div>
+                      {slot.isProtected && (
+                        <div className={styles.statRow}>
+                          <span className={styles.label}>Status:</span>
+                          <span style={{ color: 'var(--accent-success)' }}>Protected</span>
+                        </div>
+                      )}
 
                       {slot.sideVolume > 0 && (
                         <div className={styles.statRow}>
@@ -329,6 +382,13 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                       </div>
 
                       <div style={{ marginTop: 'var(--space-sm)', display: 'grid', gap: 'var(--space-xs)' }}>
+                        <button
+                          className={styles.buyButton}
+                          onClick={() => toggleDealerProtection(slot.id)}
+                          disabled={slot.isArrested}
+                        >
+                          {slot.isProtected ? 'Pay off cops: On (-15%)' : 'Pay off cops: Off'}
+                        </button>
                         <button
                           className={styles.buyButton}
                           disabled={isMaxed || state.money < upgradeCost}

--- a/src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+++ b/src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
@@ -1,97 +1,74 @@
 import { render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, vi } from 'vitest';
 import { NeonDGame } from '../NeonDGame';
 
-vi.mock('../hooks/useGameEngine', () => ({
-  useGameEngine: () => ({
-    state: {
-      money: 10_000,
-      totalEarned: 0,
-      researchSpeed: 1,
-      production: {
-        weed: { id: 'weed', name: 'Weed', stock: 100, rate: 1, yieldPerLevel: 0.2, costMultiplier: 1.12, level: 1, upgradeCost: 16 },
-      },
-      unlockedProduction: ['weed'],
-      activeDealers: [{
-        id: 'dealer-ui',
-        name: 'Test Dealer',
-        selling: 'weed',
-        volume: 1,
-        margin: 10,
-        volumeBonus: 0,
-        marginBonus: 0,
-        sideVolume: 0,
-        equipmentCount: 0,
-        baseVolumeGps: 1,
-        baseMarginMult: 10,
-        volumeStars: 3,
-        marginStars: 3,
-        isProtected: true,
-        isArrested: false,
-        nextArrestCheckAt: Date.now() + 60_000,
-      }],
-      availableDealers: [],
-      unlockedSlots: 1,
-      lastRefreshTime: 0,
-      lastEarningsPerDealer: { 'dealer-ui': 8.5 },
+const mockNeonD = vi.hoisted(() => {
+  const buyEquipmentMock = vi.fn();
+  const startDealerUpgradeMock = vi.fn();
+  const dealerUpgradeOptions = [
+    { type: 'VOLUME', label: 'Armed Gang', description: 'Volume +15%', value: 0.15 },
+    { type: 'MARGIN', label: 'Ferrari', description: 'Margin +15%', value: 0.15 },
+    { type: 'SIDE_HUSTLE', label: 'JACKPOT: Side Hustle', description: 'Add 10% side volume bleed', value: 0.1, sideVolumeValue: 0.1 },
+  ] as const;
+
+  const createDealer = (overrides: Record<string, unknown> = {}) => ({
+    id: 'dealer-ui',
+    name: 'Test Dealer',
+    selling: 'weed',
+    volume: 1,
+    margin: 10,
+    volumeBonus: 0,
+    marginBonus: 0,
+    sideVolume: 0,
+    equipmentCount: 0,
+    baseVolumeGps: 1,
+    baseMarginMult: 10,
+    volumeStars: 3,
+    marginStars: 3,
+    isProtected: true,
+    isArrested: false,
+    nextArrestCheckAt: Date.now() + 60_000,
+    hasPendingUpgrade: true,
+    pendingUpgradeOptions: dealerUpgradeOptions,
+    ...overrides,
+  });
+
+  const createState = (overrides: Record<string, unknown> = {}) => ({
+    money: 10_000,
+    totalEarned: 0,
+    researchSpeed: 1,
+    production: {
+      weed: { id: 'weed', name: 'Weed', stock: 100, rate: 1, yieldPerLevel: 0.2, costMultiplier: 1.12, level: 1, upgradeCost: 16 },
     },
-    upgrade: vi.fn(),
-    unlockProduction: vi.fn(),
-    hireDealer: vi.fn(),
-    fireDealer: vi.fn(),
-    refreshPool: vi.fn(),
-    resetGame: vi.fn(),
-    unlockSlot: vi.fn(),
-    setDealerSelling: vi.fn(),
-    buyEquipment: vi.fn(),
-    toggleDealerProtection: vi.fn(),
-    payDealerBail: vi.fn(),
-    forceArrestDealer: vi.fn(),
-  }),
-}));
+    unlockedProduction: ['weed'],
+    activeDealers: [createDealer()],
+    availableDealers: [],
+    unlockedSlots: 1,
+    lastRefreshTime: 0,
+    lastEarningsPerDealer: { 'dealer-ui': 8.5 },
+    ...overrides,
+  });
 
-it('shows protection state and risk label on an active dealer card', () => {
-  render(<NeonDGame />);
-  expect(screen.getByText(/protected/i)).toBeInTheDocument();
-  expect(screen.getByText(/low risk/i)).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /pay off cops/i })).toBeInTheDocument();
-});
+  let state = createState();
 
-it('shows bail and fire actions for arrested dealers', async () => {
-  vi.resetModules();
-  vi.doMock('../hooks/useGameEngine', () => ({
+  return {
+    buyEquipmentMock,
+    startDealerUpgradeMock,
+    dealerUpgradeOptions,
+    createDealer,
+    createState,
+    getState: () => state,
+    setState: (nextState: ReturnType<typeof createState>) => {
+      state = nextState;
+    },
+    reset: () => {
+      state = createState();
+      buyEquipmentMock.mockReset();
+      startDealerUpgradeMock.mockReset();
+    },
     useGameEngine: () => ({
-      state: {
-        money: 10_000,
-        totalEarned: 0,
-        researchSpeed: 1,
-        production: {
-          weed: { id: 'weed', name: 'Weed', stock: 100, rate: 1, yieldPerLevel: 0.2, costMultiplier: 1.12, level: 1, upgradeCost: 16 },
-        },
-        unlockedProduction: ['weed'],
-        activeDealers: [{
-          id: 'dealer-arrested',
-          name: 'Arrested Dealer',
-          selling: 'weed',
-          volume: 1,
-          margin: 10,
-          volumeBonus: 0,
-          marginBonus: 0,
-          sideVolume: 0,
-          equipmentCount: 1,
-          baseVolumeGps: 1,
-          baseMarginMult: 10,
-          volumeStars: 3,
-          marginStars: 3,
-          isProtected: false,
-          isArrested: true,
-          nextArrestCheckAt: Date.now() + 60_000,
-        }],
-        availableDealers: [],
-        unlockedSlots: 1,
-        lastRefreshTime: 0,
-        lastEarningsPerDealer: { 'dealer-arrested': 0 },
-      },
+      state,
       upgrade: vi.fn(),
       unlockProduction: vi.fn(),
       hireDealer: vi.fn(),
@@ -100,19 +77,148 @@ it('shows bail and fire actions for arrested dealers', async () => {
       resetGame: vi.fn(),
       unlockSlot: vi.fn(),
       setDealerSelling: vi.fn(),
-      buyEquipment: vi.fn(),
+      startDealerUpgrade: startDealerUpgradeMock,
+      buyEquipment: buyEquipmentMock,
       toggleDealerProtection: vi.fn(),
       payDealerBail: vi.fn(),
       forceArrestDealer: vi.fn(),
     }),
-  }));
+  };
+});
 
-  const { NeonDGame: ArrestedNeonDGame } = await import('../NeonDGame');
-  render(<ArrestedNeonDGame />);
+vi.mock('../hooks/useGameEngine', () => ({
+  useGameEngine: () => mockNeonD.useGameEngine(),
+}));
+
+beforeEach(() => {
+  mockNeonD.reset();
+});
+
+it('shows protection state and risk label on an active dealer card', () => {
+  render(<NeonDGame />);
+
+  expect(screen.getByText(/protected/i)).toBeInTheDocument();
+  expect(screen.queryByText(/low risk/i)).not.toBeInTheDocument();
+  expect(screen.getByText(/-15% income/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /pay off cops/i })).toBeInTheDocument();
+  expect(screen.getByLabelText(/production and dealer sales are balanced/i)).toBeInTheDocument();
+});
+
+it('reopens stored dealer upgrade options without rerolling and uses the engine flow', async () => {
+  const user = userEvent.setup();
+  const { rerender } = render(<NeonDGame />);
+
+  await user.click(screen.getByRole('button', { name: /upgrade/i }));
+
+  expect(mockNeonD.startDealerUpgradeMock).toHaveBeenCalledWith('dealer-ui');
+  expect(screen.getByText(/select equipment/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /armed gang/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /ferrari/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /jackpot: side hustle/i })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+
+  mockNeonD.setState(
+    mockNeonD.createState({
+      activeDealers: [mockNeonD.createDealer({ hasPendingUpgrade: false, pendingUpgradeOptions: [] })],
+    }),
+  );
+  rerender(<NeonDGame />);
+  expect(screen.queryByText(/select equipment/i)).not.toBeInTheDocument();
+
+  mockNeonD.setState(
+    mockNeonD.createState({
+      activeDealers: [mockNeonD.createDealer()],
+    }),
+  );
+  rerender(<NeonDGame />);
+
+  await user.click(screen.getByRole('button', { name: /upgrade/i }));
+
+  expect(screen.getByRole('button', { name: /armed gang/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /ferrari/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /jackpot: side hustle/i })).toBeInTheDocument();
+});
+
+it('allows reopening stored dealer upgrade options even when current money is below the normal upgrade cost', async () => {
+  const user = userEvent.setup();
+
+  mockNeonD.setState(
+    mockNeonD.createState({
+      money: 100,
+      activeDealers: [
+        mockNeonD.createDealer({
+          hasPendingUpgrade: true,
+          pendingUpgradeOptions: mockNeonD.dealerUpgradeOptions,
+        }),
+      ],
+    }),
+  );
+
+  render(<NeonDGame />);
+
+  await user.click(screen.getByRole('button', { name: /upgrade/i }));
+
+  expect(mockNeonD.startDealerUpgradeMock).toHaveBeenCalledWith('dealer-ui');
+  expect(screen.getByText(/select equipment/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /armed gang/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /ferrari/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /jackpot: side hustle/i })).toBeInTheDocument();
+});
+
+it('closes the modal when pending state is consumed', async () => {
+  const user = userEvent.setup();
+  const { rerender } = render(<NeonDGame />);
+
+  await user.click(screen.getByRole('button', { name: /upgrade/i }));
+  expect(screen.getByText(/select equipment/i)).toBeInTheDocument();
+
+  mockNeonD.setState(
+    mockNeonD.createState({
+      activeDealers: [mockNeonD.createDealer({ hasPendingUpgrade: false, pendingUpgradeOptions: [] })],
+    }),
+  );
+  rerender(<NeonDGame />);
+
+  expect(screen.queryByText(/select equipment/i)).not.toBeInTheDocument();
+});
+
+it('closes the modal when the dealer disappears', async () => {
+  const user = userEvent.setup();
+  const { rerender } = render(<NeonDGame />);
+
+  await user.click(screen.getByRole('button', { name: /upgrade/i }));
+  expect(screen.getByText(/select equipment/i)).toBeInTheDocument();
+
+  mockNeonD.setState(
+    mockNeonD.createState({
+      activeDealers: [null],
+    }),
+  );
+  rerender(<NeonDGame />);
+
+  expect(screen.queryByText(/select equipment/i)).not.toBeInTheDocument();
+});
+
+it('shows bail and fire actions for arrested dealers', () => {
+  mockNeonD.setState(
+    mockNeonD.createState({
+      lastEarningsPerDealer: { 'dealer-arrested': 20 },
+      activeDealers: [
+        mockNeonD.createDealer({
+          id: 'dealer-arrested',
+          name: 'Arrested Dealer',
+          isProtected: false,
+          isArrested: true,
+          hasPendingUpgrade: false,
+          pendingUpgradeOptions: [],
+        }),
+      ],
+    }),
+  );
+
+  render(<NeonDGame />);
 
   expect(screen.getAllByText(/arrested/i).length).toBeGreaterThan(0);
-  expect(screen.getByRole('button', { name: /pay bail/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /pay bail \(\$900\)/i })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /fire dealer/i })).toBeInTheDocument();
-  vi.resetModules();
-  vi.doUnmock('../hooks/useGameEngine');
 });

--- a/src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+++ b/src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { NeonDGame } from '../NeonDGame';
+
+vi.mock('../hooks/useGameEngine', () => ({
+  useGameEngine: () => ({
+    state: {
+      money: 10_000,
+      totalEarned: 0,
+      researchSpeed: 1,
+      production: {
+        weed: { id: 'weed', name: 'Weed', stock: 100, rate: 1, yieldPerLevel: 0.2, costMultiplier: 1.12, level: 1, upgradeCost: 16 },
+      },
+      unlockedProduction: ['weed'],
+      activeDealers: [{
+        id: 'dealer-ui',
+        name: 'Test Dealer',
+        selling: 'weed',
+        volume: 1,
+        margin: 10,
+        volumeBonus: 0,
+        marginBonus: 0,
+        sideVolume: 0,
+        equipmentCount: 0,
+        baseVolumeGps: 1,
+        baseMarginMult: 10,
+        volumeStars: 3,
+        marginStars: 3,
+        isProtected: true,
+        isArrested: false,
+        nextArrestCheckAt: Date.now() + 60_000,
+      }],
+      availableDealers: [],
+      unlockedSlots: 1,
+      lastRefreshTime: 0,
+      lastEarningsPerDealer: { 'dealer-ui': 8.5 },
+    },
+    upgrade: vi.fn(),
+    unlockProduction: vi.fn(),
+    hireDealer: vi.fn(),
+    fireDealer: vi.fn(),
+    refreshPool: vi.fn(),
+    resetGame: vi.fn(),
+    unlockSlot: vi.fn(),
+    setDealerSelling: vi.fn(),
+    buyEquipment: vi.fn(),
+    toggleDealerProtection: vi.fn(),
+    payDealerBail: vi.fn(),
+    forceArrestDealer: vi.fn(),
+  }),
+}));
+
+it('shows protection state and risk label on an active dealer card', () => {
+  render(<NeonDGame />);
+  expect(screen.getByText(/protected/i)).toBeInTheDocument();
+  expect(screen.getByText(/low risk/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /pay off cops/i })).toBeInTheDocument();
+});
+
+it('shows bail and fire actions for arrested dealers', async () => {
+  vi.resetModules();
+  vi.doMock('../hooks/useGameEngine', () => ({
+    useGameEngine: () => ({
+      state: {
+        money: 10_000,
+        totalEarned: 0,
+        researchSpeed: 1,
+        production: {
+          weed: { id: 'weed', name: 'Weed', stock: 100, rate: 1, yieldPerLevel: 0.2, costMultiplier: 1.12, level: 1, upgradeCost: 16 },
+        },
+        unlockedProduction: ['weed'],
+        activeDealers: [{
+          id: 'dealer-arrested',
+          name: 'Arrested Dealer',
+          selling: 'weed',
+          volume: 1,
+          margin: 10,
+          volumeBonus: 0,
+          marginBonus: 0,
+          sideVolume: 0,
+          equipmentCount: 1,
+          baseVolumeGps: 1,
+          baseMarginMult: 10,
+          volumeStars: 3,
+          marginStars: 3,
+          isProtected: false,
+          isArrested: true,
+          nextArrestCheckAt: Date.now() + 60_000,
+        }],
+        availableDealers: [],
+        unlockedSlots: 1,
+        lastRefreshTime: 0,
+        lastEarningsPerDealer: { 'dealer-arrested': 0 },
+      },
+      upgrade: vi.fn(),
+      unlockProduction: vi.fn(),
+      hireDealer: vi.fn(),
+      fireDealer: vi.fn(),
+      refreshPool: vi.fn(),
+      resetGame: vi.fn(),
+      unlockSlot: vi.fn(),
+      setDealerSelling: vi.fn(),
+      buyEquipment: vi.fn(),
+      toggleDealerProtection: vi.fn(),
+      payDealerBail: vi.fn(),
+      forceArrestDealer: vi.fn(),
+    }),
+  }));
+
+  const { NeonDGame: ArrestedNeonDGame } = await import('../NeonDGame');
+  render(<ArrestedNeonDGame />);
+
+  expect(screen.getAllByText(/arrested/i).length).toBeGreaterThan(0);
+  expect(screen.getByRole('button', { name: /pay bail/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /fire dealer/i })).toBeInTheDocument();
+  vi.resetModules();
+  vi.doUnmock('../hooks/useGameEngine');
+});

--- a/src/Brmble.Web/src/components/NeonD/constants.ts
+++ b/src/Brmble.Web/src/components/NeonD/constants.ts
@@ -422,3 +422,34 @@ export const SLOT_UNLOCK_COSTS = [0, 1000, 100000]; // Slot 0 is free, 1 is $1k,
 
 export const DEALER_FIRST_NAMES = ['Thomas', 'Dutch', 'Belgian', 'Chemist', 'Slick', 'Vito', 'Snake', 'Mick', 'Jack', 'Dave', 'Miller', 'Bob', 'Ghost'];
 export const DEALER_LAST_NAMES = ['Palmer', 'Dave', 'Bob', 'Carlos', 'Snake', 'Miller', 'The Fixer', 'The Ghost', 'Slick'];
+
+export const DEALER_PROTECTION_INCOME_MULTIPLIER = 0.85;
+
+export const ARREST_CHECK_INTERVAL_MS = {
+  min: 300_000,
+  max: 600_000,
+} as const;
+
+export const BAIL_BASE_FLOOR = 500;
+export const BAIL_INCOME_MULTIPLIER = 45;
+
+export const PRODUCT_ARREST_RISK: Record<string, { chance: number; label: 'LOW' | 'MEDIUM' | 'HIGH' }> = {
+  weed: { chance: 0.10, label: 'LOW' },
+  mushrooms: { chance: 0.12, label: 'LOW' },
+  blueLotus: { chance: 0.15, label: 'MEDIUM' },
+  frostBite: { chance: 0.17, label: 'MEDIUM' },
+  electricLace: { chance: 0.20, label: 'MEDIUM' },
+  meth: { chance: 0.25, label: 'HIGH' },
+  pharmGrade: { chance: 0.28, label: 'HIGH' },
+  khole: { chance: 0.30, label: 'HIGH' },
+  lunarRegolith: { chance: 0.33, label: 'HIGH' },
+  martianSpores: { chance: 0.36, label: 'HIGH' },
+  nebulaMist: { chance: 0.40, label: 'HIGH' },
+  voidCrystals: { chance: 0.45, label: 'HIGH' },
+  chronoSalt: { chance: 0.50, label: 'HIGH' },
+  stardustResin: { chance: 0.55, label: 'HIGH' },
+  darkMatterInk: { chance: 0.60, label: 'HIGH' },
+  singularityShards: { chance: 0.65, label: 'HIGH' },
+  neutronFlakes: { chance: 0.70, label: 'HIGH' },
+  galacticCore: { chance: 0.75, label: 'HIGH' },
+};

--- a/src/Brmble.Web/src/components/NeonD/economy.ts
+++ b/src/Brmble.Web/src/components/NeonD/economy.ts
@@ -1,0 +1,7 @@
+import { BAIL_BASE_FLOOR, BAIL_INCOME_MULTIPLIER } from './constants';
+
+export const getCurrentTotalIncomePerSecond = (earnings: Record<string, number>) =>
+  Object.values(earnings).reduce((sum, value) => sum + value, 0);
+
+export const getBailCost = (earnings: Record<string, number>) =>
+  Math.max(BAIL_BASE_FLOOR, getCurrentTotalIncomePerSecond(earnings) * BAIL_INCOME_MULTIPLIER);

--- a/src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useGameEngine } from '../useGameEngine';
 import type { Dealer } from '../../types';
+type GameEngineState = ReturnType<typeof useGameEngine>;
 
 const makeDealer = (overrides: Partial<Dealer> = {}): Dealer => ({
   id: 'test-dealer',
@@ -20,6 +21,8 @@ const makeDealer = (overrides: Partial<Dealer> = {}): Dealer => ({
   isProtected: false,
   isArrested: false,
   nextArrestCheckAt: Date.now() + 300000,
+  hasPendingUpgrade: false,
+  pendingUpgradeOptions: [],
   ...overrides,
 });
 
@@ -39,13 +42,40 @@ const setupWithMoney = () => {
   return hook;
 };
 
+const mockDealerUpgradeRolls = (values: number[]) => {
+  const sequence = [...values];
+  return vi.spyOn(Math, 'random').mockImplementation(() => {
+    const next = sequence.shift();
+    if (next === undefined) {
+      throw new Error('Unexpected Math.random call while generating dealer upgrades');
+    }
+    return next;
+  });
+};
+
+const startPendingDealerUpgrade = (
+  result: { current: GameEngineState },
+  rolls: number[],
+  dealerId = 'test-dealer'
+) => {
+  const randomSpy = mockDealerUpgradeRolls(rolls);
+  act(() => {
+    result.current.startDealerUpgrade(dealerId);
+  });
+  randomSpy.mockRestore();
+  return result.current.state.activeDealers[0];
+};
+
 describe('useGameEngine', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    localStorage.clear();
   });
 
   afterEach(() => {
+    localStorage.clear();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('newly hired dealers start unprotected, unarrested, and with a scheduled risk check', () => {
@@ -180,54 +210,74 @@ describe('useGameEngine', () => {
   });
 
   describe('equipment upgrades', () => {
-    it('VOLUME upgrade increases volumeBonus', () => {
+    it('starting a dealer upgrade charges once and stores 3 pending options', () => {
       const { result } = setupWithMoney();
-      const before = result.current.state.activeDealers[0]!.volumeBonus;
-      act(() => {
-        result.current.buyEquipment('test-dealer', { type: 'VOLUME', label: 'HC', description: '', value: 0.15 });
-      });
-      expect(result.current.state.activeDealers[0]?.volumeBonus).toBeCloseTo(before + 0.15, 5);
+      const moneyBefore = result.current.state.money;
+
+      const dealer = startPendingDealerUpgrade(result, [0.5, 0, 0.5, 0, 0.5, 0]);
+
+      expect(result.current.state.money).toBeCloseTo(moneyBefore - 500, 1);
+      expect(dealer?.hasPendingUpgrade).toBe(true);
+      expect(dealer?.pendingUpgradeOptions).toHaveLength(3);
     });
 
-    it('MARGIN upgrade increases marginBonus', () => {
+    it('calling startDealerUpgrade again with an existing pending roll does not charge twice and keeps same options', () => {
       const { result } = setupWithMoney();
-      const before = result.current.state.activeDealers[0]!.marginBonus;
-      act(() => {
-        result.current.buyEquipment('test-dealer', { type: 'MARGIN', label: 'PC', description: '', value: 0.15 });
-      });
-      expect(result.current.state.activeDealers[0]?.marginBonus).toBeCloseTo(before + 0.15, 5);
+
+      const firstDealer = startPendingDealerUpgrade(result, [0.5, 0, 0.5, 0, 0.5, 0]);
+      const moneyAfterFirstRoll = result.current.state.money;
+      const firstOptions = firstDealer?.pendingUpgradeOptions ?? [];
+
+      const secondDealer = startPendingDealerUpgrade(result, [0.5, 1 / 3, 0.5, 1 / 3, 0.5, 1 / 3]);
+
+      expect(result.current.state.money).toBeCloseTo(moneyAfterFirstRoll, 1);
+      expect(secondDealer?.pendingUpgradeOptions).toEqual(firstOptions);
     });
 
-    it('BULK upgrade increases volumeBonus and reduces marginBonus', () => {
+    it('buyEquipment applies a chosen pending option and clears pending state', () => {
       const { result } = setupWithMoney();
-      const volBefore = result.current.state.activeDealers[0]!.volumeBonus;
-      const margBefore = result.current.state.activeDealers[0]!.marginBonus;
+      const dealerBefore = result.current.state.activeDealers[0]!;
+      const volumeBefore = dealerBefore.volumeBonus;
+
+      const dealer = startPendingDealerUpgrade(result, [0.5, 0, 0.5, 1 / 3, 0.5, 2 / 3])!;
+      const chosenUpgrade = dealer.pendingUpgradeOptions.find(option => option.type === 'VOLUME') ?? dealer.pendingUpgradeOptions[0];
+
       act(() => {
-        result.current.buyEquipment('test-dealer', { type: 'BULK', label: 'BS', description: '', value: 0.35, marginPenalty: 0.1 });
+        result.current.buyEquipment('test-dealer', chosenUpgrade);
       });
-      const d = result.current.state.activeDealers[0];
-      expect(d?.volumeBonus).toBeCloseTo(volBefore + 0.35, 5);
-      expect(d?.marginBonus).toBeCloseTo(margBefore - 0.1, 5);
+
+      const updatedDealer = result.current.state.activeDealers[0];
+      expect(updatedDealer?.volumeBonus).toBeCloseTo(volumeBefore + chosenUpgrade.value, 5);
+      expect(updatedDealer?.equipmentCount).toBe(dealerBefore.equipmentCount + 1);
+      expect(updatedDealer?.hasPendingUpgrade).toBe(false);
+      expect(updatedDealer?.pendingUpgradeOptions).toEqual([]);
     });
 
-    it('ALL_AROUNDER upgrade increases both volumeBonus and marginBonus', () => {
+    it('fireDealer after a pending roll leaves the slot null', () => {
       const { result } = setupWithMoney();
-      const volBefore = result.current.state.activeDealers[0]!.volumeBonus;
-      const margBefore = result.current.state.activeDealers[0]!.marginBonus;
+
+      startPendingDealerUpgrade(result, [0.5, 0, 0.5, 0, 0.5, 0]);
+
       act(() => {
-        result.current.buyEquipment('test-dealer', { type: 'ALL_AROUNDER', label: 'PE', description: '', value: 0.05 });
+        result.current.fireDealer('test-dealer');
       });
-      const d = result.current.state.activeDealers[0];
-      expect(d?.volumeBonus).toBeCloseTo(volBefore + 0.05, 5);
-      expect(d?.marginBonus).toBeCloseTo(margBefore + 0.05, 5);
+
+      expect(result.current.state.activeDealers[0]).toBeNull();
     });
 
-    it('SIDE_HUSTLE upgrade adds sideVolume', () => {
+    it('startDealerUpgrade deducts the correct cost and buyEquipment does not charge again', () => {
       const { result } = setupWithMoney();
+      const moneyBefore = result.current.state.money;
+
+      const dealer = startPendingDealerUpgrade(result, [0.5, 0, 0.5, 0, 0.5, 0])!;
+      expect(result.current.state.money).toBeCloseTo(moneyBefore - 500, 1);
+
+      const moneyAfterRoll = result.current.state.money;
       act(() => {
-        result.current.buyEquipment('test-dealer', { type: 'SIDE_HUSTLE', label: 'SH', description: '', value: 0.1, sideVolumeValue: 0.1 });
+        result.current.buyEquipment('test-dealer', dealer.pendingUpgradeOptions[0]);
       });
-      expect(result.current.state.activeDealers[0]?.sideVolume).toBeCloseTo(0.2, 5);
+
+      expect(result.current.state.money).toBeCloseTo(moneyAfterRoll, 1);
     });
 
     it('equipment slots are capped at 3', () => {
@@ -239,20 +289,73 @@ describe('useGameEngine', () => {
       });
       act(() => { vi.advanceTimersByTime(50000); });
       act(() => {
-        result.current.buyEquipment('test-dealer', { type: 'VOLUME', label: 'HC', description: '', value: 0.15 });
+        result.current.startDealerUpgrade('test-dealer');
       });
       // equipmentCount must remain 3 (maxed)
       expect(result.current.state.activeDealers[0]?.equipmentCount).toBe(3);
     });
 
-    it('buyEquipment deducts the correct cost', () => {
+    it('VOLUME upgrade increases volumeBonus', () => {
       const { result } = setupWithMoney();
-      const moneyBefore = result.current.state.money;
-      const expectedCost = 500 * Math.pow(2.5, 0); // equipmentCount=0 → $500
+      const dealer = startPendingDealerUpgrade(result, [0.5, 0, 0.5, 0, 0.5, 0])!;
+      const before = result.current.state.activeDealers[0]!.volumeBonus;
+      const upgrade = dealer.pendingUpgradeOptions.find(option => option.type === 'VOLUME')!;
       act(() => {
-        result.current.buyEquipment('test-dealer', { type: 'VOLUME', label: 'HC', description: '', value: 0.15 });
+        result.current.buyEquipment('test-dealer', upgrade);
       });
-      expect(result.current.state.money).toBeCloseTo(moneyBefore - expectedCost, 1);
+      expect(result.current.state.activeDealers[0]?.volumeBonus).toBeCloseTo(before + 0.15, 5);
+    });
+
+    it('MARGIN upgrade increases marginBonus', () => {
+      const { result } = setupWithMoney();
+      const dealer = startPendingDealerUpgrade(result, [0.5, 1 / 3, 0.5, 1 / 3, 0.5, 1 / 3])!;
+      const before = result.current.state.activeDealers[0]!.marginBonus;
+      const upgrade = dealer.pendingUpgradeOptions.find(option => option.type === 'MARGIN')!;
+      act(() => {
+        result.current.buyEquipment('test-dealer', upgrade);
+      });
+      expect(result.current.state.activeDealers[0]?.marginBonus).toBeCloseTo(before + 0.15, 5);
+    });
+
+    it('BULK upgrade increases volumeBonus and reduces marginBonus', () => {
+      const { result } = setupWithMoney();
+      const dealer = startPendingDealerUpgrade(result, [0.2, 0, 0.5, 0, 0.5, 0])!;
+      const volBefore = result.current.state.activeDealers[0]!.volumeBonus;
+      const margBefore = result.current.state.activeDealers[0]!.marginBonus;
+      const upgrade = dealer.pendingUpgradeOptions.find(option => option.type === 'BULK')!;
+      act(() => {
+        result.current.buyEquipment('test-dealer', upgrade);
+      });
+      const d = result.current.state.activeDealers[0];
+      expect(d?.volumeBonus).toBeCloseTo(volBefore + 0.35, 5);
+      expect(d?.marginBonus).toBeCloseTo(margBefore - 0.1, 5);
+    });
+
+    it('ALL_AROUNDER upgrade increases both volumeBonus and marginBonus', () => {
+      const { result } = setupWithMoney();
+      const dealer = startPendingDealerUpgrade(result, [0.5, 2 / 3, 0.5, 2 / 3, 0.5, 2 / 3])!;
+      const volBefore = result.current.state.activeDealers[0]!.volumeBonus;
+      const margBefore = result.current.state.activeDealers[0]!.marginBonus;
+      const upgrade = dealer.pendingUpgradeOptions.find(option => option.type === 'ALL_AROUNDER')!;
+      act(() => {
+        result.current.buyEquipment('test-dealer', upgrade);
+      });
+      const d = result.current.state.activeDealers[0];
+      expect(d?.volumeBonus).toBeCloseTo(volBefore + 0.05, 5);
+      expect(d?.marginBonus).toBeCloseTo(margBefore + 0.05, 5);
+    });
+
+    it('SIDE_HUSTLE upgrade adds sideVolume', () => {
+      const { result } = setupWithMoney();
+      act(() => {
+        result.current.unlockProduction('mushrooms');
+      });
+      const dealer = startPendingDealerUpgrade(result, [0.05, 0.5, 0, 0.5, 0, 0.5, 0])!;
+      const upgrade = dealer.pendingUpgradeOptions.find(option => option.type === 'SIDE_HUSTLE')!;
+      act(() => {
+        result.current.buyEquipment('test-dealer', upgrade);
+      });
+      expect(result.current.state.activeDealers[0]?.sideVolume).toBeCloseTo(0.2, 5);
     });
   });
 
@@ -262,6 +365,7 @@ describe('useGameEngine', () => {
       act(() => {
         result.current.unlockProduction('weed');
         result.current.upgrade('weed');
+        result.current.unlockProduction('mushrooms');
         // Dealer with extreme volume and side hustle
         result.current.hireDealer(makeDealer({ volume: 1000, sideVolume: 0.5 }), 0);
       });
@@ -429,5 +533,63 @@ describe('useGameEngine', () => {
     expect(dealer?.isProtected).toBe(false);
     expect(dealer?.isArrested).toBe(false);
     expect(typeof dealer?.nextArrestCheckAt).toBe('number');
+  });
+
+  it('restores older saves by filling in missing pending dealer upgrade fields', () => {
+    localStorage.setItem('brmble_neon_d_save', JSON.stringify({
+      activeDealers: [{
+        id: 'legacy',
+        name: 'Legacy Dealer',
+        selling: 'weed',
+        volume: 1,
+        margin: 1,
+        volumeBonus: 0,
+        marginBonus: 0,
+        sideVolume: 0,
+        equipmentCount: 0,
+        baseVolumeGps: 1,
+        baseMarginMult: 1,
+        volumeStars: 1,
+        marginStars: 1,
+        isProtected: false,
+        isArrested: false,
+        nextArrestCheckAt: Date.now() + 10_000,
+      }],
+    }));
+
+    const { result } = renderHook(() => useGameEngine());
+    const dealer = result.current.state.activeDealers[0];
+
+    expect(dealer?.hasPendingUpgrade).toBe(false);
+    expect(dealer?.pendingUpgradeOptions).toEqual([]);
+  });
+
+  it('restores older saves by filling in missing pending upgrade fields on available dealers', () => {
+    localStorage.setItem('brmble_neon_d_save', JSON.stringify({
+      availableDealers: [{
+        id: 'available-legacy',
+        name: 'Available Legacy Dealer',
+        selling: 'weed',
+        volume: 1,
+        margin: 1,
+        volumeBonus: 0,
+        marginBonus: 0,
+        sideVolume: 0,
+        equipmentCount: 0,
+        baseVolumeGps: 1,
+        baseMarginMult: 1,
+        volumeStars: 1,
+        marginStars: 1,
+        isProtected: false,
+        isArrested: false,
+        nextArrestCheckAt: Date.now() + 10_000,
+      }],
+    }));
+
+    const { result } = renderHook(() => useGameEngine());
+    const dealer = result.current.state.availableDealers[0];
+
+    expect(dealer?.hasPendingUpgrade).toBe(false);
+    expect(dealer?.pendingUpgradeOptions).toEqual([]);
   });
 });

--- a/src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
@@ -17,6 +17,9 @@ const makeDealer = (overrides: Partial<Dealer> = {}): Dealer => ({
   baseMarginMult: 1,
   volumeStars: 3,
   marginStars: 3,
+  isProtected: false,
+  isArrested: false,
+  nextArrestCheckAt: Date.now() + 300000,
   ...overrides,
 });
 
@@ -43,6 +46,20 @@ describe('useGameEngine', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('newly hired dealers start unprotected, unarrested, and with a scheduled risk check', () => {
+    const { result } = renderHook(() => useGameEngine());
+
+    act(() => {
+      result.current.hireDealer(makeDealer({ id: 'dealer-state' }), 0);
+    });
+
+    const dealer = result.current.state.activeDealers[0];
+    expect(dealer?.isProtected).toBe(false);
+    expect(dealer?.isArrested).toBe(false);
+    expect(typeof dealer?.nextArrestCheckAt).toBe('number');
+    expect((dealer?.nextArrestCheckAt ?? 0)).toBeGreaterThan(Date.now());
   });
 
   it('should update production without dealer', async () => {
@@ -281,5 +298,136 @@ describe('useGameEngine', () => {
       // Mushrooms is sold as side hustle; stock should not go below zero
       expect(result.current.state.production.mushrooms.stock).toBeGreaterThanOrEqual(0);
     });
+  });
+
+  it('protected dealers earn 15 percent less than unprotected dealers', () => {
+    const { result } = renderHook(() => useGameEngine());
+
+    act(() => {
+      result.current.upgrade('weed');
+      result.current.hireDealer(makeDealer({ id: 'protected-check', margin: 10, volume: 1, sideVolume: 0 }), 0);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    const baseline = result.current.state.lastEarningsPerDealer['protected-check'];
+
+    act(() => {
+      result.current.toggleDealerProtection('protected-check');
+      vi.advanceTimersByTime(1_000);
+    });
+
+    const protectedIncome = result.current.state.lastEarningsPerDealer['protected-check'];
+    expect(protectedIncome).toBeCloseTo(baseline * 0.85, 5);
+  });
+
+  it('arrested dealers generate zero earnings per tick', () => {
+    const { result } = renderHook(() => useGameEngine());
+
+    act(() => {
+      result.current.upgrade('weed');
+      result.current.hireDealer(makeDealer({ id: 'arrested-check', isArrested: true, nextArrestCheckAt: Date.now() + 999999 }), 0);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(result.current.state.lastEarningsPerDealer['arrested-check']).toBe(0);
+  });
+
+  it('unprotected dealers use current product risk when the arrest timer expires', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const { result } = renderHook(() => useGameEngine());
+    act(() => {
+      result.current.hireDealer(makeDealer({
+        id: 'risk-check',
+        selling: 'meth',
+        isProtected: false,
+        isArrested: false,
+        nextArrestCheckAt: Date.now() - 1,
+      }), 0);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(result.current.state.activeDealers[0]?.isArrested).toBe(true);
+  });
+
+  it('protected dealers never get arrested when the timer expires', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const { result } = renderHook(() => useGameEngine());
+    act(() => {
+      result.current.hireDealer(makeDealer({
+        id: 'safe-check',
+        selling: 'meth',
+        isProtected: true,
+        isArrested: false,
+        nextArrestCheckAt: Date.now() - 1,
+      }), 0);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(result.current.state.activeDealers[0]?.isArrested).toBe(false);
+  });
+
+  it('payBail uses current total income per second with a minimum floor', () => {
+    const { result } = setupWithMoney();
+    act(() => {
+      result.current.upgrade('weed');
+      result.current.hireDealer(makeDealer({ id: 'earner', margin: 1, volume: 1, sideVolume: 0 }), 0);
+      vi.advanceTimersByTime(1_000);
+    });
+
+    const dealerIncome = result.current.state.lastEarningsPerDealer['earner'];
+    const expectedCost = Math.max(500, dealerIncome * 45);
+
+    act(() => {
+      result.current.forceArrestDealer('earner');
+    });
+
+    const moneyBefore = result.current.state.money;
+    act(() => {
+      result.current.payDealerBail('earner');
+    });
+
+    expect(result.current.state.money).toBeCloseTo(moneyBefore - expectedCost, 5);
+    expect(result.current.state.activeDealers[0]?.isArrested).toBe(false);
+    expect(result.current.state.activeDealers[0]?.isProtected).toBe(false);
+  });
+
+  it('restores older saves by filling in missing dealer risk fields', () => {
+    localStorage.setItem('brmble_neon_d_save', JSON.stringify({
+      activeDealers: [{
+        id: 'legacy',
+        name: 'Legacy Dealer',
+        selling: 'weed',
+        volume: 1,
+        margin: 1,
+        volumeBonus: 0,
+        marginBonus: 0,
+        sideVolume: 0,
+        equipmentCount: 0,
+        baseVolumeGps: 1,
+        baseMarginMult: 1,
+        volumeStars: 1,
+        marginStars: 1,
+      }],
+    }));
+
+    const { result } = renderHook(() => useGameEngine());
+    const dealer = result.current.state.activeDealers[0];
+
+    expect(dealer?.isProtected).toBe(false);
+    expect(dealer?.isArrested).toBe(false);
+    expect(typeof dealer?.nextArrestCheckAt).toBe('number');
   });
 });

--- a/src/Brmble.Web/src/components/NeonD/hooks/__tests__/usePersistedGameState.test.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/__tests__/usePersistedGameState.test.ts
@@ -52,6 +52,31 @@ describe('usePersistedGameState', () => {
     expect(JSON.parse(localStorage.getItem('test_key') || '{}')).toEqual({ a: 55, nested: { b: 2, c: 3 } });
   });
 
+  it('saves to localStorage when document becomes hidden', () => {
+    const { result } = renderHook(() => usePersistedGameState('test_key', initial));
+    act(() => {
+      result.current[1]({ a: 77, nested: { b: 2, c: 3 } });
+    });
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(JSON.parse(localStorage.getItem('test_key') || '{}')).toEqual({ a: 77, nested: { b: 2, c: 3 } });
+  });
+
+  it('saves to localStorage on unmount', () => {
+    const { result, unmount } = renderHook(() => usePersistedGameState('test_key', initial));
+    act(() => {
+      result.current[1]({ a: 88, nested: { b: 2, c: 3 } });
+    });
+
+    unmount();
+    expect(JSON.parse(localStorage.getItem('test_key') || '{}')).toEqual({ a: 88, nested: { b: 2, c: 3 } });
+  });
+
   it('clears localStorage when clear function is called', () => {
     localStorage.setItem('test_key', JSON.stringify({ a: 99, nested: { b: 99, c: 99 } }));
     const { result } = renderHook(() => usePersistedGameState('test_key', initial));

--- a/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
@@ -130,7 +130,7 @@ const generateRandomDealer = (unlockedProducts: string[], totalEarned: number): 
     marginStars,
     isProtected: false,
     isArrested: false,
-    nextArrestCheckAt: Date.now() + ARREST_CHECK_INTERVAL_MS.min,
+    nextArrestCheckAt: scheduleNextArrestCheck(Date.now()),
     hasPendingUpgrade: false,
     pendingUpgradeOptions: [],
   };
@@ -146,7 +146,7 @@ const normalizeDealerRiskState = (dealer: Dealer): Dealer => ({
   ...dealer,
   isProtected: dealer.isProtected ?? false,
   isArrested: dealer.isArrested ?? false,
-  nextArrestCheckAt: dealer.nextArrestCheckAt ?? (Date.now() + ARREST_CHECK_INTERVAL_MS.min),
+  nextArrestCheckAt: dealer.nextArrestCheckAt ?? scheduleNextArrestCheck(Date.now()),
   hasPendingUpgrade: dealer.hasPendingUpgrade ?? false,
   pendingUpgradeOptions: dealer.pendingUpgradeOptions ?? [],
 });
@@ -404,7 +404,7 @@ export const useGameEngine = () => {
     setState(prev => {
       const slotIndex = prev.activeDealers.findIndex(d => d?.id === dealerId);
       const dealer = slotIndex === -1 ? null : prev.activeDealers[slotIndex];
-      if (!dealer || dealer.equipmentCount >= 3) return prev;
+      if (!dealer || dealer.equipmentCount >= 3 || dealer.isArrested) return prev;
       if (!dealer.hasPendingUpgrade || dealer.pendingUpgradeOptions.length !== 3) return prev;
 
       const selectedUpgrade = dealer.pendingUpgradeOptions.find(option => upgradeMatches(option, upgrade));
@@ -472,21 +472,24 @@ export const useGameEngine = () => {
 
   const payDealerBail = (dealerId: string) => {
     setState(prev => {
+      const dealer = prev.activeDealers.find(d => d?.id === dealerId);
+      if (!dealer || !dealer.isArrested) return prev;
+
       const bailCost = getBailCost(prev.lastEarningsPerDealer);
       if (prev.money < bailCost) return prev;
 
       return {
         ...prev,
         money: prev.money - bailCost,
-        activeDealers: prev.activeDealers.map(dealer =>
-          dealer?.id === dealerId
+        activeDealers: prev.activeDealers.map(d =>
+          d?.id === dealerId
             ? {
-                ...dealer,
+                ...d,
                 isArrested: false,
                 isProtected: false,
                 nextArrestCheckAt: scheduleNextArrestCheck(Date.now()),
               }
-            : dealer
+            : d
         ),
       };
     });

--- a/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect } from 'react';
 import { useInterval } from './useInterval';
 import { usePersistedGameState } from './usePersistedGameState';
 import type { GameState, Dealer, DealerUpgrade } from '../types';
-import { INITIAL_GAME_STATE, UNLOCK_COSTS, PRODUCT_TIERS, DEALER_FIRST_NAMES, DEALER_LAST_NAMES, SLOT_UNLOCK_COSTS, VOLUME_RANGES, MARGIN_RANGES, ARREST_CHECK_INTERVAL_MS, DEALER_PROTECTION_INCOME_MULTIPLIER, PRODUCT_ARREST_RISK, BAIL_BASE_FLOOR, BAIL_INCOME_MULTIPLIER } from '../constants';
+import { INITIAL_GAME_STATE, UNLOCK_COSTS, PRODUCT_TIERS, DEALER_FIRST_NAMES, DEALER_LAST_NAMES, SLOT_UNLOCK_COSTS, VOLUME_RANGES, MARGIN_RANGES, ARREST_CHECK_INTERVAL_MS, DEALER_PROTECTION_INCOME_MULTIPLIER, PRODUCT_ARREST_RISK } from '../constants';
+import { getBailCost } from '../economy';
 
 // Roll a random value within a given range
 function rollWithinRange(min: number, max: number): number {
@@ -22,6 +23,76 @@ function rollMarginMultiplier(stars: number): number {
   if (!range) return 1.0;  // Fallback
   return rollWithinRange(range[0], range[1]);
 }
+
+const COMMON_DEALER_UPGRADES: DealerUpgrade[] = [
+  { type: 'VOLUME', label: 'Armed Gang', description: 'Volume +15%', value: 0.15 },
+  { type: 'MARGIN', label: 'Ferrari', description: 'Margin +15%', value: 0.15 },
+  { type: 'ALL_AROUNDER', label: 'Copter', description: 'Volume & Margin +5%', value: 0.05 },
+];
+
+const UNCOMMON_DEALER_UPGRADES: DealerUpgrade[] = [
+  { type: 'BULK', label: 'The Crew', description: 'Volume +35%, Margin -10%', value: 0.35, marginPenalty: 0.1 },
+];
+
+const getDealerEquipmentUpgradeCost = (equipmentCount: number) => 500 * Math.pow(2.5, equipmentCount);
+
+const upgradeMatches = (a: DealerUpgrade, b: DealerUpgrade) =>
+  a.type === b.type &&
+  a.label === b.label &&
+  a.description === b.description &&
+  a.value === b.value &&
+  (a.marginPenalty ?? 0) === (b.marginPenalty ?? 0) &&
+  (a.sideVolumeValue ?? 0) === (b.sideVolumeValue ?? 0);
+
+const generateDealerUpgradeOptions = (dealer: Dealer, unlockedProduction: string[]): DealerUpgrade[] => {
+  const sideHustleProducts = unlockedProduction.filter(id => id !== dealer.selling);
+  const options: DealerUpgrade[] = [];
+
+  for (let i = 0; i < 3; i++) {
+    const roll = Math.random();
+    if (roll < 0.10 && sideHustleProducts.length > 0) {
+      options.push({
+        type: 'SIDE_HUSTLE',
+        label: 'JACKPOT: Side Hustle',
+        description: 'Add 10% side volume bleed',
+        value: 0.1,
+        sideVolumeValue: 0.1,
+      });
+    } else if (roll < 0.30) {
+      const upgrade = UNCOMMON_DEALER_UPGRADES[Math.floor(Math.random() * UNCOMMON_DEALER_UPGRADES.length)];
+      options.push({ ...upgrade });
+    } else {
+      const upgrade = COMMON_DEALER_UPGRADES[Math.floor(Math.random() * COMMON_DEALER_UPGRADES.length)];
+      options.push({ ...upgrade });
+    }
+  }
+
+  return options;
+};
+
+const applyDealerUpgrade = (dealer: Dealer, upgrade: DealerUpgrade): Dealer => {
+  const nextDealer = { ...dealer, equipmentCount: dealer.equipmentCount + 1 };
+
+  if (upgrade.type === 'VOLUME') nextDealer.volumeBonus += upgrade.value;
+  if (upgrade.type === 'MARGIN') nextDealer.marginBonus += upgrade.value;
+  if (upgrade.type === 'ALL_AROUNDER') {
+    nextDealer.volumeBonus += upgrade.value;
+    nextDealer.marginBonus += upgrade.value;
+  }
+  if (upgrade.type === 'BULK') {
+    nextDealer.volumeBonus += upgrade.value;
+    nextDealer.marginBonus -= upgrade.marginPenalty || 0.1;
+  }
+  if (upgrade.type === 'SIDE_HUSTLE') {
+    nextDealer.sideVolume = (nextDealer.sideVolume ?? 0) + (upgrade.sideVolumeValue ?? 0.10);
+  }
+
+  return {
+    ...nextDealer,
+    hasPendingUpgrade: false,
+    pendingUpgradeOptions: [],
+  };
+};
 
 const generateRandomDealer = (unlockedProducts: string[], totalEarned: number): Dealer => {
   const firstNames = DEALER_FIRST_NAMES;
@@ -60,6 +131,8 @@ const generateRandomDealer = (unlockedProducts: string[], totalEarned: number): 
     isProtected: false,
     isArrested: false,
     nextArrestCheckAt: Date.now() + ARREST_CHECK_INTERVAL_MS.min,
+    hasPendingUpgrade: false,
+    pendingUpgradeOptions: [],
   };
 };
 
@@ -69,17 +142,13 @@ const scheduleNextArrestCheck = (now: number) =>
 const getDealerRisk = (productId: string) =>
   PRODUCT_ARREST_RISK[productId] ?? { chance: 0.10, label: 'LOW' as const };
 
-const getCurrentTotalIncomePerSecond = (earnings: Record<string, number>) =>
-  Object.values(earnings).reduce((sum, value) => sum + value, 0);
-
-const getBailCost = (earnings: Record<string, number>) =>
-  Math.max(BAIL_BASE_FLOOR, getCurrentTotalIncomePerSecond(earnings) * BAIL_INCOME_MULTIPLIER);
-
 const normalizeDealerRiskState = (dealer: Dealer): Dealer => ({
   ...dealer,
   isProtected: dealer.isProtected ?? false,
   isArrested: dealer.isArrested ?? false,
   nextArrestCheckAt: dealer.nextArrestCheckAt ?? (Date.now() + ARREST_CHECK_INTERVAL_MS.min),
+  hasPendingUpgrade: dealer.hasPendingUpgrade ?? false,
+  pendingUpgradeOptions: dealer.pendingUpgradeOptions ?? [],
 });
 
 export const useGameEngine = () => {
@@ -100,7 +169,17 @@ export const useGameEngine = () => {
       dealer !== null && (
         dealer.isProtected === undefined ||
         dealer.isArrested === undefined ||
-        dealer.nextArrestCheckAt === undefined
+        dealer.nextArrestCheckAt === undefined ||
+        dealer.hasPendingUpgrade === undefined ||
+        dealer.pendingUpgradeOptions === undefined
+      )
+    ) || state.availableDealers.some(dealer =>
+      dealer !== null && (
+        dealer.isProtected === undefined ||
+        dealer.isArrested === undefined ||
+        dealer.nextArrestCheckAt === undefined ||
+        dealer.hasPendingUpgrade === undefined ||
+        dealer.pendingUpgradeOptions === undefined
       )
     );
 
@@ -109,8 +188,9 @@ export const useGameEngine = () => {
     setState(prev => ({
       ...prev,
       activeDealers: prev.activeDealers.map(dealer => (dealer ? normalizeDealerRiskState(dealer) : null)),
+      availableDealers: prev.availableDealers.map(dealer => normalizeDealerRiskState(dealer)),
     }));
-  }, [state.activeDealers, setState]);
+  }, [state.activeDealers, state.availableDealers, setState]);
 
   const tick = () => {
     setState(prev => {
@@ -283,36 +363,60 @@ export const useGameEngine = () => {
     });
   };
 
-  const buyEquipment = (dealerId: string, upgrade: DealerUpgrade) => {
+  const startDealerUpgrade = (dealerId: string) => {
     setState(prev => {
-      const dealer = prev.activeDealers.find(d => d?.id === dealerId);
-      
+      const slotIndex = prev.activeDealers.findIndex(d => d?.id === dealerId);
+      const dealer = slotIndex === -1 ? null : prev.activeDealers[slotIndex];
       if (!dealer || dealer.equipmentCount >= 3) return prev;
 
-      const upgradeCost = 500 * Math.pow(2.5, dealer.equipmentCount);
+      if (dealer.pendingUpgradeOptions.length === 3) {
+        if (dealer.hasPendingUpgrade) return prev;
+        const nextActiveDealers = [...prev.activeDealers];
+        nextActiveDealers[slotIndex] = {
+          ...dealer,
+          hasPendingUpgrade: true,
+        };
+        return {
+          ...prev,
+          activeDealers: nextActiveDealers,
+        };
+      }
+
+      const upgradeCost = getDealerEquipmentUpgradeCost(dealer.equipmentCount);
       if (prev.money < upgradeCost) return prev;
 
-      const nextDealers = prev.activeDealers.map(d => {
-        if (d?.id !== dealerId) return d;
-        const newDealer = { ...d, equipmentCount: d.equipmentCount + 1 };
-        
-        if (upgrade.type === 'VOLUME') newDealer.volumeBonus += upgrade.value;
-        if (upgrade.type === 'MARGIN') newDealer.marginBonus += upgrade.value;
-        if (upgrade.type === 'ALL_AROUNDER') {
-          newDealer.volumeBonus += upgrade.value;
-          newDealer.marginBonus += upgrade.value;
-        }
-        if (upgrade.type === 'BULK') {
-          newDealer.volumeBonus += upgrade.value;
-          newDealer.marginBonus -= upgrade.marginPenalty || 0.1;
-        }
-        if (upgrade.type === 'SIDE_HUSTLE') {
-          newDealer.sideVolume = (newDealer.sideVolume ?? 0) + (upgrade.sideVolumeValue ?? 0.10);
-        }
-        return newDealer;
-      });
+      const nextActiveDealers = [...prev.activeDealers];
+      nextActiveDealers[slotIndex] = {
+        ...dealer,
+        hasPendingUpgrade: true,
+        pendingUpgradeOptions: generateDealerUpgradeOptions(dealer, prev.unlockedProduction),
+      };
 
-      return { ...prev, money: prev.money - upgradeCost, activeDealers: nextDealers };
+      return {
+        ...prev,
+        money: prev.money - upgradeCost,
+        activeDealers: nextActiveDealers,
+      };
+    });
+  };
+
+  const buyEquipment = (dealerId: string, upgrade: DealerUpgrade) => {
+    setState(prev => {
+      const slotIndex = prev.activeDealers.findIndex(d => d?.id === dealerId);
+      const dealer = slotIndex === -1 ? null : prev.activeDealers[slotIndex];
+      if (!dealer || dealer.equipmentCount >= 3) return prev;
+      if (!dealer.hasPendingUpgrade || dealer.pendingUpgradeOptions.length !== 3) return prev;
+
+      const selectedUpgrade = dealer.pendingUpgradeOptions.find(option => upgradeMatches(option, upgrade));
+      if (!selectedUpgrade) return prev;
+
+      const nextActiveDealers = [...prev.activeDealers];
+      nextActiveDealers[slotIndex] = applyDealerUpgrade(dealer, selectedUpgrade);
+
+      return {
+        ...prev,
+        activeDealers: nextActiveDealers,
+      };
     });
   };
 
@@ -412,6 +516,7 @@ export const useGameEngine = () => {
     resetGame,
     unlockSlot,
     setDealerSelling,
+    startDealerUpgrade,
     buyEquipment,
     toggleDealerProtection,
     forceArrestDealer,

--- a/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useInterval } from './useInterval';
 import { usePersistedGameState } from './usePersistedGameState';
 import type { GameState, Dealer, DealerUpgrade } from '../types';
-import { INITIAL_GAME_STATE, UNLOCK_COSTS, PRODUCT_TIERS, DEALER_FIRST_NAMES, DEALER_LAST_NAMES, SLOT_UNLOCK_COSTS, VOLUME_RANGES, MARGIN_RANGES } from '../constants';
+import { INITIAL_GAME_STATE, UNLOCK_COSTS, PRODUCT_TIERS, DEALER_FIRST_NAMES, DEALER_LAST_NAMES, SLOT_UNLOCK_COSTS, VOLUME_RANGES, MARGIN_RANGES, ARREST_CHECK_INTERVAL_MS, DEALER_PROTECTION_INCOME_MULTIPLIER, PRODUCT_ARREST_RISK, BAIL_BASE_FLOOR, BAIL_INCOME_MULTIPLIER } from '../constants';
 
 // Roll a random value within a given range
 function rollWithinRange(min: number, max: number): number {
@@ -56,9 +56,31 @@ const generateRandomDealer = (unlockedProducts: string[], totalEarned: number): 
     baseVolumeGps,
     baseMarginMult,
     volumeStars,
-    marginStars
+    marginStars,
+    isProtected: false,
+    isArrested: false,
+    nextArrestCheckAt: Date.now() + ARREST_CHECK_INTERVAL_MS.min,
   };
 };
+
+const scheduleNextArrestCheck = (now: number) =>
+  now + ARREST_CHECK_INTERVAL_MS.min + Math.floor(Math.random() * (ARREST_CHECK_INTERVAL_MS.max - ARREST_CHECK_INTERVAL_MS.min));
+
+const getDealerRisk = (productId: string) =>
+  PRODUCT_ARREST_RISK[productId] ?? { chance: 0.10, label: 'LOW' as const };
+
+const getCurrentTotalIncomePerSecond = (earnings: Record<string, number>) =>
+  Object.values(earnings).reduce((sum, value) => sum + value, 0);
+
+const getBailCost = (earnings: Record<string, number>) =>
+  Math.max(BAIL_BASE_FLOOR, getCurrentTotalIncomePerSecond(earnings) * BAIL_INCOME_MULTIPLIER);
+
+const normalizeDealerRiskState = (dealer: Dealer): Dealer => ({
+  ...dealer,
+  isProtected: dealer.isProtected ?? false,
+  isArrested: dealer.isArrested ?? false,
+  nextArrestCheckAt: dealer.nextArrestCheckAt ?? (Date.now() + ARREST_CHECK_INTERVAL_MS.min),
+});
 
 export const useGameEngine = () => {
   const [state, setState, clearStorage] = usePersistedGameState<GameState>('brmble_neon_d_save', () => {
@@ -72,6 +94,23 @@ export const useGameEngine = () => {
       )
     };
   });
+
+  useEffect(() => {
+    const needsMigration = state.activeDealers.some(dealer =>
+      dealer !== null && (
+        dealer.isProtected === undefined ||
+        dealer.isArrested === undefined ||
+        dealer.nextArrestCheckAt === undefined
+      )
+    );
+
+    if (!needsMigration) return;
+
+    setState(prev => ({
+      ...prev,
+      activeDealers: prev.activeDealers.map(dealer => (dealer ? normalizeDealerRiskState(dealer) : null)),
+    }));
+  }, [state.activeDealers, setState]);
 
   const tick = () => {
     setState(prev => {
@@ -90,6 +129,10 @@ export const useGameEngine = () => {
 
       prev.activeDealers.forEach((dealer) => {
         if (!dealer) return;
+        if (dealer.isArrested) {
+          nextEarnings[dealer.id] = 0;
+          return;
+        }
         let dealerGross = 0;
 
         const effectiveVolume = dealer.volume * (1 + dealer.volumeBonus);
@@ -119,8 +162,35 @@ export const useGameEngine = () => {
           }
         }
 
+        if (dealer.isProtected) {
+          dealerGross *= DEALER_PROTECTION_INCOME_MULTIPLIER;
+        }
+
         nextEarnings[dealer.id] = dealerGross;
         totalEarnedThisTick += dealerGross;
+      });
+
+      const now = Date.now();
+      let nextDealers = prev.activeDealers.map(dealer => dealer ? { ...dealer } : null);
+      nextDealers = nextDealers.map(dealer => {
+        if (!dealer || dealer.isArrested || dealer.isProtected) return dealer;
+        if (dealer.nextArrestCheckAt > now) return dealer;
+
+        const risk = getDealerRisk(dealer.selling);
+        const rolledArrest = Math.random() < risk.chance;
+
+        if (rolledArrest) {
+          return {
+            ...dealer,
+            isArrested: true,
+            isProtected: false,
+          };
+        }
+
+        return {
+          ...dealer,
+          nextArrestCheckAt: scheduleNextArrestCheck(now),
+        };
       });
 
       return {
@@ -128,6 +198,7 @@ export const useGameEngine = () => {
         money: prev.money + totalEarnedThisTick,
         totalEarned: prev.totalEarned + totalEarnedThisTick,
         production: nextProduction,
+        activeDealers: nextDealers,
         lastEarningsPerDealer: nextEarnings
       };
     });
@@ -174,7 +245,7 @@ export const useGameEngine = () => {
     setState(prev => {
       if (slotIndex >= prev.unlockedSlots) return prev;
       const newActiveDealers = [...prev.activeDealers];
-      newActiveDealers[slotIndex] = dealer;
+      newActiveDealers[slotIndex] = normalizeDealerRiskState(dealer);
       return {
         ...prev,
         activeDealers: newActiveDealers,
@@ -269,6 +340,54 @@ export const useGameEngine = () => {
     });
   };
 
+  const toggleDealerProtection = (dealerId: string) => {
+    setState(prev => ({
+      ...prev,
+      activeDealers: prev.activeDealers.map(dealer => {
+        if (!dealer || dealer.id !== dealerId || dealer.isArrested) return dealer;
+        const nextProtected = !dealer.isProtected;
+        return {
+          ...dealer,
+          isProtected: nextProtected,
+          nextArrestCheckAt: nextProtected ? dealer.nextArrestCheckAt : scheduleNextArrestCheck(Date.now()),
+        };
+      }),
+    }));
+  };
+
+  const forceArrestDealer = (dealerId: string) => {
+    setState(prev => ({
+      ...prev,
+      activeDealers: prev.activeDealers.map(dealer =>
+        dealer?.id === dealerId
+          ? { ...dealer, isArrested: true, isProtected: false }
+          : dealer
+      ),
+    }));
+  };
+
+  const payDealerBail = (dealerId: string) => {
+    setState(prev => {
+      const bailCost = getBailCost(prev.lastEarningsPerDealer);
+      if (prev.money < bailCost) return prev;
+
+      return {
+        ...prev,
+        money: prev.money - bailCost,
+        activeDealers: prev.activeDealers.map(dealer =>
+          dealer?.id === dealerId
+            ? {
+                ...dealer,
+                isArrested: false,
+                isProtected: false,
+                nextArrestCheckAt: scheduleNextArrestCheck(Date.now()),
+              }
+            : dealer
+        ),
+      };
+    });
+  };
+
   const resetGame = useCallback(() => {
     clearStorage();
     setState({
@@ -283,5 +402,19 @@ export const useGameEngine = () => {
 
   useInterval(tick, 1000);
   
-  return { state, upgrade, unlockProduction, hireDealer, fireDealer, refreshPool, resetGame, unlockSlot, setDealerSelling, buyEquipment };
+  return {
+    state,
+    upgrade,
+    unlockProduction,
+    hireDealer,
+    fireDealer,
+    refreshPool,
+    resetGame,
+    unlockSlot,
+    setDealerSelling,
+    buyEquipment,
+    toggleDealerProtection,
+    forceArrestDealer,
+    payDealerBail,
+  };
 };

--- a/src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts
@@ -89,7 +89,18 @@ export function usePersistedGameState<T extends object>(
 
   useEffect(() => {
     window.addEventListener('beforeunload', saveToStorage);
-    return () => window.removeEventListener('beforeunload', saveToStorage);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        saveToStorage();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      saveToStorage();
+      window.removeEventListener('beforeunload', saveToStorage);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, [saveToStorage]);
 
   return [state, setState, clearStorage];

--- a/src/Brmble.Web/src/components/NeonD/types.ts
+++ b/src/Brmble.Web/src/components/NeonD/types.ts
@@ -20,6 +20,8 @@ export interface DealerUpgrade {
   sideVolumeValue?: number;
 }
 
+export type DealerRiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
+
 export interface Dealer {
   id: string;
   name: string;
@@ -34,6 +36,9 @@ export interface Dealer {
   baseMarginMult: number;
   volumeStars: number;
   marginStars: number;
+  isProtected: boolean;
+  isArrested: boolean;
+  nextArrestCheckAt: number;
 }
 
 export interface GameState {

--- a/src/Brmble.Web/src/components/NeonD/types.ts
+++ b/src/Brmble.Web/src/components/NeonD/types.ts
@@ -39,6 +39,8 @@ export interface Dealer {
   isProtected: boolean;
   isArrested: boolean;
   nextArrestCheckAt: number;
+  hasPendingUpgrade: boolean;
+  pendingUpgradeOptions: DealerUpgrade[];
 }
 
 export interface GameState {

--- a/src/Brmble.Web/tsconfig.app.json
+++ b/src/Brmble.Web/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__"]
 }

--- a/src/Brmble.Web/tsconfig.json
+++ b/src/Brmble.Web/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/src/Brmble.Web/tsconfig.test.json
+++ b/src/Brmble.Web/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**/*"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

This PR implements a comprehensive dealer arrest risk system for Neon-D that adds meaningful economic tradeoffs without disrupting idle gameplay. Dealers can now be arrested based on product risk, protected for a 15% income penalty, or recovered via bail costs that scale with player economy.

## Key Features

### 1. Dealer Arrest System
- Three dealer states: active, protected, or arrested
- Risk-based arrests: Each product has configurable arrest chances (Low/Medium/High)
- Scheduled checks: Arrest checks happen on randomized intervals (5-10 min) per dealer instead of constant punishment
- Product-driven: Only the product a dealer is actively selling determines their risk at check time

### 2. Dealer Protection (Pay Off Cops)
- Per-dealer toggle to prevent arrests
- Protected dealers earn 15% less income (0.85x multiplier)
- Can be toggled on/off without penalties or state loss
- Protection is immediately applied to game calculations

### 3. Bail System
- Scales with economy: Math.max(500, totalIncomePerSecond * 45)
- Dynamic cost: As your run gets stronger, bail costs increase proportionally
- Recovery action: Arrested dealers can be freed or permanently fired
- Bailed dealers return to unprotected state by default

### 4. UI Updates
- Risk labels on dealer cards (Low/Medium/High Risk)
- Protection status indicator on protected dealers
- Pay off cops toggle button with income penalty display
- Arrested state with Pay Bail and Fire Dealer action buttons
- Zero earnings displayed for arrested dealers

### 5. Game Engine Improvements
- Arrest checks integrated into main game tick
- Income calculations respect protection multiplier
- State migrations handle old saves gracefully
- New dealer fields properly initialized

## Implementation Details

### Constants Added
- PRODUCT_ARREST_RISK: Per-product arrest chance and risk label (0.10-0.75 range)
- ARREST_CHECK_INTERVAL_MS: 5-10 minute randomized check window
- DEALER_PROTECTION_INCOME_MULTIPLIER: 0.85x (15% penalty)
- BAIL_BASE_FLOOR: 500 minimum
- BAIL_INCOME_MULTIPLIER: 45x current income/sec

### Dealer Type Extensions
- isProtected: boolean - Whether Pay off cops is enabled
- isArrested: boolean - Current arrest status
- nextArrestCheckAt: number - Timestamp of next risk check

### New Engine Functions
- toggleDealerProtection(dealerId) - Toggle protection state
- payDealerBail(dealerId) - Pay bail and free dealer
- forceArrestDealer(dealerId) - For testing; force arrest immediately

### Persistence
- usePersistedGameState now saves on:
  - visibilitychange events (when tab becomes hidden)
  - beforeunload (normal unload)
  - Component unmount
- Migration handles missing risk fields in old saves

## Testing

### New Test Coverage
1. NeonDGame component tests:
   - Protected dealer card rendering with status and toggle
   - Arrested dealer card rendering with bail/fire actions

2. useGameEngine tests:
   - New dealers initialize with correct risk state
   - Protected dealers earn 15% less (0.85x multiplier)
   - Arrested dealers produce zero earnings
   - Arrest checks use current product risk
   - Protected dealers never get arrested
   - Bail scales from total income with minimum floor
   - Old saves restore missing risk fields gracefully

3. usePersistedGameState tests:
   - Saves on visibilitychange event
   - Saves on component unmount

## Files Changed
- src/Brmble.Web/src/components/NeonD/NeonDGame.tsx - UI for protection toggle, risk labels, arrested actions
- src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts - Arrest check logic, protection income, bail calculation
- src/Brmble.Web/src/components/NeonD/hooks/usePersistedGameState.ts - Enhanced save persistence
- src/Brmble.Web/src/components/NeonD/constants.ts - Arrest risk configuration per product
- src/Brmble.Web/src/components/NeonD/types.ts - Dealer type extensions
- src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx - New component tests
- src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts - New engine tests
- src/Brmble.Web/src/components/NeonD/hooks/__tests__/usePersistedGameState.test.ts - Persistence tests

## Design Philosophy

The system preserves idle progress by using infrequent scheduled checks instead of constant risk accumulation, allowing full immunity via protection (at income cost) for idle play, making bail meaningful throughout all game phases by scaling to economy, and keeping UI simple and legible with clear risk indicators.

## Balancing Values (Tunable)

All risk and bail parameters are in constants.ts for easy iteration:
- Product arrest chances: 0.10 (weed) to 0.75 (galactic core)
- Arrest check interval: 300-600 seconds (randomized)
- Bail base floor: 500
- Bail multiplier: 45x current income/second
- Protection penalty: 15% income reduction

## Related Issues

Resolves work from the dealer risk design session on 2026-05-15.