### PR TITLE
feat: themed Win11 rounded corners + 1px window outline

### DIFF
--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -136,8 +136,8 @@ static class Program
             }
 
             var startupTheme = _appConfigService.GetSettings().Appearance.Theme;
-            var (sr, sg, sb) = ThemeColors.GetBgPrimary(startupTheme);
-            uint startupBgColorRef = (uint)(sb << 16 | sg << 8 | sr);
+            var (br0, bg0, bb0) = ThemeColors.GetBgPrimary(startupTheme);
+            uint startupBgColorRef = Win32Window.ToColorRef(br0, bg0, bb0);
             _hwnd = Win32Window.Create("BrmbleWindow", "Brmble", wx, wy, ww, wh, WndProc, startupBgColorRef);
             if (restoreMaximized)
                 Win32Window.ShowWindow(_hwnd, Win32Window.SW_MAXIMIZE);
@@ -147,8 +147,8 @@ static class Program
             // Win11 chrome: rounded corners + 1px themed outline. Both are
             // silently ignored on older Windows / pre-22H2 builds.
             Win32Window.EnableRoundedCorners(_hwnd);
-            var (br, bg, bb) = ThemeColors.GetBorderSubtle(startupTheme);
-            Win32Window.SetBorderColor(_hwnd, (uint)(bb << 16 | bg << 8 | br));
+            var (sbr, sbg, sbb) = ThemeColors.GetBorderSubtle(startupTheme);
+            Win32Window.SetBorderColor(_hwnd, Win32Window.ToColorRef(sbr, sbg, sbb));
             TrayIcon.Create(_hwnd);
             TaskbarBadge.Initialize(_hwnd);
             _ = InitWebView2Async(_hwnd, useDevServer);
@@ -475,8 +475,7 @@ static class Program
                 // before WebView2 catches up — matching --bg-primary blends
                 // that flash with the sidebar instead of contrasting darkly.
                 var (r, g, b) = ThemeColors.GetBgPrimary(theme);
-                uint colorRef = (uint)(b << 16 | g << 8 | r);
-                var newBrush = Win32Window.CreateBackgroundBrush(colorRef);
+                var newBrush = Win32Window.CreateBackgroundBrush(Win32Window.ToColorRef(r, g, b));
                 var oldBrush = Win32Window.SetClassLongPtr(
                     _hwnd, Win32Window.GCL_HBRBACKGROUND, newBrush);
                 if (oldBrush != IntPtr.Zero && oldBrush != newBrush)
@@ -485,8 +484,8 @@ static class Program
                 Win32Window.InvalidateRect(_hwnd, IntPtr.Zero, true);
 
                 // Update the 1px DWM outline to match --border-subtle.
-                var (br, bg, bb) = ThemeColors.GetBorderSubtle(theme);
-                Win32Window.SetBorderColor(_hwnd, (uint)(bb << 16 | bg << 8 | br));
+                var (bsr, bsg, bsb) = ThemeColors.GetBorderSubtle(theme);
+                Win32Window.SetBorderColor(_hwnd, Win32Window.ToColorRef(bsr, bsg, bsb));
             }
             return Task.CompletedTask;
         });

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -143,6 +143,12 @@ static class Program
                 Win32Window.ShowWindow(_hwnd, Win32Window.SW_MAXIMIZE);
             Win32Window.ExtendFrameIntoClientArea(_hwnd);
             Win32Window.ForceFrameChange(_hwnd);
+
+            // Win11 chrome: rounded corners + 1px themed outline. Both are
+            // silently ignored on older Windows / pre-22H2 builds.
+            Win32Window.EnableRoundedCorners(_hwnd);
+            var (br, bg, bb) = ThemeColors.GetBorderSubtle(startupTheme);
+            Win32Window.SetBorderColor(_hwnd, (uint)(bb << 16 | bg << 8 | br));
             TrayIcon.Create(_hwnd);
             TaskbarBadge.Initialize(_hwnd);
             _ = InitWebView2Async(_hwnd, useDevServer);
@@ -477,6 +483,10 @@ static class Program
                     Win32Window.DeleteObject(oldBrush);
                 _currentBgBrush = newBrush;
                 Win32Window.InvalidateRect(_hwnd, IntPtr.Zero, true);
+
+                // Update the 1px DWM outline to match --border-subtle.
+                var (br, bg, bb) = ThemeColors.GetBorderSubtle(theme);
+                Win32Window.SetBorderColor(_hwnd, (uint)(bb << 16 | bg << 8 | br));
             }
             return Task.CompletedTask;
         });

--- a/src/Brmble.Client/ThemeColors.cs
+++ b/src/Brmble.Client/ThemeColors.cs
@@ -65,6 +65,28 @@ internal static class ThemeColors
     }
 
     /// <summary>
