### PR TITLE
fix: handle Brmble service bootstrap recovery

### DIFF
--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1389,7 +1389,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         bool credentialsAlreadyFetched,
         bool previousHealthWasConnected,
         bool sawHealthFailureSinceCredentials)
-        => !previousHealthWasConnected && sawHealthFailureSinceCredentials;
+        => !credentialsAlreadyFetched && sawHealthFailureSinceCredentials
+            || !previousHealthWasConnected && sawHealthFailureSinceCredentials;
+
+    internal static bool ShouldMarkCredentialFailureAsServiceOutage(int httpStatus)
+        => httpStatus != 409;
 
     internal static bool ShouldStartHealthCheckBeforeCredentialFetch(string? apiUrl)
         => !string.IsNullOrWhiteSpace(apiUrl);
@@ -1489,8 +1493,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             var (credentials, httpStatus, errorBody) = await FetchCredentialsViaBcTls(cert, tokenUri, _reconnectUsername);
             if (credentials is null)
             {
-                _sawServerHealthFailureSinceCredentials = true;
-                SendBrmbleServiceStatus("server", "reconnecting", reason: httpStatus > 0 ? $"http-{httpStatus}" : "credentials-unavailable");
+                if (ShouldMarkCredentialFailureAsServiceOutage(httpStatus))
+                {
+                    _sawServerHealthFailureSinceCredentials = true;
+                    SendBrmbleServiceStatus("server", "reconnecting", reason: httpStatus > 0 ? $"http-{httpStatus}" : "credentials-unavailable");
+                }
                 if (httpStatus == 409)
                 {
                     // Name conflict — parse error body and send to frontend

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1389,7 +1389,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         bool credentialsAlreadyFetched,
         bool previousHealthWasConnected,
         bool sawHealthFailureSinceCredentials)
-        => credentialsAlreadyFetched && !previousHealthWasConnected && sawHealthFailureSinceCredentials;
+        => !previousHealthWasConnected && sawHealthFailureSinceCredentials;
+
+    internal static bool ShouldStartHealthCheckBeforeCredentialFetch(string? apiUrl)
+        => !string.IsNullOrWhiteSpace(apiUrl);
 
     internal static bool ShouldEmitSessionStoppedStatus(
         bool isCancellationRequested,
@@ -1486,6 +1489,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             var (credentials, httpStatus, errorBody) = await FetchCredentialsViaBcTls(cert, tokenUri, _reconnectUsername);
             if (credentials is null)
             {
+                _sawServerHealthFailureSinceCredentials = true;
+                SendBrmbleServiceStatus("server", "reconnecting", reason: httpStatus > 0 ? $"http-{httpStatus}" : "credentials-unavailable");
                 if (httpStatus == 409)
                 {
                     // Name conflict — parse error body and send to frontend
@@ -1566,6 +1571,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         catch (Exception ex)
         {
             Debug.WriteLine($"[Matrix] Failed to fetch credentials: {ex.Message}");
+            _sawServerHealthFailureSinceCredentials = true;
+            SendBrmbleServiceStatus("server", "reconnecting", reason: "credentials-unavailable");
             _bridge?.Send("voice.error", new { message = $"Failed to fetch chat credentials: {ex.Message}" });
             _bridge?.NotifyUiThread();
         }
@@ -3141,6 +3148,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         if (credentialUrl is not null)
         {
             var url = credentialUrl;
+            if (ShouldStartHealthCheckBeforeCredentialFetch(url))
+            {
+                StartHealthCheck(url);
+            }
+
             Task.Run(async () =>
             {
                 await FetchAndSendCredentials(url);

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -86,12 +86,12 @@ describe('getBrmbleServiceBootstrapPhase', () => {
     }, false, false)).toBe('bootstrap');
   });
 
-  it('becomes degraded when initial Brmble service connection fails', () => {
+  it('stays in bootstrap when initial Brmble service connection fails before the grace period expires', () => {
     expect(getBrmbleServiceBootstrapPhase({
       ...connectedStatuses,
       server: { state: 'disconnected', error: 'unavailable' },
       chat: { state: 'connecting' },
-    }, false, false)).toBe('degraded');
+    }, false, false)).toBe('bootstrap');
   });
 
   it('becomes degraded when the initial bootstrap grace period expires', () => {
@@ -111,6 +111,14 @@ describe('getBrmbleServiceBootstrapPhase', () => {
       ...connectedStatuses,
       chat: { state: 'connecting' },
     }, false, true)).toBe('degraded');
+  });
+
+  it('becomes degraded when an initial service failure remains after the grace period expires', () => {
+    expect(getBrmbleServiceBootstrapPhase({
+      ...connectedStatuses,
+      server: { state: 'disconnected', error: 'unavailable' },
+      chat: { state: 'connecting' },
+    }, true, false)).toBe('degraded');
   });
 });
 
