### PR TITLE
Add LiveKit screen-share quality indicators

### DIFF
--- a/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
@@ -108,7 +108,7 @@ See full spec: `2026-04-17-multi-share-foundation-design.md`
 - [x] 37. Graceful degradation -- implemented as informational reconnecting/poor-quality UI that preserves watched tiles during transient LiveKit reconnects.
 - [x] 38. Disconnect notification when share ends unexpectedly -- implemented through Brmble notifications for watched/local share interruption.
 - [x] 39. Reconnect non-voice services independently when Mumble stays connected -- implemented for Brmble server/session, Matrix chat, and screen-share support state.
-- [ ] 40. Share state recovery after crash -- intentionally deferred; users restart sharing/watching manually.
+- [x] 40. Share state recovery after crash -- completed by intentionally clearing stale LiveKit state; users restart sharing/watching manually after crash or terminal service loss.
 
 ## G. UI/UX Polish
 

--- a/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
@@ -1,7 +1,7 @@
 # LiveKit & Screen Sharing Feature Roadmap
 
 **Date:** 2026-04-17
-**Status:** Active roadmap. Foundation, recent follow-up fixes, E. Token & Security, and F1 reliability work are implemented; remaining F work is F2/future reliability hardening.
+**Status:** Active roadmap. Foundation, recent follow-up fixes, E. Token & Security, and F1/F2 reliability work are implemented; remaining F work is future reliability hardening.
 
 This is the master feature list for LiveKit and screen sharing work. Completed sub-projects and shipped follow-up fixes are tracked here, while future work should continue through design -> plan -> implementation cycles.
 
@@ -15,7 +15,7 @@ This is the master feature list for LiveKit and screen sharing work. Completed s
 | C | Viewing Experience | Not started | -- |
 | D | Game Overlay | Not started | -- |
 | E | Token & Security | Implemented | `2026-04-30-livekit-token-security-phase-design.md`, `2026-05-11-livekit-token-refresh-revocation-design.md` |
-| F | Connection & Reliability | F1 implemented; F2 pending | -- |
+| F | Connection & Reliability | F1/F2 implemented; future hardening pending | `2026-05-15-livekit-connection-reliability-f2-design.md` |
 | G | UI/UX Polish | Not started | -- |
 | H | Clips & Screenshots | Not started | -- |
 | I | Performance & Quality | Not started | -- |
@@ -104,8 +104,8 @@ See full spec: `2026-04-17-multi-share-foundation-design.md`
 
 - [x] 34. Auto-reconnect on drop -- implemented for Brmble server/session and Matrix reconnect after Brmble services restarts; LiveKit rooms intentionally clear and require manual restart/watch.
 - [ ] 35. ICE fallback / TURN relay hardening -- future work.
-- [ ] 36. Connection quality indicator -- F2.
-- [ ] 37. Graceful degradation -- F2.
+- [x] 36. Connection quality indicator -- implemented for LiveKit screen-share UI through room/share quality state, sidebar tooltip text, and watched-tile quality badges.
+- [x] 37. Graceful degradation -- implemented as informational reconnecting/poor-quality UI that preserves watched tiles during transient LiveKit reconnects.
 - [x] 38. Disconnect notification when share ends unexpectedly -- implemented through Brmble notifications for watched/local share interruption.
 - [x] 39. Reconnect non-voice services independently when Mumble stays connected -- implemented for Brmble server/session, Matrix chat, and screen-share support state.
 - [ ] 40. Share state recovery after crash -- intentionally deferred; users restart sharing/watching manually.

--- a/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
@@ -180,12 +180,10 @@ These items were discussed and explicitly parked:
 
 ## Next-Phase Issue Shortlist
 
-Remaining F priority work is F2/future reliability hardening:
+Remaining F priority work is future reliability hardening:
 
 - ICE/TURN relay hardening
-- connection quality indicator
-- graceful degradation
-- crash recovery and LiveKit room recovery decisions
+- production TURN/relay deployment decisions
 
 Implemented by the current E-pass:
 
@@ -196,9 +194,7 @@ Implemented by the current E-pass:
 
 Known phase-F roadmap gaps with no dedicated issue yet:
 
-- LiveKit room recovery after interruption or crash
 - ICE/TURN relay hardening
-- connection quality indicator and graceful degradation
 
 ## Suggested Build Order
 
@@ -207,7 +203,7 @@ The recommended next sequence is:
 1. **A. Multi-Share Foundation** -- implemented
 2. **A2. Multi-Share Layouts** -- implemented
 3. **E. Token & Security** -- implemented
-4. **F. Connection & Reliability** -- F1 implemented; remaining priority is F2/future reliability hardening for ICE/TURN, connection quality, graceful degradation, and recovery decisions
+4. **F. Connection & Reliability** -- F1/F2 implemented; remaining priority is future ICE/TURN relay hardening
 5. **C. Viewing Experience** -- pop-out, PiP, fullscreen (needed before overlay)
 6. **B. Broadcaster Controls** -- window picker, audio, quality presets
 7. **D. Game Overlay** -- depends on C (PiP/pop-out patterns) and voice system

--- a/docs/superpowers/specs/2026-05-15-livekit-connection-reliability-f2-design.md
+++ b/docs/superpowers/specs/2026-05-15-livekit-connection-reliability-f2-design.md
@@ -1,14 +1,14 @@
 # LiveKit Connection Reliability F2 Design
 
 **Date:** 2026-05-15
-**Status:** Approved design
+**Status:** Implemented
 **Roadmap phase:** F. Connection & Reliability, second slice
 
 ## Context
 
 F1 implemented non-voice service reconnect handling for Brmble server, Matrix chat, and screen-share support. It intentionally clears stale LiveKit room state after service loss and requires users to restart sharing or watching manually. That keeps recovery safe, but it does not yet tell users whether an active LiveKit room is healthy before it fails.
 
-The roadmap leaves two F2 items open: connection quality indicator and graceful degradation. For this slice, graceful degradation is informational: Brmble should explain degraded screen-share conditions and keep the UI stable during transient LiveKit reconnects, but it should not automatically lower publisher quality, change capture settings, add TURN/ICE infrastructure, or recover crashed rooms.
+F2 covered the connection quality indicator and graceful degradation roadmap items. For this slice, graceful degradation is informational: Brmble explains degraded screen-share conditions and keeps the UI stable during transient LiveKit reconnects, but it does not automatically lower publisher quality, change capture settings, add TURN/ICE infrastructure, or recover crashed rooms.
 
 ## Goals
 