+    /// Returns the --border-subtle color for the given theme. Used by the
+    /// DWM window border (DWMWA_BORDER_COLOR) so the 1px outline around
+    /// the window matches the rest of the structural dividers in the UI.
+    /// These values must stay in sync with the CSS tokens in src/Brmble.Web/src/themes/.
+    /// </summary>
+    public static (byte R, byte G, byte B) GetBorderSubtle(string? themeName)
+    {
+        return themeName switch
+        {
+            "classic"        => (0x3D, 0x2A, 0x5C), // #3d2a5c
+            "clean"          => (0x3D, 0x2A, 0x5C), // #3d2a5c (inherits classic)
+            "blue-lagoon"    => (0x24, 0x38, 0x48), // #243848
+            "cosmopolitan"   => (0x3D, 0x24, 0x30), // #3d2430
+            "aperol-spritz"  => (0x3D, 0x2A, 0x1C), // #3d2a1c
+            "midori-sour"    => (0x1C, 0x3D, 0x2C), // #1c3d2c
+            "lemon-drop"     => (0x3D, 0x36, 0x20), // #3d3620
+            "retro-terminal" => (0x1A, 0x3A, 0x1A), // #1a3a1a
+            _                => (0x3D, 0x2A, 0x5C), // default to classic
+        };
+    }
+
+    /// <summary>
     /// Resolves the path to a theme's brmble.ico file.
     /// Falls back to the root Resources/brmble.ico if the theme folder doesn't exist.
     /// </summary>

--- a/src/Brmble.Client/Win32Window.cs
+++ b/src/Brmble.Client/Win32Window.cs
@@ -364,6 +364,12 @@ internal static class Win32Window
     private const int DWMWCP_ROUND = 2;
 
     /// <summary>
+    /// Packs an (R, G, B) triple into a Win32 COLORREF (0x00BBGGRR).
+    /// Used by the window-class background brush and DWMWA_BORDER_COLOR.
+    /// </summary>
+    public static uint ToColorRef(byte r, byte g, byte b) => (uint)(b << 16 | g << 8 | r);
+
+    /// <summary>
     /// Enables Win11 rounded window corners (~8px radius). No-op on Windows 10.
     /// </summary>
     public static void EnableRoundedCorners(IntPtr hwnd)

--- a/src/Brmble.Client/Win32Window.cs
+++ b/src/Brmble.Client/Win32Window.cs
@@ -355,6 +355,34 @@ internal static class Win32Window
     [DllImport("dwmapi.dll")]
     public static extern int DwmDefWindowProc(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam, out IntPtr result);
 
+    [DllImport("dwmapi.dll")]
+    private static extern int DwmSetWindowAttribute(IntPtr hwnd, uint attribute, ref int pvAttribute, uint cbAttribute);
+
+    // Win11-only DWM attributes. Older Windows versions silently ignore them.
+    private const uint DWMWA_WINDOW_CORNER_PREFERENCE = 33;
+    private const uint DWMWA_BORDER_COLOR = 34;
+    private const int DWMWCP_ROUND = 2;
+
+    /// <summary>
+    /// Enables Win11 rounded window corners (~8px radius). No-op on Windows 10.
+    /// </summary>
+    public static void EnableRoundedCorners(IntPtr hwnd)
+    {
+        int preference = DWMWCP_ROUND;
+        DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, ref preference, sizeof(int));
+    }
+
+    /// <summary>
+    /// Sets the 1px DWM-drawn outline color around the window. Win11 22H2+ only;
+    /// older Windows versions silently ignore the call. colorRef is COLORREF
+    /// (0x00BBGGRR) — same layout as the window-class brush colors.
+    /// </summary>
+    public static void SetBorderColor(IntPtr hwnd, uint colorRef)
+    {
+        int c = (int)colorRef;
+        DwmSetWindowAttribute(hwnd, DWMWA_BORDER_COLOR, ref c, sizeof(int));
+    }
+
     private static readonly List<WndProc> _wndProcRefs = []; // prevent GC of delegates
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds Win11 DWM chrome that follows the active theme:
- `DWMWA_WINDOW_CORNER_PREFERENCE = DWMWCP_ROUND` — default Win11 rounded corner radius.
- `DWMWA_BORDER_COLOR` — 1px outline coloured from the theme's `--border-subtle`, the same token glass panels and other structural dividers use.

The outline updates on theme switch via the existing `notification.theme` bridge handler.

## Compatibility

Both DWM attributes were introduced in Win11 22H2. Older Windows versions (Win10, Win11 pre-22H2) silently ignore the calls — the window falls back to a sharp rectangle with no themed outline. No code-path branching required.

## Test plan

- [x] Restored state: visible 1px outline around the window in the theme's `--border-subtle` colour
- [x] Rounded corners at the 4 window corners
- [x] Theme switch: outline colour updates immediately
- [x] Maximised: outline disappears (DWM behaviour), restore brings it back

🤖 Generated with [Claude Code](https://claude.com/claude-code)