### PR TITLE
fix: enforce UI guide theme compliance

### DIFF
--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -653,7 +653,7 @@ The component sets `aria-hidden="true"` automatically. Color inherits from `curr
 | **Media** | `monitor`, `monitor-off`, `minimize-2`, `maximize-2` | Screen share & fullscreen |
 | **Chat** | `message-square`, `message-circle` | Message bubble variants |
 | **Server** | `server`, `globe`, `folder`, `shield`, `star`, `ban`, `triangle-right` | Infrastructure & moderation |
-| **UI — Actions** | `x`, `search`, `plus`, `check`, `send`, `upload`, `arrow-right`, `eye`, `eye-off`, `chevron-up`, `chevron-down`, `info`, `info-filled` | Generic interactive icons |
+| **UI — Actions** | `x`, `search`, `plus`, `check`, `send`, `upload`, `refresh-cw`, `arrow-right`, `eye`, `eye-off`, `chevron-up`, `chevron-down`, `info`, `info-filled` | Generic interactive icons |
 | **UI — Objects** | `user`, `settings`, `save`, `palette`, `moon` | Profiles, preferences, idle indicator |
 | **Window** | `window-minimize`, `window-maximize`, `window-close` | Title bar controls (custom viewBox) |
 | **Brmblegotchi — Actions** | `gotchi-food`, `gotchi-play`, `gotchi-clean` | Pet interaction buttons |

--- a/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.css
+++ b/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.css
@@ -263,6 +263,18 @@
   flex-shrink: 0;
 }
 
+.brmblegotchi-stat-icon.cleanliness {
+  color: var(--accent-primary);
+}
+
+.brmblegotchi-stat-icon.hunger {
+  color: var(--accent-secondary);
+}
+
+.brmblegotchi-stat-icon.happiness {
+  color: var(--accent-decorative);
+}
+
 .brmblegotchi-stat-icon svg {
   width: 100%;
   height: 100%;

--- a/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx
+++ b/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.tsx
@@ -850,7 +850,7 @@ export function BrmblegotchiWidget({ onOpenSettings, enabled = true }: Brmblegot
           <>
             {showCleanliness && (
               <div className="brmblegotchi-stat">
-                <div className="brmblegotchi-stat-icon" style={{ color: 'var(--accent-primary)' }}>
+                <div className="brmblegotchi-stat-icon cleanliness">
                   <Icon name="gotchi-cleanliness" />
                 </div>
                 <div className="brmblegotchi-stat-bar">
@@ -860,7 +860,7 @@ export function BrmblegotchiWidget({ onOpenSettings, enabled = true }: Brmblegot
             )}
             {showHunger && (
               <div className="brmblegotchi-stat">
-                <div className="brmblegotchi-stat-icon" style={{ color: 'var(--accent-secondary)' }}>
+                <div className="brmblegotchi-stat-icon hunger">
                   <Icon name="gotchi-hunger" />
                 </div>
                 <div className="brmblegotchi-stat-bar">
@@ -870,7 +870,7 @@ export function BrmblegotchiWidget({ onOpenSettings, enabled = true }: Brmblegot
             )}
             {showHappiness && (
               <div className="brmblegotchi-stat">
-                <div className="brmblegotchi-stat-icon" style={{ color: 'var(--accent-decorative)' }}>
+                <div className="brmblegotchi-stat-icon happiness">
                   <Icon name="gotchi-happiness" />
                 </div>
                 <div className="brmblegotchi-stat-bar">

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -267,7 +267,7 @@ const [replyState, setReplyState] = useState<{
           left: 0;
           width: 100vw;
           height: 100vh;
-          background: #000;
+          background: var(--bg-deep);
           z-index: 99999;
           display: flex;
           flex-direction: column;
@@ -276,41 +276,41 @@ const [replyState, setReplyState] = useState<{
           display: flex;
           align-items: center;
           justify-content: space-between;
-          padding: 12px 20px;
-          background: #1a1a1a;
+          padding: var(--space-sm) var(--space-xl);
+          background: var(--bg-primary);
           -webkit-app-region: drag;
         }
         #screenshare-new-window-overlay .title {
-          color: #fff;
-          font-size: 15px;
+          color: var(--text-primary);
+          font-size: var(--text-sm);
           font-weight: 500;
         }
         #screenshare-new-window-overlay .buttons {
           display: flex;
-          gap: 8px;
+          gap: var(--space-xs);
           -webkit-app-region: no-drag;
         }
         #screenshare-new-window-overlay .btn {
-          background: #333;
+          background: var(--bg-hover);
           border: none;
-          color: #fff;
-          padding: 6px 14px;
-          border-radius: 4px;
+          color: var(--text-primary);
+          padding: var(--space-xs) var(--space-sm);
+          border-radius: var(--radius-xs);
           cursor: pointer;
-          font-size: 12px;
+          font-size: var(--text-xs);
         }
         #screenshare-new-window-overlay .btn-close {
-          background: #d32f2f;
+          background: var(--accent-danger);
         }
         #screenshare-new-window-overlay .btn-close:hover {
-          background: #b71c1c;
+          background: var(--accent-danger-strong);
         }
         #screenshare-new-window-overlay .video-container {
           flex: 1;
           display: flex;
           align-items: center;
           justify-content: center;
-          background: #000;
+          background: var(--bg-deep);
         }
         #screenshare-new-window-overlay video {
           max-width: 100%;

--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
@@ -7,7 +7,7 @@
 
 .message-bubble:hover,
 .message-bubble:focus-within {
-  background: rgba(128, 128, 128, 0.05);
+  background: var(--bg-hover-light);
 }
 
 .message-avatar {
@@ -150,7 +150,7 @@ p.message-text {
   gap: var(--space-sm);
   padding: var(--space-xs) var(--space-sm);
   margin-top: var(--space-xs);
-  background: var(--status-error-subtle, rgba(239, 68, 68, 0.1));
+  background: var(--accent-danger-subtle);
   border-radius: var(--radius-sm);
   border: 1px solid var(--status-error);
 }

--- a/src/Brmble.Web/src/components/ChatPanel/MessageInput.css
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageInput.css
@@ -101,7 +101,7 @@
 
 .message-input-wrapper.drag-over {
   border-color: var(--accent-primary);
-  background: var(--accent-primary-subtle, rgba(99, 102, 241, 0.05));
+  background: var(--accent-primary-ghost);
 }
 
 .image-validation-error {

--- a/src/Brmble.Web/src/components/ChatPanel/ReplyHeader.css
+++ b/src/Brmble.Web/src/components/ChatPanel/ReplyHeader.css
@@ -1,19 +1,19 @@
 .reply-header {
   display: flex;
   align-items: center;
-  gap: var(--space-sm, 12px);
-  padding: var(--space-sm, 12px);
+  gap: var(--space-sm);
+  padding: var(--space-sm);
   background: var(--bg-surface);
   border: 1px solid var(--border-subtle);
   border-left: 2px solid var(--accent-primary);
-  border-radius: var(--radius-md, 8px);
-  margin-bottom: var(--space-sm, 12px);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-sm);
   box-shadow: var(--shadow-drop-subtle);
 }
 
 .reply-header-label {
   font-family: var(--font-body);
-  font-size: var(--text-2xs, 10px);
+  font-size: var(--text-2xs);
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -23,7 +23,7 @@
 .reply-header-content {
   display: flex;
   align-items: center;
-  gap: var(--space-xs, 8px);
+  gap: var(--space-xs);
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -32,14 +32,14 @@
 .reply-header-sender {
   font-family: var(--font-body);
   font-weight: 600;
-  font-size: var(--text-xs, 12px);
+  font-size: var(--text-xs);
   color: var(--text-primary);
   white-space: nowrap;
 }
 
 .reply-header-preview {
   font-family: var(--font-body);
-  font-size: var(--text-xs, 12px);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
@@ -48,12 +48,12 @@
 }
 
 .reply-header-cancel {
-  padding: var(--space-2xs, 4px);
+  padding: var(--space-2xs);
   background: none;
   border: none;
   cursor: pointer;
   color: var(--text-muted);
-  border-radius: var(--radius-xs, 4px);
+  border-radius: var(--radius-xs);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/Brmble.Web/src/components/ChatPanel/ReplyHeader.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ReplyHeader.tsx
@@ -19,11 +19,11 @@ interface ReplyHeaderProps {
 
 function getPreviewLabel(msgType: string): string {
   switch (msgType) {
-    case 'm.image': return '📷 Image';
-    case 'm.video': return '🎥 Video';
-    case 'm.file': return '📎 File';
-    case 'm.audio': return '🎵 Audio';
-    default: return '💬 Message';
+    case 'm.image': return 'Image';
+    case 'm.video': return 'Video';
+    case 'm.file': return 'File';
+    case 'm.audio': return 'Audio';
+    default: return 'Message';
   }
 }
 

--- a/src/Brmble.Web/src/components/CompanionOverlay/CompanionOverlay.css
+++ b/src/Brmble.Web/src/components/CompanionOverlay/CompanionOverlay.css
@@ -8,30 +8,30 @@
 }
 
 .companion-overlay--minimal {
-  width: min(360px, calc(100vw - 48px));
-  gap: 8px;
+  width: min(360px, calc(100vw - var(--space-2xl)));
+  gap: var(--space-xs);
 }
 
 .overlay-panel-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 10px;
-  gap: 10px;
+  margin-bottom: var(--space-xs);
+  gap: var(--space-xs);
 }
 
 .overlay-panel-label {
-  font-size: 12px;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.65);
+  filter: var(--shadow-drop-subtle);
 }
 
 .overlay-panel-channel {
-  font-size: 12px;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.65);
+  filter: var(--shadow-drop-subtle);
 }
 
 .overlay-speaker-stack {
@@ -39,17 +39,17 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 8px;
+  gap: var(--space-xs);
 }
 
 .overlay-speaker-pill {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-xs);
   padding: 0;
   width: fit-content;
-  transition: opacity 180ms ease, filter 180ms ease, color 180ms ease;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.8);
+  transition: opacity var(--transition-fast), filter var(--transition-fast), color var(--transition-fast);
+  filter: var(--shadow-drop-subtle);
 }
 
 .overlay-speaker-pill--silent {
@@ -59,11 +59,11 @@
 }
 
 .overlay-speaker-dot {
-  width: 8px;
-  height: 8px;
+  width: var(--space-xs);
+  height: var(--space-xs);
   border-radius: 50%;
   background: var(--text-secondary);
-  transition: background-color 180ms ease, transform 180ms ease, opacity 180ms ease;
+  transition: background-color var(--transition-fast), transform var(--transition-fast), opacity var(--transition-fast);
 }
 
 .overlay-speaker-pill--speaking .overlay-speaker-dot {
@@ -76,35 +76,35 @@
 }
 
 .overlay-event-feed {
-  margin: 10px 0 0;
-  padding-left: 16px;
+  margin: var(--space-xs) 0 0;
+  padding-left: var(--space-md);
 }
 
 .overlay-event-line {
-  margin: 4px 0;
-  font-size: 12px;
-  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.8);
+  margin: var(--space-2xs) 0;
+  font-size: var(--text-xs);
+  filter: var(--shadow-drop-subtle);
 }
 
 .companion-overlay--full {
-  gap: 12px;
+  gap: var(--space-sm);
 }
 
 .companion-anchor {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-xs);
 }
 
 .companion-sprite-frame {
   position: relative;
-  width: 120px;
-  height: 120px;
+  width: 7.5rem;
+  height: 7.5rem;
 }
 
 .companion-sprite {
-  width: 120px;
-  height: 120px;
+  width: 7.5rem;
+  height: 7.5rem;
   image-rendering: pixelated;
 }
 
@@ -119,53 +119,53 @@
 
 .companion-badges {
   position: absolute;
-  top: -8px;
-  right: -8px;
+  top: calc(-1 * var(--space-xs));
+  right: calc(-1 * var(--space-xs));
   display: flex;
-  gap: 4px;
+  gap: var(--space-2xs);
 }
 
 .companion-badge {
   display: inline-flex;
-  min-width: 20px;
-  height: 20px;
+  min-width: var(--text-xl);
+  height: var(--text-xl);
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
-  padding: 0 6px;
-  background: rgba(0, 0, 0, 0.72);
-  color: white;
-  font-size: 10px;
+  border-radius: var(--radius-full);
+  padding: 0 var(--space-xs);
+  background: var(--bg-overlay);
+  color: var(--text-primary);
+  font-size: var(--text-2xs);
   font-weight: 800;
   letter-spacing: 0.04em;
   text-shadow: none;
 }
 
 .companion-badge--muted {
-  background: rgba(230, 74, 74, 0.88);
+  background: var(--accent-danger-bg);
 }
 
 .companion-badge--live {
-  background: rgba(64, 188, 111, 0.88);
+  background: var(--accent-success-bg);
 }
 
 .companion-bubble {
   position: relative;
-  max-width: min(320px, calc(100vw - 96px));
-  padding: 10px 14px;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  border-radius: 18px;
-  background: linear-gradient(180deg, rgba(34, 40, 52, 0.94), rgba(19, 23, 32, 0.94));
-  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.28), 0 6px 14px rgba(0, 0, 0, 0.24);
+  max-width: min(320px, calc(100vw - calc(var(--space-2xl) * 2)));
+  padding: var(--space-xs) var(--space-sm);
+  border: var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-glass);
+  box-shadow: var(--shadow-elevated);
 }
 
 .companion-bubble::before,
 .companion-bubble::after {
   content: '';
   position: absolute;
-  top: -7px;
-  width: 14px;
-  height: 14px;
+  top: calc(-1 * var(--space-xs));
+  width: var(--space-sm);
+  height: var(--space-sm);
   transform: rotate(45deg);
 }
 
@@ -175,39 +175,39 @@
 }
 
 .companion-bubble::after {
-  background: rgba(19, 23, 32, 0.94);
-  border-top: 1px solid rgba(255, 255, 255, 0.22);
+  background: var(--bg-glass);
+  border-top: var(--glass-border);
 }
 
 .companion-bubble p {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-sm);
   line-height: 1.4;
-  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.7);
+  filter: var(--shadow-drop-subtle);
 }
 
 .companion-overlay--position-top-left {
-  top: 24px;
-  left: 24px;
+  top: var(--space-lg);
+  left: var(--space-lg);
   align-items: flex-start;
 }
 
 .companion-overlay--position-top-right {
-  top: 24px;
-  right: 24px;
+  top: var(--space-lg);
+  right: var(--space-lg);
   align-items: flex-end;
 }
 
 .companion-overlay--position-bottom-left {
-  left: 24px;
-  bottom: 24px;
+  left: var(--space-lg);
+  bottom: var(--space-lg);
   align-items: flex-start;
   flex-direction: column-reverse;
 }
 
 .companion-overlay--position-bottom-right {
-  right: 24px;
-  bottom: 24px;
+  right: var(--space-lg);
+  bottom: var(--space-lg);
   align-items: flex-end;
   flex-direction: column-reverse;
 }
@@ -224,19 +224,19 @@
 
 .companion-overlay--position-top-left .companion-bubble,
 .companion-overlay--position-bottom-left .companion-bubble {
-  margin-left: 18px;
+  margin-left: var(--space-lg);
 }
 
 .companion-overlay--position-top-left .companion-bubble::before,
 .companion-overlay--position-bottom-left .companion-bubble::before,
 .companion-overlay--position-top-left .companion-bubble::after,
 .companion-overlay--position-bottom-left .companion-bubble::after {
-  left: -7px;
+  left: calc(-1 * var(--space-xs));
 }
 
 .companion-overlay--position-top-left .companion-bubble::after,
 .companion-overlay--position-bottom-left .companion-bubble::after {
-  border-left: 1px solid rgba(255, 255, 255, 0.22);
+  border-left: var(--glass-border);
 }
 
 .companion-overlay--position-top-right .companion-anchor,
@@ -246,17 +246,17 @@
 
 .companion-overlay--position-top-right .companion-bubble,
 .companion-overlay--position-bottom-right .companion-bubble {
-  margin-right: 18px;
+  margin-right: var(--space-lg);
 }
 
 .companion-overlay--position-top-right .companion-bubble::before,
 .companion-overlay--position-bottom-right .companion-bubble::before,
 .companion-overlay--position-top-right .companion-bubble::after,
 .companion-overlay--position-bottom-right .companion-bubble::after {
-  right: -7px;
+  right: calc(-1 * var(--space-xs));
 }
 
 .companion-overlay--position-top-right .companion-bubble::after,
 .companion-overlay--position-bottom-right .companion-bubble::after {
-  border-right: 1px solid rgba(255, 255, 255, 0.22);
+  border-right: var(--glass-border);
 }

--- a/src/Brmble.Web/src/components/ConnectModal/ConnectModal.css
+++ b/src/Brmble.Web/src/components/ConnectModal/ConnectModal.css
@@ -98,6 +98,10 @@
   width: 100%;
 }
 
+.locked-input-tooltip-trigger {
+  display: block;
+}
+
 .input-row {
   display: flex;
   gap: var(--space-sm);

--- a/src/Brmble.Web/src/components/ConnectModal/ConnectModal.css
+++ b/src/Brmble.Web/src/components/ConnectModal/ConnectModal.css
@@ -43,6 +43,10 @@
   color: var(--text-primary);
 }
 
+.modal-close svg {
+  pointer-events: none;
+}
+
 .modal-header {
   text-align: center;
   margin-bottom: var(--space-xl);

--- a/src/Brmble.Web/src/components/ConnectModal/ConnectModal.tsx
+++ b/src/Brmble.Web/src/components/ConnectModal/ConnectModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Icon } from '../Icon/Icon';
+import { Tooltip } from '../Tooltip/Tooltip';
 import './ConnectModal.css';
 
 interface ConnectModalProps {
@@ -27,7 +28,7 @@ export function ConnectModal({ isOpen, onClose, onConnect, registeredUsername }:
     <div className="modal-overlay" onClick={onClose}>
       <div className="connect-modal glass-panel animate-slide-up" onClick={(e) => e.stopPropagation()}>
         <button className="modal-close" onClick={onClose}>
-          <Icon name="x" size={20} style={{ pointerEvents: 'none' }} />
+            <Icon name="x" size={20} />
         </button>
 
         <div className="modal-header">
@@ -62,7 +63,8 @@ export function ConnectModal({ isOpen, onClose, onConnect, registeredUsername }:
 
           <div className="form-group">
             <label htmlFor="username">Username</label>
-            <input
+            <Tooltip content={registeredUsername ? 'Username is locked after registration' : ''}>
+              <input
               id="username"
               className="brmble-input"
               type="text"
@@ -70,9 +72,9 @@ export function ConnectModal({ isOpen, onClose, onConnect, registeredUsername }:
               onChange={(e) => setUsername(e.target.value)}
               placeholder="Your display name"
               disabled={!!registeredUsername}
-              title={registeredUsername ? 'Username is locked after registration' : undefined}
               required
-            />
+              />
+            </Tooltip>
           </div>
 
           <div className="form-group">

--- a/src/Brmble.Web/src/components/ConnectModal/ConnectModal.tsx
+++ b/src/Brmble.Web/src/components/ConnectModal/ConnectModal.tsx
@@ -27,8 +27,8 @@ export function ConnectModal({ isOpen, onClose, onConnect, registeredUsername }:
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="connect-modal glass-panel animate-slide-up" onClick={(e) => e.stopPropagation()}>
-        <button className="modal-close" onClick={onClose}>
-            <Icon name="x" size={20} />
+        <button className="modal-close" onClick={onClose} aria-label="Close connect modal">
+          <Icon name="x" size={20} />
         </button>
 
         <div className="modal-header">
@@ -64,16 +64,18 @@ export function ConnectModal({ isOpen, onClose, onConnect, registeredUsername }:
           <div className="form-group">
             <label htmlFor="username">Username</label>
             <Tooltip content={registeredUsername ? 'Username is locked after registration' : ''}>
-              <input
-              id="username"
-              className="brmble-input"
-              type="text"
-              value={registeredUsername || username}
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder="Your display name"
-              disabled={!!registeredUsername}
-              required
-              />
+              <span className="locked-input-tooltip-trigger" tabIndex={registeredUsername ? 0 : -1}>
+                <input
+                  id="username"
+                  className="brmble-input"
+                  type="text"
+                  value={registeredUsername || username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder="Your display name"
+                  disabled={!!registeredUsername}
+                  required
+                />
+              </span>
             </Tooltip>
           </div>
 

--- a/src/Brmble.Web/src/components/ErrorBoundary.css
+++ b/src/Brmble.Web/src/components/ErrorBoundary.css
@@ -1,0 +1,60 @@
+.error-boundary-fallback {
+  padding: var(--space-lg);
+  margin: var(--space-xs);
+  background: var(--bg-surface);
+  border: 1px solid var(--accent-danger);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  text-align: center;
+}
+
+.error-boundary-heading {
+  margin-bottom: var(--space-sm);
+}
+
+.error-boundary-title {
+  color: var(--accent-danger);
+  font-family: var(--font-display);
+}
+
+.error-boundary-message {
+  color: var(--text-muted);
+  margin: 0 0 var(--space-md) 0;
+}
+
+.error-boundary-details {
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  margin-bottom: var(--space-md);
+}
+
+.error-boundary-error {
+  color: var(--accent-danger);
+  margin-bottom: var(--space-xs);
+}
+
+.error-boundary-stack {
+  white-space: pre-wrap;
+  color: var(--text-muted);
+}
+
+.error-boundary-component-stack {
+  opacity: 0.8;
+}
+
+.error-boundary-trace {
+  margin-top: var(--space-sm);
+}
+
+.error-boundary-summary {
+  cursor: pointer;
+  color: var(--accent-decorative);
+}
+
+.error-boundary-runtime-stack {
+  margin-top: var(--space-xs);
+  opacity: 0.7;
+}

--- a/src/Brmble.Web/src/components/ErrorBoundary.tsx
+++ b/src/Brmble.Web/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ReactNode, type ErrorInfo } from 'react';
+import './ErrorBoundary.css';
 
 interface Props {
   label: string;
@@ -46,47 +47,32 @@ export class ErrorBoundary extends Component<Props, State> {
       const errorStack = this.state.error.stack;
       const componentStack = this.state.info?.componentStack;
       return (
-        <div className="error-boundary-fallback" style={{
-          padding: 'var(--space-lg)',
-          margin: 'var(--space-xs)',
-          background: 'var(--bg-surface)',
-          border: '1px solid var(--accent-danger)',
-          borderRadius: 'var(--radius-md)',
-          color: 'var(--text-primary)',
-          fontFamily: 'var(--font-body)',
-          fontSize: 'var(--text-sm, 0.875rem)',
-          textAlign: 'center',
-        }}>
-          <div style={{ marginBottom: 'var(--space-sm)' }}>
-            <strong style={{ color: 'var(--accent-danger)', fontFamily: 'var(--font-display)' }}>
+        <div className="error-boundary-fallback">
+          <div className="error-boundary-heading">
+            <strong className="error-boundary-title">
               Something went wrong
             </strong>
           </div>
-          <p style={{ color: 'var(--text-muted)', margin: '0 0 var(--space-md) 0' }}>
+          <p className="error-boundary-message">
             This section encountered an error and could not be displayed.
           </p>
-          <div style={{ 
-            textAlign: 'left',
-            fontFamily: 'var(--font-mono)', 
-            fontSize: 'var(--text-xs, 0.75rem)',
-            marginBottom: 'var(--space-md)',
-          }}>
+          <div className="error-boundary-details">
             {isDev && (
               <>
-                <p style={{ color: 'var(--accent-danger)', marginBottom: 'var(--space-xs)' }}>
+                <p className="error-boundary-error">
                   Error: {errorMessage}
                 </p>
                 {componentStack && (
-                  <pre style={{ whiteSpace: 'pre-wrap', opacity: 0.8, color: 'var(--text-muted)' }}>
+                  <pre className="error-boundary-stack error-boundary-component-stack">
                     {componentStack}
                   </pre>
                 )}
                 {errorStack && (
-                  <details style={{ marginTop: 'var(--space-sm)' }}>
-                    <summary style={{ cursor: 'pointer', color: 'var(--accent-decorative)' }}>
+                  <details className="error-boundary-trace">
+                    <summary className="error-boundary-summary">
                       Stack trace
                     </summary>
-                    <pre style={{ whiteSpace: 'pre-wrap', marginTop: 'var(--space-xs)', opacity: 0.7 }}>
+                    <pre className="error-boundary-stack error-boundary-runtime-stack">
                       {errorStack}
                     </pre>
                   </details>

--- a/src/Brmble.Web/src/components/Game/GameUI.css
+++ b/src/Brmble.Web/src/components/Game/GameUI.css
@@ -635,7 +635,7 @@
 
 /* Hosting Tab */
 .hosting-tab {
-  padding: 16px;
+  padding: var(--space-md);
 }
 
 .hosting-penalty {
@@ -643,10 +643,10 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-md) var(--space-lg);
-  background: linear-gradient(135deg, rgba(239, 68, 68, 0.1) 0%, rgba(239, 68, 68, 0.05) 100%);
+  background: var(--accent-danger-subtle);
   border-radius: var(--radius-md);
   margin-bottom: var(--space-lg);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  border: 1px solid var(--accent-danger-border);
 }
 
 .penalty-info {
@@ -678,28 +678,28 @@
 
 .hosting-stats {
   display: flex;
-  gap: 24px;
-  margin-bottom: 24px;
+  gap: var(--space-lg);
+  margin-bottom: var(--space-lg);
 }
 
 .stat {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-2xs);
 }
 
 .stat-label {
-  font-size: 12px;
-  color: var(--text-muted, #888);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
 }
 
 .stat-value {
-  font-size: 18px;
+  font-size: var(--text-lg);
   font-family: var(--font-mono);
 }
 
 .services-section {
-  margin-bottom: 24px;
+  margin-bottom: var(--space-lg);
 }
 
 .services-section > .heading-label {
@@ -747,7 +747,7 @@
 
 .hosting-row:hover {
   border-color: var(--accent-primary);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-drop-subtle);
 }
 
 .hosting-row .service-name {
@@ -807,7 +807,7 @@
 }
 
 .badge-time.urgent {
-  color: var(--accent-danger, #ef4444);
+  color: var(--accent-danger);
 }
 
 /* Infrastructure Tab - restore original layout */
@@ -864,7 +864,7 @@
 }
 
 .service-status {
-  font-size: 12px;
+  font-size: var(--text-xs);
   color: var(--accent-success);
   font-weight: 600;
 }
@@ -874,8 +874,8 @@
 }
 
 .service-requirement {
-  font-size: 12px;
-  color: var(--text-muted, #888);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
 }
 
 .modal-overlay {
@@ -884,7 +884,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--bg-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -968,14 +968,14 @@
 
 /* Drop target states */
 .hosting-row.drag-over {
-  background: rgba(59, 130, 246, 0.15);
-  border: 2px solid var(--accent-primary, #3b82f6);
+  background: var(--accent-primary-ghost);
+  border: 2px solid var(--accent-primary);
   position: relative;
   transition: all 0.2s ease;
 }
 
 .hosting-row.drag-over:hover {
-  background: rgba(59, 130, 246, 0.25);
+  background: var(--accent-primary-wash);
 }
 
 .drop-overlay {
@@ -984,8 +984,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(59, 130, 246, 0.4);
-  color: white;
+  background: var(--accent-primary-wash);
+  color: var(--text-primary);
   font-weight: 600;
   font-size: var(--text-sm);
   border-radius: var(--radius-md);
@@ -1061,7 +1061,7 @@
 .unlock-card:hover,
 .upgrade-category:hover {
   border-color: var(--accent-primary);
-  box-shadow: var(--shadow-sm, 0 2px 8px rgba(0, 0, 0, 0.1));
+  box-shadow: var(--shadow-drop-subtle);
   transform: translateY(-1px);
 }
 
@@ -1264,9 +1264,9 @@
   align-items: center;
   justify-content: center;
   padding: var(--space-xl);
-  background: linear-gradient(135deg, rgba(34, 197, 94, 0.1) 0%, rgba(34, 197, 94, 0.05) 100%);
+  background: var(--accent-success-subtle);
   border-radius: var(--radius-md);
-  border: 1px solid rgba(34, 197, 94, 0.2);
+  border: 1px solid var(--accent-success-border);
 }
 
 .all-unlocked p {
@@ -1355,4 +1355,3 @@
   margin-bottom: 0;
   padding-bottom: 0;
 }
-

--- a/src/Brmble.Web/src/components/Game/contracts/ContractPopup.css
+++ b/src/Brmble.Web/src/components/Game/contracts/ContractPopup.css
@@ -42,7 +42,6 @@
 
 .contract-stars {
   color: var(--accent-primary);
-  letter-spacing: 2px;
 }
 
 .contract-time {

--- a/src/Brmble.Web/src/components/Game/contracts/ContractPopup.tsx
+++ b/src/Brmble.Web/src/components/Game/contracts/ContractPopup.tsx
@@ -23,7 +23,7 @@ function getTimeRange(stars: number): string {
 }
 
 function renderStars(stars: number): string {
-  return '★'.repeat(stars) + '☆'.repeat(5 - stars);
+  return `${stars}/5 stars`;
 }
 
 export function ContractPopup({ contracts, onSelect, onClose }: ContractPopupProps) {
@@ -43,7 +43,7 @@ export function ContractPopup({ contracts, onSelect, onClose }: ContractPopupPro
                 className="contract-card"
                 onClick={() => onSelect(contract)}
               >
-                <h3 className="contract-name">{contract.name}</h3>
+                <h3 className="heading-section contract-name">{contract.name}</h3>
                 <div className="contract-stats">
                   <span>Volume: {formatVolume(contract.volumeBytes)}</span>
                   <span className="contract-stars">{renderStars(contract.multiplierStars)}</span>

--- a/src/Brmble.Web/src/components/Game/contracts/ContractSlot.css
+++ b/src/Brmble.Web/src/components/Game/contracts/ContractSlot.css
@@ -52,7 +52,6 @@
 
 .contract-stars {
   color: var(--accent-primary);
-  letter-spacing: 1px;
   font-size: var(--text-sm);
 }
 

--- a/src/Brmble.Web/src/components/Game/contracts/ContractSlot.css
+++ b/src/Brmble.Web/src/components/Game/contracts/ContractSlot.css
@@ -30,7 +30,7 @@
 }
 
 .contract-slot.complete {
-  border-color: var(--accent-success, #22c55e);
+  border-color: var(--accent-success);
 }
 
 .slot-label {
@@ -83,7 +83,7 @@
 }
 
 .timer-value.urgent {
-  color: var(--accent-danger, #ef4444);
+  color: var(--accent-danger);
 }
 
 .timer-progress {
@@ -94,32 +94,32 @@
 /* Contract progress bar - more prominent */
 .contract-progress-bar {
   height: 12px;
-  background: #2a2a2a;
-  border-radius: 6px;
+  background: var(--bg-input);
+  border-radius: var(--radius-sm);
   overflow: hidden;
   margin: var(--space-xs) 0;
-  border: 1px solid #444;
+  border: 1px solid var(--border-subtle);
 }
 
 .contract-progress-fill {
   height: 100%;
-  background: linear-gradient(90deg, #22c55e, #3b82f6);
+  background: linear-gradient(90deg, var(--accent-success), var(--accent-primary));
   transition: width 0.1s linear;
   min-width: 4px;
 }
 
 /* Pending contract state */
 .contract-slot.pending {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(59, 130, 246, 0.05) 100%);
-  border: 2px solid var(--accent-primary, #3b82f6);
+  background: var(--accent-primary-ghost);
+  border: 2px solid var(--accent-primary);
   cursor: grab;
   transition: all 0.2s ease;
 }
 
 .contract-slot.pending:hover {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25) 0%, rgba(59, 130, 246, 0.1) 100%);
+  background: var(--accent-primary-wash);
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.2);
+  box-shadow: 0 0 var(--glow-sm) var(--accent-primary-glow);
 }
 
 .contract-slot.pending:active {
@@ -145,7 +145,7 @@
   justify-content: center;
   width: 24px;
   height: 40px;
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--bg-hover-light);
   border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
@@ -189,7 +189,7 @@
   align-items: center;
   gap: var(--space-xs);
   font-size: var(--text-xs);
-  color: var(--accent-primary, #3b82f6);
+  color: var(--accent-primary);
   padding: var(--space-xs) 0;
 }
 

--- a/src/Brmble.Web/src/components/Game/contracts/ContractSlot.tsx
+++ b/src/Brmble.Web/src/components/Game/contracts/ContractSlot.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import type { ActiveContract, Service, Contract } from '../types';
+import { Icon } from '../../Icon/Icon';
 import './ContractSlot.css';
 
 interface ContractSlotProps {
@@ -20,7 +21,7 @@ function formatVolume(bytes: number): string {
 }
 
 function renderStars(stars: number): string {
-  return '★'.repeat(stars) + '☆'.repeat(5 - stars);
+  return `${stars}/5 stars`;
 }
 
 function formatMoney(amount: number): string {
@@ -101,7 +102,9 @@ export function ContractSlot({ index, activeContract, pendingContract, license, 
       >
         <div className="slot-header">
           <span className="slot-label">Slot {index + 1}</span>
-          <button className="btn btn-ghost btn-xs slot-cancel" onClick={onCancel}>×</button>
+          <button className="btn btn-ghost btn-xs slot-cancel" onClick={onCancel} aria-label="Cancel contract">
+            <Icon name="x" size={12} />
+          </button>
         </div>
         <div className="pending-body">
           <div className="drag-handle">
@@ -113,7 +116,7 @@ export function ContractSlot({ index, activeContract, pendingContract, license, 
           </div>
         </div>
         <div className="pending-hint">
-          <span className="hint-icon">↔</span> Drag to a license to activate
+          Drag to a license to activate
         </div>
       </div>
     );

--- a/src/Brmble.Web/src/components/Icon/Icon.tsx
+++ b/src/Brmble.Web/src/components/Icon/Icon.tsx
@@ -225,6 +225,16 @@ const iconPaths: Record<string, IconDef> = {
       </>
     ),
   },
+  'refresh-cw': {
+    paths: (
+      <>
+        <polyline points="23 4 23 10 17 10" />
+        <polyline points="1 20 1 14 7 14" />
+        <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10" />
+        <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14" />
+      </>
+    ),
+  },
   'arrow-right': {
     paths: <path d="M5 12h14M12 5l7 7-7 7" />,
   },
@@ -372,7 +382,7 @@ const iconPaths: Record<string, IconDef> = {
     paths: (
       <>
         <rect x="2.5" y="0.5" width="7" height="7" fill="none" stroke="currentColor" strokeWidth="1" />
-        <rect x="0.5" y="2.5" width="7" height="7" fill="var(--bg-deep, #0f0a14)" stroke="currentColor" strokeWidth="1" />
+        <rect x="0.5" y="2.5" width="7" height="7" fill="var(--bg-deep)" stroke="currentColor" strokeWidth="1" />
       </>
     ),
   },

--- a/src/Brmble.Web/src/components/NeonD/NeonD.module.css
+++ b/src/Brmble.Web/src/components/NeonD/NeonD.module.css
@@ -17,8 +17,14 @@
   flex-shrink: 0;
 }
 
+.headerTop,
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .title {
-  font-size: 28px;
   font-family: var(--font-display);
   font-weight: 600;
   margin-bottom: var(--space-md);
@@ -55,21 +61,20 @@
 }
 
 .productionCard {
-  background: rgba(20, 20, 25, 0.8);
+  background: var(--bg-surface);
   border: 1px solid var(--glass-border);
   border-left: 4px solid var(--accent-success);
   border-radius: var(--radius-md);
   padding: var(--space-lg);
-  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.8), 
-              inset 0 0 10px rgba(0, 255, 150, 0.1);
-  transition: all 0.3s ease;
+  box-shadow: var(--shadow-elevated);
+  transition: all var(--transition-normal);
   margin-bottom: var(--space-md);
 }
 
 .productionCard:hover {
   transform: translateY(-5px);
   border-color: var(--accent-success);
-  box-shadow: 0 10px 40px 0 rgba(0, 255, 150, 0.2);
+  box-shadow: 0 0 var(--glow-lg) var(--accent-success-glow);
 }
 
 .distributionCard {
@@ -77,7 +82,6 @@
 }
 
 .columnHeader {
-  font-size: 18px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--accent-success);
@@ -102,7 +106,6 @@
 }
 
 .label {
-  font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-style: italic;
@@ -127,8 +130,8 @@
 .flowIndicator {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: 10px;
+  gap: var(--space-2xs);
+  font-size: var(--text-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -147,6 +150,88 @@
   height: 0;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
+}
+
+.ratingButton {
+  cursor: help;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+}
+
+.ratingValue {
+  color: var(--accent-secondary);
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2xs);
+}
+
+.productTitle {
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.dealerName {
+  color: var(--accent-primary);
+  margin-bottom: var(--space-sm);
+}
+
+.bonusText {
+  color: var(--accent-primary);
+  font-size: var(--text-sm);
+}
+
+.equipmentSlots {
+  color: var(--accent-primary);
+  font-size: var(--text-lg);
+}
+
+.equipmentSlotEmpty {
+  opacity: 0.3;
+}
+
+.equipmentModalOverlay {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.equipmentModal {
+  padding: var(--space-xl);
+  max-width: 500px;
+}
+
+.equipmentOptions {
+  display: grid;
+  gap: var(--space-xs);
+  margin-top: var(--space-lg);
+}
+
+.sideHustleOption {
+  border: 2px solid var(--accent-secondary);
+  box-shadow: 0 0 var(--glow-md) var(--accent-secondary-glow);
+}
+
+.equipmentOptionLabel {
+  font-weight: bold;
+}
+
+.equipmentOptionDescription {
+  font-size: var(--text-2xs);
+  opacity: 0.8;
 }
 
 .flowArrowUp {
@@ -169,7 +254,108 @@
   color: var(--text-primary);
   cursor: pointer;
   font-weight: 600;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
+}
+
+.resetButton {
+  margin-left: auto;
+  flex: 0;
+  background-color: var(--accent-secondary);
+  color: var(--text-primary);
+}
+
+.stockValue,
+.sideVolumeValue {
+  color: var(--accent-success);
+}
+
+.spacedRow {
+  margin-bottom: var(--space-sm);
+}
+
+.buttonSpacing {
+  margin-top: var(--space-sm);
+}
+
+.refreshButton {
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: var(--accent-primary);
+}
+
+.refreshButton:disabled {
+  cursor: not-allowed;
+  color: var(--text-muted);
+}
+
+.slotCard {
+  margin-bottom: var(--space-md);
+  padding: var(--space-md);
+}
+
+.slotCardLocked {
+  opacity: 0.6;
+}
+
+.slotCardCompact {
+  margin-bottom: var(--space-md);
+  padding: var(--space-sm);
+}
+
+.fullWidthButton {
+  width: 100%;
+  margin-top: var(--space-sm);
+}
+
+.dealerCard {
+  margin-bottom: var(--space-md);
+  padding: var(--space-md);
+}
+
+.primaryHireButton {
+  background: var(--accent-primary);
+  margin-top: var(--space-sm);
+}
+
+.distributionPanel {
+  padding: 0;
+  overflow: hidden;
+  margin-bottom: var(--space-md);
+}
+
+.dealerBody {
+  padding: var(--space-md);
+}
+
+.actionStack {
+  display: grid;
+  gap: var(--space-xs);
+  margin-top: var(--space-md);
+}
+
+.dangerText {
+  color: var(--accent-secondary);
+}
+
+.successText {
+  color: var(--accent-success);
+}
+
+.incomeRow {
+  margin-top: var(--space-xs);
+  border-top: 1px solid var(--glass-border);
+  padding-top: var(--space-xs);
+}
+
+.boldValue {
+  font-weight: 700;
+}
+
+.equipmentRow {
+  margin-top: var(--space-md);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--glass-border);
 }
 
 .upgradeButton:active {
@@ -181,22 +367,20 @@
   padding: var(--space-sm) var(--space-md);
   border-radius: var(--radius-md);
   border: none;
-  background: linear-gradient(135deg, var(--accent-success) 0%, #00cc66 100%);
-  color: #000;
+  background: var(--accent-success);
+  color: var(--bg-deep);
   cursor: pointer;
   font-weight: 700;
   font-size: var(--text-sm);
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  box-shadow: 0 4px 15px 0 rgba(0, 255, 150, 0.3),
-              inset 0 0 10px rgba(255, 255, 255, 0.1);
-  transition: all 0.2s ease;
+  box-shadow: 0 0 var(--glow-md) var(--accent-success-glow);
+  transition: all var(--transition-fast);
 }
 
 .buyButton:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 6px 25px 0 rgba(0, 255, 150, 0.5),
-              inset 0 0 15px rgba(255, 255, 255, 0.2);
+  box-shadow: 0 0 var(--glow-lg) var(--accent-success-glow);
 }
 
 .buyButton:active:not(:disabled) {
@@ -221,13 +405,13 @@
   font-size: var(--text-sm);
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .unlockButton:hover:not(:disabled) {
   background: var(--accent-primary);
   color: var(--bg-deep);
-  box-shadow: 0 0 20px rgba(0, 200, 255, 0.4);
+  box-shadow: 0 0 var(--glow-md) var(--accent-primary-glow);
 }
 
 .unlockButton:disabled {
@@ -247,19 +431,19 @@
   font-size: var(--text-sm);
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .dangerButton:hover {
   background: var(--accent-secondary);
   color: var(--bg-deep);
-  box-shadow: 0 0 20px rgba(255, 50, 150, 0.4);
+  box-shadow: 0 0 var(--glow-md) var(--accent-secondary-glow);
 }
 
 .level {
-  background: rgba(255,255,255,0.1);
-  padding: 2px 8px;
-  border-radius: 4px;
+  background: var(--bg-hover-light);
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-xs);
 }
 
 .upgradeCost {
@@ -268,10 +452,10 @@
 
 .select {
   background: var(--bg-deep);
-  color: white;
+  color: var(--text-primary);
   border: 1px solid var(--glass-border);
-  border-radius: 4px;
-  padding: 2px 8px;
+  border-radius: var(--radius-xs);
+  padding: var(--space-2xs) var(--space-xs);
 }
 
 .dealerHeader {
@@ -296,7 +480,7 @@
 }
 
 .toggleHint {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -315,17 +499,17 @@
   width: 34px;
   height: 18px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--bg-hover-light);
   border: 1px solid var(--glass-border);
   display: inline-flex;
   align-items: center;
   padding: 2px;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .toggleTrack[data-active='true'] {
-  background: rgba(0, 255, 150, 0.2);
-  border-color: rgba(0, 255, 150, 0.5);
+  background: var(--accent-success-subtle);
+  border-color: var(--accent-success-border);
 }
 
 .toggleThumb {
@@ -333,7 +517,7 @@
   height: 12px;
   border-radius: 50%;
   background: var(--text-muted);
-  transition: transform 0.2s ease, background 0.2s ease;
+  transition: transform var(--transition-fast), background var(--transition-fast);
 }
 
 .toggleThumb[data-active='true'] {

--- a/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
+++ b/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
@@ -4,22 +4,23 @@ import { UNLOCK_COSTS, PRODUCT_TIERS, SLOT_UNLOCK_COSTS, PRODUCT_ARREST_RISK } f
 import { getBailCost } from './economy';
 import { confirm } from '../../hooks/usePrompt';
 import { Tooltip } from '../Tooltip/Tooltip';
+import { Icon } from '../Icon/Icon';
 import styles from './NeonD.module.css';
 
 
 
 function StarRating({ rating, label, tooltipText }: { rating: number; label?: string; tooltipText?: string }) {
   const clampedRating = Math.min(5, Math.max(0, Math.round(rating)));
-  const stars = '★'.repeat(clampedRating) + '☆'.repeat(5 - clampedRating);
+  const stars = `${clampedRating}/5`;
   const text = tooltipText || (label ? `${label}: ${clampedRating}/5` : `Rating: ${clampedRating}/5`);
   return (
     <Tooltip content={text}>
       <button 
         tabIndex={0}
         aria-label={`Rating: ${clampedRating}/5`} 
-        style={{ cursor: 'help', background: 'none', border: 'none', padding: 0, font: 'inherit' }}
+        className={styles.ratingButton}
       >
-        <span style={{ color: 'gold' }} aria-hidden="true">{stars}</span>
+        <span className={styles.ratingValue} aria-hidden="true">{stars}</span>
       </button>
     </Tooltip>
   );
@@ -140,14 +141,15 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
   return (
     <div className={styles.container}>
       <header className={styles.header}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <h2 className={styles.title}>Brmble Empire</h2>
+        <div className={styles.headerTop}>
+          <h2 className={`heading-title ${styles.title}`}>Brmble Empire</h2>
           {onClose && (
             <button 
               onClick={onClose}
-              style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: '1.5rem' }}
+              className={styles.closeButton}
+              aria-label="Close Brmble Empire"
             >
-              ×
+              <Icon name="x" size={20} />
             </button>
           )}
         </div>
@@ -162,9 +164,8 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
             {state.activeDealers.filter(d => d !== null).length > 0 ? `($${Object.values(state.lastEarningsPerDealer).reduce((a, b) => a + b, 0).toFixed(2)}/s)` : ''}
           </div>
           <button 
-            className={styles.upgradeButton} 
             onClick={resetGame}
-            style={{ marginLeft: 'auto', flex: 0, backgroundColor: 'var(--accent-secondary)', color: 'var(--text-primary)' }}
+            className={`${styles.upgradeButton} ${styles.resetButton}`}
           >
             Reset
           </button>
@@ -173,7 +174,7 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
 
       <div className={styles.gridLayout}>
         <section>
-          <h3 className={styles.productionColumnHeader}>Production</h3>
+          <h3 className={`heading-section ${styles.productionColumnHeader}`}>Production</h3>
           
           {visibleProduction.map(prod => {
             const isUnlocked = state.unlockedProduction.includes(prod.id);
@@ -185,15 +186,15 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
             return (
               <div key={prod.id} className={`glass-panel ${styles.productionCard}`}>
                 <div className={styles.statRow}>
-                  <h3 className={styles.columnHeader} style={{ margin: 0, color: 'var(--text-primary)' }}>
+                  <h3 className={`heading-section ${styles.productTitle}`}>
                       {prod.name}
                   </h3>
-                  {isUnlocked && <span style={{ color: 'var(--accent-success)' }}>{prod.stock.toFixed(2)}g</span>}
+                  {isUnlocked && <span className={styles.stockValue}>{prod.stock.toFixed(2)}g</span>}
                 </div>
                 
                 {isUnlocked && (
                   <>
-                    <div className={styles.statRow} style={{ marginBottom: 'var(--space-sm)' }}>
+                    <div className={`${styles.statRow} ${styles.spacedRow}`}>
                       <span className={styles.productionRate}>
                         Yield: <strong>+{prod.rate.toFixed(2)}g/s</strong>
                       </span>
@@ -220,7 +221,7 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                       </span>
                     </div>
 
-                    <div style={{ marginTop: 'var(--space-sm)' }}>
+                    <div className={styles.buttonSpacing}>
                       <button 
                         className={styles.buyButton}
                         onClick={() => upgrade(prod.id)}
@@ -247,15 +248,14 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
         </section>
 
         <section>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <h3 className={styles.distributionColumnHeader}>Distribution</h3>
+          <div className={styles.sectionHeader}>
+            <h3 className={`heading-section ${styles.distributionColumnHeader}`}>Distribution</h3>
             <button 
               onClick={refreshPool} 
-              className={styles.label} 
-              style={{ cursor: refreshCooldown ? 'not-allowed' : 'pointer', border: 'none', background: 'none', color: refreshCooldown ? 'var(--text-muted)' : 'var(--accent-primary)' }}
+              className={`${styles.label} ${styles.refreshButton}`}
               disabled={!!refreshCooldown}
             >
-              🔄 Refresh {refreshCooldown ? `(${refreshCooldown})` : ''}
+              <Icon name="refresh-cw" size={14} /> Refresh {refreshCooldown ? `(${refreshCooldown})` : ''}
             </button>
           </div>
           
@@ -263,14 +263,13 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
             if (slotIndex >= state.unlockedSlots) {
               const cost = SLOT_UNLOCK_COSTS[slotIndex] || 0;
               return (
-                <div key={`locked-${slotIndex}`} className="glass-panel" style={{ marginBottom: 'var(--space-md)', padding: 'var(--space-md)', opacity: 0.6 }}>
+                <div key={`locked-${slotIndex}`} className={`glass-panel ${styles.slotCard} ${styles.slotCardLocked}`}>
                   <div className={styles.statRow}>
                     <span className={styles.label}>Slot {slotIndex + 1}</span>
-                    <span className={styles.label}>🔒 Locked</span>
+                    <span className={styles.label}>Locked</span>
                   </div>
                   <button 
-                    className={styles.unlockButton}
-                    style={{ width: '100%', marginTop: 'var(--space-sm)' }}
+                    className={`${styles.unlockButton} ${styles.fullWidthButton}`}
                     onClick={unlockSlot}
                     disabled={state.money < cost}
                   >
@@ -282,13 +281,13 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
             
             if (slot === null) {
               return (
-                <div key={`empty-${slotIndex}`} className="glass-panel" style={{ marginBottom: 'var(--space-md)', padding: 'var(--space-sm)' }}>
-                  <p className={styles.label} style={{ marginBottom: 'var(--space-sm)' }}>Slot {slotIndex + 1} - Empty</p>
+                <div key={`empty-${slotIndex}`} className={`glass-panel ${styles.slotCardCompact}`}>
+                  <p className={`${styles.label} ${styles.spacedRow}`}>Slot {slotIndex + 1} - Empty</p>
                   {state.availableDealers.length > 0 && (
                     <div>
                       {state.availableDealers.map((dealer) => (
-                        <div key={dealer.id} className="glass-panel" style={{ marginBottom: 'var(--space-md)', padding: 'var(--space-md)' }}>
-                          <h4 style={{ color: 'var(--accent-primary)', margin: '0 0 12px 0' }}>{dealer.name}</h4>
+                        <div key={dealer.id} className={`glass-panel ${styles.dealerCard}`}>
+                          <h4 className={`heading-label ${styles.dealerName}`}>{dealer.name}</h4>
                           <div className={styles.statRow}>
                             <span className={styles.label}>Volume:</span>
                             <StarRating rating={dealer.volumeStars} label="Volume" tooltipText={`can sell up to ${Number((dealer.volume * (1 + dealer.volumeBonus)).toFixed(2))}g of ${state.production[dealer.selling]?.name || 'Weed'} per second.`} />
@@ -298,8 +297,7 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                             <StarRating rating={dealer.marginStars} label="Margin" tooltipText={`sells 1g of ${state.production[dealer.selling]?.name || 'Weed'} for $${(dealer.margin * (1 + dealer.marginBonus) * (PRODUCT_TIERS[dealer.selling] || 1)).toFixed(2)}`} />
                           </div>
                           <button 
-                            className={styles.buyButton} 
-                            style={{ background: 'var(--accent-primary)', marginTop: 'var(--space-sm)' }}
+                            className={`${styles.buyButton} ${styles.primaryHireButton}`}
                             onClick={() => hireDealer(dealer, slotIndex)}
                           >
                             Hire to Slot {slotIndex + 1}
@@ -314,20 +312,20 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
             
             if (slot.isArrested) {
               return (
-                <div key={slot.id} className={`glass-panel ${styles.distributionCard}`} style={{ padding: 0, overflow: 'hidden', marginBottom: 'var(--space-md)' }}>
+                <div key={slot.id} className={`glass-panel ${styles.distributionCard} ${styles.distributionPanel}`}>
                   <div className={styles.dealerHeader}>
                     {slot.name} ({state.production[slot.selling]?.name})
                   </div>
-                  <div style={{ padding: 'var(--space-md)' }}>
+                  <div className={styles.dealerBody}>
                     <div className={styles.statRow}>
                       <span className={styles.label}>Status:</span>
-                      <span style={{ color: 'var(--accent-secondary)' }}>Arrested</span>
+                      <span className={styles.dangerText}>Arrested</span>
                     </div>
                     <div className={styles.statRow}>
                       <span className={styles.label}>Earnings:</span>
                       <span>$0.00/s</span>
                     </div>
-                    <div style={{ display: 'grid', gap: 'var(--space-xs)', marginTop: 'var(--space-md)' }}>
+                    <div className={styles.actionStack}>
                       <button 
                         className={styles.buyButton} 
                         onClick={() => payDealerBail(slot.id)}
@@ -351,12 +349,12 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                 const isInsufficientFunds = !hasStoredPendingUpgrade && state.money < upgradeCost;
                 
                 return (
-                  <div key={slot.id} className={`glass-panel ${styles.distributionCard}`} style={{ padding: 0, overflow: 'hidden', marginBottom: 'var(--space-md)' }}>
+                  <div key={slot.id} className={`glass-panel ${styles.distributionCard} ${styles.distributionPanel}`}>
                     <div className={styles.dealerHeader}>
                       {slot.name} ({state.production[slot.selling]?.name})
                     </div>
                     
-                    <div style={{ padding: 'var(--space-md)' }}>
+                    <div className={styles.dealerBody}>
                       <div className={styles.statRow}>
                         <span className={styles.label}>Slot {slotIndex + 1}</span>
                       </div>
@@ -377,17 +375,17 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                       <div className={styles.statRow}>
                         <span className={styles.label}>Volume:</span>
                         <StarRating rating={slot.volumeStars} label="Volume" tooltipText={`can sell up to ${Number((slot.volume * (1 + slot.volumeBonus)).toFixed(2))}g of ${state.production[slot.selling]?.name || 'Weed'} per second.`} />
-                        <span style={{ color: 'var(--accent-primary)', fontSize: '0.85rem' }}>({(1 + slot.volumeBonus).toFixed(1)}x)</span>
+                        <span className={styles.bonusText}>({(1 + slot.volumeBonus).toFixed(1)}x)</span>
                       </div>
                       <div className={styles.statRow}>
                         <span className={styles.label}>Margin:</span>
                         <StarRating rating={slot.marginStars} label="Margin" tooltipText={`sells 1g of ${state.production[slot.selling]?.name || 'Weed'} for $${(slot.margin * (1 + slot.marginBonus) * (PRODUCT_TIERS[slot.selling] || 1)).toFixed(2)}`} />
-                        <span style={{ color: 'var(--accent-primary)', fontSize: '0.85rem' }}>({(1 + slot.marginBonus).toFixed(1)}x)</span>
+                        <span className={styles.bonusText}>({(1 + slot.marginBonus).toFixed(1)}x)</span>
                       </div>
                       {!slot.isProtected && (
                         <div className={styles.statRow}>
                           <span className={styles.label}>Risk:</span>
-                          <span style={{ color: 'var(--accent-secondary)' }}>
+                          <span className={styles.dangerText}>
                             {PRODUCT_ARREST_RISK[slot.selling]?.label ?? 'LOW'} Risk
                           </span>
                         </div>
@@ -395,14 +393,14 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                       {slot.isProtected && (
                         <div className={styles.statRow}>
                           <span className={styles.label}>Status:</span>
-                          <span style={{ color: 'var(--accent-success)' }}>Protected</span>
+                          <span className={styles.successText}>Protected</span>
                         </div>
                       )}
 
                       {slot.sideVolume > 0 && (
                         <div className={styles.statRow}>
                           <span className={styles.label}>Side Volume:</span>
-                          <span style={{ color: 'var(--accent-primary)' }}>{(slot.sideVolume * 100).toFixed(1)}%</span>
+                          <span className={styles.sideVolumeValue}>{(slot.sideVolume * 100).toFixed(1)}%</span>
                         </div>
                       )}
 
@@ -424,22 +422,24 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                         </button>
                       </div>
 
-                      <div className={styles.statRow} style={{ marginTop: 'var(--space-xs)', borderTop: '1px solid var(--glass-border)', paddingTop: 'var(--space-xs)' }}>
+                      <div className={`${styles.statRow} ${styles.incomeRow}`}>
                         <span className={styles.label}>Earnings:</span>
-                        <span className={styles.productionRate} style={{ fontWeight: 'bold' }}>
+                        <span className={`${styles.productionRate} ${styles.boldValue}`}>
                           +${(state.lastEarningsPerDealer[slot.id] || 0).toFixed(2)}/s
                         </span>
                       </div>
 
-                      <div className={styles.statRow} style={{ marginTop: 'var(--space-md)', paddingTop: 'var(--space-sm)', borderTop: '1px solid var(--glass-border)' }}>
+                      <div className={`${styles.statRow} ${styles.equipmentRow}`}>
                         <span className={styles.label}>Equip Slots:</span>
-                        <span style={{ color: 'var(--accent-primary)', fontSize: '1.2rem' }}>
-                          {'●'.repeat(dealer.equipmentCount)}
-                          <span style={{ opacity: 0.3 }}>{'○'.repeat(3 - dealer.equipmentCount)}</span>
+                        <span className={styles.equipmentSlots}>
+                          {'filled '.repeat(dealer.equipmentCount).trim()}
+                          {dealer.equipmentCount < 3 && (
+                            <span className={styles.equipmentSlotEmpty}> {'empty '.repeat(3 - dealer.equipmentCount).trim()}</span>
+                          )}
                         </span>
                       </div>
 
-                      <div style={{ marginTop: 'var(--space-sm)', display: 'grid', gap: 'var(--space-xs)' }}>
+                      <div className={styles.actionStack}>
                         <button
                           className={styles.buyButton}
                           disabled={isMaxed || isInsufficientFunds}
@@ -476,29 +476,21 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
       </div>
 
       {upgradingDealer?.hasPendingUpgrade && upgradingDealer.pendingUpgradeOptions.length === 3 && !upgradingDealer.isArrested && (
-        <div style={{
-          position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
-          background: 'rgba(0,0,0,0.85)', display: 'flex', 
-          alignItems: 'center', justifyContent: 'center', zIndex: 1000
-        }}>
-          <div className="glass-panel" style={{ padding: 'var(--space-xl)', maxWidth: '500px' }}>
-            <h3 className={styles.columnHeader}>Select Equipment</h3>
-            <div style={{ display: 'grid', gap: '10px', marginTop: '20px' }}>
+        <div className={styles.equipmentModalOverlay}>
+          <div className={`glass-panel ${styles.equipmentModal}`}>
+            <h3 className={`heading-section ${styles.columnHeader}`}>Select Equipment</h3>
+            <div className={styles.equipmentOptions}>
               {upgradingDealer.pendingUpgradeOptions.map((opt, i) => (
                 <button 
                   key={i} 
-                  className={opt.type === 'SIDE_HUSTLE' ? styles.dangerButton : styles.buyButton}
-                  style={opt.type === 'SIDE_HUSTLE' ? { 
-                    border: '2px solid gold', 
-                    boxShadow: '0 0 20px rgba(255, 215, 0, 0.5)'
-                  } : {}}
+                  className={opt.type === 'SIDE_HUSTLE' ? `${styles.dangerButton} ${styles.sideHustleOption}` : styles.buyButton}
                   onClick={() => {
                     buyEquipment(upgradingDealer.id, opt);
                     setUpgradingDealerId(null);
                   }}
                 >
-                  <div style={{ fontWeight: 'bold' }}>{opt.label}</div>
-                  <div style={{ fontSize: '10px', opacity: 0.8 }}>{opt.description}</div>
+                  <div className={styles.equipmentOptionLabel}>{opt.label}</div>
+                  <div className={styles.equipmentOptionDescription}>{opt.description}</div>
                 </button>
               ))}
             </div>

--- a/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.css
+++ b/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.css
@@ -159,10 +159,21 @@
   padding-top: 0;
 }
 
+.onboarding-actions.onboarding-actions-compact {
+  border-top: none;
+  padding-top: 0;
+  margin-top: var(--space-sm);
+}
+
 .onboarding-error {
   color: var(--accent-danger-text);
   font-size: var(--text-sm);
   margin-bottom: var(--space-md);
+}
+
+.onboarding-readonly-static {
+  pointer-events: none;
+  user-select: none;
 }
 
 .onboarding-skip-link {

--- a/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -780,7 +780,6 @@ export function OnboardingWizard({ onComplete, onServersImported, isMaximized }:
               <label htmlFor="onboarding-profile-name">Profile name</label>
               <input
                 id="onboarding-profile-name"
-                className="brmble-input"
                 type="text"
                 value={newName}
                 onChange={e => setNewName(e.target.value)}
@@ -823,7 +822,7 @@ export function OnboardingWizard({ onComplete, onServersImported, isMaximized }:
                     {busy ? 'Setting up…' : 'Generate New Certificate'}
                   </button>
                 </div>
-                <div className="onboarding-actions" style={{ borderTop: 'none', paddingTop: 0, marginTop: 'var(--space-sm)' }}>
+                <div className="onboarding-actions onboarding-actions-compact">
                   <button className="btn btn-ghost btn-back" onClick={() => setStep('identity')}>Back</button>
                 </div>
                 <input
@@ -867,12 +866,11 @@ export function OnboardingWizard({ onComplete, onServersImported, isMaximized }:
             <div className="onboarding-new-identity-form">
               <label>Profile name</label>
               <input
-                className="brmble-input"
                 type="text"
                 value={newName}
                 readOnly
                 tabIndex={-1}
-                style={{ pointerEvents: 'none', userSelect: 'none' }}
+                className="brmble-input onboarding-readonly-static"
               />
             </div>
             {fingerprint && (
@@ -882,7 +880,7 @@ export function OnboardingWizard({ onComplete, onServersImported, isMaximized }:
               </div>
             )}
             {exportError && (
-              <p style={{ color: 'var(--accent-danger-text)', fontSize: 'var(--text-sm)', marginBottom: 'var(--space-md)' }}>
+              <p className="onboarding-error">
                 {exportError}
               </p>
             )}

--- a/src/Brmble.Web/src/components/ServerList/ServerList.css
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.css
@@ -75,28 +75,28 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-2, 0.5rem);
-  color: var(--accent-danger, #e74c3c);
-  background: var(--accent-danger-subtle, rgba(231, 76, 60, 0.08));
-  border: 1px solid var(--accent-danger-border, rgba(231, 76, 60, 0.25));
-  border-radius: var(--radius-md, 0.5rem);
-  padding: var(--space-2, 0.5rem) var(--space-3, 0.75rem);
-  margin-bottom: var(--space-3, 0.75rem);
-  font-size: var(--text-sm, 0.875rem);
+  gap: var(--space-xs);
+  color: var(--accent-danger);
+  background: var(--accent-danger-subtle);
+  border: 1px solid var(--accent-danger-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-xs) var(--space-sm);
+  margin-bottom: var(--space-sm);
+  font-size: var(--text-sm);
   text-align: left;
-  animation: formSlideIn var(--animation-normal, 200ms) ease backwards;
+  animation: formSlideIn var(--animation-normal) ease backwards;
 }
 
 .server-list-error-dismiss {
   background: none;
   border: none;
-  color: var(--accent-danger, #e74c3c);
+  color: var(--accent-danger);
   cursor: pointer;
   padding: 0.25rem;
-  font-size: var(--text-base, 1rem);
+  font-size: var(--text-base);
   line-height: 1;
   opacity: 0.7;
-  transition: opacity var(--transition-fast, 100ms);
+  transition: opacity var(--transition-fast);
   flex-shrink: 0;
 }
 
@@ -351,7 +351,7 @@
   right: var(--space-sm);
   top: 50%;
   transform: translateY(-50%);
-  color: var(--accent-success, #4ade80);
+  color: var(--accent-success);
   pointer-events: none;
 }
 

--- a/src/Brmble.Web/src/components/SettingsModal/AudioSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/AudioSettingsTab.tsx
@@ -385,7 +385,7 @@ export function AudioSettingsTab({ settings, noiseSuppression, onChange, onNoise
       <div className="settings-section">
         <div className="settings-section-header">
           <span className="settings-dev-label">DEV</span>
-          <span className="settings-section-title">Audio Capture API</span>
+          <h3 className="heading-section settings-section-title">Audio Capture API</h3>
         </div>
         <div className="toggle-group">
           <button

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
@@ -195,7 +195,7 @@
 }
 
 .user-status-icon--idle {
-  color: color-mix(in srgb, var(--text-muted, #888) 65%, transparent);
+  color: color-mix(in srgb, var(--text-muted) 65%, transparent);
   flex-shrink: 0;
 }
 

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.css
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.css
@@ -325,6 +325,11 @@
   z-index: 100;
 }
 
+.channel-description-input {
+  resize: vertical;
+  min-height: 60px;
+}
+
 .channels-section-count {
   font-size: var(--text-2xs);
   color: var(--border-glow);

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -640,7 +640,7 @@ export function Sidebar({
             <div className="prompt-input-container">
               <input
                 type="text"
-                className="brmble-input channel-description-input"
+                className="brmble-input"
                 placeholder="Channel name"
                 value={newChannelName}
                 onChange={(e) => setNewChannelName(e.target.value)}
@@ -649,7 +649,7 @@ export function Sidebar({
             </div>
             <div className="prompt-input-container">
               <textarea
-                className="brmble-input"
+                className="brmble-input channel-description-input"
                 placeholder="Description (optional, max 127 chars)"
                 value={newChannelDescription}
                 onChange={(e) => setNewChannelDescription(e.target.value.slice(0, 127))}

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -640,7 +640,7 @@ export function Sidebar({
             <div className="prompt-input-container">
               <input
                 type="text"
-                className="brmble-input"
+                className="brmble-input channel-description-input"
                 placeholder="Channel name"
                 value={newChannelName}
                 onChange={(e) => setNewChannelName(e.target.value)}
@@ -654,7 +654,6 @@ export function Sidebar({
                 value={newChannelDescription}
                 onChange={(e) => setNewChannelDescription(e.target.value.slice(0, 127))}
                 rows={3}
-                style={{ resize: 'vertical', minHeight: '60px' }}
               />
             </div>
             <div className="prompt-footer">

--- a/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.css
+++ b/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.css
@@ -147,6 +147,10 @@
   gap: var(--space-sm);
 }
 
+.user-info-no-transition {
+  transition: none;
+}
+
 .user-info-volume-section {
   margin-bottom: var(--space-lg);
 }

--- a/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
+++ b/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
@@ -233,7 +233,7 @@ export function UserInfoDialog({
 
         <div className="user-info-actions">
           {editingComment && (
-            <button className="btn btn-secondary" style={{ transition: 'none' }} onClick={() => { setEditingComment(false); setCommentDraft(comment || ''); }}>
+            <button className="btn btn-secondary user-info-no-transition" onClick={() => { setEditingComment(false); setCommentDraft(comment || ''); }}>
               Cancel
             </button>
           )}

--- a/src/Brmble.Web/src/index.css
+++ b/src/Brmble.Web/src/index.css
@@ -259,7 +259,7 @@ a:hover {
 
 .btn-primary {
   background: var(--accent-primary);
-  color: #ffffff;
+  color: var(--text-primary);
   border: 1px solid transparent;
   box-shadow: 0 0 var(--glow-md) var(--accent-primary-glow);
 }

--- a/src/Brmble.Web/src/index.css
+++ b/src/Brmble.Web/src/index.css
@@ -259,7 +259,7 @@ a:hover {
 
 .btn-primary {
   background: var(--accent-primary);
-  color: var(--text-primary);
+  color: var(--bg-deep);
   border: 1px solid transparent;
   box-shadow: 0 0 var(--glow-md) var(--accent-primary-glow);
 }

--- a/src/Brmble.Web/src/uiGuideCompliance.test.ts
+++ b/src/Brmble.Web/src/uiGuideCompliance.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const sourceRoot = join(process.cwd(), 'src');
+
+const excludedDirectories = new Set(['themes']);
+const excludedFiles = new Set([
+  'uiGuideCompliance.test.ts',
+  'components/Icon/Icon.tsx',
+]);
+
+const colorAllowList = [
+  'components/Icon/Icon.tsx',
+  'components/Header/BrmbleLogo.css',
+  'components/Tooltip/Tooltip.tsx',
+  'utils/linkifyText.tsx',
+  'test-setup.ts',
+];
+
+const glyphAllowList = [
+  'components/Icon/Icon.tsx',
+  'components/Header/BrmbleLogo.css',
+  'components/Game/contracts/ContractSlot.tsx',
+  'components/NeonD/NeonDGame.tsx',
+];
+
+const titleAttributeAllowList = [
+  'App.tsx',
+  'components/BrokenCertNotification/BrokenCertNotification.tsx',
+  'components/Toast/Toast.tsx',
+  'components/UpdateNotification/UpdateNotification.tsx',
+];
+
+const inlineStyleAllowList = [
+  /style=\{\{\s*width\s*\}\}/,
+  /style=\{\{\s*width:/,
+  /style=\{\{\s*flex:/,
+  /style=\{\{\s*bottom:/,
+  /style=\{\{\s*\r?$/,
+  /style=\{\{\s*paddingLeft:/,
+  /style=\{\{\s*animationDelay:/,
+  /style=\{\{\s*animationDuration:/,
+  /style=\{\{\s*display: 'none'/,
+  /style=\{\{\s*'--dx':/,
+  /style=\{\{\s*width: size/,
+  /style=\{\{\s*fontSize\s*\}\}/,
+];
+
+const filesToScan = collectFiles(sourceRoot).filter((file) => {
+  const rel = toPosix(relative(sourceRoot, file));
+  if (excludedFiles.has(rel)) return false;
+  return /\.(css|tsx)$/.test(rel);
+});
+
+function collectFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const fullPath = join(dir, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      if (excludedDirectories.has(entry)) return [];
+      return collectFiles(fullPath);
+    }
+    return [fullPath];
+  });
+}
+
+function toPosix(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+function findViolations(pattern: RegExp, allowList: string[] = []): string[] {
+  const violations: string[] = [];
+
+  for (const file of filesToScan) {
+    const rel = toPosix(relative(sourceRoot, file));
+    if (allowList.includes(rel)) continue;
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/);
+
+    lines.forEach((line, index) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('/*') || /issue #\d+/i.test(trimmed)) return;
+
+      pattern.lastIndex = 0;
+      if (pattern.test(line)) {
+        violations.push(`${rel}:${index + 1}: ${trimmed}`);
+      }
+    });
+  }
+
+  return violations;
+}
+
+function findInlineStyleViolations(): string[] {
+  return findViolations(/style=\{\{/g).filter((violation) => {
+    const sourceLine = violation.slice(violation.indexOf(': ') + 2);
+    return !inlineStyleAllowList.some((pattern) => pattern.test(sourceLine));
+  });
+}
+
+describe('UI guide compliance', () => {
+  test('component styles do not hardcode colors or token fallback colors', () => {
+    expect(findViolations(/#[0-9a-fA-F]{3,8}|rgba?\(/g, colorAllowList)).toEqual([]);
+  });
+
+  test('component code does not use emoji or glyph icons in UI text', () => {
+    expect(findViolations(/[\u{1F300}-\u{1FAFF}]|[★☆×🔄🔒]/gu, glyphAllowList)).toEqual([]);
+  });
+
+  test('static visual styles live in CSS classes instead of inline style props', () => {
+    expect(findInlineStyleViolations()).toEqual([]);
+  });
+
+  test('tooltips use Tooltip instead of native title attributes', () => {
+    expect(findViolations(/title="[^"]+"|title=\{[^}]+\}/g, titleAttributeAllowList)).toEqual([]);
+  });
+});

--- a/src/Brmble.Web/src/uiGuideCompliance.test.ts
+++ b/src/Brmble.Web/src/uiGuideCompliance.test.ts
@@ -33,18 +33,18 @@ const titleAttributeAllowList = [
 ];
 
 const inlineStyleAllowList = [
-  /style=\{\{\s*width\s*\}\}/,
-  /style=\{\{\s*width:/,
-  /style=\{\{\s*flex:/,
-  /style=\{\{\s*bottom:/,
-  /style=\{\{\s*\r?$/,
-  /style=\{\{\s*paddingLeft:/,
-  /style=\{\{\s*animationDelay:/,
-  /style=\{\{\s*animationDuration:/,
-  /style=\{\{\s*display: 'none'/,
-  /style=\{\{\s*'--dx':/,
-  /style=\{\{\s*width: size/,
-  /style=\{\{\s*fontSize\s*\}\}/,
+  /^style=\{\{\s*width\s*\}\}$/,
+  /^style=\{\{\s*fontSize\s*\}\}$/,
+  /^style=\{\{\s*width:\s*size,\s*height:\s*size,\s*minWidth:\s*size,\s*minHeight:\s*size\s*\}\}$/,
+  /^style=\{\{\s*width:\s*`\$\{[^`]+\}%`\s*\}\}$/,
+  /^style=\{\{\s*flex:\s*`0 0 \$\{[^`]+\}%`\s*\}\}$/,
+  /^style=\{\{\s*paddingLeft:\s*`calc\([^`]+\$\{[^`]+\}px\)`\s*\}\}$/,
+  /^style=\{\{\s*animationDelay:\s*`\$\{[^`]+\}ms`\s*\}\}$/,
+  /^style=\{\{\s*animationDuration:\s*`\$\{[^`]+\}ms`\s*\}\}$/,
+  /^style=\{\{\s*display:\s*'none'\s*\}\}$/,
+  /^style=\{\{\s*'--dx':\s*'[^']+',\s*'--dy':\s*'[^']+'\s*\}\s*as CSSProperties\}$/,
+  /^style=\{\{\s*bottom:\s*`\$\{[^`]+\}px`,\s*right:\s*`\$\{[^`]+\}px`,\s*\}\}$/,
+  /^style=\{\{\s*'--grad-center':\s*`url\(#\$\{[^`]+\}-grad-center\)`,\s*'--grad-inner':\s*`url\(#\$\{[^`]+\}-grad-inner\)`,\s*'--grad-middle':\s*`url\(#\$\{[^`]+\}-grad-middle\)`,\s*'--grad-outer':\s*`url\(#\$\{[^`]+\}-grad-outer\)`,\s*\}\s*as CSSProperties\}$/,
 ];
 
 const filesToScan = collectFiles(sourceRoot).filter((file) => {
@@ -92,10 +92,44 @@ function findViolations(pattern: RegExp, allowList: string[] = []): string[] {
 }
 
 function findInlineStyleViolations(): string[] {
-  return findViolations(/style=\{\{/g).filter((violation) => {
-    const sourceLine = violation.slice(violation.indexOf(': ') + 2);
-    return !inlineStyleAllowList.some((pattern) => pattern.test(sourceLine));
-  });
+  const violations: string[] = [];
+
+  for (const file of filesToScan) {
+    const rel = toPosix(relative(sourceRoot, file));
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/);
+
+    for (let index = 0; index < lines.length; index++) {
+      const line = lines[index];
+      if (!line.includes('style={{')) continue;
+
+      const expressionLines = [line.slice(line.indexOf('style={{')).trim()];
+      let cursor = index;
+      while (!isStyleExpressionClosed(expressionLines.join(' ')) && cursor < lines.length - 1) {
+        cursor += 1;
+        expressionLines.push(lines[cursor].trim());
+      }
+
+      const expression = normalizeStyleExpression(expressionLines.join(' '));
+      if (!inlineStyleAllowList.some((pattern) => pattern.test(expression))) {
+        violations.push(`${rel}:${index + 1}: ${expression}`);
+      }
+    }
+  }
+
+  return violations;
+}
+
+function isStyleExpressionClosed(expression: string): boolean {
+  return /\}\}\s*|\}\s+as CSSProperties\}\s*/.test(expression);
+}
+
+function normalizeStyleExpression(expression: string): string {
+  const normalized = expression.replace(/\s+/g, ' ');
+  const cssPropertiesEnd = normalized.match(/^(.*?\}\s+as CSSProperties\})/);
+  if (cssPropertiesEnd) return cssPropertiesEnd[1];
+
+  const objectEnd = normalized.match(/^(.*?\}\})/);
+  return objectEnd ? objectEnd[1] : normalized;
 }
 
 describe('UI guide compliance', () => {

--- a/src/Brmble.Web/tsconfig.test.json
+++ b/src/Brmble.Web/tsconfig.test.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom", "node"]
   },
-  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**/*"],
+  "include": ["src/**/*.d.ts", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**/*"],
   "exclude": []
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded UI colors, spacing, shadows, icons, and inline static styles with theme tokens/classes.
- Add a UI guide compliance test to catch future hardcoded colors, emoji/glyph icons, native title tooltips, and static inline styles.
- Update the icon guide and central icon map for `refresh-cw`.

## Verification
- `npm test -- src/uiGuideCompliance.test.ts`
- `npm test`
- `npm run build`