@@ -190,6 +198,10 @@ describe('shouldShowBrmbleServiceWarningNotification', () => {
   });
 
   it('does not show the notification during initial Brmble service bootstrap', () => {
+    expect(shouldShowBrmbleServiceWarningNotification(true, false, 'bootstrap')).toBe(false);
+  });
+
+  it('clears the notification outside degraded outages', () => {
     expect(shouldShowBrmbleServiceWarningNotification(true, false, 'bootstrap')).toBe(false);
   });
 });

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BRMBLE_SERVICE_CONNECTING_CHAT_NOTICE,
+  getBrmbleServiceBootstrapPhase,
+  getBrmbleServiceChatNotice,
   isBrmbleServiceOutageActive,
   isMatrixChannelChatActive,
   isTemporaryChannelChatActive,
@@ -74,43 +77,119 @@ describe('isBrmbleServiceOutageActive', () => {
   });
 });
 
+describe('getBrmbleServiceBootstrapPhase', () => {
+  it('stays in bootstrap while initial Brmble services are still connecting', () => {
+    expect(getBrmbleServiceBootstrapPhase({
+      ...connectedStatuses,
+      server: { state: 'connecting' },
+      chat: { state: 'connecting' },
+    }, false, false)).toBe('bootstrap');
+  });
+
+  it('becomes degraded when initial Brmble service connection fails', () => {
+    expect(getBrmbleServiceBootstrapPhase({
+      ...connectedStatuses,
+      server: { state: 'disconnected', error: 'unavailable' },
+      chat: { state: 'connecting' },
+    }, false, false)).toBe('degraded');
+  });
+
+  it('becomes degraded when the initial bootstrap grace period expires', () => {
+    expect(getBrmbleServiceBootstrapPhase({
+      ...connectedStatuses,
+      server: { state: 'connecting' },
+      chat: { state: 'connecting' },
+    }, true, false)).toBe('degraded');
+  });
+
+  it('becomes ready once Brmble server and Matrix chat are connected', () => {
+    expect(getBrmbleServiceBootstrapPhase(connectedStatuses, false, false)).toBe('ready');
+  });
+
+  it('becomes degraded immediately after previously ready services drop', () => {
+    expect(getBrmbleServiceBootstrapPhase({
+      ...connectedStatuses,
+      chat: { state: 'connecting' },
+    }, false, true)).toBe('degraded');
+  });
+});
+
 describe('isTemporaryChannelChatActive', () => {
   it('is true for a normal channel during a Brmble service outage', () => {
     expect(isTemporaryChannelChatActive('1', {
       ...connectedStatuses,
       server: { state: 'connecting' },
-    })).toBe(true);
+    }, 'degraded')).toBe(true);
+  });
+
+  it('is false for a normal channel during initial Brmble service bootstrap', () => {
+    expect(isTemporaryChannelChatActive('1', {
+      ...connectedStatuses,
+      server: { state: 'connecting' },
+      chat: { state: 'connecting' },
+    }, 'bootstrap')).toBe(false);
   });
 
   it('is false for server root during a Brmble service outage', () => {
     expect(isTemporaryChannelChatActive('server-root', {
       ...connectedStatuses,
       server: { state: 'connecting' },
-    })).toBe(false);
+    }, 'degraded')).toBe(false);
   });
 
   it('is false when no channel is selected', () => {
     expect(isTemporaryChannelChatActive(undefined, {
       ...connectedStatuses,
       server: { state: 'connecting' },
-    })).toBe(false);
+    }, 'degraded')).toBe(false);
   });
 
   it('is false when Brmble and Matrix chat are connected', () => {
-    expect(isTemporaryChannelChatActive('1', connectedStatuses)).toBe(false);
+    expect(isTemporaryChannelChatActive('1', connectedStatuses, 'ready')).toBe(false);
+  });
+});
+
+describe('getBrmbleServiceChatNotice', () => {
+  it('shows a connecting notice during initial Brmble service bootstrap', () => {
+    expect(getBrmbleServiceChatNotice('1', {
+      ...connectedStatuses,
+      server: { state: 'connecting' },
+      chat: { state: 'connecting' },
+    }, 'bootstrap')).toBe(BRMBLE_SERVICE_CONNECTING_CHAT_NOTICE);
+    expect(BRMBLE_SERVICE_CONNECTING_CHAT_NOTICE).not.toContain('sync');
+  });
+
+  it('shows an unavailable notice after bootstrap degrades', () => {
+    expect(getBrmbleServiceChatNotice('1', {
+      ...connectedStatuses,
+      server: { state: 'connecting' },
+      chat: { state: 'connecting' },
+    }, 'degraded')).toContain('currently unavailable');
+  });
+
+  it('does not show a notice at server root', () => {
+    expect(getBrmbleServiceChatNotice('server-root', {
+      ...connectedStatuses,
+      server: { state: 'connecting' },
+      chat: { state: 'connecting' },
+    }, 'bootstrap')).toBeUndefined();
   });
 });
 
 describe('shouldShowBrmbleServiceWarningNotification', () => {
   it('shows the notification during a new outage', () => {
-    expect(shouldShowBrmbleServiceWarningNotification(true, false)).toBe(true);
+    expect(shouldShowBrmbleServiceWarningNotification(true, false, 'degraded')).toBe(true);
   });
 
   it('does not re-show the notification after the user dismissed it during the same outage', () => {
-    expect(shouldShowBrmbleServiceWarningNotification(true, true)).toBe(false);
+    expect(shouldShowBrmbleServiceWarningNotification(true, true, 'degraded')).toBe(false);
   });
 
   it('does not show the notification when there is no outage', () => {
-    expect(shouldShowBrmbleServiceWarningNotification(false, false)).toBe(false);
+    expect(shouldShowBrmbleServiceWarningNotification(false, false, 'ready')).toBe(false);
+  });
+
+  it('does not show the notification during initial Brmble service bootstrap', () => {
+    expect(shouldShowBrmbleServiceWarningNotification(true, false, 'bootstrap')).toBe(false);
   });
 });

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -622,8 +622,6 @@ export function getBrmbleServiceBootstrapPhase(
   if (statuses.voice.state !== 'connected') return 'idle';
   if (statuses.server.state === 'connected' && statuses.chat.state === 'connected') return 'ready';
   if (brmbleServicesConnectedOnce || bootstrapTimedOut) return 'degraded';
-  if (statuses.server.state === 'disconnected' || statuses.server.state === 'unavailable') return 'degraded';
-  if (statuses.chat.state === 'disconnected' || statuses.chat.state === 'unavailable') return 'degraded';
   return 'bootstrap';
 }
 