--- a/docs/superpowers/specs/2026-05-15-livekit-connection-reliability-f2-design.md
+++ b/docs/superpowers/specs/2026-05-15-livekit-connection-reliability-f2-design.md
@@ -1,0 +1,146 @@
+# LiveKit Connection Reliability F2 Design
+
+**Date:** 2026-05-15
+**Status:** Approved design
+**Roadmap phase:** F. Connection & Reliability, second slice
+
+## Context
+
+F1 implemented non-voice service reconnect handling for Brmble server, Matrix chat, and screen-share support. It intentionally clears stale LiveKit room state after service loss and requires users to restart sharing or watching manually. That keeps recovery safe, but it does not yet tell users whether an active LiveKit room is healthy before it fails.
+
+The roadmap leaves two F2 items open: connection quality indicator and graceful degradation. For this slice, graceful degradation is informational: Brmble should explain degraded screen-share conditions and keep the UI stable during transient LiveKit reconnects, but it should not automatically lower publisher quality, change capture settings, add TURN/ICE infrastructure, or recover crashed rooms.
+
+## Goals
+
+- Show LiveKit screen-share quality in existing Brmble UI surfaces.
+- Distinguish available screen-share support from an actively connected LiveKit room with good, fair, poor, or reconnecting quality.
+- Keep watched tiles visible during transient LiveKit reconnecting states instead of immediately removing them.
+- Surface poor quality and reconnecting states without notification spam.
+- Preserve F1 cleanup for terminal LiveKit disconnects, token failures, and service-loss trust-boundary events.
+
+## Non-Goals
+
+- Do not automatically reduce publisher resolution, frame rate, or bitrate.
+- Do not prompt users to change quality settings in this slice.
+- Do not implement ICE/TURN relay hardening or deployment changes.
+- Do not persist or recover LiveKit room state after app, server, or LiveKit process crashes.
+- Do not replace the existing service-status model or redesign screen-share layout.
+
+## Chosen Approach
+
+Use LiveKit room and participant events as the source of truth for screen-share quality, then map them into small UI-facing state.
+
+`useScreenShare` already owns the LiveKit `Room`, watched shares, local share lifecycle, reconnect cleanup, and tile video elements. It should also own LiveKit room-quality state. React can derive aggregate Screenshare status from this state and pass per-share quality to screen-share tiles.
+
+This keeps F2 small and avoids WebRTC stats polling. LiveKit already provides high-level quality and reconnect lifecycle signals that are sufficient for user-facing good/fair/poor/reconnecting indicators. More detailed bitrate, RTT, or frame-rate telemetry can be added later under the Performance & Quality roadmap.
+
+## Quality Model
+
+Add a lightweight screen-share quality type in the web layer:
+
+```ts
+type ScreenShareQuality = 'unknown' | 'good' | 'fair' | 'poor' | 'reconnecting';
+```
+
+Quality meanings:
+
+- `unknown`: no active LiveKit room, no track yet, or LiveKit has not emitted a useful signal.
+- `good`: LiveKit reports strong participant quality and the room is connected.
+- `fair`: LiveKit reports degraded but usable quality.
+- `poor`: LiveKit reports poor quality or equivalent degraded state.
+- `reconnecting`: the LiveKit room is reconnecting after a transient network interruption.
+
+The aggregate Screenshare service dot should remain `connected` when the LiveKit room is connected but poor. Poor quality is not the same as a disconnected service. Reconnecting should map to `connecting` only while the room is actively reconnecting. Terminal disconnects continue through the existing interrupted cleanup path.
+
+## React Design
+
+### `useScreenShare`
+
+Extend the hook return value with:
+
+- `roomQuality`: aggregate quality for the current LiveKit room.
+- `shareQualities`: map of watched `userId` to quality for individual watched shares.
+
+Bind LiveKit events when a room is created:
+
+- Room reconnecting: set `roomQuality` to `reconnecting` and keep watched shares in place.
+- Room reconnected/connected: return `roomQuality` to the best known participant quality or `unknown` until LiveKit emits one.
+- Participant connection quality changes: update `shareQualities` for watched remote participants and update `roomQuality` to the worst active watched-share quality when viewing.
+- Local participant quality changes, if available from LiveKit: update `roomQuality` while publishing.
+- Terminal room disconnected: keep F1 behavior. Notify unexpected watched-share ends, clear watched state, and stop local share if needed.
+
+The hook should not create a second lifecycle system. Quality state resets should happen alongside existing room cleanup paths such as `clearWatchingState`, token refresh failure cleanup, and explicit viewer disconnect.
+
+### Service Status
+
+Reuse `ServiceStatus` for aggregate quality metadata instead of adding a parallel context. Add an optional screen-share quality field or reuse a label field if that keeps the type smaller.
+
+The effective Screenshare dot should show:
+
+- `Available` when Brmble/LiveKit support is connected but no LiveKit room is active.
+- `Connected - good/fair/poor` when a LiveKit room is active.
+- `Reconnecting` when the active LiveKit room is in a transient reconnect state.
+- Existing disconnected/error text for service loss or terminal failures.
+
+Poor quality should appear in tooltip text and visual styling, but should not mark the service as failed.
+
+### Screen-Share Tiles
+
+`ScreenShareTile` should accept optional quality state for the watched share.
+
+Tile behavior:
+
+- `reconnecting`: keep the last video element mounted and show a small overlay such as `Reconnecting...`.
+- `poor`: show a subtle status badge or overlay such as `Poor connection`.
+- `fair`: optionally show a subdued `Fair connection` tooltip or badge only if it fits existing visual patterns.
+- `good`/`unknown`: no extra visual noise.
+
+All styling must use existing CSS tokens and the centralized icon system if an icon is needed.
+
+## Error Handling
+
+- Do not emit repeated notifications for every quality change.
+- Quality changes should not block share start, watch start, or stop actions.
+- Reconnecting is transient. If LiveKit later emits terminal disconnect, existing F1 cleanup takes over.
+- If LiveKit quality events are unavailable in a test or runtime environment, default to `unknown` and keep existing behavior.
+- Stale room events must be ignored when `roomRef.current` no longer matches the event source.
+
+## Testing Strategy
+
+### Unit Tests
+
+- Quality mapping helper maps LiveKit quality values to Brmble quality states.
+- Worst-quality derivation prefers `poor` over `fair`, `fair` over `good`, and `reconnecting` while the room is reconnecting.
+- Unknown or unsupported LiveKit values map to `unknown`.
+
+### Hook Tests
+
+- `useScreenShare` sets room quality to reconnecting on LiveKit reconnecting events without clearing watched shares.
+- `useScreenShare` restores quality after reconnect events.
+- Remote participant quality changes update the matching watched share quality.
+- Terminal room disconnect still clears watched shares and reports unexpected ended notifications.
+- Explicit viewer disconnect clears quality for that watched share.
+
+### UI Tests
+
+- Sidebar Screenshare tooltip shows available when no room is connected.
+- Sidebar Screenshare tooltip shows good/fair/poor quality for active LiveKit rooms.
+- Sidebar Screenshare tooltip shows reconnecting during transient reconnect.
+- `ScreenShareTile` shows reconnecting overlay and poor-connection badge without unmounting video.
+
+## Manual Validation
+
+- Start sharing and watching in a normal channel; confirm Screenshare dot shows active quality.
+- Simulate LiveKit reconnecting; confirm watched tile stays visible with reconnecting overlay.
+- Restore network; confirm reconnecting UI clears without requiring Watch again.
+- Simulate poor quality; confirm the UI reports poor quality but does not stop sharing or watching.
+- Drop the LiveKit room terminally; confirm existing unexpected-ended cleanup still runs.
+
+## Roadmap Updates
+
+After implementation, update `docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md`:
+
+- Mark item 36, connection quality indicator, implemented for LiveKit screen-share UI.
+- Mark item 37, graceful degradation, implemented as informational reconnecting/poor-quality UI that preserves tile state during transient reconnects.
+- Leave item 35, ICE fallback / TURN relay hardening, as future work.
+- Leave item 40, share state recovery after crash, deferred.

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -3439,6 +3439,7 @@ const handleConnect = (serverData: SavedServer) => {
                     watchingShares={watchingShares}
                     focusedShare={focusedShare}
                     remoteVideoEls={remoteVideoEls}
+                    roomQuality={roomQuality}
                     shareQualities={shareQualities}
                     onFocusShare={setFocusedShare}
                     onCloseShare={(share) => disconnectViewer(share.userId)}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2848,7 +2848,7 @@ const handleConnect = (serverData: SavedServer) => {
     setWatchedShareEndedNotifications(prev => [...prev, notification]);
   }, []);
 