@@ -3225,7 +3223,7 @@ const handleConnect = (serverData: SavedServer) => {
       return;
     }
 
-    if (!brmbleServiceOutageActive) {
+    if (!brmbleServiceOutageActive || brmbleServiceBootstrapPhase !== 'degraded') {
       brmbleServiceWarningDismissedForOutageRef.current = false;
       if (statuses.voice.state !== 'connected') {
         brmbleServicesConnectedOnceRef.current = false;

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -595,6 +595,9 @@ export const BRMBLE_SERVICE_WARNING_ID = 'brmble-service-disconnected';
 export const BRMBLE_SERVICE_TEMPORARY_CHAT_NOTICE =
   'Brmble services are currently unavailable. You can keep talking in voice chat, but new chat messages are temporary and will not be saved.';
 
+export const BRMBLE_SERVICE_CONNECTING_CHAT_NOTICE =
+  'Brmble services are still connecting. Voice chat is available; channel chat may be limited until services are ready.';
+
 export const BRMBLE_SERVICE_DISCONNECTED_NOTIFICATION = {
   id: BRMBLE_SERVICE_WARNING_ID,
   status: 'warning' as const,
@@ -607,19 +610,52 @@ export function isBrmbleServiceOutageActive(statuses: ServiceStatusMap): boolean
     && (statuses.server.state !== 'connected' || statuses.chat.state !== 'connected');
 }
 
+export type BrmbleServiceBootstrapPhase = 'idle' | 'bootstrap' | 'ready' | 'degraded';
+
+export const BRMBLE_SERVICE_BOOTSTRAP_GRACE_MS = 15000;
+
+export function getBrmbleServiceBootstrapPhase(
+  statuses: ServiceStatusMap,
+  bootstrapTimedOut: boolean,
+  brmbleServicesConnectedOnce: boolean,
+): BrmbleServiceBootstrapPhase {
+  if (statuses.voice.state !== 'connected') return 'idle';
+  if (statuses.server.state === 'connected' && statuses.chat.state === 'connected') return 'ready';
+  if (brmbleServicesConnectedOnce || bootstrapTimedOut) return 'degraded';
+  if (statuses.server.state === 'disconnected' || statuses.server.state === 'unavailable') return 'degraded';
+  if (statuses.chat.state === 'disconnected' || statuses.chat.state === 'unavailable') return 'degraded';
+  return 'bootstrap';
+}
+
 export function isTemporaryChannelChatActive(
   channelId: string | undefined,
   statuses: ServiceStatusMap,
+  brmbleServiceBootstrapPhase: BrmbleServiceBootstrapPhase,
 ): boolean {
   if (!channelId || channelId === 'server-root') return false;
-  return isBrmbleServiceOutageActive(statuses);
+  return brmbleServiceBootstrapPhase === 'degraded' && isBrmbleServiceOutageActive(statuses);
+}
+
+export function getBrmbleServiceChatNotice(
+  channelId: string | undefined,
+  statuses: ServiceStatusMap,
+  brmbleServiceBootstrapPhase: BrmbleServiceBootstrapPhase,
+): string | undefined {
+  if (!channelId || channelId === 'server-root') return undefined;
+  if (!isBrmbleServiceOutageActive(statuses)) return undefined;
+  if (brmbleServiceBootstrapPhase === 'bootstrap') return BRMBLE_SERVICE_CONNECTING_CHAT_NOTICE;
+  if (brmbleServiceBootstrapPhase === 'degraded') return BRMBLE_SERVICE_TEMPORARY_CHAT_NOTICE;
+  return undefined;
 }
 
 export function shouldShowBrmbleServiceWarningNotification(
   brmbleServiceOutageActive: boolean,
   dismissedForCurrentOutage: boolean,
+  brmbleServiceBootstrapPhase: BrmbleServiceBootstrapPhase,
 ): boolean {
-  return brmbleServiceOutageActive && !dismissedForCurrentOutage;
+  return brmbleServiceOutageActive
+    && brmbleServiceBootstrapPhase === 'degraded'
+    && !dismissedForCurrentOutage;
 }
 
 interface QueuedMovedChannelNotification extends ScreenShareEndedNotification {
@@ -792,6 +828,8 @@ function App() {
   const [settingsTab, setSettingsTab] = useState<'profile' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection'>('profile');
   const [showGame, setShowGame] = useState(false);
   const [showAvatarEditor, setShowAvatarEditor] = useState(false);
+  const brmbleServicesConnectedOnceRef = useRef(false);
+  const [brmbleServiceBootstrapTimedOut, setBrmbleServiceBootstrapTimedOut] = useState(false);
 
   // Close avatar editor modal when disconnected — profile is not editable while disconnected
   useEffect(() => {
@@ -1394,6 +1432,7 @@ function App() {
     const onVoiceConnected = ((data: unknown) => {
       setConnectionStatus('connected');
       updateStatus('voice', { state: 'connected', error: undefined });
+      setBrmbleServiceBootstrapTimedOut(false);
       overlayConnectedAtRef.current = Date.now();
       notifQueue.unregister('server-removal');
       setServerRemovalNotification(null);
@@ -1531,6 +1570,7 @@ function App() {
       setDmDividerTs(null);
       updateStatus('livekit', { state: 'idle', error: undefined });
       updateStatus('server', { state: 'idle', error: undefined });
+      setBrmbleServiceBootstrapTimedOut(false);
     };
 
     const onServerCredentials = (data: unknown) => {
@@ -2452,6 +2492,8 @@ const handleConnect = (serverData: SavedServer) => {
     setServerAddress(`${serverData.host}:${serverData.port}`);
     setConnectionStatus('connecting');
     userSawConnectedRef.current = false;
+    brmbleServicesConnectedOnceRef.current = false;
+    setBrmbleServiceBootstrapTimedOut(false);
     bridge.send('voice.connect', serverData);
     updateStatus('voice', { state: 'connecting', error: undefined, label: `${serverData.host}:${serverData.port}` });
     
@@ -2855,8 +2897,13 @@ const handleConnect = (serverData: SavedServer) => {
   const isMatrixActive = activeChannelId
     ? isMatrixChannelChatActive(activeChannelId, matrixCredentials, statuses, selfUserForChat)
     : false;
-  const brmbleTemporaryChatActive = isTemporaryChannelChatActive(activeChannelId, statuses);
   const brmbleServiceOutageActive = isBrmbleServiceOutageActive(statuses);
+  const brmbleServiceBootstrapPhase = getBrmbleServiceBootstrapPhase(
+    statuses,
+    brmbleServiceBootstrapTimedOut,
+    brmbleServicesConnectedOnceRef.current,
+  );
+  const brmbleServiceChatNotice = getBrmbleServiceChatNotice(activeChannelId, statuses, brmbleServiceBootstrapPhase);
   const matrixMessages = activeChannelId
     ? matrixClient.activeMessages
     : undefined;
@@ -3147,9 +3194,31 @@ const handleConnect = (serverData: SavedServer) => {
   }, [serverRemovalNotification, notifQueue]);
 
   useEffect(() => {
+    if (statuses.server.state === 'connected' && statuses.chat.state === 'connected') {
+      brmbleServicesConnectedOnceRef.current = true;
+    }
+  }, [statuses.server.state, statuses.chat.state]);
+
+  useEffect(() => {
+    if (brmbleServiceBootstrapPhase !== 'bootstrap') {
+      if (brmbleServiceBootstrapPhase === 'idle' || brmbleServiceBootstrapPhase === 'ready') {
+        setBrmbleServiceBootstrapTimedOut(false);
+      }
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setBrmbleServiceBootstrapTimedOut(true);
+    }, BRMBLE_SERVICE_BOOTSTRAP_GRACE_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [brmbleServiceBootstrapPhase]);
+
+  useEffect(() => {
     if (shouldShowBrmbleServiceWarningNotification(
       brmbleServiceOutageActive,
       brmbleServiceWarningDismissedForOutageRef.current,
+      brmbleServiceBootstrapPhase,
     )) {
       setBrmbleServiceWarningNotification(BRMBLE_SERVICE_DISCONNECTED_NOTIFICATION);
       notifQueue.register(BRMBLE_SERVICE_WARNING_ID, 'warning');
@@ -3158,10 +3227,14 @@ const handleConnect = (serverData: SavedServer) => {
 
     if (!brmbleServiceOutageActive) {
       brmbleServiceWarningDismissedForOutageRef.current = false;
+      if (statuses.voice.state !== 'connected') {
+        brmbleServicesConnectedOnceRef.current = false;
+        setBrmbleServiceBootstrapTimedOut(false);
+      }
       setBrmbleServiceWarningNotification(null);
       notifQueue.unregister(BRMBLE_SERVICE_WARNING_ID);
     }
-  }, [brmbleServiceOutageActive, notifQueue]);
+  }, [brmbleServiceOutageActive, brmbleServiceBootstrapPhase, notifQueue, statuses.voice.state]);
 
   const { isOnCooldown: leaveVoiceOnCooldown, trigger: triggerLeaveVoiceCooldown } = useLeaveVoiceCooldown(1000);
   const { isOnCooldown: muteOnCooldown, trigger: triggerMuteCooldown } = useLeaveVoiceCooldown(1000);
@@ -3640,7 +3713,7 @@ const handleConnect = (serverData: SavedServer) => {
                     onCloseShare={(share) => disconnectViewer(share.userId)}
                     screenShareViewerMode={screenShareSettings.viewerMode}
                     users={users}
-                    topNotice={brmbleTemporaryChatActive ? BRMBLE_SERVICE_TEMPORARY_CHAT_NOTICE : undefined}
+                    topNotice={brmbleServiceChatNotice}
                     onMessageContextMenu={handleChatMessageContextMenu}
                     onCopyToClipboard={handleCopyToClipboard}
                   />

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterCredentialsTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterCredentialsTests.cs
@@ -130,6 +130,33 @@ public class MumbleAdapterCredentialsTests
     }
 
     [TestMethod]
+    public void ShouldRefreshCredentialsAfterHealthSuccess_InitialRecoveryAfterFailure_ReturnsTrue()
+    {
+        var result = MumbleAdapter.ShouldRefreshCredentialsAfterHealthSuccess(
+            credentialsAlreadyFetched: false,
+            previousHealthWasConnected: false,
+            sawHealthFailureSinceCredentials: true);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void ShouldStartHealthCheckBeforeCredentialFetch_WithApiUrl_ReturnsTrue()
+    {
+        var result = MumbleAdapter.ShouldStartHealthCheckBeforeCredentialFetch("https://api.example.com");
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void ShouldStartHealthCheckBeforeCredentialFetch_WithoutApiUrl_ReturnsFalse()
+    {
+        var result = MumbleAdapter.ShouldStartHealthCheckBeforeCredentialFetch(null);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
     public void ShouldRefreshCredentialsAfterHealthSuccess_StillConnected_ReturnsFalse()
     {
         var result = MumbleAdapter.ShouldRefreshCredentialsAfterHealthSuccess(

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterCredentialsTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterCredentialsTests.cs
@@ -168,6 +168,30 @@ public class MumbleAdapterCredentialsTests
     }
 
     [TestMethod]
+    public void ShouldRefreshCredentialsAfterHealthSuccess_InitialCredentialFailureWhileHealthStaysConnected_ReturnsTrue()
+    {
+        var result = MumbleAdapter.ShouldRefreshCredentialsAfterHealthSuccess(
+            credentialsAlreadyFetched: false,
+            previousHealthWasConnected: true,
+            sawHealthFailureSinceCredentials: true);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void ShouldMarkCredentialFailureAsServiceOutage_ForUnavailableService_ReturnsTrue()
+    {
+        Assert.IsTrue(MumbleAdapter.ShouldMarkCredentialFailureAsServiceOutage(503));
+        Assert.IsTrue(MumbleAdapter.ShouldMarkCredentialFailureAsServiceOutage(0));
+    }
+
+    [TestMethod]
+    public void ShouldMarkCredentialFailureAsServiceOutage_ForNameConflict_ReturnsFalse()
+    {
+        Assert.IsFalse(MumbleAdapter.ShouldMarkCredentialFailureAsServiceOutage(409));
+    }
+
+    [TestMethod]
     public void ShouldEmitSessionStoppedStatus_StaleCanceledGeneration_ReturnsFalse()
     {
         var result = MumbleAdapter.ShouldEmitSessionStoppedStatus(


### PR DESCRIPTION
## Summary
- Add a Brmble service bootstrap phase so initial service startup shows a neutral chat notice instead of immediately warning users.
- Keep degraded temporary-chat/warning behavior after bootstrap timeout or post-ready service loss.
- Start Brmble health monitoring before initial credential fetch so clients recover when Brmble comes online after Mumble already connected.

## Verification
- npm test -- App.chatMode.test.ts
- npm run build
- dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter FullyQualifiedName~MumbleAdapterCredentialsTests
- dotnet build src/Brmble.Client/Brmble.Client.csproj