-  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, disconnectViewer, connectAsViewer, isViewerConnectPending, handleScreenShareServiceUnavailable } = useScreenShare(() => {
+  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, roomQuality, shareQualities, disconnectViewer, connectAsViewer, isViewerConnectPending, handleScreenShareServiceUnavailable } = useScreenShare(() => {
     setSharingChannelId(undefined);
     sharingChannelIdRef.current = undefined;
   }, screenShareSettings, handleLocalScreenShareEnded, handleWatchedShareEnded);
@@ -3398,6 +3398,7 @@ const handleConnect = (serverData: SavedServer) => {
           activeShares={activeShares}
           watchingShares={watchingShares}
           isLiveKitRoomConnected={isSharing || watchingShares.length > 0}
+          screenShareQuality={roomQuality}
           onWatchScreenShare={handleWatchScreenShare}
           onStopWatching={(userId) => disconnectViewer(userId)}
           onEditAvatar={connected ? () => setShowAvatarEditor(true) : undefined}
@@ -3438,6 +3439,7 @@ const handleConnect = (serverData: SavedServer) => {
                     watchingShares={watchingShares}
                     focusedShare={focusedShare}
                     remoteVideoEls={remoteVideoEls}
+                    shareQualities={shareQualities}
                     onFocusShare={setFocusedShare}
                     onCloseShare={(share) => disconnectViewer(share.userId)}
                     screenShareViewerMode={screenShareSettings.viewerMode}

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -8,6 +8,7 @@ import { formatDateSeparator, formatFullDate } from '../../utils/formatDateSepar
 import type { ChatMessage, MentionableUser } from '../../types';
 import { ScreenShareGrid } from '../ScreenShareGrid';
 import type { ShareInfo } from '../../hooks/useScreenShare';
+import type { ScreenShareQuality } from '../../utils/screenShareQuality';
 import { ContextMenu } from '../ContextMenu/ContextMenu';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { Icon } from '../Icon/Icon';
@@ -28,6 +29,7 @@ interface ChatPanelProps {
   watchingShares?: ShareInfo[];
   focusedShare?: ShareInfo | null;
   remoteVideoEls?: Map<number, HTMLVideoElement>;
+  shareQualities?: Map<number, ScreenShareQuality>;
   onFocusShare?: (share: ShareInfo | null) => void;
   onCloseShare?: (share: ShareInfo) => void;
   screenShareViewerMode?: 'in-app' | 'new-window';
@@ -45,7 +47,7 @@ const SPLIT_STORAGE_KEY = 'brmble-screenshare-split';
 const DEFAULT_SPLIT = 50;
 const REPLY_TARGET_HIGHLIGHT_MS = 1600;
 
-export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, focusedShare, remoteVideoEls, onFocusShare, onCloseShare, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard }: ChatPanelProps) {
+export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, focusedShare, remoteVideoEls, shareQualities, onFocusShare, onCloseShare, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard }: ChatPanelProps) {
   // Build lookup maps from sender name and matrixUserId → avatar data for MessageBubble.
   // Name-based lookup works when Mumble name matches message sender.
   // MatrixUserId-based lookup handles cases where the user connected with a different
@@ -834,6 +836,7 @@ const [replyState, setReplyState] = useState<{
               watchingShares={watchingShares!}
               focusedShare={focusedShare ?? null}
               videoElements={remoteVideoEls!}
+              shareQualities={shareQualities}
               onFocus={onFocusShare ?? (() => {})}
               onClose={onCloseShare!}
             />

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -29,6 +29,7 @@ interface ChatPanelProps {
   watchingShares?: ShareInfo[];
   focusedShare?: ShareInfo | null;
   remoteVideoEls?: Map<number, HTMLVideoElement>;
+  roomQuality?: ScreenShareQuality;
   shareQualities?: Map<number, ScreenShareQuality>;
   onFocusShare?: (share: ShareInfo | null) => void;
   onCloseShare?: (share: ShareInfo) => void;
@@ -47,7 +48,7 @@ const SPLIT_STORAGE_KEY = 'brmble-screenshare-split';
 const DEFAULT_SPLIT = 50;
 const REPLY_TARGET_HIGHLIGHT_MS = 1600;
 
-export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, focusedShare, remoteVideoEls, shareQualities, onFocusShare, onCloseShare, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard }: ChatPanelProps) {
+export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, focusedShare, remoteVideoEls, roomQuality, shareQualities, onFocusShare, onCloseShare, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard }: ChatPanelProps) {
   // Build lookup maps from sender name and matrixUserId → avatar data for MessageBubble.
   // Name-based lookup works when Mumble name matches message sender.
   // MatrixUserId-based lookup handles cases where the user connected with a different
@@ -836,6 +837,7 @@ const [replyState, setReplyState] = useState<{
               watchingShares={watchingShares!}
               focusedShare={focusedShare ?? null}
               videoElements={remoteVideoEls!}
+              roomQuality={roomQuality}
               shareQualities={shareQualities}
               onFocus={onFocusShare ?? (() => {})}
               onClose={onCloseShare!}

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareGrid.test.tsx
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareGrid.test.tsx
@@ -124,6 +124,23 @@ describe('ScreenShareGrid', () => {
     expect(onFocus).toHaveBeenCalledWith(shares[1]);
   });
 
+  it('passes room reconnecting state to tiles', () => {
+    const shares = [makeShare(1, 'Alice')];
+    render(
+      <ScreenShareGrid
+        watchingShares={shares}
+        focusedShare={null}
+        videoElements={makeVideoMap([1])}
+        roomQuality="reconnecting"
+        shareQualities={new Map([[1, 'good']])}
+        onFocus={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Reconnecting...')).toBeTruthy();
+  });
+
   it('renders nothing when watchingShares is empty', () => {
     const { container } = render(
       <ScreenShareGrid

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareGrid.tsx
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareGrid.tsx
@@ -8,6 +8,7 @@ interface ScreenShareGridProps {
   watchingShares: ShareInfo[];
   focusedShare: ShareInfo | null;
   videoElements: Map<number, HTMLVideoElement>;
+  roomQuality?: ScreenShareQuality;
   shareQualities?: Map<number, ScreenShareQuality>;
   onFocus: (share: ShareInfo | null) => void;
   onClose: (share: ShareInfo) => void;
@@ -20,7 +21,7 @@ function getLayout(count: number, hasFocus: boolean): string {
   return `grid-${count}`;
 }
 
-export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, shareQualities, onFocus, onClose }: ScreenShareGridProps) {
+export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, roomQuality = 'unknown', shareQualities, onFocus, onClose }: ScreenShareGridProps) {
   // Clear focus when only one stream remains (revert to single-stream view)
   useEffect(() => {
     if (watchingShares.length <= 1 && focusedShare) {
@@ -55,6 +56,10 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, s
     ? [focusedShare, ...watchingShares.filter(s => s.userId !== focusedShare.userId)]
     : watchingShares;
 
+  const qualityForShare = (userId: number): ScreenShareQuality => (
+    roomQuality === 'reconnecting' ? 'reconnecting' : shareQualities?.get(userId) ?? 'unknown'
+  );
+
   return (
     <div className="screen-share-grid" data-layout={layout}>
       {focusedShare && (
@@ -68,7 +73,7 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, s
                 sharerName={focusedShare.userName}
                 isFocused={true}
                 isThumbnail={false}
-                quality={shareQualities?.get(focusedShare.userId)}
+                quality={qualityForShare(focusedShare.userId)}
                 onClick={() => handleTileClick(focusedShare)}
                 onClose={() => onClose(focusedShare)}
               />
@@ -88,7 +93,7 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, s
                 sharerName={share.userName}
                 isFocused={false}
                 isThumbnail={true}
-                quality={shareQualities?.get(share.userId)}
+                quality={qualityForShare(share.userId)}
                 onClick={() => handleTileClick(share)}
                 onClose={() => onClose(share)}
               />
@@ -108,7 +113,7 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, s
                 sharerName={share.userName}
                 isFocused={false}
                 isThumbnail={false}
-                quality={shareQualities?.get(share.userId)}
+                quality={qualityForShare(share.userId)}
                 onClick={() => handleTileClick(share)}
                 onClose={() => onClose(share)}
               />

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareGrid.tsx
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareGrid.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useCallback } from 'react';
 import { ScreenShareTile } from './ScreenShareTile';
 import type { ShareInfo } from '../../hooks/useScreenShare';
+import type { ScreenShareQuality } from '../../utils/screenShareQuality';
 import './ScreenShareGrid.css';
 
 interface ScreenShareGridProps {
   watchingShares: ShareInfo[];
   focusedShare: ShareInfo | null;
   videoElements: Map<number, HTMLVideoElement>;
+  shareQualities?: Map<number, ScreenShareQuality>;
   onFocus: (share: ShareInfo | null) => void;
   onClose: (share: ShareInfo) => void;
 }
@@ -18,7 +20,7 @@ function getLayout(count: number, hasFocus: boolean): string {
   return `grid-${count}`;
 }
 
-export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, onFocus, onClose }: ScreenShareGridProps) {
+export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, shareQualities, onFocus, onClose }: ScreenShareGridProps) {
   // Clear focus when only one stream remains (revert to single-stream view)
   useEffect(() => {
     if (watchingShares.length <= 1 && focusedShare) {
@@ -66,6 +68,7 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, o
                 sharerName={focusedShare.userName}
                 isFocused={true}
                 isThumbnail={false}
+                quality={shareQualities?.get(focusedShare.userId)}
                 onClick={() => handleTileClick(focusedShare)}
                 onClose={() => onClose(focusedShare)}
               />
@@ -85,6 +88,7 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, o
                 sharerName={share.userName}
                 isFocused={false}
                 isThumbnail={true}
+                quality={shareQualities?.get(share.userId)}
                 onClick={() => handleTileClick(share)}
                 onClose={() => onClose(share)}
               />
@@ -104,6 +108,7 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, o
                 sharerName={share.userName}
                 isFocused={false}
                 isThumbnail={false}
+                quality={shareQualities?.get(share.userId)}
                 onClick={() => handleTileClick(share)}
                 onClose={() => onClose(share)}
               />

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.css
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.css
@@ -31,6 +31,23 @@
   pointer-events: none;
 }
 
+.screen-share-tile-quality {
+  position: absolute;
+  top: var(--space-xs);
+  left: var(--space-xs);
+  z-index: 2;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  background: var(--bg-deep-glass);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  pointer-events: none;
+}
+
+.screen-share-tile-quality--poor {
+  color: var(--accent-danger);
+}
+
 /* Overlays */
 .screen-share-tile-overlay {
   position: absolute;

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.css
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.css
@@ -48,6 +48,10 @@
   color: var(--accent-danger);
 }
 
+.screen-share-tile-quality--reconnecting {
+  color: var(--accent-secondary);
+}
+
 /* Overlays */
 .screen-share-tile-overlay {
   position: absolute;

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.test.tsx
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.test.tsx
@@ -45,4 +45,15 @@ describe('ScreenShareTile', () => {
     render(<ScreenShareTile videoEl={createVideoEl()} sharerName="Alice" isFocused={false} isThumbnail={true} onClick={vi.fn()} onClose={vi.fn()} />);
     expect(screen.getByTestId('screen-share-tile').classList.contains('screen-share-tile--thumbnail')).toBe(true);
   });
+
+  it('shows reconnecting overlay while keeping the tile mounted', () => {
+    render(<ScreenShareTile videoEl={createVideoEl()} sharerName="Alice" isFocused={false} isThumbnail={false} quality="reconnecting" onClick={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByTestId('screen-share-tile')).toBeTruthy();
+    expect(screen.getByText('Reconnecting...')).toBeTruthy();
+  });
+
+  it('shows poor connection badge', () => {
+    render(<ScreenShareTile videoEl={createVideoEl()} sharerName="Alice" isFocused={false} isThumbnail={false} quality="poor" onClick={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByText('Poor connection')).toBeTruthy();
+  });
 });

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.tsx
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
 import { Icon } from '../Icon/Icon';
 import { Tooltip } from '../Tooltip/Tooltip';
+import type { ScreenShareQuality } from '../../utils/screenShareQuality';
 import './ScreenShareTile.css';
 
 interface ScreenShareTileProps {
@@ -8,11 +9,12 @@ interface ScreenShareTileProps {
   sharerName: string;
   isFocused: boolean;
   isThumbnail: boolean;
+  quality?: ScreenShareQuality;
   onClick: () => void;
   onClose: () => void;
 }
 
-export function ScreenShareTile({ videoEl, sharerName, isFocused, isThumbnail, onClick, onClose }: ScreenShareTileProps) {
+export function ScreenShareTile({ videoEl, sharerName, isFocused, isThumbnail, quality = 'unknown', onClick, onClose }: ScreenShareTileProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showControls, setShowControls] = useState(false);
@@ -92,6 +94,16 @@ export function ScreenShareTile({ videoEl, sharerName, isFocused, isThumbnail, o
       <div className="screen-share-tile-overlay screen-share-tile-overlay--name">
         {sharerName}'s screen
       </div>
+      {quality === 'reconnecting' && (
+        <div className="screen-share-tile-quality screen-share-tile-quality--reconnecting">
+          Reconnecting...
+        </div>
+      )}
+      {quality === 'poor' && (
+        <div className="screen-share-tile-quality screen-share-tile-quality--poor">
+          Poor connection
+        </div>
+      )}
       <div className="screen-share-tile-overlay screen-share-tile-overlay--close">
         <Tooltip content="Stop watching">
           <button

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
@@ -208,6 +208,26 @@ describe('Sidebar root user screen share behavior', () => {
     expect(screen.getByLabelText('Screenshare: Connected')).toBeInTheDocument();
   });
 
+  it('shows active Screenshare quality in service status tooltip text', () => {
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'poor',
+    });
+
+    expect(screen.getByLabelText('Screenshare: Connected - poor')).toBeInTheDocument();
+  });
+
+  it('shows reconnecting Screenshare state for transient LiveKit reconnects', () => {
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'reconnecting',
+    });
+
+    const dot = screen.getByLabelText('Screenshare: Reconnecting');
+    expect(dot).toBeInTheDocument();
+    expect(dot.classList.contains('service-dot--connecting')).toBe(true);
+  });
+
   it('shows local sharing without watch controls or watch actions', () => {
     const onWatchScreenShare = vi.fn();
 

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -11,6 +11,7 @@ import { usePermissions } from '../../hooks/usePermissions';
 import { useServiceStatus } from '../../hooks/useServiceStatus';
 import { useResizable } from '../../hooks/useResizable';
 import type { ShareInfo } from '../../hooks/useScreenShare';
+import type { ScreenShareQuality } from '../../utils/screenShareQuality';
 import { useProfileFingerprint } from '../../contexts/ProfileContext';
 import { prompt } from '../../hooks/usePrompt';
 import bridge from '../../bridge';
@@ -47,6 +48,7 @@ interface SidebarProps {
   activeShares?: ShareInfo[];
   watchingShares?: ShareInfo[];
   isLiveKitRoomConnected?: boolean;
+  screenShareQuality?: ScreenShareQuality;
   onEditAvatar?: () => void;
 }
 
@@ -76,6 +78,7 @@ export function Sidebar({
   activeShares,
   watchingShares,
   isLiveKitRoomConnected = false,
+  screenShareQuality = 'unknown',
   onEditAvatar
 }: SidebarProps) {
   const fingerprint = useProfileFingerprint();
@@ -119,8 +122,18 @@ export function Sidebar({
     const state = stateLabel(status.state);
     const error = status.error;
 
-    if (svc === 'livekit' && status.state === 'connected' && !error && !isLiveKitRoomConnected) {
-      return `${name}: Available`;
+    if (svc === 'livekit' && !error) {
+      if (status.state === 'connected' && !isLiveKitRoomConnected) {
+        return `${name}: Available`;
+      }
+
+      if (isLiveKitRoomConnected && screenShareQuality === 'reconnecting') {
+        return `${name}: Reconnecting`;
+      }
+
+      if (status.state === 'connected' && isLiveKitRoomConnected && screenShareQuality !== 'unknown') {
+        return `${name}: Connected - ${screenShareQuality}`;
+      }
     }
 
     if (svc === 'voice' && status.state === 'connected' && typeof status.loss === 'number') {
@@ -136,6 +149,14 @@ export function Sidebar({
     }
 
     return error ? `${name}: ${state} — ${error}` : `${name}: ${state}`;
+  };
+
+  const serviceDotState = (svc: ServiceName): ServiceState => {
+    if (svc === 'livekit' && isLiveKitRoomConnected && screenShareQuality === 'reconnecting') {
+      return 'connecting';
+    }
+
+    return effectiveStatuses[svc].state;
   };
 
   const [contextMenu, setContextMenu] = useState<{
@@ -224,7 +245,7 @@ export function Sidebar({
                 {serviceOrder.map(svc => (
                   <Tooltip key={svc} content={dotTooltip(svc)} position="top">
                     <span
-                      className={`service-dot service-dot--${effectiveStatuses[svc].state}`}
+                      className={`service-dot service-dot--${serviceDotState(svc)}`}
                       aria-label={dotTooltip(svc)}
                       tabIndex={0}
                     />
@@ -264,7 +285,7 @@ export function Sidebar({
                 {serviceOrder.map(svc => (
                   <Tooltip key={svc} content={dotTooltip(svc)} position="top">
                     <span
-                      className={`service-dot service-dot--${effectiveStatuses[svc].state}`}
+                      className={`service-dot service-dot--${serviceDotState(svc)}`}
                       aria-label={dotTooltip(svc)}
                       tabIndex={0}
                     />

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -47,6 +47,8 @@ const mockRoom = {
   name: 'channel-1',
   state: undefined as string | undefined,
   localParticipant: {
+    identity: '@me:test',
+    connectionQuality: 'unknown',
     setScreenShareEnabled: vi.fn().mockImplementation(async (enabled: boolean) => {
       localSharePublicationEnabled = enabled;
     }),
@@ -90,8 +92,19 @@ vi.mock('livekit-client', () => ({
   },
   RoomEvent: {
     Disconnected: 'disconnected',
+    Connected: 'connected',
+    Reconnecting: 'reconnecting',
+    Reconnected: 'reconnected',
+    ConnectionQualityChanged: 'connectionQualityChanged',
     TrackSubscribed: 'trackSubscribed',
     TrackUnsubscribed: 'trackUnsubscribed',
+  },
+  ConnectionQuality: {
+    Excellent: 'excellent',
+    Good: 'good',
+    Poor: 'poor',
+    Lost: 'lost',
+    Unknown: 'unknown',
   },
   Track: {
     Kind: { Video: 'video' },
@@ -118,6 +131,7 @@ describe('useScreenShare', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRoom.state = undefined;
+    mockRoom.remoteParticipants.clear();
     roomEventHandlers.clear();
     localTrackEventHandlers.clear();
     localSharePublicationEnabled = false;
@@ -1070,6 +1084,98 @@ describe('useScreenShare', () => {
     });
 
     expect(result.current.activeShares).toEqual([]);
+  });
+
+  it('sets room quality to reconnecting without clearing watched shares', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await promise;
+    });
+
+    act(() => {
+      emitRoomEvent('reconnecting');
+    });
+
+    expect(result.current.roomQuality).toBe('reconnecting');
+    expect(result.current.watchingShares).toHaveLength(1);
+  });
+
+  it('restores participant quality after reconnecting', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await promise;
+    });
+
+    act(() => {
+      emitRoomEvent('connectionQualityChanged', 'excellent', { identity: '@alice:test' });
+    });
+
+    expect(result.current.roomQuality).toBe('good');
+
+    act(() => {
+      emitRoomEvent('reconnecting');
+    });
+    expect(result.current.roomQuality).toBe('reconnecting');
+
+    act(() => {
+      emitRoomEvent('reconnected');
+    });
+    expect(result.current.roomQuality).toBe('good');
+  });
+
+  it('updates watched-share quality from LiveKit participant quality events', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await promise;
+    });
+
+    act(() => {
+      emitRoomEvent('connectionQualityChanged', 'poor', { identity: '@alice:test' });
+    });
+
+    expect(result.current.shareQualities.get(10)).toBe('poor');
+    expect(result.current.roomQuality).toBe('poor');
   });
 
   it('ignores stale room-scoped activeShareResult after global discovery becomes current', () => {

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -1114,6 +1114,33 @@ describe('useScreenShare', () => {
     expect(result.current.watchingShares).toHaveLength(1);
   });
 
+  it('marks watched-share quality as reconnecting while room reconnects', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await promise;
+    });
+
+    act(() => {
+      emitRoomEvent('reconnecting');
+    });
+
+    expect(result.current.shareQualities.get(10)).toBe('reconnecting');
+  });
+
   it('restores participant quality after reconnecting', async () => {
     let tokenHandler: ((data: unknown) => void) | null = null;
     let shareStartedHandler: ((data: unknown) => void) | null = null;
@@ -1176,6 +1203,34 @@ describe('useScreenShare', () => {
 
     expect(result.current.shareQualities.get(10)).toBe('poor');
     expect(result.current.roomQuality).toBe('poor');
+  });
+
+  it('sets initial watched-share quality from the participant when connecting as viewer', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+    mockRoom.remoteParticipants.set('@alice:test', {
+      identity: '@alice:test',
+      connectionQuality: 'good',
+      trackPublications: new Map(),
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await promise;
+    });
+
+    expect(result.current.shareQualities.get(10)).toBe('fair');
   });
 
   it('ignores stale room-scoped activeShareResult after global discovery becomes current', () => {

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -189,6 +189,7 @@ export function useScreenShare(
   const watchingSharesRef = useRef<ShareInfo[]>([]);
   const activeSharesRef = useRef<ShareInfo[]>([]);
   const shareQualitiesRef = useRef<Map<number, ScreenShareQuality>>(new Map());
+  const shareQualitiesBeforeReconnectRef = useRef<Map<number, ScreenShareQuality> | null>(null);
   const localQualityRef = useRef<ScreenShareQuality>('unknown');
   const isRoomReconnectingRef = useRef(false);
   const isSharingRef = useRef(false);
@@ -287,6 +288,7 @@ export function useScreenShare(
 
   const resetQualityState = useCallback(() => {
     isRoomReconnectingRef.current = false;
+    shareQualitiesBeforeReconnectRef.current = null;
     localQualityRef.current = 'unknown';
     shareQualitiesRef.current = new Map();
     setShareQualities(new Map());
@@ -709,6 +711,13 @@ export function useScreenShare(
       }
 
       isRoomReconnectingRef.current = true;
+      shareQualitiesBeforeReconnectRef.current = new Map(shareQualitiesRef.current);
+      const nextShareQualities = new Map(shareQualitiesRef.current);
+      for (const share of watchingSharesRef.current) {
+        nextShareQualities.set(share.userId, 'reconnecting');
+      }
+      shareQualitiesRef.current = nextShareQualities;
+      setShareQualities(nextShareQualities);
       setRoomQuality('reconnecting');
     });
 
@@ -718,6 +727,11 @@ export function useScreenShare(
       }
 
       isRoomReconnectingRef.current = false;
+      if (shareQualitiesBeforeReconnectRef.current) {
+        shareQualitiesRef.current = shareQualitiesBeforeReconnectRef.current;
+        shareQualitiesBeforeReconnectRef.current = null;
+        setShareQualities(shareQualitiesRef.current);
+      }
       recomputeRoomQuality();
     };
 
@@ -1020,8 +1034,6 @@ export function useScreenShare(
         const identity = existingShare.matrixUserId ?? String(targetUserId);
         const participant = room.remoteParticipants.get(identity);
         if (participant) {
-          const quality = mapLiveKitQuality(participant.connectionQuality);
-          updateShareQuality(targetUserId, quality);
           participant.trackPublications.forEach((pub: RemoteTrackPublication) => {
             if (pub.track && pub.track.kind === Track.Kind.Video && pub.source === Track.Source.ScreenShare) {
               pub.track.detach();
@@ -1066,6 +1078,7 @@ export function useScreenShare(
       // Subscribe to the target's screen share track
       const participant = room.remoteParticipants.get(participantIdentity);
       if (participant) {
+        updateShareQuality(targetUserId, mapLiveKitQuality(participant.connectionQuality));
         participant.trackPublications.forEach((pub: RemoteTrackPublication) => {
           if (pub.track && pub.track.kind === Track.Kind.Video && pub.source === Track.Source.ScreenShare) {
             const el = pub.track.attach() as HTMLVideoElement;

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState, useEffect, type SetStateAction } from 'react';
 import { Room, RoomEvent, Track, RemoteTrackPublication } from 'livekit-client';
 import bridge from '../bridge';
+import { type ScreenShareQuality, mapLiveKitQuality, worstQuality } from '../utils/screenShareQuality';
 
 export interface ShareInfo {
   roomName: string;
@@ -180,11 +181,16 @@ export function useScreenShare(
   const [isViewerConnectPending, setIsViewerConnectPending] = useState(false);
   const [focusedShare, _setFocusedShare] = useState<ShareInfo | null>(null);
   const [remoteVideoEls, setRemoteVideoEls] = useState<Map<number, HTMLVideoElement>>(new Map());
+  const [roomQuality, setRoomQuality] = useState<ScreenShareQuality>('unknown');
+  const [shareQualities, setShareQualities] = useState<Map<number, ScreenShareQuality>>(new Map());
 
   // Single room connection per channel — used for both publishing and subscribing
   const roomRef = useRef<Room | null>(null);
   const watchingSharesRef = useRef<ShareInfo[]>([]);
   const activeSharesRef = useRef<ShareInfo[]>([]);
+  const shareQualitiesRef = useRef<Map<number, ScreenShareQuality>>(new Map());
+  const localQualityRef = useRef<ScreenShareQuality>('unknown');
+  const isRoomReconnectingRef = useRef(false);
   const isSharingRef = useRef(false);
   const isStartingShareRef = useRef(false);
   const focusedShareRef = useRef<ShareInfo | null>(null);
@@ -261,6 +267,49 @@ export function useScreenShare(
     setWatchingShares(shares);
   }, []);
 
+  const recomputeRoomQuality = useCallback(() => {
+    if (isRoomReconnectingRef.current) {
+      setRoomQuality('reconnecting');
+      return;
+    }
+
+    const qualities: ScreenShareQuality[] = [];
+    if (isSharingRef.current) {
+      qualities.push(localQualityRef.current);
+    }
+
+    for (const share of watchingSharesRef.current) {
+      qualities.push(shareQualitiesRef.current.get(share.userId) ?? 'unknown');
+    }
+
+    setRoomQuality(qualities.length > 0 ? worstQuality(qualities) : 'unknown');
+  }, []);
+
+  const resetQualityState = useCallback(() => {
+    isRoomReconnectingRef.current = false;
+    localQualityRef.current = 'unknown';
+    shareQualitiesRef.current = new Map();
+    setShareQualities(new Map());
+    setRoomQuality('unknown');
+  }, []);
+
+  const updateShareQuality = useCallback((userId: number, quality: ScreenShareQuality) => {
+    shareQualitiesRef.current = new Map(shareQualitiesRef.current).set(userId, quality);
+    setShareQualities(shareQualitiesRef.current);
+    recomputeRoomQuality();
+  }, [recomputeRoomQuality]);
+
+  const removeShareQuality = useCallback((userId: number) => {
+    if (!shareQualitiesRef.current.has(userId)) {
+      return;
+    }
+    const next = new Map(shareQualitiesRef.current);
+    next.delete(userId);
+    shareQualitiesRef.current = next;
+    setShareQualities(next);
+    recomputeRoomQuality();
+  }, [recomputeRoomQuality]);
+
   const clearTokenRefreshTimer = useCallback(() => {
     if (tokenRefreshTimerRef.current) {
       clearTimeout(tokenRefreshTimerRef.current);
@@ -292,34 +341,38 @@ export function useScreenShare(
 
   const addWatchingShare = useCallback((share: ShareInfo) => {
     endedWatchedShareKeysRef.current.delete(watchedShareKey(share.roomName, share.userId));
-    setWatchingShares(prev => {
-      if (prev.some(s => s.userId === share.userId)) return prev;
-      let evictedUserId: number | undefined;
-      let next: ShareInfo[];
-      if (prev.length >= 4) {
-        // Evict oldest non-focused share; fall back to oldest if all focused
-        const focusId = focusedShareRef.current?.userId;
-        const evictIndex = prev.findIndex(s => s.userId !== focusId) ?? 0;
-        evictedUserId = prev[evictIndex].userId;
-        next = [...prev.slice(0, evictIndex), ...prev.slice(evictIndex + 1), share];
-      } else {
-        next = [...prev, share];
-      }
-      watchingSharesRef.current = next;
+    const prev = watchingSharesRef.current;
+    if (prev.some(s => s.userId === share.userId)) return;
 
-      // Clean up evicted share state
-      if (evictedUserId != null) {
-        const evicted = evictedUserId;
-        setFocusedShare(p => p?.userId === evicted ? null : p);
-        setRemoteVideoEls(p => {
-          const m = new Map(p);
-          m.delete(evicted);
-          return m;
-        });
-      }
-      return next;
-    });
-  }, []);
+    let evictedUserId: number | undefined;
+    let next: ShareInfo[];
+    if (prev.length >= 4) {
+      // Evict oldest non-focused share; fall back to oldest if all focused
+      const focusId = focusedShareRef.current?.userId;
+      const nonFocusedIndex = prev.findIndex(s => s.userId !== focusId);
+      const evictIndex = nonFocusedIndex >= 0 ? nonFocusedIndex : 0;
+      evictedUserId = prev[evictIndex].userId;
+      next = [...prev.slice(0, evictIndex), ...prev.slice(evictIndex + 1), share];
+    } else {
+      next = [...prev, share];
+    }
+    watchingSharesRef.current = next;
+    setWatchingShares(next);
+
+    // Clean up evicted share state
+    if (evictedUserId != null) {
+      const evicted = evictedUserId;
+      setFocusedShare(p => p?.userId === evicted ? null : p);
+      removeShareQuality(evicted);
+      setRemoteVideoEls(p => {
+        const m = new Map(p);
+        m.delete(evicted);
+        return m;
+      });
+    }
+
+    recomputeRoomQuality();
+  }, [recomputeRoomQuality, removeShareQuality, setFocusedShare]);
 
   const removeWatchingShare = useCallback((userId: number, options?: { clearPending?: boolean }) => {
     const removedShares = watchingSharesRef.current.filter(s => s.userId === userId);
@@ -337,14 +390,18 @@ export function useScreenShare(
       next.delete(userId);
       return next;
     });
+    removeShareQuality(userId);
     return next;
-  }, [setFocusedShare]);
+  }, [removeShareQuality, setFocusedShare]);
 
   const clearWatchingState = useCallback(() => {
     setRemoteVideoEls(new Map());
     updateWatchingShares([]);
     setFocusedShare(null);
-  }, [setFocusedShare, updateWatchingShares]);
+    shareQualitiesRef.current = new Map();
+    setShareQualities(new Map());
+    recomputeRoomQuality();
+  }, [recomputeRoomQuality, setFocusedShare, updateWatchingShares]);
 
   const endWatchedShare = useCallback((share: ShareInfo, reason: WatchedShareEndReason) => {
     const key = watchedShareKey(share.roomName, share.userId);
@@ -470,13 +527,14 @@ export function useScreenShare(
       roomRef.current = null;
       roomAccessModeRef.current = null;
       roomReconnectUpgradeRef.current = false;
+      resetQualityState();
       clearTokenLease();
       invalidateRoomLifecycle('maybeDisconnectRoom');
       try { await room.disconnect(); } catch { /* ignore */ }
     } else {
       sendScreenShareDebugEvent('maybeDisconnectRoom.skip');
     }
-  }, [clearTokenLease, invalidateRoomLifecycle]);
+  }, [clearTokenLease, invalidateRoomLifecycle, resetQualityState]);
 
   const stopLocalShare = useCallback(async (
     reason: LocalShareStopReason,
@@ -505,6 +563,7 @@ export function useScreenShare(
 
     isSharingRef.current = false;
     setIsSharing(false);
+    recomputeRoomQuality();
 
     if (wasSharing && roomName) {
       bridge.send('livekit.shareStopped', { roomName });
@@ -519,7 +578,7 @@ export function useScreenShare(
 
     await maybeDisconnectRoom();
     sendScreenShareDebugEvent(`stopLocalShare.${reason}.done`);
-  }, [clearLocalShareEndListener, maybeDisconnectRoom]);
+  }, [clearLocalShareEndListener, maybeDisconnectRoom, recomputeRoomQuality]);
 
   const scheduleTokenRefresh = useCallback((lease: ActiveTokenLease) => {
     clearTokenRefreshTimer();
@@ -556,6 +615,7 @@ export function useScreenShare(
           roomRef.current = null;
           roomAccessModeRef.current = null;
           roomReconnectUpgradeRef.current = false;
+          resetQualityState();
           clearTokenLease();
           invalidateRoomLifecycle('tokenRefreshFailed');
           cancelPendingViewerAttempts();
@@ -568,7 +628,7 @@ export function useScreenShare(
         }
       })();
     }, delayMs);
-  }, [cancelPendingViewerAttempts, clearTokenLease, clearTokenRefreshTimer, clearWatchingState, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, requestToken, stopLocalShare]);
+  }, [cancelPendingViewerAttempts, clearTokenLease, clearTokenRefreshTimer, clearWatchingState, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, requestToken, resetQualityState, stopLocalShare]);
 
   const bindLocalShareEndListener = useCallback((room: Room) => {
     clearLocalShareEndListener();
@@ -643,6 +703,49 @@ export function useScreenShare(
       }
     });
 
+    room.on(RoomEvent.Reconnecting, () => {
+      if (roomRef.current !== room) {
+        return;
+      }
+
+      isRoomReconnectingRef.current = true;
+      setRoomQuality('reconnecting');
+    });
+
+    const onReconnected = () => {
+      if (roomRef.current !== room) {
+        return;
+      }
+
+      isRoomReconnectingRef.current = false;
+      recomputeRoomQuality();
+    };
+
+    room.on(RoomEvent.Connected, onReconnected);
+    room.on(RoomEvent.Reconnected, onReconnected);
+
+    room.on(RoomEvent.ConnectionQualityChanged, (connectionQuality, participant) => {
+      if (roomRef.current !== room) {
+        return;
+      }
+
+      const quality = mapLiveKitQuality(connectionQuality);
+      const participantIdentity = participant.identity;
+      if (participantIdentity === room.localParticipant.identity) {
+        localQualityRef.current = quality;
+        recomputeRoomQuality();
+        return;
+      }
+
+      const matchedShare = watchingSharesRef.current.find(s => {
+        const identity = s.matrixUserId ?? String(s.userId);
+        return identity === participantIdentity;
+      });
+      if (matchedShare) {
+        updateShareQuality(matchedShare.userId, quality);
+      }
+    });
+
     room.on(RoomEvent.Disconnected, () => {
       sendScreenShareDebugEvent('room.disconnected.event');
       if (roomRef.current !== room) {
@@ -659,6 +762,7 @@ export function useScreenShare(
 
       roomRef.current = null;
       roomAccessModeRef.current = null;
+      resetQualityState();
       clearTokenLease();
       invalidateRoomLifecycle('roomDisconnected');
       notifyUnexpectedWatchedShareEnds();
@@ -670,7 +774,7 @@ export function useScreenShare(
         void stopLocalShare(teardownIntent ?? 'interrupted', room);
       }
     });
-  }, [clearTokenLease, clearWatchingState, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, removeWatchingShare, stopLocalShare]);
+  }, [clearTokenLease, clearWatchingState, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, recomputeRoomQuality, removeWatchingShare, resetQualityState, stopLocalShare, updateShareQuality]);
 
   // Ensure we have a connected room for the given channel.
   // Returns the existing room if already connected to this channel, otherwise connects.
@@ -728,6 +832,7 @@ export function useScreenShare(
           roomRef.current = null;
           roomAccessModeRef.current = null;
           roomReconnectUpgradeRef.current = false;
+          resetQualityState();
           clearTokenLease();
           roomLifecycleGenerationRef.current += 1;
         }
@@ -756,6 +861,7 @@ export function useScreenShare(
       }
 
       roomReconnectUpgradeRef.current = false;
+      recomputeRoomQuality();
       return room;
     })();
 
@@ -780,7 +886,7 @@ export function useScreenShare(
         pendingRoomRequestRef.current = null;
       }
     }
-  }, [requestToken, clearWatchingState, invalidateRoomLifecycle, clearTokenLease, scheduleTokenRefresh, bindRoomEvents]);
+  }, [requestToken, clearWatchingState, invalidateRoomLifecycle, clearTokenLease, scheduleTokenRefresh, bindRoomEvents, recomputeRoomQuality, resetQualityState]);
 
   const startSharing = useCallback(async (roomName: string): Promise<boolean> => {
     if (isStartingShareRef.current) {
@@ -855,6 +961,7 @@ export function useScreenShare(
 
       isSharingRef.current = true;
       setIsSharing(true);
+      recomputeRoomQuality();
       bindLocalShareEndListener(room);
 
       bridge.send('livekit.shareStarted', { roomName });
@@ -890,7 +997,7 @@ export function useScreenShare(
       isStartingShareRef.current = false;
       sendScreenShareDebugEvent('startSharing.finally');
     }
-  }, [screenShareSettings, ensureRoom, bindLocalShareEndListener, clearLocalShareEndListener, maybeDisconnectRoom, stopLocalShare]);
+  }, [screenShareSettings, ensureRoom, bindLocalShareEndListener, clearLocalShareEndListener, maybeDisconnectRoom, recomputeRoomQuality, stopLocalShare]);
 
   const stopSharing = useCallback(async () => {
     if (isStartingShareRef.current) {
@@ -913,6 +1020,8 @@ export function useScreenShare(
         const identity = existingShare.matrixUserId ?? String(targetUserId);
         const participant = room.remoteParticipants.get(identity);
         if (participant) {
+          const quality = mapLiveKitQuality(participant.connectionQuality);
+          updateShareQuality(targetUserId, quality);
           participant.trackPublications.forEach((pub: RemoteTrackPublication) => {
             if (pub.track && pub.track.kind === Track.Kind.Video && pub.source === Track.Source.ScreenShare) {
               pub.track.detach();
@@ -977,7 +1086,7 @@ export function useScreenShare(
       unregisterPendingViewerAttempt(pendingAttempt);
       endViewerConnectAttempt();
     }
-  }, [activeShares, ensureRoom, addWatchingShare, removeWatchingShare, maybeDisconnectRoom, beginViewerConnectAttempt, endViewerConnectAttempt, registerPendingViewerAttempt, unregisterPendingViewerAttempt]);
+  }, [activeShares, ensureRoom, addWatchingShare, removeWatchingShare, maybeDisconnectRoom, beginViewerConnectAttempt, endViewerConnectAttempt, registerPendingViewerAttempt, unregisterPendingViewerAttempt, updateShareQuality]);
 
   const disconnectViewer = useCallback(async (userId?: number) => {
     const room = roomRef.current;
@@ -1076,6 +1185,7 @@ export function useScreenShare(
           roomRef.current = null;
           roomAccessModeRef.current = null;
           roomReconnectUpgradeRef.current = false;
+          resetQualityState();
           clearTokenLease();
           invalidateRoomLifecycle('shareStoppedDisconnectRoom');
         }
@@ -1155,7 +1265,7 @@ export function useScreenShare(
       bridge.off('livekit.activeShareResult', onActiveShareResult);
       bridge.off('livekit.activeShareError', onActiveShareError);
     };
-  }, [endWatchedShare, removeWatchingShare, updateActiveShares, invalidateRoomLifecycle, cancelPendingViewerAttempts, clearTokenLease]);
+  }, [endWatchedShare, removeWatchingShare, updateActiveShares, invalidateRoomLifecycle, cancelPendingViewerAttempts, clearTokenLease, resetQualityState]);
 
   useEffect(() => {
     return () => {
@@ -1181,6 +1291,7 @@ export function useScreenShare(
     roomRef.current = null;
     roomAccessModeRef.current = null;
     roomReconnectUpgradeRef.current = false;
+    resetQualityState();
     clearTokenLease();
     invalidateRoomLifecycle('serviceUnavailable');
     setDiscoveryTarget(null);
@@ -1190,7 +1301,7 @@ export function useScreenShare(
       await stopLocalShare('interrupted', room);
     }
     try { await room?.disconnect(); } catch { /* ignore */ }
-  }, [cancelPendingViewerAttempts, clearTokenLease, clearWatchingState, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, setDiscoveryTarget, stopLocalShare]);
+  }, [cancelPendingViewerAttempts, clearTokenLease, clearWatchingState, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, resetQualityState, setDiscoveryTarget, stopLocalShare]);
 
   return {
     isSharing,
@@ -1208,6 +1319,8 @@ export function useScreenShare(
     setDiscoveryTarget,
     remoteVideoEl,     // backward compat
     remoteVideoEls,    // new
+    roomQuality,
+    shareQualities,
     addWatchingShare,      // new
     removeWatchingShare,   // new
     disconnectViewer,

--- a/src/Brmble.Web/src/utils/screenShareQuality.test.ts
+++ b/src/Brmble.Web/src/utils/screenShareQuality.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { ConnectionQuality } from 'livekit-client';
+import { mapLiveKitQuality, worstQuality } from './screenShareQuality';
+
+describe('screenShareQuality', () => {
+  it('maps LiveKit quality values to screen-share quality states', () => {
+    expect(mapLiveKitQuality(ConnectionQuality.Excellent)).toBe('good');
+    expect(mapLiveKitQuality(ConnectionQuality.Good)).toBe('fair');
+    expect(mapLiveKitQuality(ConnectionQuality.Poor)).toBe('poor');
+    expect(mapLiveKitQuality(ConnectionQuality.Lost)).toBe('poor');
+    expect(mapLiveKitQuality(ConnectionQuality.Unknown)).toBe('unknown');
+  });
+
+  it('returns the worst quality from active quality states', () => {
+    expect(worstQuality(['good'])).toBe('good');
+    expect(worstQuality(['good', 'fair', 'poor'])).toBe('poor');
+    expect(worstQuality(['good', 'unknown', 'fair'])).toBe('fair');
+    expect(worstQuality(['good', 'poor', 'reconnecting'])).toBe('reconnecting');
+  });
+
+  it('defaults to unknown for an empty quality collection', () => {
+    expect(worstQuality([])).toBe('unknown');
+  });
+});

--- a/src/Brmble.Web/src/utils/screenShareQuality.ts
+++ b/src/Brmble.Web/src/utils/screenShareQuality.ts
@@ -1,0 +1,37 @@
+import { ConnectionQuality } from 'livekit-client';
+
+export type ScreenShareQuality = 'unknown' | 'good' | 'fair' | 'poor' | 'reconnecting';
+
+export function mapLiveKitQuality(q: ConnectionQuality): ScreenShareQuality {
+  switch (q) {
+    case ConnectionQuality.Excellent:
+      return 'good';
+    case ConnectionQuality.Good:
+      return 'fair';
+    case ConnectionQuality.Poor:
+    case ConnectionQuality.Lost:
+      return 'poor';
+    case ConnectionQuality.Unknown:
+    default:
+      return 'unknown';
+  }
+}
+
+const QUALITY_RANK: Record<ScreenShareQuality, number> = {
+  reconnecting: 4,
+  poor: 3,
+  fair: 2,
+  good: 1,
+  unknown: 0,
+};
+
+/** Returns the worst quality from a collection, preferring reconnecting > poor > fair > good > unknown. */
+export function worstQuality(qualities: Iterable<ScreenShareQuality>): ScreenShareQuality {
+  let worst: ScreenShareQuality = 'unknown';
+  for (const q of qualities) {
+    if (QUALITY_RANK[q] > QUALITY_RANK[worst]) {
+      worst = q;
+    }
+  }
+  return worst;
+}


### PR DESCRIPTION
## Summary
- add LiveKit screen-share room/share quality tracking for good/fair/poor/reconnecting states
- preserve watched tiles during transient LiveKit reconnects and show reconnecting/poor-quality UI
- update Screenshare service tooltip and LiveKit roadmap/F2 docs

## Validation
- npm run build
- npm test -- --run src\\hooks\\useScreenShare.test.ts src\\utils\\screenShareQuality.test.ts src\\components\\ScreenShareGrid\\ScreenShareTile.test.tsx src\\components\\Sidebar\\Sidebar.test.tsx
- dotnet build

Note: npm run lint still reports pre-existing unrelated lint issues in App.screenShareStart.test.ts and App.tsx.