### PR TITLE
Add channel access permissions and align UI guide compliance

### DIFF
--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -738,7 +738,7 @@ The component sets `aria-hidden="true"` automatically. Color inherits from `curr
 | **Voice** | `mic`, `mic-off`, `headphones`, `headphones-off`, `phone-off` | Audio & call controls |
 | **Media** | `monitor`, `monitor-off`, `minimize-2`, `maximize-2` | Screen share & fullscreen |
 | **Chat** | `message-square`, `message-circle` | Message bubble variants |
-| **Server** | `server`, `globe`, `folder`, `shield`, `star`, `ban`, `triangle-right` | Infrastructure & moderation |
+| **Server** | `server`, `globe`, `folder`, `lock`, `unlock`, `shield`, `star`, `ban`, `triangle-right` | Infrastructure, moderation, and restricted channel access states (`lock` denied, `unlock` allowed) |
 | **UI — Actions** | `x`, `search`, `plus`, `check`, `send`, `upload`, `refresh-cw`, `arrow-right`, `eye`, `eye-off`, `chevron-up`, `chevron-down`, `info`, `info-filled` | Generic interactive icons |
 | **UI — Objects** | `user`, `settings`, `save`, `palette`, `moon` | Profiles, preferences, idle indicator |
 | **Window** | `window-minimize`, `window-maximize`, `window-close` | Title bar controls (custom viewBox) |

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -738,7 +738,7 @@ The component sets `aria-hidden="true"` automatically. Color inherits from `curr
 | **Voice** | `mic`, `mic-off`, `headphones`, `headphones-off`, `phone-off` | Audio & call controls |
 | **Media** | `monitor`, `monitor-off`, `minimize-2`, `maximize-2` | Screen share & fullscreen |
 | **Chat** | `message-square`, `message-circle` | Message bubble variants |
-| **Server** | `server`, `globe`, `folder`, `lock`, `unlock`, `shield`, `star`, `ban`, `triangle-right` | Infrastructure, moderation, and restricted channel access states (`lock` denied, `unlock` allowed) |
+| **Server** | `server`, `globe`, `folder`, `lock`, `unlock`, `key-round`, `shield`, `star`, `ban`, `triangle-right` | Infrastructure, moderation, and restricted channel access states (`lock` denied, `unlock` allowed, `key-round` password-protected) |
 | **UI — Actions** | `x`, `search`, `plus`, `check`, `send`, `upload`, `refresh-cw`, `arrow-right`, `eye`, `eye-off`, `chevron-up`, `chevron-down`, `info`, `info-filled` | Generic interactive icons |
 | **UI — Objects** | `user`, `settings`, `save`, `palette`, `moon` | Profiles, preferences, idle indicator |
 | **Window** | `window-minimize`, `window-maximize`, `window-close` | Title bar controls (custom viewBox) |

--- a/docs/superpowers/plans/2026-05-19-channel-access-permissions.md
+++ b/docs/superpowers/plans/2026-05-19-channel-access-permissions.md
@@ -1,0 +1,1596 @@
+# Channel Access Permissions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Brmble surface Mumble channel entry restrictions, password-gated joins, and Matrix channel chat access based on Mumble permissions.
+
+**Architecture:** Mumble remains the source of truth. Server-side chat access uses ICE `hasPermission(..., PermissionTextMessage)` through `IMumbleAclService`, while the native client forwards Mumble's channel enter state and structured denial events to React. React uses the forwarded state for lock icons and join UX, and uses server-reported chat access to gate channel chat navigation, unread badges, history display, and Matrix sends.
+
+**Tech Stack:** C#/.NET minimal APIs, MSTest/Moq, MumbleSharp protocol models, raw Win32/WebView2 native bridge, React 19 + TypeScript + Vitest/Testing Library, existing Brmble UI guide tokens/components.
+
+---
+
+## File Structure
+
+### Server ACL And Chat Access
+
+- Modify: `src/Brmble.Server/Mumble/IMumbleAclService.cs`
+  - Add `HasTextMessagePermissionAsync(int sessionId, int channelId)` to `IMumbleAclService`.
+  - Keep `IMumbleAclIceClient.HasPermissionAsync(...)` unchanged.
+- Modify: `src/Brmble.Server/Mumble/MumbleAclService.cs`
+  - Implement `HasTextMessagePermissionAsync` by delegating to `MumbleServer.PermissionTextMessage.value`.
+- Create: `src/Brmble.Server/Mumble/ChannelChatAccessEndpoints.cs`
+  - Add authenticated endpoint `POST /chat/channel-access` that resolves the current Brmble user from the client certificate, resolves their live Mumble session through `ISessionMappingService`, and returns per-channel `canRead`/`canSend` values.
+  - Filter invalid channel IDs out of the response rather than failing the whole request.
+- Modify: `src/Brmble.Server/Program.cs`
+  - Register `app.MapChannelChatAccessEndpoints();` near other Brmble API endpoint mappings.
+- Modify: `tests/Brmble.Server.Tests/Mumble/MumbleAclServiceTests.cs`
+  - Add delegation coverage for `PermissionTextMessage`.
+- Modify: `tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs`
+  - Add injectable mocks for `IMumbleAclService` and `ISessionMappingService` used by the new endpoint tests.
+- Create: `tests/Brmble.Server.Tests/Integration/ChannelChatAccessEndpointTests.cs`
+  - Cover unauthenticated, unknown user, unmapped session, successful response, and filtering of invalid channel IDs.
+
+### Native Client Bridge
+
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`
+  - Include `canEnter` and `hasPasswordRestriction` in `voice.connected` and `voice.channelJoined` channel payloads.
+  - Add a small helper that detects Brmble-managed password restrictions from channel ACL snapshots already fetched for ACL admin support without exposing the plaintext password to React.
+  - Forward structured `PermissionDenied` fields: `denyType`, `permission`, `channelId`, `session`, `reason`, `name`, and `message`.
+  - Join with password by sending `UserState.TemporaryAccessTokens` for the join attempt instead of persisting an access token through authenticate.
+- Modify: `tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs`
+  - Cover initial channel snapshot payloads with `canEnter` and password boolean.
+  - Cover channel update payloads with `canEnter`.
+  - Cover structured permission denied payloads.
+- Modify: `tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs`
+  - Cover `voice.joinChannel` password payload sending a temporary access token and not storing it as a persistent access token.
+
+### React Types And Chat Access State
+
+- Modify: `src/Brmble.Web/src/types/index.ts`
+  - Add `canEnter`, `hasPasswordRestriction`, `canOpenChat`, and `canSendChat` to exported `Channel`.
+- Modify: `src/Brmble.Web/src/App.tsx`
+  - Add the same fields to the local `Channel` interface.
+  - Add pure helpers for channel chat access merging and checks so Vitest can cover behavior without rendering the whole app:
+    - `mergeChannelChatAccess(channels, access)`
+    - `canOpenChannelChat(channelId, channels)`
+    - `canSendToChannelChat(channelId, channels)`
+    - `isStructuredEnterDenied(data)`
+    - `getChannelAccessDeniedMessage(channel)`
+  - Request channel chat access when Brmble API credentials become available and channels change.
+  - Merge access results into `channels` without replacing voice-side channel fields.
+  - Gate Matrix active channel, channel selection, channel unread badges, message history display, and Matrix sends with `canOpenChat`/`canSendChat`.
+  - Preserve Mumble temporary chat behavior during Brmble service outages.
+- Modify: `src/Brmble.Web/src/App.chatMode.test.ts`
+  - Extend pure helper coverage for chat access gating and structured denial behavior.
+
+### React Channel Tree And Join UX
+
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`
+  - Add `canEnter` and `hasPasswordRestriction` to local `Channel` interface.
+  - Render no lock, open lock, or closed lock with existing `<Icon>`/`Tooltip` patterns.
+  - Keep all visual styling in existing CSS tokens and existing channel-row structure.
+- Modify: `src/Brmble.Web/src/components/Icon/Icon.tsx`
+  - Add `lock` and `unlock` icon definitions in the server/channel icon section.
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.css`
+  - Add token-based lock icon spacing/color classes for the new lock element.
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx`
+  - Add lock icon rendering coverage.
+  - Add assertions that no plaintext password appears in lock UI.
+- Modify: `src/Brmble.Web/src/App.tsx`
+  - Prompt before the first join attempt when `canEnter === false && hasPasswordRestriction === true`.
+  - Send password through `voice.joinChannel` payload only for that attempt.
+  - Show a non-fatal access message for denied restricted joins.
+  - Do not update `voice` service status to broken/disconnected for `PermissionDenied` enter denials.
+
+### Chat Panel UX
+
+- Modify: `src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx`
+  - Use existing `disabled` and `topNotice` props to show channel chat access feedback.
+  - Do not add a new notification/toast system.
+- Modify: `src/Brmble.Web/src/App.chatMode.test.ts`
+  - Prefer pure App helper tests for chat gating and notice decisions.
+
+---
+
+## Task 1: Server ACL TextMessage Permission
+
+**Files:**
+- Modify: `src/Brmble.Server/Mumble/IMumbleAclService.cs`
+- Modify: `src/Brmble.Server/Mumble/MumbleAclService.cs`
+- Test: `tests/Brmble.Server.Tests/Mumble/MumbleAclServiceTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `tests/Brmble.Server.Tests/Mumble/MumbleAclServiceTests.cs` after `HasWritePermissionAsync_DelegatesToMumblePermissionWrite`:
+
+```csharp
+[TestMethod]
+public async Task HasTextMessagePermissionAsync_DelegatesToMumblePermissionTextMessage()
+{
+    var ice = new Mock<IMumbleAclIceClient>();
+    ice.Setup(i => i.HasPermissionAsync(12, 5, MumbleServer.PermissionTextMessage.value)).ReturnsAsync(true);
+    var service = new MumbleAclService(ice.Object, NullLogger<MumbleAclService>.Instance);
+
+    Assert.IsTrue(await service.HasTextMessagePermissionAsync(sessionId: 12, channelId: 5));
+    ice.Verify(i => i.HasPermissionAsync(12, 5, MumbleServer.PermissionTextMessage.value), Times.Once);
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter HasTextMessagePermissionAsync_DelegatesToMumblePermissionTextMessage`
+
+Expected: FAIL with a compile error because `MumbleAclService` has no `HasTextMessagePermissionAsync` method.
+
+- [ ] **Step 3: Add the interface method**
+
+Update `src/Brmble.Server/Mumble/IMumbleAclService.cs`:
+
+```csharp
+public interface IMumbleAclService
+{
+    Task<AclChannelSnapshotDto> GetChannelAclAsync(int channelId);
+    Task SetChannelAclAsync(int channelId, AclUpdateRequest request);
+    Task AddUserToGroupAsync(int channelId, int sessionId, string group);
+    Task RemoveUserFromGroupAsync(int channelId, int sessionId, string group);
+    Task<bool> HasWritePermissionAsync(int sessionId, int channelId);
+    Task<bool> HasTextMessagePermissionAsync(int sessionId, int channelId);
+}
+```
+
+- [ ] **Step 4: Implement the service method**
+
+Add this method to `src/Brmble.Server/Mumble/MumbleAclService.cs` after `HasWritePermissionAsync`:
+
+```csharp
+public async Task<bool> HasTextMessagePermissionAsync(int sessionId, int channelId)
+{
+    try
+    {
+        return await _iceClient.HasPermissionAsync(sessionId, channelId, MumbleServer.PermissionTextMessage.value);
+    }
+    catch (Exception ex) when (ex is not MumbleAclUnavailableException and not MumbleAclException)
+    {
+        _logger.LogWarning(ex, "Failed to verify text message permission for session {SessionId} on channel {ChannelId}", sessionId, channelId);
+        throw new MumbleAclException($"Failed to verify text message permission for session {sessionId} on channel {channelId}.", ex);
+    }
+}
+```
+
+- [ ] **Step 5: Run the focused test and verify it passes**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter HasTextMessagePermissionAsync_DelegatesToMumblePermissionTextMessage`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Server/Mumble/IMumbleAclService.cs src/Brmble.Server/Mumble/MumbleAclService.cs tests/Brmble.Server.Tests/Mumble/MumbleAclServiceTests.cs
+git commit -m "feat: add Mumble text message permission check"
+```
+
+---
+
+## Task 2: Server Channel Chat Access Endpoint
+
+**Files:**
+- Create: `src/Brmble.Server/Mumble/ChannelChatAccessEndpoints.cs`
+- Modify: `src/Brmble.Server/Program.cs`
+- Modify: `tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs`
+- Test: `tests/Brmble.Server.Tests/Integration/ChannelChatAccessEndpointTests.cs`
+
+- [ ] **Step 1: Extend the integration factory with mocks**
+
+Modify `tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs` to add the missing using and two mock properties:
+
+```csharp
+using Brmble.Server.Events;
+```
+
+Add properties next to the existing mocks:
+
+```csharp
+public Mock<IMumbleAclService> MumbleAclMock { get; } = new();
+public Mock<ISessionMappingService> SessionMappingMock { get; } = new();
+```
+
+Add replacements in `ConfigureServices` after the ACL coordinator replacement:
+
+```csharp
+var aclService = services.FirstOrDefault(d => d.ServiceType == typeof(IMumbleAclService));
+if (aclService != null) services.Remove(aclService);
+services.AddSingleton(MumbleAclMock.Object);
+
+var sessionMapping = services.FirstOrDefault(d => d.ServiceType == typeof(ISessionMappingService));
+if (sessionMapping != null) services.Remove(sessionMapping);
+services.AddSingleton(SessionMappingMock.Object);
+```
+
+- [ ] **Step 2: Write the failing endpoint tests**
+
+Create `tests/Brmble.Server.Tests/Integration/ChannelChatAccessEndpointTests.cs`:
+
+```csharp
+using System.Net;
+using System.Net.Http.Json;
+using Brmble.Server.Auth;
+using Brmble.Server.Events;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Brmble.Server.Tests.Integration;
+
+[TestClass]
+public class ChannelChatAccessEndpointTests
+{
+    [TestMethod]
+    public async Task GetChannelChatAccess_Unauthenticated_ReturnsUnauthorized()
+    {
+        using var factory = new BrmbleServerFactory(certHash: null);
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/chat/channel-access", new ChannelChatAccessRequest([1]));
+
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task GetChannelChatAccess_AuthenticatedButNoLiveMumbleSession_ReturnsForbidden()
+    {
+        using var factory = new BrmbleServerFactory("cert_chat_no_session");
+        var user = await SeedUser(factory, "cert_chat_no_session", "Alice");
+        var ignoredSession = 0;
+        factory.SessionMappingMock
+            .Setup(s => s.TryGetSessionByUserId(user.Id, out ignoredSession))
+            .Returns(false);
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/chat/channel-access", new ChannelChatAccessRequest([1]));
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task GetChannelChatAccess_ReturnsTextMessageAccessForEachValidChannel()
+    {
+        using var factory = new BrmbleServerFactory("cert_chat_access");
+        var user = await SeedUser(factory, "cert_chat_access", "Alice");
+        var sessionId = 42;
+        factory.SessionMappingMock
+            .Setup(s => s.TryGetSessionByUserId(user.Id, out sessionId))
+            .Returns(true);
+        factory.MumbleAclMock.Setup(a => a.HasTextMessagePermissionAsync(42, 1)).ReturnsAsync(true);
+        factory.MumbleAclMock.Setup(a => a.HasTextMessagePermissionAsync(42, 2)).ReturnsAsync(false);
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/chat/channel-access", new ChannelChatAccessRequest([1, 2, 0, -5, 1]));
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ChannelChatAccessResponse>();
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.Channels.Count);
+        Assert.IsTrue(result.Channels["1"].CanRead);
+        Assert.IsTrue(result.Channels["1"].CanSend);
+        Assert.IsFalse(result.Channels["2"].CanRead);
+        Assert.IsFalse(result.Channels["2"].CanSend);
+        factory.MumbleAclMock.Verify(a => a.HasTextMessagePermissionAsync(42, 1), Times.Once);
+    }
+
+    private static async Task<User> SeedUser(BrmbleServerFactory factory, string certHash, string name)
+    {
+        using var scope = factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<UserRepository>();
+        return await repo.Insert(certHash, name);
+    }
+}
+```
+
+- [ ] **Step 3: Run the focused tests and verify they fail**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter ChannelChatAccessEndpointTests`
+
+Expected: FAIL with compile errors because `ChannelChatAccessRequest`, `ChannelChatAccessResponse`, and the endpoint do not exist.
+
+- [ ] **Step 4: Create the endpoint file**
+
+Create `src/Brmble.Server/Mumble/ChannelChatAccessEndpoints.cs`:
+
+```csharp
+using Brmble.Server.Auth;
+using Brmble.Server.Events;
+
+namespace Brmble.Server.Mumble;
+
+public sealed record ChannelChatAccessRequest(int[] ChannelIds);
+
+public sealed record ChannelChatAccessState(bool CanRead, bool CanSend);
+
+public sealed record ChannelChatAccessResponse(Dictionary<string, ChannelChatAccessState> Channels);
+
+public static class ChannelChatAccessEndpoints
+{
+    public static IEndpointRouteBuilder MapChannelChatAccessEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/chat/channel-access", async (
+            ChannelChatAccessRequest request,
+            HttpContext httpContext,
+            ICertificateHashExtractor certHashExtractor,
+            UserRepository userRepo,
+            ISessionMappingService sessionMapping,
+            IMumbleAclService aclService) =>
+        {
+            var certHash = certHashExtractor.GetCertHash(httpContext);
+            if (string.IsNullOrWhiteSpace(certHash))
+            {
+                return Results.Unauthorized();
+            }
+
+            var user = await userRepo.GetByCertHash(certHash);
+            if (user is null)
+            {
+                return Results.Unauthorized();
+            }
+
+            if (!sessionMapping.TryGetSessionByUserId(user.Id, out var sessionId))
+            {
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+
+            var channels = new Dictionary<string, ChannelChatAccessState>();
+            foreach (var channelId in request.ChannelIds.Where(id => id > 0).Distinct())
+            {
+                var allowed = await aclService.HasTextMessagePermissionAsync(sessionId, channelId);
+                channels[channelId.ToString()] = new ChannelChatAccessState(allowed, allowed);
+            }
+
+            return Results.Ok(new ChannelChatAccessResponse(channels));
+        });
+
+        return app;
+    }
+}
+```
+
+- [ ] **Step 5: Register the endpoint**
+
+Modify `src/Brmble.Server/Program.cs` so the endpoint mappings include:
+
+```csharp
+app.MapAclAdminEndpoints();
+app.MapChannelChatAccessEndpoints();
+app.Map("/ws", BrmbleWebSocketHandler.HandleAsync);
+```
+
+- [ ] **Step 6: Run the focused tests and verify they pass**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter ChannelChatAccessEndpointTests`
+
+Expected: PASS.
+
+- [ ] **Step 7: Run ACL server tests**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "MumbleAclServiceTests|ChannelChatAccessEndpointTests|AclAdminEndpointTests"`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Server/Program.cs src/Brmble.Server/Mumble/ChannelChatAccessEndpoints.cs tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs tests/Brmble.Server.Tests/Integration/ChannelChatAccessEndpointTests.cs
+git commit -m "feat: expose channel chat access endpoint"
+```
+
+---
+
+## Task 3: Native Channel State Payloads
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`
+- Test: `tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs`
+
+- [ ] **Step 1: Write failing tests for `canEnter` in snapshots and updates**
+
+In `tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs`, replace `SendVoiceConnected_IncludesChannelEnterRestrictionState` with:
+
+```csharp
+[TestMethod]
+public void SendVoiceConnected_IncludesChannelEnterRestrictionState()
+{
+    var adapter = CreateAdapterWithBridge(out var bridge);
+    var channels = GetChannelDictionary(adapter);
+    channels[4] = new Channel(adapter, 4, "Secret", 0)
+    {
+        IsEnterRestricted = true,
+        CanEnter = false,
+    };
+
+    InvokePrivate(adapter, "SendVoiceConnected");
+
+    var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+    var connected = sent.Single(m => m.Type == "voice.connected");
+    using var doc = JsonDocument.Parse(connected.DataJson);
+    var channel = doc.RootElement.GetProperty("channels").EnumerateArray().Single();
+
+    Assert.AreEqual(4u, channel.GetProperty("id").GetUInt32());
+    Assert.IsTrue(channel.GetProperty("isEnterRestricted").GetBoolean());
+    Assert.IsFalse(channel.GetProperty("canEnter").GetBoolean());
+    Assert.IsFalse(channel.GetProperty("hasPasswordRestriction").GetBoolean());
+}
+
+[TestMethod]
+public void ChannelState_IncludesCanEnterInBridgePayload()
+{
+    var adapter = CreateAdapterWithBridge(out var bridge);
+
+    adapter.ChannelState(new MumbleProto.ChannelState
+    {
+        ChannelId = 4,
+        Name = "Secret",
+        Parent = 0,
+        IsEnterRestricted = true,
+        CanEnter = true,
+    });
+
+    var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+    var channelJoined = sent.Single(m => m.Type == "voice.channelJoined");
+    using var doc = JsonDocument.Parse(channelJoined.DataJson);
+
+    Assert.AreEqual(4u, doc.RootElement.GetProperty("id").GetUInt32());
+    Assert.IsTrue(doc.RootElement.GetProperty("isEnterRestricted").GetBoolean());
+    Assert.IsTrue(doc.RootElement.GetProperty("canEnter").GetBoolean());
+    Assert.IsFalse(doc.RootElement.GetProperty("hasPasswordRestriction").GetBoolean());
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "SendVoiceConnected_IncludesChannelEnterRestrictionState|ChannelState_IncludesCanEnterInBridgePayload"`
+
+Expected: FAIL because `canEnter` and `hasPasswordRestriction` are missing from payloads.
+
+- [ ] **Step 3: Add a channel payload helper**
+
+In `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`, add this private helper near `SendVoiceConnected`:
+
+```csharp
+private object CreateChannelPayload(Channel channel) => new
+{
+    id = channel.Id,
+    name = channel.Name,
+    parent = channel.Parent,
+    isEnterRestricted = channel.IsEnterRestricted,
+    canEnter = channel.CanEnter,
+    hasPasswordRestriction = false,
+};
+```
+
+- [ ] **Step 4: Use the helper in the initial snapshot**
+
+Replace the `channels` projection in `SendVoiceConnected` with:
+
+```csharp
+var channels = Channels.Select(CreateChannelPayload).ToList();
+```
+
+- [ ] **Step 5: Use the helper in channel updates**
+
+Replace the `voice.channelJoined` anonymous object in `ChannelState(ChannelState channelState)` with:
+
+```csharp
+_bridge?.Send("voice.channelJoined", CreateChannelPayload(channel));
+```
+
+- [ ] **Step 6: Run the focused tests and verify they pass**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "SendVoiceConnected_IncludesChannelEnterRestrictionState|ChannelState_IncludesCanEnterInBridgePayload"`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/MumbleAdapter.cs tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+git commit -m "feat: forward channel enter state to UI"
+```
+
+---
+
+## Task 4: Native Password Restriction Boolean
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`
+- Test: `tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs`
+
+- [ ] **Step 1: Write the failing password boolean test**
+
+Add this test to `tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs`:
+
+```csharp
+[TestMethod]
+public void SendVoiceConnected_DoesNotExposeManagedPasswordPlaintext()
+{
+    var adapter = CreateAdapterWithBridge(out var bridge);
+    var channels = GetChannelDictionary(adapter);
+    channels[4] = new Channel(adapter, 4, "Secret", 0)
+    {
+        IsEnterRestricted = true,
+        CanEnter = false,
+    };
+    SetPrivateField(adapter, "_channelPasswordRestrictions", new System.Collections.Concurrent.ConcurrentDictionary<uint, bool>(
+        new[] { new KeyValuePair<uint, bool>(4, true) }));
+
+    InvokePrivate(adapter, "SendVoiceConnected");
+
+    var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+    var connected = sent.Single(m => m.Type == "voice.connected");
+    using var doc = JsonDocument.Parse(connected.DataJson);
+    var channel = doc.RootElement.GetProperty("channels").EnumerateArray().Single();
+
+    Assert.IsTrue(channel.GetProperty("hasPasswordRestriction").GetBoolean());
+    Assert.IsFalse(connected.DataJson.Contains("secret", StringComparison.OrdinalIgnoreCase));
+}
+```
+
+Add this helper near the other private helpers in the test file:
+
+```csharp
+private static void SetPrivateField(object instance, string name, object? value)
+    => instance.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter SendVoiceConnected_DoesNotExposeManagedPasswordPlaintext`
+
+Expected: FAIL because `_channelPasswordRestrictions` does not exist.
+
+- [ ] **Step 3: Add password restriction state**
+
+In `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`, add this field near other channel/session state fields:
+
+```csharp
+private readonly System.Collections.Concurrent.ConcurrentDictionary<uint, bool> _channelPasswordRestrictions = new();
+```
+
+- [ ] **Step 4: Use the password boolean in payloads**
+
+Update `CreateChannelPayload`:
+
+```csharp
+private object CreateChannelPayload(Channel channel) => new
+{
+    id = channel.Id,
+    name = channel.Name,
+    parent = channel.Parent,
+    isEnterRestricted = channel.IsEnterRestricted,
+    canEnter = channel.CanEnter,
+    hasPasswordRestriction = _channelPasswordRestrictions.TryGetValue(channel.Id, out var hasPasswordRestriction) && hasPasswordRestriction,
+};
+```
+
+- [ ] **Step 5: Update the map from ACL payloads without exposing passwords**
+
+Find the existing `HandleWebSocketMessage` code path that forwards `acl.changed` to `acl.changed`. In that code path, after extracting `channelId`, call:
+
+```csharp
+UpdateChannelPasswordRestriction(channelId, json);
+```
+
+Add these helpers near ACL helper methods:
+
+```csharp
+private void UpdateChannelPasswordRestriction(uint channelId, string aclJson)
+{
+    _channelPasswordRestrictions[channelId] = ContainsManagedPasswordMarker(aclJson);
+    if (ChannelDictionary.TryGetValue(channelId, out var channel))
+    {
+        _bridge?.Send("voice.channelJoined", CreateChannelPayload(channel));
+        _bridge?.NotifyUiThread();
+    }
+}
+
+private static bool ContainsManagedPasswordMarker(string aclJson)
+    => aclJson.Contains("__brmble_password_marker__:#", StringComparison.Ordinal);
+```
+
+This deliberately stores only a boolean and does not parse or forward the token value.
+
+- [ ] **Step 6: Run focused native tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter MumbleAdapterBridgeTests`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/MumbleAdapter.cs tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+git commit -m "feat: expose channel password restriction state"
+```
+
+---
+
+## Task 5: Native Password Join And PermissionDenied Payloads
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`
+- Test: `tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs`
+- Test: `tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs`
+
+- [ ] **Step 1: Write failing structured denial test**
+
+Add this test to `tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs`:
+
+```csharp
+[TestMethod]
+public void PermissionDenied_ForwardsStructuredFields()
+{
+    var adapter = CreateAdapterWithBridge(out var bridge);
+
+    adapter.PermissionDenied(new MumbleProto.PermissionDenied
+    {
+        Type = MumbleProto.PermissionDenied.Types.DenyType.Permission,
+        Permission = MumbleProto.PermissionDenied.Types.Permission.Enter,
+        ChannelId = 4,
+        Session = 12,
+        Reason = "Denied",
+        Name = "Secret",
+    });
+
+    var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+    var error = sent.Single(m => m.Type == "voice.error");
+    using var doc = JsonDocument.Parse(error.DataJson);
+
+    Assert.AreEqual("permissionDenied", doc.RootElement.GetProperty("type").GetString());
+    Assert.AreEqual("Permission", doc.RootElement.GetProperty("denyType").GetString());
+    Assert.AreEqual((int)MumbleProto.PermissionDenied.Types.Permission.Enter, doc.RootElement.GetProperty("permission").GetInt32());
+    Assert.AreEqual(4u, doc.RootElement.GetProperty("channelId").GetUInt32());
+    Assert.AreEqual(12u, doc.RootElement.GetProperty("session").GetUInt32());
+    Assert.AreEqual("Denied", doc.RootElement.GetProperty("reason").GetString());
+    Assert.AreEqual("Secret", doc.RootElement.GetProperty("name").GetString());
+}
+```
+
+- [ ] **Step 2: Write failing temporary token join test**
+
+Add this reflection-based test to `tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs`. This matches the existing test harness style and avoids adding `InternalsVisibleTo` just for one helper.
+
+```csharp
+[TestMethod]
+public void CreateJoinUserState_IncludesTemporaryAccessTokenOnlyForThisJoin()
+{
+    var method = typeof(MumbleAdapter).GetMethod("CreateJoinUserState", BindingFlags.Static | BindingFlags.NonPublic);
+    Assert.IsNotNull(method);
+
+    var state = (UserState)method.Invoke(null, [4u, "secret-token"])!;
+
+    Assert.AreEqual(4u, state.ChannelId);
+    Assert.AreEqual(1, state.TemporaryAccessTokens.Count);
+    Assert.AreEqual("secret-token", state.TemporaryAccessTokens[0]);
+
+    var normalState = (UserState)method.Invoke(null, [5u, null])!;
+    Assert.AreEqual(5u, normalState.ChannelId);
+    Assert.AreEqual(0, normalState.TemporaryAccessTokens.Count);
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify they fail**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "PermissionDenied_ForwardsStructuredFields|CreateJoinUserState"`
+
+Expected: FAIL because structured fields and temporary token user-state construction are missing.
+
+- [ ] **Step 4: Add a join state helper and use temporary tokens**
+
+In `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`, add this private helper:
+
+```csharp
+private static UserState CreateJoinUserState(uint channelId, string? password)
+{
+    var userState = new UserState { ChannelId = channelId };
+    if (!string.IsNullOrWhiteSpace(password))
+    {
+        userState.TemporaryAccessTokens.Add(password);
+    }
+    return userState;
+}
+```
+
+Update `JoinChannel(uint channelId, string? password)` to remove `_pendingJoinPassword`, `ApplyPendingJoinPasswordToken();`, and the old `new UserState { ChannelId = channelId }` send. Use:
+
+```csharp
+Connection.SendControl(PacketType.UserState, CreateJoinUserState(channelId, password));
+```
+
+Keep `SendPermissionQuery(new PermissionQuery { ChannelId = channelId });`.
+
+- [ ] **Step 5: Stop clearing a persisted join token on permission denied**
+
+In `PermissionDenied(PermissionDenied permissionDenied)`, remove:
+
+```csharp
+_pendingJoinPassword = null;
+ClearTemporaryJoinToken();
+```
+
+Remove the now-unused `_pendingJoinPassword`, `_hasActiveJoinToken`, `ApplyPendingJoinPasswordToken`, and `ClearTemporaryJoinToken` members from `MumbleAdapter.cs`.
+
+- [ ] **Step 6: Forward structured denial payloads**
+
+Replace the bridge send in `PermissionDenied` with:
+
+```csharp
+_bridge?.Send("voice.error", new
+{
+    type = "permissionDenied",
+    denyType = permissionDenied.Type.ToString(),
+    permission = permissionDenied.ShouldSerializePermission() ? (int?)permissionDenied.Permission : null,
+    channelId = permissionDenied.ShouldSerializeChannelId() ? (uint?)permissionDenied.ChannelId : null,
+    session = permissionDenied.ShouldSerializeSession() ? (uint?)permissionDenied.Session : null,
+    reason = permissionDenied.Reason,
+    name = permissionDenied.Name,
+    message = reason,
+});
+```
+
+- [ ] **Step 7: Run focused native tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "MumbleAdapterBridgeTests|MumbleAdapterParseTests"`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/MumbleAdapter.cs tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+git commit -m "feat: use temporary tokens for channel password joins"
+```
+
+---
+
+## Task 6: React Channel Chat Access Helpers
+
+**Files:**
+- Modify: `src/Brmble.Web/src/types/index.ts`
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Test: `src/Brmble.Web/src/App.chatMode.test.ts`
+
+- [ ] **Step 1: Write failing pure helper tests**
+
+Add imports in `src/Brmble.Web/src/App.chatMode.test.ts`:
+
+```ts
+import {
+  canOpenChannelChat,
+  canSendToChannelChat,
+  getChannelAccessDeniedMessage,
+  isStructuredEnterDenied,
+  mergeChannelChatAccess,
+} from './App';
+```
+
+Add tests:
+
+```ts
+describe('channel chat access helpers', () => {
+  it('merges canRead and canSend without dropping voice channel state', () => {
+    const result = mergeChannelChatAccess([
+      { id: 1, name: 'General', isEnterRestricted: true, canEnter: false, hasPasswordRestriction: true },
+      { id: 2, name: 'Quiet' },
+    ], {
+      '1': { canRead: false, canSend: false },
+      '2': { canRead: true, canSend: true },
+    });
+
+    expect(result[0]).toMatchObject({
+      id: 1,
+      isEnterRestricted: true,
+      canEnter: false,
+      hasPasswordRestriction: true,
+      canOpenChat: false,
+      canSendChat: false,
+    });
+    expect(result[1]).toMatchObject({ canOpenChat: true, canSendChat: true });
+  });
+
+  it('allows server root chat and gates restricted Matrix channels', () => {
+    const channels = [
+      { id: 1, name: 'Allowed', canOpenChat: true, canSendChat: true },
+      { id: 2, name: 'Denied', canOpenChat: false, canSendChat: false },
+    ];
+
+    expect(canOpenChannelChat('server-root', channels)).toBe(true);
+    expect(canOpenChannelChat('1', channels)).toBe(true);
+    expect(canOpenChannelChat('2', channels)).toBe(false);
+    expect(canSendToChannelChat('1', channels)).toBe(true);
+    expect(canSendToChannelChat('2', channels)).toBe(false);
+  });
+});
+
+describe('structured channel access denial helpers', () => {
+  it('classifies Enter permission denials by structured permission field', () => {
+    expect(isStructuredEnterDenied({ type: 'permissionDenied', permission: 2, message: 'anything' })).toBe(true);
+    expect(isStructuredEnterDenied({ type: 'permissionDenied', permission: 4, message: 'Enter appears in text only' })).toBe(false);
+  });
+
+  it('uses password-specific copy only when the channel is known password restricted', () => {
+    expect(getChannelAccessDeniedMessage({ id: 1, name: 'Secret', hasPasswordRestriction: true })).toBe('Incorrect password or no access.');
+    expect(getChannelAccessDeniedMessage({ id: 2, name: 'Private' })).toBe('You do not have access to that channel.');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run from `src/Brmble.Web`: `npm test -- App.chatMode.test.ts`
+
+Expected: FAIL because the helpers and fields do not exist.
+
+- [ ] **Step 3: Extend exported Channel type**
+
+Modify `src/Brmble.Web/src/types/index.ts`:
+
+```ts
+export interface Channel {
+  id: number;
+  name: string;
+  parent?: number;
+  type?: 'voice' | 'text';
+  description?: string;
+  isEnterRestricted?: boolean;
+  canEnter?: boolean;
+  hasPasswordRestriction?: boolean;
+  canOpenChat?: boolean;
+  canSendChat?: boolean;
+}
+```
+
+- [ ] **Step 4: Extend App local Channel type**
+
+Modify the local `Channel` interface in `src/Brmble.Web/src/App.tsx`:
+
+```ts
+interface Channel {
+  id: number;
+  name: string;
+  parent?: number;
+  isEnterRestricted?: boolean;
+  canEnter?: boolean;
+  hasPasswordRestriction?: boolean;
+  canOpenChat?: boolean;
+  canSendChat?: boolean;
+}
+```
+
+- [ ] **Step 5: Add helper types and functions**
+
+Add near `isMatrixChannelChatActive` in `src/Brmble.Web/src/App.tsx`:
+
+```ts
+interface ChannelChatAccessState {
+  canRead: boolean;
+  canSend: boolean;
+}
+
+type ChannelChatAccessMap = Record<string, ChannelChatAccessState>;
+
+const MUMBLE_PERMISSION_ENTER = 2;
+
+export function mergeChannelChatAccess(channels: Channel[], access: ChannelChatAccessMap): Channel[] {
+  return channels.map(channel => {
+    const state = access[String(channel.id)];
+    if (!state) return channel;
+    return {
+      ...channel,
+      canOpenChat: state.canRead,
+      canSendChat: state.canSend,
+    };
+  });
+}
+
+export function canOpenChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
+  if (!channelId) return false;
+  if (channelId === 'server-root') return true;
+  const channel = channels.find(c => String(c.id) === channelId);
+  return channel?.canOpenChat !== false;
+}
+
+export function canSendToChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
+  if (!channelId) return false;
+  if (channelId === 'server-root') return true;
+  const channel = channels.find(c => String(c.id) === channelId);
+  return channel?.canSendChat !== false;
+}
+
+export function isStructuredEnterDenied(data: unknown): boolean {
+  const d = data as { type?: string; permission?: number } | undefined;
+  return d?.type === 'permissionDenied' && d.permission === MUMBLE_PERMISSION_ENTER;
+}
+
+export function getChannelAccessDeniedMessage(channel: Pick<Channel, 'hasPasswordRestriction'> | undefined): string {
+  return channel?.hasPasswordRestriction
+    ? 'Incorrect password or no access.'
+    : 'You do not have access to that channel.';
+}
+```
+
+- [ ] **Step 6: Run focused tests and verify they pass**
+
+Run from `src/Brmble.Web`: `npm test -- App.chatMode.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Web/src/types/index.ts src/Brmble.Web/src/App.tsx src/Brmble.Web/src/App.chatMode.test.ts
+git commit -m "feat: add channel chat access helpers"
+```
+
+---
+
+## Task 7: React Fetch And Apply Channel Chat Access
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Test: `src/Brmble.Web/src/App.chatMode.test.ts`
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs`
+- Test: `tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs`
+
+- [ ] **Step 1: Add a pure request planning helper test**
+
+Add this test to `src/Brmble.Web/src/App.chatMode.test.ts`:
+
+```ts
+import { getChannelChatAccessRequestIds } from './App';
+
+describe('getChannelChatAccessRequestIds', () => {
+  it('requests only positive non-root channel IDs once', () => {
+    expect(getChannelChatAccessRequestIds([
+      { id: 0, name: 'Root' },
+      { id: 1, name: 'General' },
+      { id: 1, name: 'General duplicate' },
+      { id: -2, name: 'Invalid' },
+    ])).toEqual([1]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run from `src/Brmble.Web`: `npm test -- App.chatMode.test.ts`
+
+Expected: FAIL because `getChannelChatAccessRequestIds` is missing.
+
+- [ ] **Step 3: Add request ID helper**
+
+Add near the chat access helpers in `src/Brmble.Web/src/App.tsx`:
+
+```ts
+export function getChannelChatAccessRequestIds(channels: Channel[]): number[] {
+  return [...new Set(channels.map(channel => channel.id).filter(id => id > 0))];
+}
+```
+
+- [ ] **Step 4: Add bridge/API plumbing through native**
+
+Because React does not own client certificates directly, use native bridge request/response events instead of `fetch` in React.
+
+First add this native bridge test to `tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs`:
+
+```csharp
+[TestMethod]
+public async Task ChatGetChannelAccess_WithoutApiUrl_ReturnsEmptyAccessMap()
+{
+    var bridge = NativeBridgeTestHarness.Create();
+    var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge, apiUrl: null);
+    adapter.RegisterHandlers(bridge);
+
+    using var doc = JsonDocument.Parse("""
+    { "channelIds": [1, 2] }
+    """);
+
+    await NativeBridgeTestHarness.InvokeAsync(bridge, "chat.getChannelAccess", doc.RootElement.Clone());
+
+    var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+    var access = sent.Single(m => m.Type == "chat.channelAccess");
+    using var payload = JsonDocument.Parse(access.DataJson);
+    Assert.AreEqual(0, payload.RootElement.GetProperty("channels").EnumerateObject().Count());
+}
+```
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter ChatGetChannelAccess_WithoutApiUrl_ReturnsEmptyAccessMap`
+
+Expected: FAIL because `chat.getChannelAccess` is not registered.
+
+Add this handler to `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` in `RegisterHandlers` near ACL handlers:
+
+```csharp
+bridge.RegisterHandler("chat.getChannelAccess", async data =>
+{
+    var channelIds = data.TryGetProperty("channelIds", out var ids) && ids.ValueKind == System.Text.Json.JsonValueKind.Array
+        ? ids.EnumerateArray().Where(e => e.ValueKind == System.Text.Json.JsonValueKind.Number).Select(e => e.GetInt32()).Where(id => id > 0).Distinct().ToArray()
+        : [];
+
+    if (channelIds.Length == 0 || _apiUrl is null)
+    {
+        _bridge?.Send("chat.channelAccess", new { channels = new Dictionary<string, object>() });
+        _bridge?.NotifyUiThread();
+        return;
+    }
+
+    using var cert = _certService?.GetExportableCertificate();
+    if (cert is null)
+    {
+        _bridge?.Send("chat.channelAccessError", new { error = "No client certificate" });
+        _bridge?.NotifyUiThread();
+        return;
+    }
+
+    var uri = new Uri(new Uri(_apiUrl, UriKind.Absolute), "chat/channel-access");
+    var requestJson = System.Text.Json.JsonSerializer.Serialize(new { channelIds });
+    var result = await PostViaBcTls(cert, uri, requestJson);
+    _bridge?.Send(result.Success ? "chat.channelAccess" : "chat.channelAccessError", new { body = result.Body, statusCode = result.StatusCode, error = result.Error });
+    _bridge?.NotifyUiThread();
+});
+```
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter ChatGetChannelAccess_WithoutApiUrl_ReturnsEmptyAccessMap`
+
+Expected: PASS.
+
+- [ ] **Step 5: Listen for access responses in React**
+
+In `src/Brmble.Web/src/App.tsx`, add a bridge listener in the main bridge handler effect:
+
+```ts
+const onChatChannelAccess = (data: unknown) => {
+  const payload = data as { body?: string; channels?: ChannelChatAccessMap } | undefined;
+  let channelsAccess = payload?.channels;
+  if (!channelsAccess && payload?.body) {
+    try {
+      channelsAccess = (JSON.parse(payload.body) as { channels?: ChannelChatAccessMap }).channels;
+    } catch {
+      channelsAccess = undefined;
+    }
+  }
+  if (!channelsAccess) return;
+  setChannels(prev => mergeChannelChatAccess(prev, channelsAccess));
+};
+
+bridge.on('chat.channelAccess', onChatChannelAccess);
+```
+
+Add cleanup:
+
+```ts
+bridge.off('chat.channelAccess', onChatChannelAccess);
+```
+
+- [ ] **Step 6: Request access when channels are available**
+
+Add an effect in `App` after refs are initialized:
+
+```ts
+useEffect(() => {
+  if (statuses.server.state !== 'connected' || !matrixCredentials?.roomMap) return;
+  const channelIds = getChannelChatAccessRequestIds(channels);
+  if (channelIds.length === 0) return;
+  bridge.send('chat.getChannelAccess', { channelIds });
+}, [channels, matrixCredentials?.roomMap, statuses.server.state]);
+```
+
+- [ ] **Step 7: Run frontend and native focused tests**
+
+Run from `src/Brmble.Web`: `npm test -- App.chatMode.test.ts`
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter MumbleAdapterParseTests`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx src/Brmble.Web/src/App.chatMode.test.ts src/Brmble.Client/Services/Voice/MumbleAdapter.cs tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+git commit -m "feat: fetch channel chat access in client"
+```
+
+---
+
+## Task 8: React Chat Gating
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Test: `src/Brmble.Web/src/App.chatMode.test.ts`
+
+- [ ] **Step 1: Add pure helper tests for Matrix activation with chat access**
+
+Modify the existing `isMatrixChannelChatActive` tests to pass a channel list argument. The first test should become:
+
+```ts
+expect(isMatrixChannelChatActive(
+  '1',
+  credentials,
+  connectedStatuses,
+  { session: 1, name: 'Me', self: true, isBrmbleClient: true },
+  [{ id: 1, name: 'General', canOpenChat: true }],
+)).toBe(true);
+```
+
+Add a denied-channel test:
+
+```ts
+it('does not use Matrix when channel chat access is denied', () => {
+  expect(isMatrixChannelChatActive(
+    '1',
+    credentials,
+    connectedStatuses,
+    { session: 1, name: 'Me', self: true, isBrmbleClient: true },
+    [{ id: 1, name: 'General', canOpenChat: false }],
+  )).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run from `src/Brmble.Web`: `npm test -- App.chatMode.test.ts`
+
+Expected: FAIL because `isMatrixChannelChatActive` does not accept channels or check `canOpenChat`.
+
+- [ ] **Step 3: Gate Matrix activation by `canOpenChat`**
+
+Update `isMatrixChannelChatActive` signature in `src/Brmble.Web/src/App.tsx`:
+
+```ts
+export function isMatrixChannelChatActive(
+  channelId: string | undefined,
+  credentials: MatrixCredentials | null,
+  statuses: ServiceStatusMap,
+  selfUser: User | undefined,
+  channels: Channel[] = [],
+): boolean {
+  if (!channelId || channelId === 'server-root') return false;
+  if (!canOpenChannelChat(channelId, channels)) return false;
+  if (statuses.server.state !== 'connected' || statuses.chat.state !== 'connected') return false;
+  if (!selfUser?.isBrmbleClient) return false;
+  return credentials?.roomMap[channelId] !== undefined;
+}
+```
+
+Update all call sites to pass `channelsRef.current` or `channels`:
+
+```ts
+isMatrixChannelChatActive(channelId, matrixCredentialsRef.current, statusesRef.current, selfUser, channelsRef.current)
+```
+
+and:
+
+```ts
+isMatrixChannelChatActive(activeChannelId, matrixCredentials, statuses, selfUserForChat, channels)
+```
+
+- [ ] **Step 4: Gate channel selection and unread badges**
+
+Update `handleSelectChannel` after locating `channel`:
+
+```ts
+if (!canOpenChannelChat(String(channelId), channels)) {
+  setCurrentChannelId(String(channelId));
+  setCurrentChannelName(channel.name);
+  setUnreadCount(0);
+  setShowGame(false);
+  return;
+}
+```
+
+Update `channelUnreads` calculation:
+
+```ts
+for (const [channelId, roomId] of Object.entries(matrixCredentials.roomMap)) {
+  if (!canOpenChannelChat(channelId, channels)) continue;
+  const unread = unreadTracker.getRoomUnread(roomId);
+  ...
+}
+```
+
+- [ ] **Step 5: Gate message display and input**
+
+Add derived booleans near `isMatrixActive`:
+
+```ts
+const canOpenActiveChannelChat = canOpenChannelChat(activeChannelId, channels);
+const canSendActiveChannelChat = canSendToChannelChat(activeChannelId, channels);
+const channelChatAccessNotice = activeChannelId && activeChannelId !== 'server-root' && !canOpenActiveChannelChat
+  ? 'You do not have access to this channel chat.'
+  : activeChannelId && activeChannelId !== 'server-root' && !canSendActiveChannelChat
+    ? 'You can read this channel chat, but cannot send messages.'
+    : undefined;
+```
+
+Update `channelChatMessages`:
+
+```ts
+const channelChatMessages = useMemo(
+  () => canOpenActiveChannelChat
+    ? [
+        ...(isMatrixActive ? (matrixMessages ?? []) : messages),
+        ...optimisticImages.filter(m => m.channelId === currentChannelId),
+      ]
+    : [],
+  [canOpenActiveChannelChat, isMatrixActive, matrixMessages, messages, optimisticImages, currentChannelId],
+);
+```
+
+Update channel `ChatPanel` props:
+
+```tsx
+disabled={!canSendActiveChannelChat}
+topNotice={channelChatAccessNotice ?? (brmbleTemporaryChatActive ? BRMBLE_SERVICE_TEMPORARY_CHAT_NOTICE : undefined)}
+```
+
+- [ ] **Step 6: Gate Matrix sends and Mumble channel sends**
+
+At the start of `handleSendMessage`, after resolving `channelId`, add:
+
+```ts
+if (!canSendToChannelChat(channelId, channelsRef.current)) {
+  return;
+}
+```
+
+This applies to Matrix channel sends and Mumble channel messages from Brmble UI. Server-root and DMs remain unaffected.
+
+- [ ] **Step 7: Run frontend tests**
+
+Run from `src/Brmble.Web`: `npm test -- App.chatMode.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx src/Brmble.Web/src/App.chatMode.test.ts
+git commit -m "feat: gate channel chat by Mumble text permission"
+```
+
+---
+
+## Task 9: Channel Lock Icons
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Icon/Icon.tsx`
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.css`
+- Test: `src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx`
+
+- [ ] **Step 1: Write failing lock icon tests**
+
+Add tests to `src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx`:
+
+```tsx
+describe('ChannelTree channel access locks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders no lock for unrestricted channels', () => {
+    render(<ChannelTree channels={[{ id: 1, name: 'Open' }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
+
+    const row = screen.getByText('Open').closest('.channel-row');
+    expect(row?.querySelector('[data-icon="lock"]')).toBeNull();
+    expect(row?.querySelector('[data-icon="unlock"]')).toBeNull();
+  });
+
+  it('renders an open lock for restricted channels the user can enter', () => {
+    render(<ChannelTree channels={[{ id: 1, name: 'Allowed', isEnterRestricted: true, canEnter: true }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
+
+    const row = screen.getByText('Allowed').closest('.channel-row');
+    expect(row?.querySelector('[data-icon="unlock"]')).not.toBeNull();
+    expect(row?.querySelector('[data-icon="lock"]')).toBeNull();
+  });
+
+  it('renders a closed lock for restricted channels the user cannot enter without exposing a password', () => {
+    render(<ChannelTree channels={[{ id: 1, name: 'Secret', isEnterRestricted: true, canEnter: false, hasPasswordRestriction: true }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
+
+    const row = screen.getByText('Secret').closest('.channel-row');
+    expect(row?.querySelector('[data-icon="lock"]')).not.toBeNull();
+    expect(row?.textContent).not.toContain('password');
+  });
+});
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run from `src/Brmble.Web`: `npm test -- ChannelTree.test.tsx`
+
+Expected: FAIL because lock icons are not rendered.
+
+- [ ] **Step 3: Add icons**
+
+In `src/Brmble.Web/src/components/Icon/Icon.tsx`, add in the server/channel icon section after `folder`:
+
+```tsx
+'lock': {
+  paths: (
+    <>
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </>
+  ),
+},
+'unlock': {
+  paths: (
+    <>
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+    </>
+  ),
+},
+```
+
+- [ ] **Step 4: Extend local Channel type in ChannelTree**
+
+Modify `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`:
+
+```ts
+interface Channel {
+  id: number;
+  name: string;
+  parent?: number;
+  description?: string;
+  isEnterRestricted?: boolean;
+  canEnter?: boolean;
+  hasPasswordRestriction?: boolean;
+}
+```
+
+- [ ] **Step 5: Render lock icons with existing patterns**
+
+In `renderChannel`, add before the return:
+
+```ts
+const lockIconName = channel.isEnterRestricted
+  ? channel.canEnter === false ? 'lock' : 'unlock'
+  : null;
+const lockTooltip = channel.canEnter === false
+  ? 'Restricted channel'
+  : 'Restricted channel, access allowed';
+```
+
+After `<span className="channel-name">{channel.name}</span>`, add:
+
+```tsx
+{lockIconName && (
+  <Tooltip content={lockTooltip}>
+    <span className="channel-access-icon" aria-label={lockTooltip}>
+      <Icon name={lockIconName} size={11} />
+    </span>
+  </Tooltip>
+)}
+```
+
+- [ ] **Step 6: Add token-based spacing styles**
+
+If the icon needs spacing, add to `src/Brmble.Web/src/components/Sidebar/ChannelTree.css`:
+
+```css
+.channel-access-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-muted);
+  margin-left: var(--space-2xs);
+}
+```
+
+- [ ] **Step 7: Run focused tests and verify they pass**
+
+Run from `src/Brmble.Web`: `npm test -- ChannelTree.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Icon/Icon.tsx src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx src/Brmble.Web/src/components/Sidebar/ChannelTree.css src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+git commit -m "feat: show restricted channel lock icons"
+```
+
+---
+
+## Task 10: Password Prompt And Non-Fatal Join Denials
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Test: `src/Brmble.Web/src/App.chatMode.test.ts`
+
+- [ ] **Step 1: Add pure join decision helper tests**
+
+Add imports and tests to `src/Brmble.Web/src/App.chatMode.test.ts`:
+
+```ts
+import { getJoinAccessAction } from './App';
+
+describe('getJoinAccessAction', () => {
+  it('joins normally when channel is enterable or canEnter is unknown', () => {
+    expect(getJoinAccessAction({ id: 1, name: 'General', canEnter: true })).toBe('join');
+    expect(getJoinAccessAction({ id: 2, name: 'Unknown' })).toBe('join');
+  });
+
+  it('prompts only for known password restricted denied channels', () => {
+    expect(getJoinAccessAction({ id: 1, name: 'Secret', canEnter: false, hasPasswordRestriction: true })).toBe('promptPassword');
+    expect(getJoinAccessAction({ id: 2, name: 'Private', canEnter: false })).toBe('deny');
+  });
+});
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run from `src/Brmble.Web`: `npm test -- App.chatMode.test.ts`
+
+Expected: FAIL because `getJoinAccessAction` is missing.
+
+- [ ] **Step 3: Add join decision helper**
+
+Add in `src/Brmble.Web/src/App.tsx` near other channel helpers:
+
+```ts
+export type JoinAccessAction = 'join' | 'promptPassword' | 'deny';
+
+export function getJoinAccessAction(channel: Pick<Channel, 'canEnter' | 'hasPasswordRestriction'>): JoinAccessAction {
+  if (channel.canEnter !== false) return 'join';
+  return channel.hasPasswordRestriction ? 'promptPassword' : 'deny';
+}
+```
+
+- [ ] **Step 4: Update password join flow**
+
+Modify `handleJoinChannel` after the screen share check and before `startPendingAction(channelId)`:
+
+```ts
+const joinAction = getJoinAccessAction(channel);
+if (joinAction === 'deny') {
+  addMessageToStore('server-root', 'Server', getChannelAccessDeniedMessage(channel), 'system');
+  return;
+}
+
+if (joinAction === 'promptPassword') {
+  const password = await prompt({
+    title: 'Channel Password',
+    message: `Enter the password for ${channel.name}.`,
+    placeholder: 'Password',
+    confirmLabel: 'Join',
+    cancelLabel: 'Cancel',
+    isPassword: true,
+  });
+
+  if (!password) {
+    return;
+  }
+
+  startPendingAction(channelId);
+  pendingJoinAttemptRef.current = {
+    channelId,
+    channelName: channel.name,
+    passwordRetrySent: true,
+  };
+  sendJoinChannel(channelId, password);
+  return;
+}
+```
+
+Then keep the existing normal `startPendingAction`, `pendingJoinAttemptRef.current`, and `sendJoinChannel(channelId)` for the `'join'` case.
+
+- [ ] **Step 5: Stop message-string password detection from driving routing**
+
+Replace `isPasswordProtectedJoinError` with structured logic:
+
+```ts
+function isPasswordProtectedJoinError(data: unknown, channel?: Channel): boolean {
+  return isStructuredEnterDenied(data) && channel?.hasPasswordRestriction === true;
+}
+```
+
+Update the call site in `onVoiceError`:
+
+```ts
+const pendingChannel = pendingJoinAttempt
+  ? channelsRef.current.find(channel => channel.id === pendingJoinAttempt.channelId)
+  : undefined;
+if (pendingJoinAttempt && isPasswordProtectedJoinError(data, pendingChannel)) {
+```
+
+- [ ] **Step 6: Make enter permission denial non-fatal**
+
+In `onVoiceError`, before generic `updateStatus('voice', { error: errorMsg })`, add:
+
+```ts
+if (isStructuredEnterDenied(data)) {
+  const d = data as { channelId?: number };
+  const deniedChannel = d.channelId != null
+    ? channelsRef.current.find(channel => channel.id === d.channelId)
+    : pendingJoinAttempt
+      ? channelsRef.current.find(channel => channel.id === pendingJoinAttempt.channelId)
+      : undefined;
+  addMessageToStore('server-root', 'Server', getChannelAccessDeniedMessage(deniedChannel), 'system');
+  clearPendingJoinAttempt();
+  return;
+}
+```
+
+Do not call `updateStatus('voice', { error: errorMsg })` for this branch.
+
+- [ ] **Step 7: Run focused tests**
+
+Run from `src/Brmble.Web`: `npm test -- App.chatMode.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx src/Brmble.Web/src/App.chatMode.test.ts
+git commit -m "feat: prompt for restricted channel passwords"
+```
+
+---
+
+## Task 11: Full Verification
+
+**Files:**
+- No code changes expected.
+
+- [ ] **Step 1: Run server tests**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run client tests**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run frontend tests**
+
+Run from `src/Brmble.Web`: `npm test`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run frontend build**
+
+Run from `src/Brmble.Web`: `npm run build`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full .NET build**
+
+Run: `dotnet build`
+
+Expected: PASS.
+
+- [ ] **Step 6: Inspect final diff**
+
+Run: `git diff --stat HEAD`
+
+Expected: Diff contains only channel access permission implementation files from this plan.
+
+- [ ] **Step 7: Final commit if verification required fixes**
+
+If verification required fixes after Task 10, commit them:
+
+```bash
+git add <fixed-files>
+git commit -m "fix: stabilize channel access permission implementation"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: server text permission delegation and endpoint are covered in Tasks 1-2; native channel state, password boolean, structured denial, and temporary token joins are covered in Tasks 3-5; React channel fields, lock icons, join UX, chat gating, unread gating, message history, and send gating are covered in Tasks 6-10; verification is covered in Task 11.
+- Non-goals: no Mumble ACL evaluator is implemented; no Matrix room membership source-of-truth change is made; submitted channel passwords are sent only in the join payload and are not stored; plaintext managed passwords are not exposed in channel payloads.
+- UI guide: the plan uses existing `Icon`, `Tooltip`, prompt, notification avoidance, `ChatPanel disabled`, and `topNotice` patterns. No new UI pattern is expected.

--- a/docs/superpowers/specs/2026-05-19-channel-access-permissions-design.md
+++ b/docs/superpowers/specs/2026-05-19-channel-access-permissions-design.md
@@ -1,0 +1,195 @@
+# Channel Access Permissions Design
+
+## Goal
+
+Make Brmble understand Mumble channel access well enough to:
+
+- show Mumble-like lock icons on restricted voice channels;
+- prompt for a password only when Brmble knows a channel has a password restriction;
+- treat denied voice entry as non-fatal access feedback;
+- gate Matrix channel chat, unread badges, and message sending with Mumble `TextMessage` permission.
+
+Mumble remains the source of truth. Brmble should not duplicate Mumble's ACL evaluator.
+
+## Mumble Access Model
+
+Mumble exposes voice entry state through `ChannelState`:
+
+- `is_enter_restricted`: the channel has an ACL rule denying `Enter`.
+- `can_enter`: the current client can enter this channel.
+
+These fields are per recipient. Two users can receive different `can_enter` values for the same channel.
+
+Mumble clients render locks from these fields:
+
+- no lock: `is_enter_restricted = false`;
+- open lock: `is_enter_restricted = true` and `can_enter = true`;
+- closed lock: `is_enter_restricted = true` and `can_enter = false`.
+
+Failed joins are reported with `PermissionDenied`. For denied channel entry this is usually `type = Permission`, `permission = Enter`, and `channel_id = targetChannel`. Mumble does not expose a dedicated "password required" denial type.
+
+## Password Restrictions
+
+Mumble channel passwords are ACL access-token conventions, not a separate channel field.
+
+A password such as `secret` becomes a token group named `#secret`. A typical password-protected channel has:
+
+- an `@all` ACL denying entry and related permissions;
+- a `#secret` ACL granting those permissions back to users who present token `secret`.
+
+Brmble should distinguish only Brmble-managed password restrictions. Native or unknown Mumble ACLs remain generic restricted access.
+
+Brmble-managed password detection must not expose the plaintext password to React. The client only needs a boolean such as `hasPasswordRestriction`.
+
+When a user attempts to enter a Brmble-managed password-restricted channel, Brmble prompts for a password and sends it as a temporary access token for that join attempt. The token must not be persisted in local storage or saved as a server access token.
+
+## Chat Access Model
+
+Matrix channel chat access is based on Mumble's effective `TextMessage` permission, checked server-side through ICE:
+
+```csharp
+ServerPrx.hasPermission(sessionId, channelId, PermissionTextMessage)
+```
+
+This determines whether a Brmble user can:
+
+- open a channel chat;
+- fetch or display unread badges for that channel;
+- fetch/display Matrix messages for that channel;
+- send Matrix messages to that channel.
+
+Brmble should not manually compute this from ACL rows. Mumble ACL semantics include inheritance, group rules, access tokens, user IDs, special groups, and deny precedence. ICE `hasPermission` already applies the correct server logic.
+
+For now, Matrix room membership may remain broad. The Brmble UI and Brmble APIs must treat Mumble `TextMessage` permission as the authorization gate for channel chat behavior.
+
+## Backend Design
+
+Extend the ACL service with a text-message permission check:
+
+```csharp
+Task<bool> HasTextMessagePermissionAsync(int sessionId, int channelId);
+```
+
+Implementation delegates to:
+
+```csharp
+IMumbleAclIceClient.HasPermissionAsync(sessionId, channelId, MumbleServer.PermissionTextMessage.value)
+```
+
+Add a Brmble API endpoint that returns channel chat access for the current authenticated user. The endpoint resolves the user's live Mumble session through existing session mapping, then calls the ACL service for relevant channel IDs.
+
+The response should be simple and explicit:
+
+```json
+{
+  "channels": {
+    "1": { "canRead": true, "canSend": true },
+    "2": { "canRead": false, "canSend": false }
+  }
+}
+```
+
+For Brmble's initial model, `canRead` and `canSend` are both derived from `TextMessage`. If later requirements need read-only channels, the response shape already allows separating them.
+
+Unread badge endpoints or data fetches must filter out channels without `canRead`.
+
+## Native Client Bridge Design
+
+Forward complete channel entry state from `MumbleAdapter` to React on both initial snapshots and channel updates:
+
+```ts
+{
+  id: number,
+  name: string,
+  parent?: number,
+  isEnterRestricted?: boolean,
+  canEnter?: boolean,
+  hasPasswordRestriction?: boolean
+}
+```
+
+Forward full `PermissionDenied` details instead of only a generic message:
+
+```ts
+{
+  type: 'permissionDenied',
+  denyType: string | number,
+  permission?: number,
+  channelId?: number,
+  session?: number,
+  reason?: string,
+  name?: string,
+  message: string
+}
+```
+
+Join attempts use normal `UserState.channel_id` unless a password is entered. Password joins use `UserState.temporary_access_tokens` with the submitted password.
+
+## React Design
+
+Add channel model fields:
+
+```ts
+interface Channel {
+  id: number;
+  name: string;
+  parent?: number;
+  isEnterRestricted?: boolean;
+  canEnter?: boolean;
+  hasPasswordRestriction?: boolean;
+  canOpenChat?: boolean;
+  canSendChat?: boolean;
+}
+```
+
+Channel tree rendering follows the UI guide and existing icon patterns:
+
+- no icon for unrestricted channels;
+- open lock icon for restricted channels the user can enter;
+- closed lock icon for restricted channels the user cannot enter.
+
+Chat navigation, unread badges, message history loading, and send actions must check `canOpenChat`/`canSendChat` before using Matrix channel data.
+
+## Join UX
+
+When a user clicks a channel:
+
+1. If `canEnter` is true, send a normal join.
+2. If `canEnter` is false and `hasPasswordRestriction` is true, prompt for a password.
+3. If the user submits a password, send a join with that password as a temporary access token.
+4. If the user cancels, do nothing.
+5. If the join fails after a password prompt, show a non-fatal message such as "Incorrect password or no access."
+6. If `canEnter` is false and no password restriction is known, show a non-fatal access-denied message.
+
+Denied joins must not mark the voice service as disconnected or broken.
+
+## Error Handling
+
+`PermissionDenied` should be classified by structured fields:
+
+- `permission == Enter` and `hasPasswordRestriction`: password retry or password failure UX;
+- `permission == Enter` without known password restriction: access denied;
+- `permission == TextMessage`: chat permission denied;
+- `denyType == ChannelFull`: channel full message;
+- other denial: generic non-fatal permission message.
+
+The human-readable `reason` is display/logging text only. It must not drive core routing logic.
+
+## Testing
+
+Add tests for:
+
+- `HasTextMessagePermissionAsync` delegating to `PermissionTextMessage`;
+- chat access endpoint filtering/response behavior;
+- bridge payloads including `canEnter` and full `PermissionDenied` fields;
+- channel lock icon rendering;
+- password prompt and temporary-token join flow;
+- chat navigation and unread badge gating by `canOpenChat`;
+- message send gating by `canSendChat`.
+
+## Non-Goals
+
+- Do not persist submitted channel passwords as Mumble access tokens.
+- Do not manually implement Mumble's effective ACL evaluator in Brmble.
+- Do not make Matrix room membership the source of truth for channel chat access in this phase.
+- Do not expose plaintext channel passwords to React.

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -40,8 +40,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private readonly CertificateService? _certService;
     private uint? _previousChannelId;
     private uint? _pendingLocalJoinChannelId;
-    private string? _pendingJoinPassword;
-    private bool _hasActiveJoinToken;
     private bool _leftVoice;
     private bool _leaveVoiceInProgress;
     private bool _canRejoin;
@@ -421,8 +419,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         _lastWelcomeText = null;
         _previousChannelId = null;
         _pendingLocalJoinChannelId = null;
-        _pendingJoinPassword = null;
-        _hasActiveJoinToken = false;
         if (_intentionalDisconnect || _reconnectHost == null)
         {
             _apiUrl = null;
@@ -962,44 +958,18 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             return;
 
         _pendingLocalJoinChannelId = channelId;
-        _pendingJoinPassword = string.IsNullOrWhiteSpace(password) ? null : password;
-        ApplyPendingJoinPasswordToken();
-        Connection.SendControl(PacketType.UserState, new UserState { ChannelId = channelId });
+        Connection.SendControl(PacketType.UserState, CreateJoinUserState(channelId, password));
         SendPermissionQuery(new PermissionQuery { ChannelId = channelId });
     }
 
-    private void ApplyPendingJoinPasswordToken()
+    private static UserState CreateJoinUserState(uint channelId, string? password)
     {
-        if (string.IsNullOrWhiteSpace(_pendingJoinPassword))
-            return;
-
-        var auth = new Authenticate
+        var userState = new UserState { ChannelId = channelId };
+        if (!string.IsNullOrWhiteSpace(password))
         {
-            Username = LocalUser?.Name ?? _reconnectUsername ?? string.Empty,
-            Opus = true,
-        };
-        auth.Tokens.Add(_pendingJoinPassword);
-        SendAuthenticate(auth);
-        _hasActiveJoinToken = true;
-    }
-
-    private void ClearTemporaryJoinToken()
-    {
-        if (!_hasActiveJoinToken)
-            return;
-
-        if (Connection is not { State: ConnectionStates.Connected })
-            return;
-
-        // Send empty token list to clear the temporary token from session
-        var auth = new Authenticate
-        {
-            Username = LocalUser?.Name ?? _reconnectUsername ?? string.Empty,
-            Opus = true,
-        };
-        // Empty Tokens collection removes all tokens from the session
-        SendAuthenticate(auth);
-        _hasActiveJoinToken = false;
+            userState.TemporaryAccessTokens.Add(password);
+        }
+        return userState;
     }
 
     public void RequestPermissions(uint channelId)
@@ -3860,15 +3830,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 if (_pendingLocalJoinChannelId == currentChannelId)
                 {
                     _pendingLocalJoinChannelId = null;
-                    _pendingJoinPassword = null;
-                    ClearTemporaryJoinToken();
                 }
             }
             else if (_pendingLocalJoinChannelId == currentChannelId)
             {
                 _pendingLocalJoinChannelId = null;
-                _pendingJoinPassword = null;
-                ClearTemporaryJoinToken();
                 if (_leftVoice && LocalUser != null)
                 {
                     ClearLeaveVoiceState();
@@ -4119,14 +4085,21 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     {
         base.PermissionDenied(permissionDenied);
 
-        _pendingJoinPassword = null;
-        ClearTemporaryJoinToken();
-
         var reason = !string.IsNullOrEmpty(permissionDenied.Reason)
             ? permissionDenied.Reason
             : $"Permission denied: {permissionDenied.Type}";
 
-        _bridge?.Send("voice.error", new { message = reason, type = "permissionDenied" });
+        _bridge?.Send("voice.error", new
+        {
+            type = "permissionDenied",
+            denyType = permissionDenied.Type.ToString(),
+            permission = permissionDenied.ShouldSerializePermission() ? (int?)permissionDenied.Permission : null,
+            channelId = permissionDenied.ShouldSerializeChannelId() ? (uint?)permissionDenied.ChannelId : null,
+            session = permissionDenied.ShouldSerializeSession() ? (uint?)permissionDenied.Session : null,
+            reason = permissionDenied.Reason,
+            name = permissionDenied.Name,
+            message = reason,
+        });
         _bridge?.NotifyUiThread();
     }
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -3654,13 +3654,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private void SendVoiceConnected(uint? overrideChannelId = null)
     {
         var channelId = overrideChannelId ?? (uint)(LocalUser?.Channel?.Id ?? 0);
-        var channels = Channels.Select(c => new
-        {
-            id = c.Id,
-            name = c.Name,
-            parent = c.Parent,
-            isEnterRestricted = c.IsEnterRestricted
-        }).ToList();
+        var channels = Channels.Select(CreateChannelPayload).ToList();
         var users = Users.Select(u =>
         {
             var hasMap = _sessionMappings.TryGetValue(u.Id, out var sm);
@@ -3696,6 +3690,16 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         Debug.WriteLine($"[Mumble] Sent {channels.Count} channels and {users.Count} users");
     }
+
+    private object CreateChannelPayload(Channel channel) => new
+    {
+        id = channel.Id,
+        name = channel.Name,
+        parent = channel.Parent,
+        isEnterRestricted = channel.IsEnterRestricted,
+        canEnter = channel.CanEnter,
+        hasPasswordRestriction = false,
+    };
 
     /// <summary>
     /// Called when the server sends updated configuration.
@@ -4056,13 +4060,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         if (ChannelDictionary.TryGetValue(channelState.ChannelId, out var channel))
         {
-            _bridge?.Send("voice.channelJoined", new
-            {
-                id = channel.Id,
-                name = channel.Name,
-                parent = channel.Parent,
-                isEnterRestricted = channel.IsEnterRestricted
-            });
+            _bridge?.Send("voice.channelJoined", CreateChannelPayload(channel));
         }
     }
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -61,6 +61,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private string? _activeServerId;
     private Dictionary<string, string> _userMappings = new();
     private readonly ConcurrentDictionary<uint, SessionMappingEntry> _sessionMappings = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<uint, bool> _channelPasswordRestrictions = new();
     private CancellationTokenSource? _wsCts;
     private long _wsGeneration;
     private readonly IAppConfigService? _appConfigService;
@@ -1478,6 +1479,19 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private static bool IsBrmblePasswordMarker(string? group)
         => !string.IsNullOrWhiteSpace(group) && group.StartsWith(BrmblePasswordMarkerPrefix, StringComparison.Ordinal);
 
+    private void UpdateChannelPasswordRestriction(uint channelId, string aclJson)
+    {
+        _channelPasswordRestrictions[channelId] = ContainsManagedPasswordMarker(aclJson);
+        if (ChannelDictionary.TryGetValue(channelId, out var channel))
+        {
+            _bridge?.Send("voice.channelJoined", CreateChannelPayload(channel));
+            _bridge?.NotifyUiThread();
+        }
+    }
+
+    private static bool ContainsManagedPasswordMarker(string aclJson)
+        => aclJson.Contains("__brmble_password_marker__:#", StringComparison.Ordinal);
+
     private static bool IsManagedPasswordTokenRule(System.Text.Json.JsonElement acl, string selector)
     {
         var group = acl.TryGetProperty("group", out var groupProp) && groupProp.ValueKind != System.Text.Json.JsonValueKind.Null
@@ -2515,6 +2529,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                     break;
 
                 case "acl.changed":
+                    var aclChannelId = root.TryGetProperty("channelId", out var aclChannelProp) ? aclChannelProp.GetUInt32() : 0u;
+                    if (aclChannelId > 0)
+                    {
+                        UpdateChannelPasswordRestriction(aclChannelId, json);
+                    }
                     _bridge?.Send("acl.changed", System.Text.Json.JsonSerializer.Deserialize<object>(json));
                     _bridge?.NotifyUiThread();
                     break;
@@ -3698,7 +3717,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         parent = channel.Parent,
         isEnterRestricted = channel.IsEnterRestricted,
         canEnter = channel.CanEnter,
-        hasPasswordRestriction = false,
+        hasPasswordRestriction = _channelPasswordRestrictions.TryGetValue(channel.Id, out var hasPasswordRestriction) && hasPasswordRestriction,
     };
 
     /// <summary>

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -417,6 +417,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         UserDictionary.Clear();
         ChannelDictionary.Clear();
+        _channelPasswordRestrictions.Clear();
         _lastWelcomeText = null;
         _previousChannelId = null;
         _pendingLocalJoinChannelId = null;

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -3300,6 +3300,34 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             _bridge?.NotifyUiThread();
         });
 
+        bridge.RegisterHandler("chat.getChannelAccess", async data =>
+        {
+            var channelIds = data.TryGetProperty("channelIds", out var ids) && ids.ValueKind == System.Text.Json.JsonValueKind.Array
+                ? ids.EnumerateArray().Where(e => e.ValueKind == System.Text.Json.JsonValueKind.Number).Select(e => e.GetInt32()).Where(id => id > 0).Distinct().ToArray()
+                : [];
+
+            if (channelIds.Length == 0 || _apiUrl is null)
+            {
+                _bridge?.Send("chat.channelAccess", new { channels = new Dictionary<string, object>() });
+                _bridge?.NotifyUiThread();
+                return;
+            }
+
+            using var cert = _certService?.GetExportableCertificate();
+            if (cert is null)
+            {
+                _bridge?.Send("chat.channelAccessError", new { error = "No client certificate" });
+                _bridge?.NotifyUiThread();
+                return;
+            }
+
+            var uri = new Uri(new Uri(_apiUrl, UriKind.Absolute), "chat/channel-access");
+            var requestJson = System.Text.Json.JsonSerializer.Serialize(new { channelIds });
+            var result = await PostViaBcTls(cert, uri, requestJson);
+            _bridge?.Send(result.Success ? "chat.channelAccess" : "chat.channelAccessError", new { body = result.Body, statusCode = result.StatusCode, error = result.Error });
+            _bridge?.NotifyUiThread();
+        });
+
         bridge.RegisterHandler("acl.setChannel", async data =>
         {
             var channelId = data.TryGetProperty("channelId", out var cid) && cid.ValueKind == System.Text.Json.JsonValueKind.Number

--- a/src/Brmble.Server/Mumble/ChannelChatAccessEndpoints.cs
+++ b/src/Brmble.Server/Mumble/ChannelChatAccessEndpoints.cs
@@ -39,7 +39,7 @@ public static class ChannelChatAccessEndpoints
             }
 
             var channels = new Dictionary<string, ChannelChatAccessState>();
-            foreach (var channelId in request.ChannelIds.Where(id => id > 0).Distinct())
+            foreach (var channelId in (request.ChannelIds ?? []).Where(id => id > 0).Distinct())
             {
                 var allowed = await aclService.HasTextMessagePermissionAsync(sessionId, channelId);
                 channels[channelId.ToString()] = new ChannelChatAccessState(allowed, allowed);

--- a/src/Brmble.Server/Mumble/ChannelChatAccessEndpoints.cs
+++ b/src/Brmble.Server/Mumble/ChannelChatAccessEndpoints.cs
@@ -1,0 +1,53 @@
+using Brmble.Server.Auth;
+using Brmble.Server.Events;
+
+namespace Brmble.Server.Mumble;
+
+public sealed record ChannelChatAccessRequest(int[] ChannelIds);
+
+public sealed record ChannelChatAccessState(bool CanRead, bool CanSend);
+
+public sealed record ChannelChatAccessResponse(Dictionary<string, ChannelChatAccessState> Channels);
+
+public static class ChannelChatAccessEndpoints
+{
+    public static IEndpointRouteBuilder MapChannelChatAccessEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/chat/channel-access", async (
+            ChannelChatAccessRequest request,
+            HttpContext httpContext,
+            ICertificateHashExtractor certHashExtractor,
+            UserRepository userRepo,
+            ISessionMappingService sessionMapping,
+            IMumbleAclService aclService) =>
+        {
+            var certHash = certHashExtractor.GetCertHash(httpContext);
+            if (string.IsNullOrWhiteSpace(certHash))
+            {
+                return Results.Unauthorized();
+            }
+
+            var user = await userRepo.GetByCertHash(certHash);
+            if (user is null)
+            {
+                return Results.Unauthorized();
+            }
+
+            if (!sessionMapping.TryGetSessionByUserId(user.Id, out var sessionId))
+            {
+                return Results.StatusCode(StatusCodes.Status403Forbidden);
+            }
+
+            var channels = new Dictionary<string, ChannelChatAccessState>();
+            foreach (var channelId in request.ChannelIds.Where(id => id > 0).Distinct())
+            {
+                var allowed = await aclService.HasTextMessagePermissionAsync(sessionId, channelId);
+                channels[channelId.ToString()] = new ChannelChatAccessState(allowed, allowed);
+            }
+
+            return Results.Ok(new ChannelChatAccessResponse(channels));
+        });
+
+        return app;
+    }
+}

--- a/src/Brmble.Server/Mumble/IMumbleAclService.cs
+++ b/src/Brmble.Server/Mumble/IMumbleAclService.cs
@@ -7,6 +7,7 @@ public interface IMumbleAclService
     Task AddUserToGroupAsync(int channelId, int sessionId, string group);
     Task RemoveUserFromGroupAsync(int channelId, int sessionId, string group);
     Task<bool> HasWritePermissionAsync(int sessionId, int channelId);
+    Task<bool> HasTextMessagePermissionAsync(int sessionId, int channelId);
 }
 
 public interface IMumbleAclIceClient

--- a/src/Brmble.Server/Mumble/MumbleAclService.cs
+++ b/src/Brmble.Server/Mumble/MumbleAclService.cs
@@ -78,4 +78,17 @@ public sealed class MumbleAclService : IMumbleAclService
             throw new MumbleAclException($"Failed to verify write permission for session {sessionId} on channel {channelId}.", ex);
         }
     }
+
+    public async Task<bool> HasTextMessagePermissionAsync(int sessionId, int channelId)
+    {
+        try
+        {
+            return await _iceClient.HasPermissionAsync(sessionId, channelId, MumbleServer.PermissionTextMessage.value);
+        }
+        catch (Exception ex) when (ex is not MumbleAclUnavailableException and not MumbleAclException)
+        {
+            _logger.LogWarning(ex, "Failed to verify text message permission for session {SessionId} on channel {ChannelId}", sessionId, channelId);
+            throw new MumbleAclException($"Failed to verify text message permission for session {sessionId} on channel {channelId}.", ex);
+        }
+    }
 }

--- a/src/Brmble.Server/Program.cs
+++ b/src/Brmble.Server/Program.cs
@@ -75,6 +75,7 @@ app.MapAuthEndpoints();
 app.MapAdminEndpoints();
 app.MapDmEndpoints();
 app.MapAclAdminEndpoints();
+app.MapChannelChatAccessEndpoints();
 app.Map("/ws", BrmbleWebSocketHandler.HandleAsync);
 app.MapServerInfoEndpoints();
 app.MapLiveKitEndpoints();

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   canOpenChannelChat,
   canSendToChannelChat,
+  getChannelSelectionOutcome,
   getChannelAccessDeniedMessage,
   getChannelChatAccessRequestKey,
   getChannelChatAccessRequestIds,
@@ -66,6 +67,16 @@ describe('isMatrixChannelChatActive', () => {
 });
 
 describe('channel chat access helpers', () => {
+  it('exits DM mode when selecting a channel whose chat cannot be opened', () => {
+    expect(getChannelSelectionOutcome(2, matrixChannels, 'dm')).toEqual({
+      channelId: '2',
+      channelName: 'Denied',
+      canOpenChat: false,
+      shouldExitDmMode: true,
+      shouldClearDmSelection: true,
+    });
+  });
+
   it('deduplicates positive channel ids for chat access requests', () => {
     expect(getChannelChatAccessRequestIds([
       { id: 0, name: 'Root' },

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -29,27 +29,39 @@ const connectedStatuses: ServiceStatusMap = {
   livekit: { state: 'idle' },
 };
 
+const matrixChannels = [
+  { id: 1, name: 'Allowed', canOpenChat: true, canSendChat: true },
+  { id: 2, name: 'Denied', canOpenChat: false, canSendChat: false },
+];
+
 describe('isMatrixChannelChatActive', () => {
   it('uses Matrix only when room, Brmble server, Matrix chat, and self Brmble identity are ready', () => {
-    expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: true })).toBe(true);
+    expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: true }, matrixChannels)).toBe(true);
+  });
+
+  it('falls back to Mumble when channel chat access is denied', () => {
+    expect(isMatrixChannelChatActive('2', {
+      ...credentials,
+      roomMap: { ...credentials.roomMap, '2': '!denied:example.com' },
+    }, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: true }, matrixChannels)).toBe(false);
   });
 
   it('falls back to Mumble while Brmble server is reconnecting even if credentials still exist', () => {
     expect(isMatrixChannelChatActive('1', credentials, {
       ...connectedStatuses,
       server: { state: 'connecting' },
-    }, { session: 1, name: 'Me', self: true, isBrmbleClient: true })).toBe(false);
+    }, { session: 1, name: 'Me', self: true, isBrmbleClient: true }, matrixChannels)).toBe(false);
   });
 
   it('falls back to Mumble until Matrix chat is connected', () => {
     expect(isMatrixChannelChatActive('1', credentials, {
       ...connectedStatuses,
       chat: { state: 'connecting' },
-    }, { session: 1, name: 'Me', self: true, isBrmbleClient: true })).toBe(false);
+    }, { session: 1, name: 'Me', self: true, isBrmbleClient: true }, matrixChannels)).toBe(false);
   });
 
   it('falls back to Mumble until self is restored as a Brmble client', () => {
-    expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: false })).toBe(false);
+    expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: false }, matrixChannels)).toBe(false);
   });
 });
 

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -3,6 +3,7 @@ import {
   canOpenChannelChat,
   canSendToChannelChat,
   getChannelAccessDeniedMessage,
+  getChannelChatAccessRequestKey,
   getChannelChatAccessRequestIds,
   isBrmbleServiceOutageActive,
   isMatrixChannelChatActive,
@@ -60,6 +61,16 @@ describe('channel chat access helpers', () => {
       { id: 1, name: 'General duplicate' },
       { id: -2, name: 'Invalid' },
     ])).toEqual([1]);
+  });
+
+  it('keeps the chat access request key stable when only access flags change', () => {
+    expect(getChannelChatAccessRequestKey([
+      { id: 1, name: 'General' },
+      { id: 2, name: 'Quiet', canOpenChat: false, canSendChat: false },
+    ])).toBe(getChannelChatAccessRequestKey([
+      { id: 1, name: 'General', canOpenChat: true, canSendChat: true },
+      { id: 2, name: 'Quiet', canOpenChat: true, canSendChat: false },
+    ]));
   });
 
   it('merges canRead and canSend without dropping voice channel state', () => {

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -6,6 +6,7 @@ import {
   getChannelAccessDeniedMessage,
   getChannelChatAccessRequestKey,
   getChannelChatAccessRequestIds,
+  getJoinAccessAction,
   isBrmbleServiceOutageActive,
   isMatrixChannelChatActive,
   isStructuredEnterDenied,
@@ -148,6 +149,18 @@ describe('structured channel access denial helpers', () => {
   it('uses password-specific copy only when the channel is known password restricted', () => {
     expect(getChannelAccessDeniedMessage({ hasPasswordRestriction: true })).toBe('Incorrect password or no access.');
     expect(getChannelAccessDeniedMessage({})).toBe('You do not have access to that channel.');
+  });
+});
+
+describe('getJoinAccessAction', () => {
+  it('joins normally when channel is enterable or canEnter is unknown', () => {
+    expect(getJoinAccessAction({ canEnter: true })).toBe('join');
+    expect(getJoinAccessAction({})).toBe('join');
+  });
+
+  it('prompts for password restricted denied channels and denies other restricted channels', () => {
+    expect(getJoinAccessAction({ canEnter: false, hasPasswordRestriction: true })).toBe('promptPassword');
+    expect(getJoinAccessAction({ canEnter: false })).toBe('deny');
   });
 });
 

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -189,6 +189,7 @@ describe('getJoinAccessAction', () => {
 
   it('prompts for password restricted denied channels and denies other restricted channels', () => {
     expect(getJoinAccessAction({ canEnter: false, hasPasswordRestriction: true })).toBe('promptPassword');
+    expect(getJoinAccessAction({ hasPasswordRestriction: true })).toBe('promptPassword');
     expect(getJoinAccessAction({ canEnter: false })).toBe('deny');
   });
 });

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canOpenChannelChat,
+  canSendToChannelChat,
+  getChannelAccessDeniedMessage,
   isBrmbleServiceOutageActive,
   isMatrixChannelChatActive,
+  isStructuredEnterDenied,
   isTemporaryChannelChatActive,
+  mergeChannelChatAccess,
   shouldShowBrmbleServiceWarningNotification,
 } from './App';
 import type { ServiceStatusMap } from './types';
@@ -43,6 +48,53 @@ describe('isMatrixChannelChatActive', () => {
 
   it('falls back to Mumble until self is restored as a Brmble client', () => {
     expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: false })).toBe(false);
+  });
+});
+
+describe('channel chat access helpers', () => {
+  it('merges canRead and canSend without dropping voice channel state', () => {
+    const result = mergeChannelChatAccess([
+      { id: 1, name: 'General', isEnterRestricted: true, canEnter: false, hasPasswordRestriction: true },
+      { id: 2, name: 'Quiet' },
+    ], {
+      '1': { canRead: false, canSend: false },
+      '2': { canRead: true, canSend: true },
+    });
+
+    expect(result[0]).toMatchObject({
+      id: 1,
+      isEnterRestricted: true,
+      canEnter: false,
+      hasPasswordRestriction: true,
+      canOpenChat: false,
+      canSendChat: false,
+    });
+    expect(result[1]).toMatchObject({ canOpenChat: true, canSendChat: true });
+  });
+
+  it('allows server root chat and gates restricted Matrix channels', () => {
+    const channels = [
+      { id: 1, name: 'Allowed', canOpenChat: true, canSendChat: true },
+      { id: 2, name: 'Denied', canOpenChat: false, canSendChat: false },
+    ];
+
+    expect(canOpenChannelChat('server-root', channels)).toBe(true);
+    expect(canOpenChannelChat('1', channels)).toBe(true);
+    expect(canOpenChannelChat('2', channels)).toBe(false);
+    expect(canSendToChannelChat('1', channels)).toBe(true);
+    expect(canSendToChannelChat('2', channels)).toBe(false);
+  });
+});
+
+describe('structured channel access denial helpers', () => {
+  it('classifies Enter permission denials by structured permission field', () => {
+    expect(isStructuredEnterDenied({ type: 'permissionDenied', permission: 2, message: 'anything' })).toBe(true);
+    expect(isStructuredEnterDenied({ type: 'permissionDenied', permission: 4, message: 'Enter appears in text only' })).toBe(false);
+  });
+
+  it('uses password-specific copy only when the channel is known password restricted', () => {
+    expect(getChannelAccessDeniedMessage({ id: 1, name: 'Secret', hasPasswordRestriction: true })).toBe('Incorrect password or no access.');
+    expect(getChannelAccessDeniedMessage({ id: 2, name: 'Private' })).toBe('You do not have access to that channel.');
   });
 });
 

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -3,6 +3,7 @@ import {
   canOpenChannelChat,
   canSendToChannelChat,
   getChannelAccessDeniedMessage,
+  getChannelChatAccessRequestIds,
   isBrmbleServiceOutageActive,
   isMatrixChannelChatActive,
   isStructuredEnterDenied,
@@ -52,6 +53,15 @@ describe('isMatrixChannelChatActive', () => {
 });
 
 describe('channel chat access helpers', () => {
+  it('deduplicates positive channel ids for chat access requests', () => {
+    expect(getChannelChatAccessRequestIds([
+      { id: 0, name: 'Root' },
+      { id: 1, name: 'General' },
+      { id: 1, name: 'General duplicate' },
+      { id: -2, name: 'Invalid' },
+    ])).toEqual([1]);
+  });
+
   it('merges canRead and canSend without dropping voice channel state', () => {
     const result = mergeChannelChatAccess([
       { id: 1, name: 'General', isEnterRestricted: true, canEnter: false, hasPasswordRestriction: true },
@@ -70,6 +80,15 @@ describe('channel chat access helpers', () => {
       canSendChat: false,
     });
     expect(result[1]).toMatchObject({ canOpenChat: true, canSendChat: true });
+  });
+
+  it('preserves channel array identity when access does not change', () => {
+    const channels = [{ id: 1, name: 'General', canOpenChat: true, canSendChat: true }];
+
+    expect(mergeChannelChatAccess(channels, {
+      '1': { canRead: true, canSend: true },
+    })).toBe(channels);
+    expect(mergeChannelChatAccess(channels, {})).toBe(channels);
   });
 
   it('allows server root chat and gates restricted Matrix channels', () => {

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -6,10 +6,12 @@ import {
   getChannelAccessDeniedMessage,
   getChannelChatAccessRequestKey,
   getChannelChatAccessRequestIds,
+  getPermittedMatrixChannelId,
   getJoinAccessAction,
   isBrmbleServiceOutageActive,
   isMatrixChannelChatActive,
   isStructuredEnterDenied,
+  shouldAllowChannelChatSend,
   isTemporaryChannelChatActive,
   mergeChannelChatAccess,
   shouldShowBrmbleServiceWarningNotification,
@@ -130,20 +132,47 @@ describe('channel chat access helpers', () => {
     const channels = [
       { id: 1, name: 'Allowed', canOpenChat: true, canSendChat: true },
       { id: 2, name: 'Denied', canOpenChat: false, canSendChat: false },
+      { id: 3, name: 'Unknown' },
     ];
 
     expect(canOpenChannelChat('server-root', channels)).toBe(true);
     expect(canOpenChannelChat('1', channels)).toBe(true);
     expect(canOpenChannelChat('2', channels)).toBe(false);
+    expect(canOpenChannelChat('3', channels)).toBe(false);
     expect(canSendToChannelChat('1', channels)).toBe(true);
     expect(canSendToChannelChat('2', channels)).toBe(false);
+    expect(canSendToChannelChat('3', channels)).toBe(false);
+  });
+
+  it('returns a Matrix-accessible channel only when channel chat can be opened explicitly', () => {
+    const channels = [
+      { id: 1, name: 'Allowed', canOpenChat: true, canSendChat: true },
+      { id: 2, name: 'Denied', canOpenChat: false, canSendChat: false },
+      { id: 3, name: 'Unknown' },
+    ];
+
+    expect(getPermittedMatrixChannelId('1', channels)).toBe('1');
+    expect(getPermittedMatrixChannelId('2', channels)).toBeNull();
+    expect(getPermittedMatrixChannelId('3', channels)).toBeNull();
+    expect(getPermittedMatrixChannelId('server-root', channels)).toBeNull();
+    expect(getPermittedMatrixChannelId(undefined, channels)).toBeNull();
+  });
+
+  it('allows sending unknown channel chat only during temporary Mumble outage mode', () => {
+    const channels = [{ id: 3, name: 'Unknown' }];
+
+    expect(shouldAllowChannelChatSend('3', channels, connectedStatuses)).toBe(false);
+    expect(shouldAllowChannelChatSend('3', channels, {
+      ...connectedStatuses,
+      server: { state: 'connecting' },
+    })).toBe(true);
   });
 });
 
 describe('structured channel access denial helpers', () => {
   it('classifies Enter permission denials by structured permission field', () => {
-    expect(isStructuredEnterDenied({ type: 'permissionDenied', permission: 2, message: 'anything' })).toBe(true);
-    expect(isStructuredEnterDenied({ type: 'permissionDenied', permission: 4, message: 'Enter appears in text only' })).toBe(false);
+    expect(isStructuredEnterDenied({ type: 'permissionDenied', permission: 4, message: 'anything' })).toBe(true);
+    expect(isStructuredEnterDenied({ type: 'permissionDenied', permission: 2, message: 'Enter appears in text only' })).toBe(false);
   });
 
   it('uses password-specific copy only when the channel is known password restricted', () => {

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -11,6 +11,7 @@ import {
   getChannelChatAccessRequestIds,
   getPermittedMatrixChannelId,
   getJoinAccessAction,
+  getResolvedChannelChatAccess,
   isBrmbleServiceOutageActive,
   isMatrixChannelChatActive,
   isStructuredEnterDenied,
@@ -51,6 +52,16 @@ describe('isMatrixChannelChatActive', () => {
       ...credentials,
       roomMap: { ...credentials.roomMap, '2': '!denied:example.com' },
     }, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: true }, matrixChannels)).toBe(false);
+  });
+
+  it('falls back to Mumble until channel chat access is explicitly allowed', () => {
+    expect(isMatrixChannelChatActive('3', {
+      ...credentials,
+      roomMap: { ...credentials.roomMap, '3': '!unknown:example.com' },
+    }, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: true }, [
+      ...matrixChannels,
+      { id: 3, name: 'Unknown' },
+    ])).toBe(false);
   });
 
   it('falls back to Mumble while Brmble server is reconnecting even if credentials still exist', () => {
@@ -131,6 +142,13 @@ describe('channel chat access helpers', () => {
     expect(mergeChannelChatAccess(channels, {})).toBe(channels);
   });
 
+  it('allows every requested channel when channel chat access fails', () => {
+    expect(getResolvedChannelChatAccess([1, 2])).toEqual({
+      '1': { canRead: true, canSend: true },
+      '2': { canRead: true, canSend: true },
+    });
+  });
+
   it('allows server root chat and gates restricted Matrix channels', () => {
     const channels = [
       { id: 1, name: 'Allowed', canOpenChat: true, canSendChat: true },
@@ -141,10 +159,10 @@ describe('channel chat access helpers', () => {
     expect(canOpenChannelChat('server-root', channels)).toBe(true);
     expect(canOpenChannelChat('1', channels)).toBe(true);
     expect(canOpenChannelChat('2', channels)).toBe(false);
-    expect(canOpenChannelChat('3', channels)).toBe(false);
+    expect(canOpenChannelChat('3', channels)).toBe(true);
     expect(canSendToChannelChat('1', channels)).toBe(true);
     expect(canSendToChannelChat('2', channels)).toBe(false);
-    expect(canSendToChannelChat('3', channels)).toBe(false);
+    expect(canSendToChannelChat('3', channels)).toBe(true);
   });
 
   it('returns a Matrix-accessible channel only when channel chat can be opened explicitly', () => {
@@ -161,10 +179,16 @@ describe('channel chat access helpers', () => {
     expect(getPermittedMatrixChannelId(undefined, channels)).toBeNull();
   });
 
-  it('allows sending unknown channel chat only during temporary Mumble outage mode', () => {
+  it('allows sending channel chat while access flags are still loading', () => {
     const channels = [{ id: 3, name: 'Unknown' }];
 
-    expect(shouldAllowChannelChatSend('3', channels, connectedStatuses)).toBe(false);
+    expect(shouldAllowChannelChatSend('3', channels, connectedStatuses, 'ready')).toBe(true);
+  });
+
+  it('allows temporary channel chat when access flags are denied during Mumble outage mode', () => {
+    const channels = [{ id: 3, name: 'Denied', canOpenChat: false, canSendChat: false }];
+
+    expect(shouldAllowChannelChatSend('3', channels, connectedStatuses, 'ready')).toBe(false);
     expect(shouldAllowChannelChatSend('3', channels, {
       ...connectedStatuses,
       server: { state: 'connecting' },
@@ -194,6 +218,10 @@ describe('getJoinAccessAction', () => {
     expect(getJoinAccessAction({ canEnter: false, hasPasswordRestriction: true })).toBe('promptPassword');
     expect(getJoinAccessAction({ hasPasswordRestriction: true })).toBe('promptPassword');
     expect(getJoinAccessAction({ canEnter: false })).toBe('deny');
+  });
+
+  it('joins password restricted channels when access is already granted', () => {
+    expect(getJoinAccessAction({ canEnter: true, hasPasswordRestriction: true })).toBe('join');
   });
 });
 

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -93,8 +93,8 @@ describe('structured channel access denial helpers', () => {
   });
 
   it('uses password-specific copy only when the channel is known password restricted', () => {
-    expect(getChannelAccessDeniedMessage({ id: 1, name: 'Secret', hasPasswordRestriction: true })).toBe('Incorrect password or no access.');
-    expect(getChannelAccessDeniedMessage({ id: 2, name: 'Private' })).toBe('You do not have access to that channel.');
+    expect(getChannelAccessDeniedMessage({ hasPasswordRestriction: true })).toBe('Incorrect password or no access.');
+    expect(getChannelAccessDeniedMessage({})).toBe('You do not have access to that channel.');
   });
 });
 

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -1162,6 +1162,87 @@ describe('active share discovery', () => {
     expect(screen.queryByText('Alice started sharing their screen')).not.toBeInTheDocument();
   });
 
+  it('unregisters remote screen share notification when the remote share stops', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'screen-share');
+
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [{ id: 1, name: 'General' }],
+        users: [
+          { session: 7, name: 'TestUser', self: true, channelId: 1 },
+          { session: 2, name: 'Alice', channelId: 1, matrixUserId: '@alice:example.com' },
+        ],
+      });
+    });
+
+    act(() => {
+      bridge.emit('livekit.screenShareStarted', {
+        roomName: 'channel-1',
+        userName: 'Alice',
+        userId: 42,
+        matrixUserId: '@alice:example.com',
+        sessionId: 2,
+      });
+    });
+
+    expect(screen.getByText('Alice started sharing their screen')).toBeInTheDocument();
+
+    vi.mocked(notifQueue.unregister).mockClear();
+
+    act(() => {
+      bridge.emit('livekit.screenShareStopped', {});
+    });
+
+    expect(notifQueue.unregister).toHaveBeenCalledWith('screen-share');
+    expect(screen.queryByText('Alice started sharing their screen')).not.toBeInTheDocument();
+  });
+
+  it('unregisters remote screen share notification when switching channels', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'screen-share');
+
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming' },
+        ],
+        users: [
+          { session: 7, name: 'TestUser', self: true, channelId: 1 },
+          { session: 2, name: 'Alice', channelId: 1, matrixUserId: '@alice:example.com' },
+        ],
+      });
+    });
+
+    act(() => {
+      bridge.emit('livekit.screenShareStarted', {
+        roomName: 'channel-1',
+        userName: 'Alice',
+        userId: 42,
+        matrixUserId: '@alice:example.com',
+        sessionId: 2,
+      });
+    });
+
+    expect(screen.getByText('Alice started sharing their screen')).toBeInTheDocument();
+
+    vi.mocked(notifQueue.unregister).mockClear();
+
+    act(() => {
+      bridge.emit('voice.channelChanged', { channelId: 2, name: 'Gaming' });
+    });
+
+    expect(notifQueue.unregister).toHaveBeenCalledWith('screen-share');
+    expect(screen.queryByText('Alice started sharing their screen')).not.toBeInTheDocument();
+  });
+
   it('rechecks active share discovery after reconnect when the current channel is unchanged', async () => {
     render(React.createElement(App));
 

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -1939,6 +1939,132 @@ describe('active share discovery', () => {
     expect(joinCall?.order).toBeGreaterThan(stopCall);
   });
 
+  it('screen share active denied channel join keeps sharing and does not ask to stop sharing', async () => {
+    const { confirm } = await import('./hooks/usePrompt');
+
+    const view = render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming', canEnter: false },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    await act(async () => {
+      view.getByTestId('header-toggle-screen-share').click();
+      await Promise.resolve();
+    });
+    screenShareState.isSharing = true;
+    view.rerender(React.createElement(App));
+
+    await act(async () => {
+      view.getByTestId('sidebar-join-channel-2').click();
+      await Promise.resolve();
+    });
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(stopSharing).not.toHaveBeenCalled();
+    expect(bridge.send).not.toHaveBeenCalledWith('voice.joinChannel', { channelId: 2 });
+  });
+
+  it('screen share active password join cancel keeps sharing and does not ask to stop sharing', async () => {
+    const { confirm, prompt } = await import('./hooks/usePrompt');
+    vi.mocked(prompt).mockResolvedValueOnce(null);
+
+    const view = render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming', canEnter: false, hasPasswordRestriction: true },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    await act(async () => {
+      view.getByTestId('header-toggle-screen-share').click();
+      await Promise.resolve();
+    });
+    screenShareState.isSharing = true;
+    view.rerender(React.createElement(App));
+
+    await act(async () => {
+      view.getByTestId('sidebar-join-channel-2').click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(prompt).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Channel Password',
+      message: 'Enter the password for Gaming.',
+    }));
+    expect(confirm).not.toHaveBeenCalled();
+    expect(stopSharing).not.toHaveBeenCalled();
+    expect(bridge.send).not.toHaveBeenCalledWith('voice.joinChannel', { channelId: 2 });
+  });
+
+  it('screen share active password join confirm stops sharing before sending password join', async () => {
+    const { confirm, prompt } = await import('./hooks/usePrompt');
+    vi.mocked(prompt).mockResolvedValueOnce('secret-token');
+    vi.mocked(confirm).mockResolvedValueOnce(true);
+    vi.mocked(stopSharing).mockResolvedValueOnce(undefined);
+
+    const view = render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming', canEnter: false, hasPasswordRestriction: true },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    await act(async () => {
+      view.getByTestId('header-toggle-screen-share').click();
+      await Promise.resolve();
+    });
+    screenShareState.isSharing = true;
+    view.rerender(React.createElement(App));
+
+    await act(async () => {
+      view.getByTestId('sidebar-join-channel-2').click();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(prompt).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Channel Password',
+      message: 'Enter the password for Gaming.',
+    }));
+    expect(confirm).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Screen share active',
+      message: 'Moving to another channel will end your screen share. Move and stop sharing?',
+    }));
+    expect(stopSharing).toHaveBeenCalled();
+    expect(bridge.send).toHaveBeenCalledWith('voice.joinChannel', { channelId: 2, password: 'secret-token' });
+
+    const stopCall = vi.mocked(stopSharing).mock.invocationCallOrder[0];
+    const joinCall = vi.mocked(bridge.send).mock.calls
+      .map(([type], index) => ({ type, order: vi.mocked(bridge.send).mock.invocationCallOrder[index] }))
+      .find(call => call.type === 'voice.joinChannel');
+    expect(joinCall?.order).toBeGreaterThan(stopCall);
+  });
+
   it('prompts for a channel password after a password-protected join denial and retries once', async () => {
     const { prompt } = await import('./hooks/usePrompt');
     vi.mocked(prompt).mockResolvedValueOnce('secret-token');
@@ -1954,7 +2080,7 @@ describe('active share discovery', () => {
         channelId: 1,
         channels: [
           { id: 1, name: 'General' },
-          { id: 2, name: 'Gaming' },
+          { id: 2, name: 'Gaming', hasPasswordRestriction: true },
         ],
         users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
       });
@@ -1970,6 +2096,8 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
+        permission: 2,
+        channelId: 2,
         message: CHANNEL_PASSWORD_DENIAL_MESSAGE,
       });
     });
@@ -2007,7 +2135,7 @@ describe('active share discovery', () => {
         channelId: 1,
         channels: [
           { id: 1, name: 'General' },
-          { id: 2, name: 'Gaming' },
+          { id: 2, name: 'Gaming', hasPasswordRestriction: true },
         ],
         users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
       });
@@ -2021,6 +2149,8 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
+        permission: 2,
+        channelId: 2,
         message: CHANNEL_PASSWORD_DENIAL_MESSAGE,
       });
     });
@@ -2065,6 +2195,8 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
+        permission: 2,
+        channelId: 2,
         message: 'Permission denied: missing enter permission',
       });
       await Promise.resolve();
@@ -2092,7 +2224,7 @@ describe('active share discovery', () => {
         channelId: 1,
         channels: [
           { id: 1, name: 'General' },
-          { id: 2, name: 'Gaming' },
+          { id: 2, name: 'Gaming', hasPasswordRestriction: true },
         ],
         users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
       });
@@ -2106,6 +2238,8 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
+        permission: 2,
+        channelId: 2,
         message: CHANNEL_PASSWORD_DENIAL_MESSAGE,
       });
       await Promise.resolve();
@@ -2121,6 +2255,8 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
+        permission: 2,
+        channelId: 2,
         message: CHANNEL_PASSWORD_DENIAL_MESSAGE,
       });
       await Promise.resolve();

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -2065,7 +2065,7 @@ describe('active share discovery', () => {
     expect(joinCall?.order).toBeGreaterThan(stopCall);
   });
 
-  it('prompts for a channel password after a password-protected join denial and retries once', async () => {
+  it('prompts for a known password-protected channel before joining', async () => {
     const { prompt } = await import('./hooks/usePrompt');
     vi.mocked(prompt).mockResolvedValueOnce('secret-token');
     const getJoinChannelCalls = () => vi.mocked(bridge.send).mock.calls.filter(
@@ -2091,7 +2091,48 @@ describe('active share discovery', () => {
       await Promise.resolve();
     });
 
-    expect(bridge.send).toHaveBeenCalledWith('voice.joinChannel', { channelId: 2 });
+    await waitFor(() => {
+      expect(prompt).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Channel Password',
+        message: 'Enter the password for Gaming.',
+        placeholder: 'Password',
+        confirmLabel: 'Join',
+        cancelLabel: 'Cancel',
+      }));
+    });
+    await waitFor(() => {
+      expect(bridge.send).toHaveBeenCalledWith('voice.joinChannel', { channelId: 2, password: 'secret-token' });
+    });
+    expect(getJoinChannelCalls()).toEqual([
+      ['voice.joinChannel', { channelId: 2, password: 'secret-token' }],
+    ]);
+  });
+
+  it('prompts for a channel password when a password-denial reason reveals an uncached password ACL', async () => {
+    const { prompt } = await import('./hooks/usePrompt');
+    vi.mocked(prompt).mockResolvedValueOnce('secret-token');
+    const getJoinChannelCalls = () => vi.mocked(bridge.send).mock.calls.filter(
+      ([type]) => type === 'voice.joinChannel',
+    );
+
+    const view = render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General' },
+          { id: 2, name: 'Gaming' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    await act(async () => {
+      view.getByTestId('sidebar-join-channel-2').click();
+      await Promise.resolve();
+    });
 
     await act(async () => {
       bridge.emit('voice.error', {
@@ -2106,9 +2147,6 @@ describe('active share discovery', () => {
       expect(prompt).toHaveBeenCalledWith(expect.objectContaining({
         title: 'Channel Password',
         message: 'Enter the password for Gaming.',
-        placeholder: 'Password',
-        confirmLabel: 'Join',
-        cancelLabel: 'Cancel',
       }));
     });
     await waitFor(() => {
@@ -2120,7 +2158,7 @@ describe('active share discovery', () => {
     ]);
   });
 
-  it('does not retry when the user cancels the channel password prompt', async () => {
+  it('does not join when the user cancels the known channel password prompt', async () => {
     const { prompt } = await import('./hooks/usePrompt');
     vi.mocked(prompt).mockResolvedValueOnce(null);
     const getJoinChannelCalls = () => vi.mocked(bridge.send).mock.calls.filter(
@@ -2146,15 +2184,6 @@ describe('active share discovery', () => {
       await Promise.resolve();
     });
 
-    await act(async () => {
-      bridge.emit('voice.error', {
-        type: 'permissionDenied',
-        permission: 4,
-        channelId: 2,
-        message: CHANNEL_PASSWORD_DENIAL_MESSAGE,
-      });
-    });
-
     await waitFor(() => {
       expect(prompt).toHaveBeenCalledTimes(1);
     });
@@ -2162,9 +2191,7 @@ describe('active share discovery', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(getJoinChannelCalls()).toEqual([
-      ['voice.joinChannel', { channelId: 2 }],
-    ]);
+    expect(getJoinChannelCalls()).toEqual([]);
   });
 
   it('does not prompt for unrelated permission denials', async () => {
@@ -2248,7 +2275,6 @@ describe('active share discovery', () => {
 
     expect(prompt).toHaveBeenCalledTimes(1);
     expect(getJoinChannelCalls()).toEqual([
-      ['voice.joinChannel', { channelId: 2 }],
       ['voice.joinChannel', { channelId: 2, password: 'wrong-secret' }],
     ]);
 
@@ -2265,7 +2291,6 @@ describe('active share discovery', () => {
 
     expect(prompt).toHaveBeenCalledTimes(1);
     expect(getJoinChannelCalls()).toEqual([
-      ['voice.joinChannel', { channelId: 2 }],
       ['voice.joinChannel', { channelId: 2, password: 'wrong-secret' }],
     ]);
   });

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -2096,7 +2096,7 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
-        permission: 2,
+        permission: 4,
         channelId: 2,
         message: CHANNEL_PASSWORD_DENIAL_MESSAGE,
       });
@@ -2149,7 +2149,7 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
-        permission: 2,
+        permission: 4,
         channelId: 2,
         message: CHANNEL_PASSWORD_DENIAL_MESSAGE,
       });
@@ -2195,7 +2195,7 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
-        permission: 2,
+        permission: 4,
         channelId: 2,
         message: 'Permission denied: missing enter permission',
       });
@@ -2238,7 +2238,7 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
-        permission: 2,
+        permission: 4,
         channelId: 2,
         message: CHANNEL_PASSWORD_DENIAL_MESSAGE,
       });
@@ -2255,7 +2255,7 @@ describe('active share discovery', () => {
     await act(async () => {
       bridge.emit('voice.error', {
         type: 'permissionDenied',
-        permission: 2,
+        permission: 4,
         channelId: 2,
         message: CHANNEL_PASSWORD_DENIAL_MESSAGE,
       });

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -600,7 +600,7 @@ interface ChannelChatAccessState {
 
 type ChannelChatAccessMap = Record<string, ChannelChatAccessState>;
 
-const MUMBLE_PERMISSION_ENTER = 2;
+const MUMBLE_PERMISSION_ENTER = 4;
 
 export function mergeChannelChatAccess(channels: Channel[], access: ChannelChatAccessMap): Channel[] {
   let changed = false;
@@ -630,14 +630,27 @@ export function canOpenChannelChat(channelId: string | undefined, channels: Chan
   if (!channelId) return false;
   if (channelId === 'server-root') return true;
   const channel = channels.find(c => String(c.id) === channelId);
-  return channel?.canOpenChat !== false;
+  return channel?.canOpenChat === true;
 }
 
 export function canSendToChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
   if (!channelId) return false;
   if (channelId === 'server-root') return true;
   const channel = channels.find(c => String(c.id) === channelId);
-  return channel?.canSendChat !== false;
+  return channel?.canSendChat === true;
+}
+
+export function shouldAllowChannelChatSend(
+  channelId: string | undefined,
+  channels: Channel[],
+  statuses: ServiceStatusMap,
+): boolean {
+  return canSendToChannelChat(channelId, channels) || isTemporaryChannelChatActive(channelId, statuses);
+}
+
+export function getPermittedMatrixChannelId(channelId: string | undefined, channels: Channel[]): string | null {
+  if (!channelId || channelId === 'server-root') return null;
+  return canOpenChannelChat(channelId, channels) ? channelId : null;
 }
 
 export function getChannelSelectionOutcome(
@@ -1069,11 +1082,12 @@ function App() {
 
   // Per-panel Matrix room IDs for scoping mention suggestions
   const channelMatrixRoomId = useMemo(() => {
-    if (currentChannelId && currentChannelId !== 'server-root' && matrixCredentials?.roomMap?.[currentChannelId]) {
-      return matrixCredentials.roomMap[currentChannelId];
+    const matrixChannelId = getPermittedMatrixChannelId(currentChannelId, channels);
+    if (matrixChannelId && matrixCredentials?.roomMap?.[matrixChannelId]) {
+      return matrixCredentials.roomMap[matrixChannelId];
     }
     return null;
-  }, [currentChannelId, matrixCredentials?.roomMap]);
+  }, [channels, currentChannelId, matrixCredentials?.roomMap]);
 
   const channelKey = currentChannelId === 'server-root' ? 'server-root' : currentChannelId ? `channel-${currentChannelId}` : 'no-channel';
   const { messages, addMessage } = useChatStore(channelKey);
@@ -1082,6 +1096,7 @@ function App() {
   const activeChannelId = currentChannelId && currentChannelId !== 'server-root'
     ? currentChannelId
     : undefined;
+  const permittedActiveMatrixChannelId = getPermittedMatrixChannelId(activeChannelId, channels);
 
   const dmStore = useDMStore({
     matrixDmLastMessages: matrixClient.dmLastMessages,
@@ -1099,8 +1114,8 @@ function App() {
   });
 
   useLayoutEffect(() => {
-    matrixClient.setActiveChannel(activeChannelId ?? null);
-  }, [activeChannelId, matrixClient.setActiveChannel]);
+    matrixClient.setActiveChannel(permittedActiveMatrixChannelId);
+  }, [matrixClient.setActiveChannel, permittedActiveMatrixChannelId]);
 
   useLayoutEffect(() => {
     matrixClient.setActiveDmContact(dmStore.selectedContact?.id ?? null);
@@ -1112,11 +1127,11 @@ function App() {
       const roomId = matrixClient.dmRoomMap.get(dmStore.selectedContact.id);
       if (roomId) return roomId;
     }
-    if (currentChannelId && currentChannelId !== 'server-root' && matrixCredentials?.roomMap?.[currentChannelId]) {
-      return matrixCredentials.roomMap[currentChannelId];
+    if (permittedActiveMatrixChannelId && matrixCredentials?.roomMap?.[permittedActiveMatrixChannelId]) {
+      return matrixCredentials.roomMap[permittedActiveMatrixChannelId];
     }
     return null;
-  }, [dmStore.selectedContact, currentChannelId, matrixClient?.dmRoomMap, matrixCredentials?.roomMap]);
+  }, [dmStore.selectedContact, matrixClient?.dmRoomMap, matrixCredentials?.roomMap, permittedActiveMatrixChannelId]);
 
   const dmMatrixRoomId = useMemo(() => {
     if (dmStore.selectedContact && matrixClient?.dmRoomMap) {
@@ -2622,10 +2637,10 @@ function App() {
   }, [channelChatAccessRequestKey, matrixCredentials?.roomMap, statuses.server.state]);
 
   useEffect(() => {
-    if (currentChannelId && currentChannelId !== 'server-root' && matrixCredentials) {
-      matrixClient.fetchHistory(currentChannelId).catch(console.error);
+    if (permittedActiveMatrixChannelId && matrixCredentials) {
+      matrixClient.fetchHistory(permittedActiveMatrixChannelId).catch(console.error);
     }
-  }, [currentChannelId, matrixCredentials]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [permittedActiveMatrixChannelId, matrixCredentials]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return () => {
@@ -2781,7 +2796,7 @@ const handleConnect = (serverData: SavedServer) => {
 
     const channelId = currentChannelId;
     if (!channelId) return;
-    if (!canSendToChannelChat(channelId, channelsRef.current)) {
+    if (!shouldAllowChannelChatSend(channelId, channelsRef.current, statusesRef.current)) {
       return;
     }
 
@@ -3088,7 +3103,7 @@ const handleConnect = (serverData: SavedServer) => {
     ? isMatrixChannelChatActive(activeChannelId, matrixCredentials, statuses, selfUserForChat, channels)
     : false;
   const canOpenActiveChannelChat = canOpenChannelChat(activeChannelId, channels);
-  const canSendActiveChannelChat = canSendToChannelChat(activeChannelId, channels);
+  const canSendActiveChannelChat = canSendToChannelChat(activeChannelId, channels) || isTemporaryChannelChatActive(activeChannelId, statuses);
   const channelChatAccessNotice = activeChannelId && activeChannelId !== 'server-root' && !canOpenActiveChannelChat
     ? 'You do not have access to this channel chat.'
     : activeChannelId && activeChannelId !== 'server-root' && !canSendActiveChannelChat
@@ -3668,16 +3683,16 @@ const handleConnect = (serverData: SavedServer) => {
   // We depend on roomUnreads so that on reconnect (when sync populates data after
   // the channel was already selected) we get a second chance to snapshot.
   useEffect(() => {
-    const channelChanged = currentChannelId !== prevChannelIdRef.current;
+    const channelChanged = permittedActiveMatrixChannelId !== prevChannelIdRef.current;
     if (channelChanged) {
-      prevChannelIdRef.current = currentChannelId;
+      prevChannelIdRef.current = permittedActiveMatrixChannelId ?? undefined;
     }
 
-    if (!currentChannelId || currentChannelId === 'server-root') {
+    if (!permittedActiveMatrixChannelId) {
       if (channelChanged) setChannelDividerTs(null);
       return;
     }
-    const roomId = matrixCredentials?.roomMap?.[currentChannelId];
+    const roomId = matrixCredentials?.roomMap?.[permittedActiveMatrixChannelId];
     if (!roomId || !matrixClient?.client) {
       if (channelChanged) setChannelDividerTs(null);
       return;
@@ -3717,7 +3732,7 @@ const handleConnect = (serverData: SavedServer) => {
         return markerTs;
       });
     }
-  }, [currentChannelId, matrixCredentials?.roomMap, matrixClient, unreadTracker]);
+  }, [permittedActiveMatrixChannelId, matrixCredentials?.roomMap, matrixClient, unreadTracker]);
 
   // Same pattern for DM switches
   useEffect(() => {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1275,7 +1275,8 @@ function App() {
     }
     setSharingChannelId(undefined);
     setScreenShareNotification(null);
-  }, []);
+    notifQueue.unregister('screen-share');
+  }, [notifQueue]);
 
   const {
     autoLeftAt,
@@ -1703,6 +1704,7 @@ function App() {
       disconnectViewerRef.current?.();
       setSharingChannelId(undefined);
       setScreenShareNotification(null);
+      notifQueue.unregister('screen-share');
       // Reset divider timestamps so stale snapshots from the previous session
       // don't persist across disconnect/reconnect cycles.
       setChannelDividerTs(null);
@@ -3669,6 +3671,7 @@ const handleConnect = (serverData: SavedServer) => {
 
     const onRemoteShareStopped = () => {
       setScreenShareNotification(null);
+      notifQueue.unregister('screen-share');
     };
 
     bridge.on('livekit.screenShareStarted', onRemoteShareStarted);
@@ -3703,8 +3706,9 @@ const handleConnect = (serverData: SavedServer) => {
   useEffect(() => {
     disconnectViewer();
     setScreenShareNotification(null);
+    notifQueue.unregister('screen-share');
     requestActiveShareDiscovery(currentChannelId);
-  }, [currentChannelId, disconnectViewer, requestActiveShareDiscovery]);
+  }, [currentChannelId, disconnectViewer, notifQueue, requestActiveShareDiscovery]);
 
   useEffect(() => {
     const previousConnectionStatus = previousConnectionStatusRef.current;

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2699,6 +2699,31 @@ const handleConnect = (serverData: SavedServer) => {
     if (!channel) {
       return;
     }
+
+    const joinAction = getJoinAccessAction(channel);
+    let password: string | undefined;
+    if (joinAction === 'deny') {
+      addMessageToStore('server-root', 'Server', getChannelAccessDeniedMessage(channel), 'system');
+      return;
+    }
+
+    if (joinAction === 'promptPassword') {
+      const enteredPassword = await prompt({
+        title: 'Channel Password',
+        message: `Enter the password for ${channel.name}.`,
+        placeholder: 'Password',
+        confirmLabel: 'Join',
+        cancelLabel: 'Cancel',
+        isPassword: true,
+      });
+
+      if (!enteredPassword) {
+        return;
+      }
+
+      password = enteredPassword;
+    }
+
     if (isSharing && sharingChannelId && String(channelId) !== sharingChannelId) {
       const shouldMove = await confirm({
         title: 'Screen share active',
@@ -2713,43 +2738,13 @@ const handleConnect = (serverData: SavedServer) => {
       setSharingChannelId(undefined);
     }
 
-    const joinAction = getJoinAccessAction(channel);
-    if (joinAction === 'deny') {
-      addMessageToStore('server-root', 'Server', getChannelAccessDeniedMessage(channel), 'system');
-      return;
-    }
-
-    if (joinAction === 'promptPassword') {
-      const password = await prompt({
-        title: 'Channel Password',
-        message: `Enter the password for ${channel.name}.`,
-        placeholder: 'Password',
-        confirmLabel: 'Join',
-        cancelLabel: 'Cancel',
-        isPassword: true,
-      });
-
-      if (!password) {
-        return;
-      }
-
-      startPendingAction(channelId);
-      pendingJoinAttemptRef.current = {
-        channelId,
-        channelName: channel.name,
-        passwordRetrySent: true,
-      };
-      sendJoinChannel(channelId, password);
-      return;
-    }
-
     startPendingAction(channelId);
     pendingJoinAttemptRef.current = {
       channelId,
       channelName: channel.name,
-      passwordRetrySent: false,
+      passwordRetrySent: joinAction === 'promptPassword',
     };
-    sendJoinChannel(channelId);
+    sendJoinChannel(channelId, password);
   };
 
   const handleSelectChannel = (channelId: number) => {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -662,8 +662,10 @@ export function isMatrixChannelChatActive(
   credentials: MatrixCredentials | null,
   statuses: ServiceStatusMap,
   selfUser: User | undefined,
+  channels: Channel[] = [],
 ): boolean {
   if (!channelId || channelId === 'server-root') return false;
+  if (!canOpenChannelChat(channelId, channels)) return false;
   if (statuses.server.state !== 'connected' || statuses.chat.state !== 'connected') return false;
   if (!selfUser?.isBrmbleClient) return false;
   return credentials?.roomMap[channelId] !== undefined;
@@ -1727,6 +1729,7 @@ function App() {
             matrixCredentialsRef.current,
             statusesRef.current,
             selfUser,
+            channelsRef.current,
           );
           if (!matrixActive) {
             const storeKey = `channel-${channelId}`;
@@ -2693,6 +2696,10 @@ const handleConnect = (serverData: SavedServer) => {
       setUnreadCount(0);
       setShowGame(false);
 
+      if (!canOpenChannelChat(String(channelId), channels)) {
+        return;
+      }
+
       if (dmStore.appMode === 'dm') {
         dmStore.toggleMode();
       }
@@ -2715,9 +2722,12 @@ const handleConnect = (serverData: SavedServer) => {
 
     const channelId = currentChannelId;
     if (!channelId) return;
+    if (!canSendToChannelChat(channelId, channelsRef.current)) {
+      return;
+    }
 
       const selfUser = usersRef.current.find(u => u.self);
-      const isMatrixChannel = isMatrixChannelChatActive(channelId, matrixCredentials, statuses, selfUser);
+      const isMatrixChannel = isMatrixChannelChatActive(channelId, matrixCredentials, statuses, selfUser, channels);
 
     // Send text content (existing behavior)
     if (content) {
@@ -3016,8 +3026,15 @@ const handleConnect = (serverData: SavedServer) => {
 
   const selfUserForChat = users.find(u => u.self);
   const isMatrixActive = activeChannelId
-    ? isMatrixChannelChatActive(activeChannelId, matrixCredentials, statuses, selfUserForChat)
+    ? isMatrixChannelChatActive(activeChannelId, matrixCredentials, statuses, selfUserForChat, channels)
     : false;
+  const canOpenActiveChannelChat = canOpenChannelChat(activeChannelId, channels);
+  const canSendActiveChannelChat = canSendToChannelChat(activeChannelId, channels);
+  const channelChatAccessNotice = activeChannelId && activeChannelId !== 'server-root' && !canOpenActiveChannelChat
+    ? 'You do not have access to this channel chat.'
+    : activeChannelId && activeChannelId !== 'server-root' && !canSendActiveChannelChat
+      ? 'You can read this channel chat, but cannot send messages.'
+      : undefined;
   const brmbleTemporaryChatActive = isTemporaryChannelChatActive(activeChannelId, statuses);
   const brmbleServiceOutageActive = isBrmbleServiceOutageActive(statuses);
   const matrixMessages = activeChannelId
@@ -3025,11 +3042,13 @@ const handleConnect = (serverData: SavedServer) => {
     : undefined;
 
   const channelChatMessages = useMemo(
-    () => [
-      ...(isMatrixActive ? (matrixMessages ?? []) : messages),
-      ...optimisticImages.filter(m => m.channelId === currentChannelId),
-    ],
-    [isMatrixActive, matrixMessages, messages, optimisticImages, currentChannelId],
+    () => canOpenActiveChannelChat
+      ? [
+        ...(isMatrixActive ? (matrixMessages ?? []) : messages),
+        ...optimisticImages.filter(m => m.channelId === currentChannelId),
+      ]
+      : [],
+    [canOpenActiveChannelChat, isMatrixActive, matrixMessages, messages, optimisticImages, currentChannelId],
   );
 
   const { Prompt, PromptWithInput } = usePrompt();
@@ -3375,6 +3394,7 @@ const handleConnect = (serverData: SavedServer) => {
     if (!matrixCredentials?.roomMap) return new Map<string, { notificationCount: number; highlightCount: number }>();
     const map = new Map<string, { notificationCount: number; highlightCount: number }>();
     for (const [channelId, roomId] of Object.entries(matrixCredentials.roomMap)) {
+      if (!canOpenChannelChat(channelId, channels)) continue;
       const unread = unreadTracker.getRoomUnread(roomId);
       if (unread.notificationCount > 0) {
         map.set(channelId, {
@@ -3384,7 +3404,7 @@ const handleConnect = (serverData: SavedServer) => {
       }
     }
     return map;
-  }, [matrixCredentials?.roomMap, unreadTracker.roomUnreads]);
+  }, [channels, matrixCredentials?.roomMap, unreadTracker.roomUnreads]);
 
   useEffect(() => {
     if (screenShareError) {
@@ -3803,7 +3823,8 @@ const handleConnect = (serverData: SavedServer) => {
                     onCloseShare={(share) => disconnectViewer(share.userId)}
                     screenShareViewerMode={screenShareSettings.viewerMode}
                     users={users}
-                    topNotice={brmbleTemporaryChatActive ? BRMBLE_SERVICE_TEMPORARY_CHAT_NOTICE : undefined}
+                    disabled={!canSendActiveChannelChat}
+                    topNotice={channelChatAccessNotice ?? (brmbleTemporaryChatActive ? BRMBLE_SERVICE_TEMPORARY_CHAT_NOTICE : undefined)}
                     onMessageContextMenu={handleChatMessageContextMenu}
                     onCopyToClipboard={handleCopyToClipboard}
                   />

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -352,8 +352,15 @@ interface PendingJoinAttempt {
   passwordRetrySent: boolean;
 }
 
+function isPasswordProtectedDenialReason(data: unknown): boolean {
+  const d = data as { message?: string; reason?: string } | undefined;
+  const text = `${d?.message ?? ''} ${d?.reason ?? ''}`.toLowerCase();
+  return text.includes('password') && text.includes('token');
+}
+
 function isPasswordProtectedJoinError(data: unknown, channel?: Channel): boolean {
-  return isStructuredEnterDenied(data) && channel?.hasPasswordRestriction === true;
+  return isStructuredEnterDenied(data)
+    && (channel?.hasPasswordRestriction === true || isPasswordProtectedDenialReason(data));
 }
 
 interface NextLiveKitStatusOptions {
@@ -684,8 +691,8 @@ export function getChannelAccessDeniedMessage(channel: Pick<Channel, 'hasPasswor
 export type JoinAccessAction = 'join' | 'promptPassword' | 'deny';
 
 export function getJoinAccessAction(channel: Pick<Channel, 'canEnter' | 'hasPasswordRestriction'>): JoinAccessAction {
-  if (channel.canEnter !== false) return 'join';
-  return channel.hasPasswordRestriction ? 'promptPassword' : 'deny';
+  if (channel.hasPasswordRestriction) return 'promptPassword';
+  return channel.canEnter === false ? 'deny' : 'join';
 }
 
 export function isMatrixChannelChatActive(
@@ -1695,6 +1702,12 @@ function App() {
         ? channelsRef.current.find(channel => channel.id === pendingJoinAttempt.channelId)
         : undefined;
       if (pendingJoinAttempt && isPasswordProtectedJoinError(data, pendingChannel)) {
+        if (pendingChannel && pendingChannel.hasPasswordRestriction !== true) {
+          setChannels(prev => prev.map(channel => channel.id === pendingChannel.id
+            ? { ...channel, hasPasswordRestriction: true }
+            : channel));
+        }
+
         if (!pendingJoinAttempt.passwordRetrySent) {
           pendingJoinAttemptRef.current = {
             ...pendingJoinAttempt,

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -578,6 +578,10 @@ interface Channel {
   name: string;
   parent?: number;
   isEnterRestricted?: boolean;
+  canEnter?: boolean;
+  hasPasswordRestriction?: boolean;
+  canOpenChat?: boolean;
+  canSendChat?: boolean;
 }
 
 interface User {
@@ -593,6 +597,52 @@ interface User {
   certHash?: string;
   companionId?: CompanionId;
   isBrmbleClient?: boolean;
+}
+
+interface ChannelChatAccessState {
+  canRead: boolean;
+  canSend: boolean;
+}
+
+type ChannelChatAccessMap = Record<string, ChannelChatAccessState>;
+
+const MUMBLE_PERMISSION_ENTER = 2;
+
+export function mergeChannelChatAccess(channels: Channel[], access: ChannelChatAccessMap): Channel[] {
+  return channels.map(channel => {
+    const state = access[String(channel.id)];
+    if (!state) return channel;
+    return {
+      ...channel,
+      canOpenChat: state.canRead,
+      canSendChat: state.canSend,
+    };
+  });
+}
+
+export function canOpenChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
+  if (!channelId) return false;
+  if (channelId === 'server-root') return true;
+  const channel = channels.find(c => String(c.id) === channelId);
+  return channel?.canOpenChat !== false;
+}
+
+export function canSendToChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
+  if (!channelId) return false;
+  if (channelId === 'server-root') return true;
+  const channel = channels.find(c => String(c.id) === channelId);
+  return channel?.canSendChat !== false;
+}
+
+export function isStructuredEnterDenied(data: unknown): boolean {
+  const d = data as { type?: string; permission?: number } | undefined;
+  return d?.type === 'permissionDenied' && d.permission === MUMBLE_PERMISSION_ENTER;
+}
+
+export function getChannelAccessDeniedMessage(channel: Pick<Channel, 'hasPasswordRestriction'> | undefined): string {
+  return channel?.hasPasswordRestriction
+    ? 'Incorrect password or no access.'
+    : 'You do not have access to that channel.';
 }
 
 export function isMatrixChannelChatActive(

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -628,6 +628,10 @@ export function getChannelChatAccessRequestIds(channels: Channel[]): number[] {
   return [...new Set(channels.map(channel => channel.id).filter(id => id > 0))];
 }
 
+export function getChannelChatAccessRequestKey(channels: Channel[]): string {
+  return getChannelChatAccessRequestIds(channels).join(',');
+}
+
 export function canOpenChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
   if (!channelId) return false;
   if (channelId === 'server-root') return true;
@@ -2572,12 +2576,14 @@ function App() {
     bridge.send('profiles.list');
   }, []);
 
+  const channelChatAccessRequestIds = useMemo(() => getChannelChatAccessRequestIds(channels), [channels]);
+  const channelChatAccessRequestKey = channelChatAccessRequestIds.join(',');
+
   useEffect(() => {
     if (statuses.server.state !== 'connected' || !matrixCredentials?.roomMap) return;
-    const channelIds = getChannelChatAccessRequestIds(channels);
-    if (channelIds.length === 0) return;
-    bridge.send('chat.getChannelAccess', { channelIds });
-  }, [channels, matrixCredentials?.roomMap, statuses.server.state]);
+    if (!channelChatAccessRequestKey) return;
+    bridge.send('chat.getChannelAccess', { channelIds: channelChatAccessRequestKey.split(',').map(Number) });
+  }, [channelChatAccessRequestKey, matrixCredentials?.roomMap, statuses.server.state]);
 
   useEffect(() => {
     if (currentChannelId && currentChannelId !== 'server-root' && matrixCredentials) {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -352,14 +352,8 @@ interface PendingJoinAttempt {
   passwordRetrySent: boolean;
 }
 
-function isPasswordProtectedJoinError(data: unknown): boolean {
-  const d = data as { type?: string; message?: string } | undefined;
-  if (d?.type !== 'permissionDenied') {
-    return false;
-  }
-
-  const message = (d.message ?? '').toLowerCase();
-  return message.includes('password') || message.includes('token') || message.includes('temporary access');
+function isPasswordProtectedJoinError(data: unknown, channel?: Channel): boolean {
+  return isStructuredEnterDenied(data) && channel?.hasPasswordRestriction === true;
 }
 
 interface NextLiveKitStatusOptions {
@@ -672,6 +666,13 @@ export function getChannelAccessDeniedMessage(channel: Pick<Channel, 'hasPasswor
   return channel?.hasPasswordRestriction
     ? 'Incorrect password or no access.'
     : 'You do not have access to that channel.';
+}
+
+export type JoinAccessAction = 'join' | 'promptPassword' | 'deny';
+
+export function getJoinAccessAction(channel: Pick<Channel, 'canEnter' | 'hasPasswordRestriction'>): JoinAccessAction {
+  if (channel.canEnter !== false) return 'join';
+  return channel.hasPasswordRestriction ? 'promptPassword' : 'deny';
 }
 
 export function isMatrixChannelChatActive(
@@ -1675,7 +1676,10 @@ function App() {
     const onVoiceError = ((data: unknown) => {
       clearPendingAction();
       const pendingJoinAttempt = pendingJoinAttemptRef.current;
-      if (pendingJoinAttempt && isPasswordProtectedJoinError(data)) {
+      const pendingChannel = pendingJoinAttempt
+        ? channelsRef.current.find(channel => channel.id === pendingJoinAttempt.channelId)
+        : undefined;
+      if (pendingJoinAttempt && isPasswordProtectedJoinError(data, pendingChannel)) {
         if (!pendingJoinAttempt.passwordRetrySent) {
           pendingJoinAttemptRef.current = {
             ...pendingJoinAttempt,
@@ -1704,6 +1708,18 @@ function App() {
         }
 
         clearPendingJoinAttempt();
+      }
+
+      if (isStructuredEnterDenied(data)) {
+        const d = data as { channelId?: number };
+        const deniedChannel = d.channelId != null
+          ? channelsRef.current.find(channel => channel.id === d.channelId)
+          : pendingJoinAttempt
+            ? channelsRef.current.find(channel => channel.id === pendingJoinAttempt.channelId)
+            : undefined;
+        addMessageToStore('server-root', 'Server', getChannelAccessDeniedMessage(deniedChannel), 'system');
+        clearPendingJoinAttempt();
+        return;
       }
 
       const d = data as { message?: string } | undefined;
@@ -2696,6 +2712,37 @@ const handleConnect = (serverData: SavedServer) => {
       await stopSharing();
       setSharingChannelId(undefined);
     }
+
+    const joinAction = getJoinAccessAction(channel);
+    if (joinAction === 'deny') {
+      addMessageToStore('server-root', 'Server', getChannelAccessDeniedMessage(channel), 'system');
+      return;
+    }
+
+    if (joinAction === 'promptPassword') {
+      const password = await prompt({
+        title: 'Channel Password',
+        message: `Enter the password for ${channel.name}.`,
+        placeholder: 'Password',
+        confirmLabel: 'Join',
+        cancelLabel: 'Cancel',
+        isPassword: true,
+      });
+
+      if (!password) {
+        return;
+      }
+
+      startPendingAction(channelId);
+      pendingJoinAttemptRef.current = {
+        channelId,
+        channelName: channel.name,
+        passwordRetrySent: true,
+      };
+      sendJoinChannel(channelId, password);
+      return;
+    }
+
     startPendingAction(channelId);
     pendingJoinAttemptRef.current = {
       channelId,

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -609,15 +609,23 @@ type ChannelChatAccessMap = Record<string, ChannelChatAccessState>;
 const MUMBLE_PERMISSION_ENTER = 2;
 
 export function mergeChannelChatAccess(channels: Channel[], access: ChannelChatAccessMap): Channel[] {
-  return channels.map(channel => {
+  let changed = false;
+  const merged = channels.map(channel => {
     const state = access[String(channel.id)];
     if (!state) return channel;
+    if (channel.canOpenChat === state.canRead && channel.canSendChat === state.canSend) return channel;
+    changed = true;
     return {
       ...channel,
       canOpenChat: state.canRead,
       canSendChat: state.canSend,
     };
   });
+  return changed ? merged : channels;
+}
+
+export function getChannelChatAccessRequestIds(channels: Channel[]): number[] {
+  return [...new Set(channels.map(channel => channel.id).filter(id => id > 0))];
 }
 
 export function canOpenChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
@@ -2408,6 +2416,20 @@ function App() {
       } catch { /* ignore parse errors */ }
     };
 
+    const onChatChannelAccess = (data: unknown) => {
+      const payload = data as { body?: string; channels?: ChannelChatAccessMap } | undefined;
+      let channelsAccess = payload?.channels;
+      if (!channelsAccess && payload?.body) {
+        try {
+          channelsAccess = (JSON.parse(payload.body) as { channels?: ChannelChatAccessMap }).channels;
+        } catch {
+          channelsAccess = undefined;
+        }
+      }
+      if (!channelsAccess) return;
+      setChannels(prev => mergeChannelChatAccess(prev, channelsAccess));
+    };
+
     bridge.on('brmble.serviceStatus', onBrmbleServiceStatus);
     bridge.on('voice.connected', onVoiceConnected);
     bridge.on('voice.disconnected', onVoiceDisconnected);
@@ -2476,6 +2498,7 @@ function App() {
     bridge.on('voice.brmbleClientActivated', onBrmbleClientActivated);
     bridge.on('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
     bridge.on('voice.registrationStatus', onRegistrationStatus);
+    bridge.on('chat.channelAccess', onChatChannelAccess);
     const onVoiceLoss = (data: unknown) => {
       const payload = data as { loss?: number } | null;
       const loss = typeof payload?.loss === 'number' ? payload.loss : undefined;
@@ -2539,6 +2562,7 @@ function App() {
       bridge.off('voice.brmbleClientActivated', onBrmbleClientActivated);
       bridge.off('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
       bridge.off('voice.registrationStatus', onRegistrationStatus);
+      bridge.off('chat.channelAccess', onChatChannelAccess);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -2547,6 +2571,13 @@ function App() {
     bridge.send('cert.requestStatus');
     bridge.send('profiles.list');
   }, []);
+
+  useEffect(() => {
+    if (statuses.server.state !== 'connected' || !matrixCredentials?.roomMap) return;
+    const channelIds = getChannelChatAccessRequestIds(channels);
+    if (channelIds.length === 0) return;
+    bridge.send('chat.getChannelAccess', { channelIds });
+  }, [channels, matrixCredentials?.roomMap, statuses.server.state]);
 
   useEffect(() => {
     if (currentChannelId && currentChannelId !== 'server-root' && matrixCredentials) {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -646,6 +646,23 @@ export function canSendToChannelChat(channelId: string | undefined, channels: Ch
   return channel?.canSendChat !== false;
 }
 
+export function getChannelSelectionOutcome(
+  channelId: number,
+  channels: Channel[],
+  appMode: 'channels' | 'dm',
+) {
+  const channel = channels.find(c => c.id === channelId);
+  if (!channel) return undefined;
+  const canOpenChat = canOpenChannelChat(String(channelId), channels);
+  return {
+    channelId: String(channelId),
+    channelName: channel.name,
+    canOpenChat,
+    shouldExitDmMode: appMode === 'dm',
+    shouldClearDmSelection: true,
+  };
+}
+
 export function isStructuredEnterDenied(data: unknown): boolean {
   const d = data as { type?: string; permission?: number } | undefined;
   return d?.type === 'permissionDenied' && d.permission === MUMBLE_PERMISSION_ENTER;
@@ -2689,21 +2706,21 @@ const handleConnect = (serverData: SavedServer) => {
   };
 
   const handleSelectChannel = (channelId: number) => {
-    const channel = channels.find(c => c.id === channelId);
-    if (channel) {
-      setCurrentChannelId(String(channelId));
-      setCurrentChannelName(channel.name);
+    const selection = getChannelSelectionOutcome(channelId, channels, dmStore.appMode);
+    if (selection) {
+      setCurrentChannelId(selection.channelId);
+      setCurrentChannelName(selection.channelName);
       setUnreadCount(0);
       setShowGame(false);
 
-      if (!canOpenChannelChat(String(channelId), channels)) {
-        return;
-      }
-
-      if (dmStore.appMode === 'dm') {
+      if (selection.shouldExitDmMode) {
         dmStore.toggleMode();
       }
-      dmStore.clearSelection();
+      if (selection.shouldClearDmSelection) {
+        dmStore.clearSelection();
+      }
+
+      if (!selection.canOpenChat) return;
     }
   };
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -626,6 +626,10 @@ export function mergeChannelChatAccess(channels: Channel[], access: ChannelChatA
   return changed ? merged : channels;
 }
 
+export function getResolvedChannelChatAccess(channelIds: number[]): ChannelChatAccessMap {
+  return Object.fromEntries(channelIds.map(id => [String(id), { canRead: true, canSend: true }]));
+}
+
 export function getChannelChatAccessRequestIds(channels: Channel[]): number[] {
   return [...new Set(channels.map(channel => channel.id).filter(id => id > 0))];
 }
@@ -638,14 +642,14 @@ export function canOpenChannelChat(channelId: string | undefined, channels: Chan
   if (!channelId) return false;
   if (channelId === 'server-root') return true;
   const channel = channels.find(c => String(c.id) === channelId);
-  return channel?.canOpenChat === true;
+  return channel?.canOpenChat !== false;
 }
 
 export function canSendToChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
   if (!channelId) return false;
   if (channelId === 'server-root') return true;
   const channel = channels.find(c => String(c.id) === channelId);
-  return channel?.canSendChat === true;
+  return channel?.canSendChat !== false;
 }
 
 export function shouldAllowChannelChatSend(
@@ -660,7 +664,8 @@ export function shouldAllowChannelChatSend(
 
 export function getPermittedMatrixChannelId(channelId: string | undefined, channels: Channel[]): string | null {
   if (!channelId || channelId === 'server-root') return null;
-  return canOpenChannelChat(channelId, channels) ? channelId : null;
+  const channel = channels.find(c => String(c.id) === channelId);
+  return channel?.canOpenChat === true ? channelId : null;
 }
 
 export function getChannelSelectionOutcome(
@@ -694,6 +699,7 @@ export function getChannelAccessDeniedMessage(channel: Pick<Channel, 'hasPasswor
 export type JoinAccessAction = 'join' | 'promptPassword' | 'deny';
 
 export function getJoinAccessAction(channel: Pick<Channel, 'canEnter' | 'hasPasswordRestriction'>): JoinAccessAction {
+  if (channel.canEnter === true) return 'join';
   if (channel.hasPasswordRestriction) return 'promptPassword';
   return channel.canEnter === false ? 'deny' : 'join';
 }
@@ -706,7 +712,7 @@ export function isMatrixChannelChatActive(
   channels: Channel[] = [],
 ): boolean {
   if (!channelId || channelId === 'server-root') return false;
-  if (!canOpenChannelChat(channelId, channels)) return false;
+  if (!getPermittedMatrixChannelId(channelId, channels)) return false;
   if (statuses.server.state !== 'connected' || statuses.chat.state !== 'connected') return false;
   if (!selfUser?.isBrmbleClient) return false;
   return credentials?.roomMap[channelId] !== undefined;
@@ -2544,6 +2550,10 @@ function App() {
       setChannels(prev => mergeChannelChatAccess(prev, channelsAccess));
     };
 
+    const onChatChannelAccessError = () => {
+      setChannels(prev => mergeChannelChatAccess(prev, getResolvedChannelChatAccess(getChannelChatAccessRequestIds(prev))));
+    };
+
     bridge.on('brmble.serviceStatus', onBrmbleServiceStatus);
     bridge.on('voice.connected', onVoiceConnected);
     bridge.on('voice.disconnected', onVoiceDisconnected);
@@ -2613,6 +2623,7 @@ function App() {
     bridge.on('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
     bridge.on('voice.registrationStatus', onRegistrationStatus);
     bridge.on('chat.channelAccess', onChatChannelAccess);
+    bridge.on('chat.channelAccessError', onChatChannelAccessError);
     const onVoiceLoss = (data: unknown) => {
       const payload = data as { loss?: number } | null;
       const loss = typeof payload?.loss === 'number' ? payload.loss : undefined;
@@ -2677,6 +2688,7 @@ function App() {
       bridge.off('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
       bridge.off('voice.registrationStatus', onRegistrationStatus);
       bridge.off('chat.channelAccess', onChatChannelAccess);
+      bridge.off('chat.channelAccessError', onChatChannelAccessError);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/Brmble.Web/src/components/AvatarEditorModal/AvatarEditorModal.tsx
+++ b/src/Brmble.Web/src/components/AvatarEditorModal/AvatarEditorModal.tsx
@@ -123,7 +123,7 @@ export function AvatarEditorModal({ isOpen, onClose, currentUser, comment, onSet
   }
 
   return (
-    <div className="avatar-editor-overlay" onClick={onClose}>
+    <div className="modal-overlay avatar-editor-overlay" onClick={onClose}>
       <div
         ref={dialogRef}
         className="avatar-editor glass-panel animate-slide-up"
@@ -158,7 +158,7 @@ export function AvatarEditorModal({ isOpen, onClose, currentUser, comment, onSet
           {editingComment ? (
             <>
               <textarea
-                className="avatar-editor-comment-textarea"
+                className="brmble-input avatar-editor-comment-textarea"
                 value={commentDraft}
                 onChange={(e) => setCommentDraft(e.target.value)}
                 rows={3}

--- a/src/Brmble.Web/src/components/AvatarUpload/AvatarUpload.tsx
+++ b/src/Brmble.Web/src/components/AvatarUpload/AvatarUpload.tsx
@@ -178,7 +178,7 @@ export default function AvatarUpload({ onUpload, onCancel }: AvatarUploadProps) 
   }, [imageSrc]);
 
   return (
-    <div className="avatar-upload-overlay" onClick={onCancel}>
+    <div className="modal-overlay avatar-upload-overlay" onClick={onCancel}>
       <div
         ref={dialogRef}
         className="avatar-upload glass-panel animate-slide-up"

--- a/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.css
+++ b/src/Brmble.Web/src/components/Brmblegotchi/Brmblegotchi.css
@@ -1,4 +1,33 @@
 .brmblegotchi-widget {
+  --brmblegotchi-size-sm: 36px;
+  --brmblegotchi-size-md: 48px;
+  --brmblegotchi-size-lg: 60px;
+  --brmblegotchi-size-xl: 80px;
+  --brmblegotchi-size-2xl: 100px;
+  --brmblegotchi-size-3xl: 140px;
+  --brmblegotchi-dot-size: 6px;
+  --brmblegotchi-eye-size: 8px;
+  --brmblegotchi-mouth-width: 12px;
+  --brmblegotchi-mouth-height: 6px;
+  --brmblegotchi-mouth-wide: 14px;
+  --brmblegotchi-mouth-wide-height: 7px;
+  --brmblegotchi-mouth-flat-width: 8px;
+  --brmblegotchi-mouth-flat-height: 2px;
+  --brmblegotchi-stat-icon-size: 14px;
+  --brmblegotchi-stat-bar-height: 4px;
+  --brmblegotchi-progress-height: 3px;
+  --brmblegotchi-action-size: 36px;
+  --brmblegotchi-action-icon-size: 18px;
+  --brmblegotchi-egg-width: 60px;
+  --brmblegotchi-ghost-mouth-width: 20px;
+  --brmblegotchi-ghost-mouth-height: 10px;
+  --brmblegotchi-ghost-mouth-border: 3px;
+  --brmblegotchi-pop-duration: var(--animation-normal);
+  --brmblegotchi-mood-duration: var(--animation-badge-pulse);
+  --brmblegotchi-slow-duration: var(--animation-heartbeat);
+  --brmblegotchi-fast-duration: var(--animation-pulse);
+  --brmblegotchi-action-duration: var(--animation-fast);
+  --brmblegotchi-click-duration: var(--animation-fast);
   position: fixed;
   bottom: var(--space-lg);
   right: var(--space-lg);
@@ -22,7 +51,7 @@
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-elevated);
   border: var(--glass-border);
-  animation: brmblegotchi-pop-up 200ms ease-out;
+  animation: brmblegotchi-pop-up var(--brmblegotchi-pop-duration) ease-out;
   z-index: 100;
 }
 
@@ -39,13 +68,13 @@
 }
 
 .brmblegotchi-drag-handle {
-  width: 80px;
-  height: 20px;
+  width: var(--brmblegotchi-size-xl);
+  height: var(--space-lg);
   cursor: grab;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--brmblegotchi-dot-size);
   border-radius: var(--radius-md) var(--radius-md) 0 0;
   margin-top: var(--space-sm);
 }
@@ -55,8 +84,8 @@
 }
 
 .brmblegotchi-drag-handle span {
-  width: 6px;
-  height: 6px;
+  width: var(--brmblegotchi-dot-size);
+  height: var(--brmblegotchi-dot-size);
   background: var(--text-muted);
   border-radius: 50%;
   opacity: 0.8;
@@ -68,8 +97,8 @@
 }
 
 .brmblegotchi-pet {
-  width: 80px;
-  height: 80px;
+  width: var(--brmblegotchi-size-xl);
+  height: var(--brmblegotchi-size-xl);
   position: relative;
   display: flex;
   align-items: center;
@@ -84,8 +113,8 @@
 
 .theme-dino .brmblegotchi-pet,
 .theme-cat .brmblegotchi-pet {
-  width: 100px;
-  height: 100px;
+  width: var(--brmblegotchi-size-2xl);
+  height: var(--brmblegotchi-size-2xl);
 }
 
 .brmblegotchi-pet:hover {
@@ -97,22 +126,22 @@
 }
 
 .pet-sprite {
-  width: 64px;
-  height: 64px;
+  width: var(--space-3xl);
+  height: var(--space-3xl);
   image-rendering: pixelated;
   image-rendering: crisp-edges;
 }
 
 .theme-dino .brmblegotchi-pet .pet-sprite,
 .theme-cat .brmblegotchi-pet .pet-sprite {
-  width: 100px;
-  height: 100px;
-  animation: idle-breathing 2s ease-in-out infinite;
+  width: var(--brmblegotchi-size-2xl);
+  height: var(--brmblegotchi-size-2xl);
+  animation: idle-breathing var(--brmblegotchi-mood-duration) ease-in-out infinite;
 }
 
 .theme-cat .brmblegotchi-pet .pet-sprite {
-  width: 140px;
-  height: 140px;
+  width: var(--brmblegotchi-size-3xl);
+  height: var(--brmblegotchi-size-3xl);
 }
 
 @keyframes idle-breathing {
@@ -139,35 +168,35 @@
 }
 
 .brmblegotchi-ring-outer {
-  width: 72px;
-  height: 72px;
+  width: calc(var(--brmblegotchi-size-xl) - var(--space-xs));
+  height: calc(var(--brmblegotchi-size-xl) - var(--space-xs));
   border: 3px solid var(--accent-primary);
   opacity: 0.3;
-  animation: brmblegotchi-pulse-outer 2s ease-in-out infinite;
+  animation: brmblegotchi-pulse-outer var(--brmblegotchi-mood-duration) ease-in-out infinite;
 }
 
 .brmblegotchi-ring-middle {
-  width: 60px;
-  height: 60px;
+  width: var(--brmblegotchi-size-lg);
+  height: var(--brmblegotchi-size-lg);
   border: 2px solid var(--accent-primary);
   opacity: 0.5;
-  animation: brmblegotchi-pulse-middle 2s ease-in-out infinite 0.2s;
+  animation: brmblegotchi-pulse-middle var(--brmblegotchi-mood-duration) ease-in-out infinite var(--animation-fast);
 }
 
 .brmblegotchi-ring-inner {
-  width: 48px;
-  height: 48px;
+  width: var(--brmblegotchi-size-md);
+  height: var(--brmblegotchi-size-md);
   border: 2px solid var(--accent-primary);
   opacity: 0.7;
-  animation: brmblegotchi-pulse-inner 2s ease-in-out infinite 0.4s;
+  animation: brmblegotchi-pulse-inner var(--brmblegotchi-mood-duration) ease-in-out infinite var(--animation-slow);
 }
 
 .brmblegotchi-ring-center {
-  width: 36px;
-  height: 36px;
+  width: var(--brmblegotchi-size-sm);
+  height: var(--brmblegotchi-size-sm);
   background: var(--accent-primary);
   opacity: 1;
-  animation: brmblegotchi-breathe 2s ease-in-out infinite;
+  animation: brmblegotchi-breathe var(--brmblegotchi-mood-duration) ease-in-out infinite;
 }
 
 .brmblegotchi-face {
@@ -178,26 +207,26 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--brmblegotchi-dot-size);
   z-index: 2;
 }
 
 .brmblegotchi-eyes {
   display: flex;
-  gap: 10px;
+  gap: var(--space-xs);
 }
 
 .brmblegotchi-eye {
-  width: 8px;
-  height: 8px;
+  width: var(--brmblegotchi-eye-size);
+  height: var(--brmblegotchi-eye-size);
   background: var(--bg-deep);
   border-radius: 50%;
   transition: all var(--transition-fast);
 }
 
 .brmblegotchi-eye.happy {
-  height: 4px;
-  border-radius: 4px 4px 0 0;
+  height: var(--space-2xs);
+  border-radius: var(--radius-xs) var(--radius-xs) 0 0;
   transform: translateY(2px);
 }
 
@@ -206,38 +235,38 @@
 }
 
 .brmblegotchi-mouth {
-  width: 12px;
-  height: 6px;
+  width: var(--brmblegotchi-mouth-width);
+  height: var(--brmblegotchi-mouth-height);
   border: 2px solid var(--bg-deep);
   border-top: none;
-  border-radius: 0 0 12px 12px;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   transition: all var(--transition-fast);
 }
 
 .brmblegotchi-mouth.happy {
-  width: 14px;
-  height: 7px;
+  width: var(--brmblegotchi-mouth-wide);
+  height: var(--brmblegotchi-mouth-wide-height);
 }
 
 .brmblegotchi-mouth.sad {
-  border-radius: 12px 12px 0 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   border: 2px solid var(--bg-deep);
   border-bottom: none;
-  height: 4px;
+  height: var(--space-2xs);
 }
 
 .brmblegotchi-mouth.neutral {
-  width: 8px;
-  height: 2px;
+  width: var(--brmblegotchi-mouth-flat-width);
+  height: var(--brmblegotchi-mouth-flat-height);
   background: var(--bg-deep);
   border: none;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 .brmblegotchi-stats {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-2xs);
   background: var(--bg-surface);
   padding: var(--space-xs);
   border-radius: var(--radius-md);
@@ -254,12 +283,12 @@
 .brmblegotchi-stat {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--brmblegotchi-dot-size);
 }
 
 .brmblegotchi-stat-icon {
-  width: 14px;
-  height: 14px;
+  width: var(--brmblegotchi-stat-icon-size);
+  height: var(--brmblegotchi-stat-icon-size);
   flex-shrink: 0;
 }
 
@@ -282,15 +311,15 @@
 
 .brmblegotchi-stat-bar {
   flex: 1;
-  height: 4px;
+  height: var(--brmblegotchi-stat-bar-height);
   background: var(--bg-deep);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   overflow: hidden;
 }
 
 .brmblegotchi-stat-fill {
   height: 100%;
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   transition: width var(--transition-normal);
 }
 
@@ -311,20 +340,20 @@
 }
 
 .brmblegotchi-progress-bar {
-  height: 3px;
+  height: var(--brmblegotchi-progress-height);
   background: var(--bg-deep);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   overflow: hidden;
 }
 
 .brmblegotchi-progress-fill {
   height: 100%;
   background: var(--accent-primary);
-  transition: width 1s linear;
+  transition: width var(--transition-slow);
 }
 
 .brmblegotchi-age {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   text-align: center;
   margin-top: var(--space-xs);
@@ -346,7 +375,7 @@
 }
 
 .brmblegotchi-context-header {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -360,9 +389,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 12px;
+  font-size: var(--text-xs);
   color: var(--text-secondary);
-  padding: 2px 0;
+  padding: var(--space-2xs) 0;
 }
 
 .brmblegotchi-context-item span:last-child {
@@ -402,7 +431,7 @@
   border: none;
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: var(--text-xs);
   cursor: pointer;
   transition: background var(--transition-fast);
 }
@@ -413,8 +442,8 @@
 }
 
 .brmblegotchi-action-btn {
-  width: 36px;
-  height: 36px;
+  width: var(--brmblegotchi-action-size);
+  height: var(--brmblegotchi-action-size);
   border-radius: var(--radius-md);
   border: none;
   background: var(--bg-hover);
@@ -437,8 +466,8 @@
 }
 
 .brmblegotchi-action-btn svg {
-  width: 18px;
-  height: 18px;
+  width: var(--brmblegotchi-action-icon-size);
+  height: var(--brmblegotchi-action-icon-size);
 }
 
 .brmblegotchi-action-btn.disabled {
@@ -453,7 +482,7 @@
 }
 
 .brmblegotchi-cooldown {
-  font-size: 10px;
+  font-size: var(--text-2xs);
   font-weight: 600;
   color: var(--text-muted);
 }
@@ -479,23 +508,23 @@
 }
 
 .brmblegotchi-widget.sad .brmblegotchi-ring-outer {
-  animation-duration: 4s;
+  animation-duration: var(--brmblegotchi-slow-duration);
   opacity: 0.15;
 }
 
 .brmblegotchi-widget.sad .brmblegotchi-ring-middle {
-  animation-duration: 4s;
+  animation-duration: var(--brmblegotchi-slow-duration);
   opacity: 0.25;
 }
 
 .brmblegotchi-widget.sad .brmblegotchi-ring-inner {
-  animation-duration: 4s;
+  animation-duration: var(--brmblegotchi-slow-duration);
   opacity: 0.4;
 }
 
 .brmblegotchi-widget.sad .brmblegotchi-ring-center {
   background: var(--text-muted);
-  animation-duration: 4s;
+  animation-duration: var(--brmblegotchi-slow-duration);
 }
 
 .brmblegotchi-widget.stage-baby .brmblegotchi-pet-wrapper {
@@ -515,19 +544,19 @@
 }
 
 .brmblegotchi-widget.stage-egg .brmblegotchi-pet {
-  width: 60px;
-  height: 80px;
+  width: var(--brmblegotchi-egg-width);
+  height: var(--brmblegotchi-size-xl);
   background: var(--accent-primary);
   border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
   cursor: pointer;
-  animation: egg-wobble 2s ease-in-out infinite;
+  animation: egg-wobble var(--brmblegotchi-mood-duration) ease-in-out infinite;
   box-shadow: none;
   border: none;
   transform: none;
 }
 
 .brmblegotchi-widget.stage-egg .brmblegotchi-pet-wrapper {
-  animation: egg-wobble 2s ease-in-out infinite;
+  animation: egg-wobble var(--brmblegotchi-mood-duration) ease-in-out infinite;
   transform-origin: center center;
 }
 
@@ -542,7 +571,7 @@
 }
 
 .brmblegotchi-widget.stage-child .brmblegotchi-ring {
-  animation-duration: 4s;
+  animation-duration: var(--brmblegotchi-slow-duration);
 }
 
 .brmblegotchi-widget.stage-ghost .brmblegotchi-pet {
@@ -562,7 +591,7 @@
   content: '';
   position: absolute;
   width: 100%;
-  height: 2px;
+  height: var(--brmblegotchi-mouth-flat-height);
   background: var(--accent-primary);
   top: 50%;
   left: 0;
@@ -574,10 +603,10 @@
 }
 
 .brmblegotchi-widget.stage-ghost .brmblegotchi-mouth {
-  width: 20px;
-  height: 10px;
+  width: var(--brmblegotchi-ghost-mouth-width);
+  height: var(--brmblegotchi-ghost-mouth-height);
   border: none;
-  border-top: 3px solid var(--accent-primary);
+  border-top: var(--brmblegotchi-ghost-mouth-border) solid var(--accent-primary);
   border-radius: 0;
   transform: rotate(180deg);
 }
@@ -587,25 +616,25 @@
   bottom: -30px;
   left: 50%;
   transform: translateX(-50%);
-  font-family: var(--font-body, sans-serif);
-  font-size: 12px;
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
   color: var(--accent-primary);
   opacity: 0.8;
   white-space: nowrap;
 }
 
 .brmblegotchi-widget.happy .brmblegotchi-ring-outer {
-  animation-duration: 1s;
+  animation-duration: var(--brmblegotchi-fast-duration);
   opacity: 0.5;
 }
 
 .brmblegotchi-widget.happy .brmblegotchi-ring-middle {
-  animation-duration: 1s;
+  animation-duration: var(--brmblegotchi-fast-duration);
   opacity: 0.7;
 }
 
 .brmblegotchi-widget.happy .brmblegotchi-ring-inner {
-  animation-duration: 1s;
+  animation-duration: var(--brmblegotchi-fast-duration);
   opacity: 0.9;
 }
 
@@ -614,11 +643,11 @@
   top: -25px;
   left: 50%;
   transform: translateX(-50%);
-  font-family: var(--font-body, sans-serif);
-  font-size: 10px;
+  font-family: var(--font-body);
+  font-size: var(--text-2xs);
   color: var(--text-secondary);
   white-space: nowrap;
-  animation: hint-pulse 1.5s ease-in-out infinite;
+  animation: hint-pulse var(--animation-loading-dots) ease-in-out infinite;
 }
 
 @keyframes hint-pulse {
@@ -627,7 +656,7 @@
 }
 
 .brmblegotchi-widget.action-animating .brmblegotchi-pet {
-  animation: action-shake 0.5s ease-in-out;
+  animation: action-shake var(--brmblegotchi-action-duration) ease-in-out;
 }
 
 @keyframes action-shake {
@@ -639,7 +668,7 @@
 }
 
 .brmblegotchi-widget.egg-click-animating .brmblegotchi-pet {
-  animation: egg-click-shake 0.3s ease-in-out;
+  animation: egg-click-shake var(--brmblegotchi-click-duration) ease-in-out;
 }
 
 @keyframes egg-click-shake {

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.css
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.css
@@ -403,7 +403,8 @@
 }
 
 .chat-typing-indicator {
-  min-height: 20px;
+  --chat-typing-indicator-min-height: calc(var(--space-lg) - var(--space-2xs));
+  min-height: var(--chat-typing-indicator-min-height);
   padding: 0 var(--space-md) var(--space-xs);
   color: var(--text-secondary);
   font-size: var(--text-xs);

--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
@@ -127,8 +127,9 @@ p.message-text {
 }
 
 .search-active-match {
+  --search-active-border-width: 3px;
   background: var(--bg-hover);
-  box-shadow: inset 3px 0 0 var(--accent-primary);
+  box-shadow: inset var(--search-active-border-width) 0 0 var(--accent-primary);
 }
 
 /* @mention highlighting */
@@ -219,8 +220,10 @@ p.message-text {
 }
 
 .message-reply-preview--interactive:focus-visible {
+  --message-reply-focus-inner: 2px;
+  --message-reply-focus-outer: 4px;
   outline: none;
-  box-shadow: 0 0 0 2px var(--accent-primary-wash), 0 0 0 4px color-mix(in srgb, var(--accent-primary) 35%, transparent);
+  box-shadow: 0 0 0 var(--message-reply-focus-inner) var(--accent-primary-wash), 0 0 0 var(--message-reply-focus-outer) color-mix(in srgb, var(--accent-primary) 35%, transparent);
 }
 
 .message-reply-preview .message-reply-sender {
@@ -238,20 +241,21 @@ p.message-text {
 }
 
 .message-bubble--reply-target {
+  --message-reply-target-ring: 1px;
   background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-primary) 35%, transparent);
+  box-shadow: inset 0 0 0 var(--message-reply-target-ring) color-mix(in srgb, var(--accent-primary) 35%, transparent);
   animation: message-reply-target-flash var(--animation-speaking-pulse) ease-out;
 }
 
 @keyframes message-reply-target-flash {
   0% {
     background: color-mix(in srgb, var(--accent-primary) 22%, transparent);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-primary) 55%, transparent);
+    box-shadow: inset 0 0 0 var(--message-reply-target-ring) color-mix(in srgb, var(--accent-primary) 55%, transparent);
   }
 
   100% {
     background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-primary) 35%, transparent);
+    box-shadow: inset 0 0 0 var(--message-reply-target-ring) color-mix(in srgb, var(--accent-primary) 35%, transparent);
   }
 }
 

--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.css
@@ -54,6 +54,11 @@
   word-wrap: break-word;
 }
 
+.message-text--deleted {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 p.message-text {
   white-space: pre-wrap;
 }
@@ -170,12 +175,12 @@ p.message-text {
   background: none;
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
-  padding: 2px var(--space-sm);
+  padding: var(--space-2xs) var(--space-sm);
   font-size: var(--text-sm);
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-2xs);
 }
 
 .message-error-dismiss {
@@ -196,7 +201,7 @@ p.message-text {
   border-radius: var(--radius-sm);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2xs);
 }
 
 .message-reply-preview--interactive {
@@ -235,7 +240,7 @@ p.message-text {
 .message-bubble--reply-target {
   background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-primary) 35%, transparent);
-  animation: message-reply-target-flash 1.6s ease-out;
+  animation: message-reply-target-flash var(--animation-speaking-pulse) ease-out;
 }
 
 @keyframes message-reply-target-flash {
@@ -261,8 +266,8 @@ p.message-text {
 .reaction-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px 6px;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-xs);
   background: var(--bg-tertiary);
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);

--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.test.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.test.tsx
@@ -21,9 +21,10 @@ function renderBubble(props: Partial<React.ComponentProps<typeof MessageBubble>>
 }
 
 describe('MessageBubble', () => {
-  it('renders nothing when message is redacted', () => {
-    const { container } = renderBubble({ content: '', redacted: true });
-    expect(container.firstChild).toBeNull();
+  it('renders deleted placeholder when message is redacted', () => {
+    renderBubble({ content: '', redacted: true });
+    expect(screen.getByText('Message deleted')).toBeInTheDocument();
+    expect(screen.getByText('Message deleted')).toHaveClass('message-text--deleted');
   });
 
   it('renders reaction badges and handles toggles', async () => {

--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.tsx
@@ -8,6 +8,7 @@ import { ImageAttachment } from './ImageAttachment';
 import { ImageLightbox } from './ImageLightbox';
 import { LinkPreview } from './LinkPreview';
 import Avatar from '../Avatar/Avatar';
+import { Tooltip } from '../Tooltip/Tooltip';
 import './MessageBubble.css';
 
 interface MessageBubbleProps {
@@ -182,7 +183,7 @@ export const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps & Rea
               <span className="message-time">{formatTime(timestamp)}</span>
             </div>
           )}
-          <div className="message-text" style={{ fontStyle: 'italic', opacity: 0.6 }}>
+          <div className="message-text message-text--deleted">
             Message deleted
           </div>
         </div>
@@ -286,16 +287,16 @@ export const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps & Rea
             {Object.entries(reactions).map(([emoji, senders]) => {
               const isReacted = currentUserMatrixId ? senders.includes(currentUserMatrixId) : false;
               return (
-                <button
-                  key={emoji}
-                  className={`reaction-badge${isReacted ? ' reacted' : ''}`}
-                  onClick={() => onToggleReaction?.(messageId, emoji, isReacted)}
-                  title={`${senders.length} reaction${senders.length === 1 ? '' : 's'}`}
-                  aria-label={`${emoji} ${senders.length}`}
-                >
-                  <span className="reaction-emoji">{emoji}</span>
-                  <span className="reaction-count">{senders.length}</span>
-                </button>
+                <Tooltip key={emoji} content={`${senders.length} reaction${senders.length === 1 ? '' : 's'}`}>
+                  <button
+                    className={`reaction-badge${isReacted ? ' reacted' : ''}`}
+                    onClick={() => onToggleReaction?.(messageId, emoji, isReacted)}
+                    aria-label={`${emoji} ${senders.length}`}
+                  >
+                    <span className="reaction-emoji">{emoji}</span>
+                    <span className="reaction-count">{senders.length}</span>
+                  </button>
+                </Tooltip>
               );
             })}
           </div>

--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.tsx
@@ -272,7 +272,7 @@ export const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps & Rea
             <div className="message-error-actions">
               {onDismiss && (
                 <button
-                  className="message-error-btn message-error-dismiss"
+                  className="btn btn-secondary btn-sm message-error-btn message-error-dismiss"
                   onClick={() => onDismiss(messageId)}
                   aria-label="Dismiss failed message"
                 >

--- a/src/Brmble.Web/src/components/CloseDialog/CloseDialog.tsx
+++ b/src/Brmble.Web/src/components/CloseDialog/CloseDialog.tsx
@@ -53,16 +53,17 @@ export function CloseDialog({ isOpen, onMinimize, onQuit }: CloseDialogProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="close-dialog-overlay">
+    <div className="modal-overlay close-dialog-overlay" onClick={() => onMinimize(dontAskAgain)}>
       {/* Fix 2: ARIA dialog semantics */}
       <div
         className="close-dialog-card glass-panel animate-slide-up"
         role="dialog"
         aria-modal="true"
         aria-labelledby="close-dialog-title"
+        onClick={(e) => e.stopPropagation()}
       >
         {/* Fix 2: id on heading to satisfy aria-labelledby */}
-        <h2 id="close-dialog-title" className="heading-title close-dialog-title">Leaving so soon?</h2>
+        <h2 id="close-dialog-title" className="heading-title modal-title close-dialog-title">Leaving so soon?</h2>
         <p className="close-dialog-subtitle">Choose what happens when you close the window.</p>
 
         <div className="close-dialog-buttons">

--- a/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/Brmble.Web/src/components/ContextMenu/ContextMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { Icon } from '../Icon/Icon';
 import './ContextMenu.css';
 
 const MOUSE_LEAVE_CLOSE_DELAY = 400;
@@ -81,7 +82,9 @@ function CheckboxMenuItem({ item }: { item: { type: 'checkbox'; label: string; c
         }}
       >
         <span className="context-menu-label">{item.label}</span>
-        <span aria-hidden="true">{item.checked ? '☑' : '☐'}</span>
+        <span className="context-menu-check" aria-hidden="true">
+          {item.checked ? <Icon name="check" size={14} /> : null}
+        </span>
       </div>
     </div>
   );

--- a/src/Brmble.Web/src/components/Game/GameUI.css
+++ b/src/Brmble.Web/src/components/Game/GameUI.css
@@ -936,7 +936,7 @@
   font-size: var(--text-xs);
   color: var(--text-muted);
   background: var(--bg-surface);
-  padding: 2px 6px;
+  padding: var(--space-2xs) var(--space-xs);
   border-radius: var(--radius-sm);
   width: fit-content;
 }
@@ -971,7 +971,7 @@
   background: var(--accent-primary-ghost);
   border: 2px solid var(--accent-primary);
   position: relative;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .hosting-row.drag-over:hover {
@@ -979,6 +979,7 @@
 }
 
 .drop-overlay {
+  --drop-overlay-blur: var(--glass-blur);
   position: absolute;
   inset: 0;
   display: flex;
@@ -989,7 +990,7 @@
   font-weight: 600;
   font-size: var(--text-sm);
   border-radius: var(--radius-md);
-  backdrop-filter: blur(2px);
+  backdrop-filter: var(--drop-overlay-blur);
 }
 
 /* Confirm dialog */
@@ -1041,7 +1042,7 @@
   width: 4px;
   height: 20px;
   background: var(--accent-primary);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
 }
 
 /* Unified Card/Row Base */

--- a/src/Brmble.Web/src/components/Game/GameUI.tsx
+++ b/src/Brmble.Web/src/components/Game/GameUI.tsx
@@ -6,6 +6,7 @@ import { ContractSlot } from './contracts/ContractSlot';
 import { confirm } from '../../hooks/usePrompt';
 import { Select } from '../Select/Select';
 import { Tooltip } from '../Tooltip/Tooltip';
+import { Icon } from '../Icon/Icon';
 import './GameUI.css';
 
 interface GameUIProps {
@@ -20,7 +21,7 @@ function ContractsSection({ state, actions }: { state: GameState; actions: GameA
   return (
     <div className="contracts-section">
       <div className="contracts-header">
-        <h2 className="heading-section">Contracts</h2>
+        <h3 className="heading-section">Contracts</h3>
       </div>
       
       <div className="contracts-slots">
@@ -83,21 +84,33 @@ export function GameUI({ onClose }: GameUIProps) {
   }, [state.pendingContract]);
 
   const handleConfirmContract = useCallback(async () => {
-    if (pendingLicenseId) {
-      actions.assignContract(pendingLicenseId);
-      setPendingLicenseId(null);
-    }
-  }, [pendingLicenseId, actions]);
+    if (!pendingLicenseId || !state.pendingContract) return;
 
-  const handleCancelContract = useCallback(() => {
+    const serviceName = state.services.find(s => s.id === pendingLicenseId)?.name ?? 'this service';
+    const confirmed = await confirm({
+      title: 'Activate Contract?',
+      message: `Assign ${state.pendingContract.contract.name} to ${serviceName}? Once activated, the contract will start immediately and the time limit will begin counting down.`,
+      confirmLabel: 'Activate',
+      cancelLabel: 'Cancel',
+    });
+
+    if (confirmed) {
+      actions.assignContract(pendingLicenseId);
+    }
     setPendingLicenseId(null);
-  }, []);
+  }, [pendingLicenseId, state.pendingContract, state.services, actions]);
 
   useEffect(() => {
     if (!state.pendingContract && pendingLicenseId !== null) {
       setPendingLicenseId(null);
     }
   }, [state.pendingContract, pendingLicenseId]);
+
+  useEffect(() => {
+    if (pendingLicenseId && state.pendingContract) {
+      void handleConfirmContract();
+    }
+  }, [pendingLicenseId, state.pendingContract, handleConfirmContract]);
   
   const handleClose = useCallback(() => {
     actions.saveGame();
@@ -187,7 +200,7 @@ export function GameUI({ onClose }: GameUIProps) {
             </div>
             <div className="modal-body">
               <textarea
-                className="import-textarea"
+                className="brmble-input import-textarea"
                 value={importData}
                 onChange={e => setImportData(e.target.value)}
                 placeholder="Paste save data here..."
@@ -258,32 +271,6 @@ export function GameUI({ onClose }: GameUIProps) {
         />
       )}
 
-      {pendingLicenseId && state.pendingContract && (
-        <div className="modal-overlay" onClick={handleCancelContract}>
-          <div className="prompt glass-panel animate-slide-up" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-              <h2 className="heading-title modal-title">Activate Contract?</h2>
-              <p className="modal-subtitle">
-                Assign <strong>{state.pendingContract.contract.name}</strong> to{' '}
-                <strong>{state.services.find(s => s.id === pendingLicenseId)?.name}</strong>?
-              </p>
-            </div>
-            <div className="modal-body">
-              <p className="confirm-details">
-                Once activated, the contract will start immediately and the time limit will begin counting down.
-              </p>
-            </div>
-            <div className="prompt-footer">
-              <button className="btn btn-secondary" onClick={handleCancelContract}>
-                Cancel
-              </button>
-              <button className="btn btn-primary" onClick={handleConfirmContract}>
-                Activate
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }
@@ -473,7 +460,7 @@ function InfrastructureTab({ infrastructure, onBuy, onUpgrade1, onUpgrade2, onUp
 
   return (
     <div className="infra-tab">
-      <h2 className="heading-section">Infrastructure</h2>
+      <h3 className="heading-section">Infrastructure</h3>
       <div className="services-section">
         {infrastructure.map(infra => {
           const cost = calculateCost(infra);
@@ -536,15 +523,15 @@ function TechUpgradesTab({ infrastructure, services, money, onUnlockInfrastructu
 
   return (
     <div className="upgrades-tab">
-      <h2 className="heading-section">Upgrades</h2>
+      <h3 className="heading-section">Upgrades</h3>
       
       {unlockedInfrastructure.length > 0 && (
         <div className="unlocked-section">
-          <h3 className="heading-label">Unlocked Infrastructure</h3>
+          <h4 className="heading-label">Unlocked Infrastructure</h4>
           <div className="unlocked-list">
             {unlockedInfrastructure.map(infra => (
               <div key={infra.id} className="unlocked-item">
-                <span className="unlocked-check">✓</span>
+                <Icon name="check" size={12} className="unlocked-check" />
                 <span className="unlocked-name">{infra.name}</span>
               </div>
             ))}
@@ -554,11 +541,11 @@ function TechUpgradesTab({ infrastructure, services, money, onUnlockInfrastructu
 
       {unlockedServices.length > 0 && (
         <div className="unlocked-section">
-          <h3 className="heading-label">Unlocked Services</h3>
+          <h4 className="heading-label">Unlocked Services</h4>
           <div className="unlocked-list">
             {unlockedServices.map(service => (
               <div key={service.id} className="unlocked-item">
-                <span className="unlocked-check">✓</span>
+                <Icon name="check" size={12} className="unlocked-check" />
                 <span className="unlocked-name">{service.name}</span>
               </div>
             ))}
@@ -617,7 +604,7 @@ function TechUpgradesTab({ infrastructure, services, money, onUnlockInfrastructu
       )}
 
       <div className="services-section">
-        <h3 className="heading-label">Contract Slots</h3>
+        <h4 className="heading-label">Contract Slots</h4>
         <div className="infra-row">
           <div className="infra-info">
             <span className="service-name">
@@ -675,7 +662,7 @@ function HostingTab({ services, uploadSpeed, bandwidthDemanded, onBuyService, on
       )}
       
       <div className="services-section">
-        <h3 className="heading-label">Services</h3>
+        <h4 className="heading-label">Services</h4>
         <div className="services-header">
           <span>Name</span>
           <span>Owned</span>
@@ -835,10 +822,10 @@ function OptionsTab({
 
   return (
     <div className="options-tab">
-      <h2 className="heading-section">Options</h2>
+      <h3 className="heading-section">Options</h3>
 
       <div className="options-section">
-        <h3 className="options-section-title">Theme</h3>
+        <h3 className="heading-section options-section-title">Theme</h3>
         <Select
           value={theme}
           onChange={(val) => { setTheme(val); onSetTheme(val); }}
@@ -850,7 +837,7 @@ function OptionsTab({
       </div>
 
       <div className="options-section">
-        <h3 className="options-section-title">Sound</h3>
+        <h3 className="heading-section options-section-title">Sound</h3>
         <div className="options-slider-container">
           <label className="options-label">Volume</label>
           <input 
@@ -866,7 +853,7 @@ function OptionsTab({
       </div>
 
       <div className="options-section">
-        <h3 className="options-section-title">Game Data</h3>
+        <h3 className="heading-section options-section-title">Game Data</h3>
         <div className="options-buttons">
           <button className="btn btn-secondary" onClick={onSave}>
             Save Now
@@ -882,7 +869,7 @@ function OptionsTab({
         <div className="import-section">
           <label className="options-label">Import Save Data</label>
           <textarea
-            className="options-textarea"
+            className="brmble-input options-textarea"
             value={importData}
             onChange={(e) => setImportData(e.target.value)}
             placeholder="Paste save data here..."

--- a/src/Brmble.Web/src/components/Game/contracts/ContractSlot.css
+++ b/src/Brmble.Web/src/components/Game/contracts/ContractSlot.css
@@ -103,7 +103,7 @@
 .contract-progress-fill {
   height: 100%;
   background: linear-gradient(90deg, var(--accent-success), var(--accent-primary));
-  transition: width 0.1s linear;
+  transition: width var(--transition-fast);
   min-width: 4px;
 }
 
@@ -112,7 +112,7 @@
   background: var(--accent-primary-ghost);
   border: 2px solid var(--accent-primary);
   cursor: grab;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast);
 }
 
 .contract-slot.pending:hover {
@@ -151,7 +151,7 @@
 
 .drag-dots {
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: var(--text-sm);
   letter-spacing: -2px;
   user-select: none;
 }
@@ -193,12 +193,12 @@
 }
 
 .hint-icon {
-  font-size: 12px;
+  font-size: var(--text-xs);
 }
 
 .slot-cancel {
-  padding: 2px 6px;
-  font-size: 14px;
+  padding: var(--space-2xs) var(--space-xs);
+  font-size: var(--text-sm);
   line-height: 1;
   opacity: 0.6;
 }

--- a/src/Brmble.Web/src/components/Icon/Icon.tsx
+++ b/src/Brmble.Web/src/components/Icon/Icon.tsx
@@ -168,6 +168,14 @@ const iconPaths: Record<string, IconDef> = {
       </>
     ),
   },
+  'key-round': {
+    paths: (
+      <>
+        <path d="M2 18v3h3l9.5-9.5" />
+        <circle cx="16" cy="8" r="6" />
+      </>
+    ),
+  },
   'shield': {
     paths: <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />,
   },

--- a/src/Brmble.Web/src/components/Icon/Icon.tsx
+++ b/src/Brmble.Web/src/components/Icon/Icon.tsx
@@ -152,6 +152,22 @@ const iconPaths: Record<string, IconDef> = {
   'folder': {
     paths: <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />,
   },
+  'lock': {
+    paths: (
+      <>
+        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+      </>
+    ),
+  },
+  'unlock': {
+    paths: (
+      <>
+        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+      </>
+    ),
+  },
   'shield': {
     paths: <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />,
   },

--- a/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
+++ b/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
@@ -5,6 +5,7 @@ import { getBailCost } from './economy';
 import { confirm } from '../../hooks/usePrompt';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { Icon } from '../Icon/Icon';
+import { Select } from '../Select';
 import styles from './NeonD.module.css';
 
 
@@ -361,15 +362,14 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                       
                       <div className={styles.statRow}>
                         <span className={styles.label}>Selling now:</span>
-                        <select
+                        <Select
                           value={slot.selling}
-                          onChange={(e) => handleDealerChange(slot.id, e.target.value)}
+                          onChange={(value) => handleDealerChange(slot.id, value)}
                           className={styles.select}
-                        >
-                          {visibleProduction.filter(p => state.unlockedProduction.includes(p.id)).map(p => (
-                            <option key={p.id} value={p.id}>{p.name}</option>
-                          ))}
-                        </select>
+                          options={visibleProduction
+                            .filter(p => state.unlockedProduction.includes(p.id))
+                            .map(p => ({ value: p.id, label: p.name }))}
+                        />
                       </div>
 
                       <div className={styles.statRow}>

--- a/src/Brmble.Web/src/components/Notification/Notification.css
+++ b/src/Brmble.Web/src/components/Notification/Notification.css
@@ -53,9 +53,9 @@
 }
 
 .notification__detail {
-  font-size: 0.85em;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
-  margin-top: 2px;
+  margin-top: var(--space-2xs);
   line-height: 1.4;
 }
 

--- a/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -780,6 +780,7 @@ export function OnboardingWizard({ onComplete, onServersImported, isMaximized }:
               <label htmlFor="onboarding-profile-name">Profile name</label>
               <input
                 id="onboarding-profile-name"
+                className="brmble-input"
                 type="text"
                 value={newName}
                 onChange={e => setNewName(e.target.value)}

--- a/src/Brmble.Web/src/components/ServerList/ServerList.css
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.css
@@ -92,7 +92,7 @@
   border: none;
   color: var(--accent-danger);
   cursor: pointer;
-  padding: 0.25rem;
+  padding: var(--space-2xs);
   font-size: var(--text-base);
   line-height: 1;
   opacity: 0.7;
@@ -144,6 +144,8 @@
 }
 
 .server-list-icon {
+  --server-list-icon-shadow-y: var(--space-2xs);
+  --server-list-icon-shadow-blur: var(--space-sm);
   width: 44px;
   height: 44px;
   border-radius: var(--radius-lg);
@@ -156,7 +158,7 @@
   font-weight: 600;
   color: var(--text-primary);
   flex-shrink: 0;
-  box-shadow: 0 4px 12px var(--accent-primary-glow);
+  box-shadow: 0 var(--server-list-icon-shadow-y) var(--server-list-icon-shadow-blur) var(--accent-primary-glow);
 }
 
 .server-list-info {
@@ -164,7 +166,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: var(--space-2xs);
 }
 
 .server-list-name {
@@ -400,7 +402,7 @@
   font-size: var(--text-2xs);
   color: var(--text-muted);
   background: var(--bg-deep);
-  padding: 1px var(--space-xs);
+  padding: var(--space-2xs) var(--space-xs);
   border-radius: var(--radius-sm);
   white-space: nowrap;
   flex-shrink: 0;

--- a/src/Brmble.Web/src/components/ServerList/ServerList.tsx
+++ b/src/Brmble.Web/src/components/ServerList/ServerList.tsx
@@ -127,7 +127,7 @@ export function ServerList({ onConnect, connectDisabled, connectionError, onClea
             <span>{connectionError}</span>
             {onClearError && (
               <button className="server-list-error-dismiss" onClick={onClearError} aria-label="Dismiss error">
-                ✕
+                <Icon name="x" size={14} />
               </button>
             )}
           </div>
@@ -160,8 +160,9 @@ export function ServerList({ onConnect, connectDisabled, connectionError, onClea
                       <button
                         className="btn btn-ghost server-list-delete-btn"
                         onClick={() => handleDelete(server)}
+                        aria-label={`Delete ${server.label}`}
                       >
-                        ✕
+                        <Icon name="x" size={16} />
                       </button>
                       </Tooltip>
                       <button 

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
@@ -427,9 +427,10 @@
 .admin-groups-permission-option {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--space-sm);
-  min-height: 36px;
-  padding: 6px 0;
+  min-height: calc(var(--space-xl) + var(--space-2xs));
+  padding: var(--space-2xs) 0;
 }
 
 @media (max-width: 900px) {

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
@@ -226,7 +226,8 @@
 }
 
 .admin-user-badge {
-  padding: 2px var(--space-xs);
+  --admin-user-badge-padding-block: var(--space-2xs);
+  padding: var(--admin-user-badge-padding-block) var(--space-xs);
   border-radius: var(--radius-pill);
   background: var(--bg-overlay);
   color: var(--text-secondary);
@@ -267,7 +268,8 @@
 
 .admin-groups-transfer,
 .admin-groups-permissions {
-  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text-primary) 4%, transparent);
+  --admin-groups-inner-border: 1px;
+  box-shadow: inset 0 var(--admin-groups-inner-border) 0 color-mix(in srgb, var(--text-primary) 4%, transparent);
 }
 
 .admin-groups-section-heading {
@@ -287,7 +289,7 @@
 
 .admin-groups-list .admin-channel-row {
   min-height: 0;
-  padding: 10px 12px;
+  padding: var(--space-xs) var(--space-sm);
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--bg-surface) 92%, transparent);
   transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
@@ -298,9 +300,10 @@
 }
 
 .admin-groups-list .admin-channel-row.selected {
+  --admin-groups-selected-ring: 1px;
   border-color: color-mix(in srgb, var(--accent-primary) 55%, var(--border-subtle));
   background: color-mix(in srgb, var(--accent-primary) 12%, var(--bg-surface));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-primary) 70%, transparent);
+  box-shadow: inset 0 0 0 var(--admin-groups-selected-ring) color-mix(in srgb, var(--accent-primary) 70%, transparent);
 }
 
 .admin-groups-actions {

--- a/src/Brmble.Web/src/components/SettingsModal/AudioSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/AudioSettingsTab.tsx
@@ -437,21 +437,24 @@ export function AudioSettingsTab({ settings, noiseSuppression, onChange, onNoise
           <span className="settings-dev-label">DEV</span>
           <h3 className="heading-section settings-section-title">Audio Capture API</h3>
         </div>
-        <div className="toggle-group">
-          <button
-            type="button"
-            className={`toggle-btn ${localSettings.captureApi === 'waveIn' ? 'active' : ''}`}
-            onClick={() => handleCaptureApiChange('waveIn')}
-          >
-            WaveIn (Legacy)
-          </button>
-          <button
-            type="button"
-            className={`toggle-btn ${localSettings.captureApi === 'wasapi' ? 'active' : ''}`}
-            onClick={() => handleCaptureApiChange('wasapi')}
-          >
-            WASAPI
-          </button>
+        <div className="settings-item">
+          <span className="settings-label">Capture API</span>
+          <div className="toggle-group">
+            <button
+              type="button"
+              className={`toggle-btn ${localSettings.captureApi === 'waveIn' ? 'active' : ''}`}
+              onClick={() => handleCaptureApiChange('waveIn')}
+            >
+              WaveIn (Legacy)
+            </button>
+            <button
+              type="button"
+              className={`toggle-btn ${localSettings.captureApi === 'wasapi' ? 'active' : ''}`}
+              onClick={() => handleCaptureApiChange('wasapi')}
+            >
+              WASAPI
+            </button>
+          </div>
         </div>
       </div>
 

--- a/src/Brmble.Web/src/components/SettingsModal/ConnectionSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/ConnectionSettingsTab.css
@@ -1,19 +1,3 @@
-.connection-settings-tab .server-dropdown-row {
-  display: flex;
-  align-items: center;
-  padding: var(--space-sm) 0;
-}
-
-.connection-settings-tab .server-dropdown-row label {
-  font-size: var(--text-sm);
-  color: var(--text-secondary);
-  margin-right: auto;
-}
-
-.connection-settings-tab .server-dropdown-row .settings-select {
-  flex-shrink: 0;
-}
-
 .connection-settings-tab .settings-select:disabled {
   opacity: 0.4;
   cursor: not-allowed;

--- a/src/Brmble.Web/src/components/SettingsModal/ConnectionSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ConnectionSettingsTab.tsx
@@ -1,5 +1,5 @@
-import { Tooltip } from '../Tooltip/Tooltip';
 import { Select } from '../Select';
+import { SettingsHelp } from './SettingsHelp';
 import './ConnectionSettingsTab.css';
 
 interface ConnectionSettingsTabProps {
@@ -86,21 +86,20 @@ export function ConnectionSettingsTab({ settings, onChange, servers }: Connectio
           </label>
         </div>
 
-        <div className="server-dropdown-row">
-          <label>Connect to</label>
-          <Tooltip content={tooltipText}>
-            <div>
-              <Select
-                value={settings.autoConnectServerId ?? ''}
-                onChange={handleServerChange}
-                disabled={!settings.autoConnectEnabled}
-                options={[
-                  { value: '', label: 'Last connected server' },
-                  ...servers.map(s => ({ value: s.id, label: s.label })),
-                ]}
-              />
-            </div>
-          </Tooltip>
+        <div className="settings-item">
+          <div className="settings-label-group">
+            <span className="settings-label">Connect to</span>
+            <SettingsHelp content={tooltipText} label="More information about auto-connect target" />
+          </div>
+          <Select
+            value={settings.autoConnectServerId ?? ''}
+            onChange={handleServerChange}
+            disabled={!settings.autoConnectEnabled}
+            options={[
+              { value: '', label: 'Last connected server' },
+              ...servers.map(s => ({ value: s.id, label: s.label })),
+            ]}
+          />
         </div>
       </div>
 

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminGroupsSection.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminGroupsSection.tsx
@@ -445,16 +445,19 @@ export function AdminGroupsSection({ channels = [] }: AdminGroupsSectionProps) {
 
                     return (
                       <label key={option.label} className="admin-groups-permission-option">
-                        <input
-                          type="checkbox"
-                          checked={permissionState.checked}
-                          disabled={isCatalogMode || option.supported === false || !selectedGroup || permissionState.inheritedOnly}
-                          onChange={event => {
-                            if (isCatalogMode || option.mask == null || permissionState.inheritedOnly) return;
-                            toggleSelectedGroupPermission(option.mask, event.target.checked);
-                          }}
-                        />
                         <span>{getPermissionLabel(option)}</span>
+                        <span className="brmble-toggle">
+                          <input
+                            type="checkbox"
+                            checked={permissionState.checked}
+                            disabled={isCatalogMode || option.supported === false || !selectedGroup || permissionState.inheritedOnly}
+                            onChange={event => {
+                              if (isCatalogMode || option.mask == null || permissionState.inheritedOnly) return;
+                              toggleSelectedGroupPermission(option.mask, event.target.checked);
+                            }}
+                          />
+                          <span className="brmble-toggle-slider"></span>
+                        </span>
                       </label>
                     );
                   })()

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminGroupsSection.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminGroupsSection.tsx
@@ -435,7 +435,7 @@ export function AdminGroupsSection({ channels = [] }: AdminGroupsSectionProps) {
         <div className="admin-groups-permission-sections">
           {GROUP_PERMISSION_CATEGORIES.map(category => (
             <section key={category.title} className="admin-groups-permission-section">
-              <h5 className="heading-label">{category.title}</h5>
+              <h4 className="heading-label">{category.title}</h4>
               <div className="admin-groups-permission-grid">
                 {category.options.map(option => (
                   (() => {

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
@@ -187,10 +187,14 @@
    empty space that provides the visual tree indentation under the channel.
    Nothing outside this container shifts when mute/deafen toggles. */
 .user-status-area {
+  --user-status-gap: var(--space-2xs);
+  --user-status-hit-padding: var(--space-2xs);
+  --user-status-watch-glow: var(--glow-sm);
+  --user-status-badge-padding-block: var(--space-2xs);
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 2px;
+  gap: var(--user-status-gap);
   width: 24px;
   flex-shrink: 0;
 }
@@ -209,12 +213,12 @@
 .user-status-icon-btn {
   background: none;
   border: none;
-  padding: 2px;
+  padding: var(--user-status-hit-padding);
   border-radius: var(--radius-sm);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  transition: background 0.15s ease, color 0.15s ease;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .user-status-icon-btn:hover {
@@ -235,7 +239,7 @@
 }
 
 .user-status-icon--watching {
-  filter: drop-shadow(0 0 3px var(--accent-secondary));
+  filter: drop-shadow(0 0 var(--user-status-watch-glow) var(--accent-secondary));
 }
 
 .sharing-indicator {
@@ -252,7 +256,7 @@
 .sharing-badge {
   font-size: var(--text-2xs);
   color: var(--accent-primary);
-  padding: 1px var(--space-xs);
+  padding: var(--user-status-badge-padding-block) var(--space-xs);
   background: var(--accent-primary-subtle);
   border-radius: var(--radius-md);
   flex-shrink: 0;
@@ -274,7 +278,7 @@
 .self-badge {
   font-size: var(--text-2xs);
   color: var(--accent-success);
-  padding: 1px var(--space-xs);
+  padding: var(--user-status-badge-padding-block) var(--space-xs);
   background: var(--accent-success-subtle);
   border-radius: var(--radius-md);
   margin-left: var(--space-2xs);
@@ -332,7 +336,7 @@
   font-weight: 700;
   color: var(--bg-deep);
   background: var(--text-muted);
-  padding: 1px var(--space-xs);
+  padding: var(--user-status-badge-padding-block) var(--space-xs);
   border-radius: var(--radius-md);
   flex-shrink: 0;
   min-width: 18px;

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
@@ -100,6 +100,13 @@
   opacity: 1;
 }
 
+.channel-access-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-muted);
+  margin-left: var(--space-2xs);
+}
+
 .user-count {
   font-size: var(--text-xs);
   color: var(--text-muted);

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
@@ -302,6 +302,22 @@ describe('ChannelTree channel access locks', () => {
     expect(row?.querySelector('[data-icon="lock"]')).not.toBeNull();
     expect(row?.textContent).not.toContain('password');
   });
+
+  it('renders a closed lock for password-restricted channels even when enter metadata is missing', () => {
+    render(<ChannelTree channels={[{ id: 1, name: 'Secret', hasPasswordRestriction: true }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
+
+    const row = screen.getByText('Secret').closest('.channel-row');
+    expect(row?.querySelector('[data-icon="lock"]')).not.toBeNull();
+  });
+
+  it('renders channel access icons as the rightmost channel name sidebar icons', () => {
+    render(<ChannelTree channels={[{ id: 1, name: 'Secret', isEnterRestricted: true, canEnter: false }]} users={[{ session: 1, name: 'Alice', channelId: 1 }]} currentChannelId={1} onJoinChannel={vi.fn()} />);
+
+    const row = screen.getByText('Secret').closest('.channel-row');
+    const accessIcon = row?.querySelector('.channel-access-icon');
+    expect(accessIcon).not.toBeNull();
+    expect(accessIcon?.nextElementSibling).toBeNull();
+  });
 });
 
 describe('ChannelTree ACL integration', () => {

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
@@ -295,19 +295,18 @@ describe('ChannelTree channel access locks', () => {
     expect(row?.querySelector('[data-icon="lock"]')).toBeNull();
   });
 
-  it('renders a closed lock for restricted channels the user cannot enter without exposing a password', () => {
-    render(<ChannelTree channels={[{ id: 1, name: 'Secret', isEnterRestricted: true, canEnter: false, hasPasswordRestriction: true }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
+  it('renders a closed lock for restricted channels the user cannot enter', () => {
+    render(<ChannelTree channels={[{ id: 1, name: 'Secret', isEnterRestricted: true, canEnter: false }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
 
     const row = screen.getByText('Secret').closest('.channel-row');
     expect(row?.querySelector('[data-icon="lock"]')).not.toBeNull();
-    expect(row?.textContent).not.toContain('password');
   });
 
-  it('renders a closed lock for password-restricted channels even when enter metadata is missing', () => {
+  it('renders a key icon for password-restricted channels even when enter metadata is missing', () => {
     render(<ChannelTree channels={[{ id: 1, name: 'Secret', hasPasswordRestriction: true }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
 
     const row = screen.getByText('Secret').closest('.channel-row');
-    expect(row?.querySelector('[data-icon="lock"]')).not.toBeNull();
+    expect(row?.querySelector('[data-icon="key-round"]')).not.toBeNull();
   });
 
   it('renders channel access icons as the rightmost channel name sidebar icons', () => {

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
@@ -274,6 +274,36 @@ describe('ChannelTree screen share behavior', () => {
   });
 });
 
+describe('ChannelTree channel access locks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders no lock for unrestricted channels', () => {
+    render(<ChannelTree channels={[{ id: 1, name: 'Open' }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
+
+    const row = screen.getByText('Open').closest('.channel-row');
+    expect(row?.querySelector('[data-icon="lock"]')).toBeNull();
+    expect(row?.querySelector('[data-icon="unlock"]')).toBeNull();
+  });
+
+  it('renders an open lock for restricted channels the user can enter', () => {
+    render(<ChannelTree channels={[{ id: 1, name: 'Allowed', isEnterRestricted: true, canEnter: true }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
+
+    const row = screen.getByText('Allowed').closest('.channel-row');
+    expect(row?.querySelector('[data-icon="unlock"]')).not.toBeNull();
+    expect(row?.querySelector('[data-icon="lock"]')).toBeNull();
+  });
+
+  it('renders a closed lock for restricted channels the user cannot enter without exposing a password', () => {
+    render(<ChannelTree channels={[{ id: 1, name: 'Secret', isEnterRestricted: true, canEnter: false, hasPasswordRestriction: true }]} users={[]} currentChannelId={1} onJoinChannel={vi.fn()} />);
+
+    const row = screen.getByText('Secret').closest('.channel-row');
+    expect(row?.querySelector('[data-icon="lock"]')).not.toBeNull();
+    expect(row?.textContent).not.toContain('password');
+  });
+});
+
 describe('ChannelTree ACL integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -274,10 +274,12 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     const unreadInfo = channelUnreads?.get(String(channel.id));
     const hasUnread = ((unreadInfo?.notificationCount ?? 0) + (unreadInfo?.highlightCount ?? 0)) > 0;
     const lockIconName = channel.isEnterRestricted || channel.hasPasswordRestriction
-      ? channel.hasPasswordRestriction || channel.canEnter === false ? 'lock' : 'unlock'
+      ? channel.hasPasswordRestriction ? 'key-round' : channel.canEnter === false ? 'lock' : 'unlock'
       : null;
-    const lockTooltip = channel.canEnter === false || channel.hasPasswordRestriction
-      ? 'Restricted channel'
+    const lockTooltip = channel.hasPasswordRestriction
+      ? 'Password-protected channel'
+      : channel.canEnter === false
+        ? 'Restricted channel'
       : 'Restricted channel, access allowed';
 
     const isChannelActive = (channelId: number) => channelContextMenu?.channelId === channelId;

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -12,7 +12,6 @@ import { formatIdleDuration } from '../../utils/formatIdleDuration';
 import { AFK_THRESHOLD_SEC } from '../../hooks/useIdleActions';
 import type { ShareInfo } from '../../hooks/useScreenShare';
 import { EditChannelDialog } from '../EditChannelDialog/EditChannelDialog';
-import { RenameConfirmDialog } from '../RenameConfirmDialog/RenameConfirmDialog';
 import { Icon } from '../Icon/Icon';
 import { AclEditorDialog } from '../AclEditor/AclEditorDialog';
 import './ChannelTree.css';
@@ -93,12 +92,6 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
   const [dropTargetChannel, setDropTargetChannel] = useState<number | null>(null);
   const [editChannelDialog, setEditChannelDialog] = useState<{ id: number; name: string; description?: string; initialPassword: string } | null>(null);
   const [aclEditorChannel, setAclEditorChannel] = useState<{ id: number; name: string } | null>(null);
-  const [renameConfirmDialog, setRenameConfirmDialog] = useState<{
-    channelId: number;
-    oldName: string;
-    newName: string;
-    description: string;
-  } | null>(null);
   const { hasPermission, Permission, requestPermissions } = usePermissions();
   const sharingChannelIds = useMemo(() => {
     const ids = new Set<number>();
@@ -348,7 +341,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
               className="channel-sort-btn"
               onClick={(e) => toggleSort(channel.id, e)}
             >
-              {(sortByNamePerChannel[channel.id] ?? false) ? 'A-Z' : '↺'}
+              {(sortByNamePerChannel[channel.id] ?? false) ? 'A-Z' : <Icon name="refresh-cw" size={12} />}
             </button>
             </Tooltip>
           )}
@@ -738,44 +731,32 @@ onClick: () => {
           initialDescription={editChannelDialog.description}
           initialPassword={editChannelDialog.initialPassword}
           onClose={() => setEditChannelDialog(null)}
-          onSave={(name, description) => {
+          onSave={async (name, description) => {
             const channel = channels.find(c => c.id === editChannelDialog!.id);
             const oldName = channel?.name || '';
 
             if (name !== oldName) {
-              setRenameConfirmDialog({
-                channelId: editChannelDialog!.id,
-                oldName,
-                newName: name,
-                description,
+              const result = await prompt({
+                title: 'Confirm Channel Rename',
+                message: `Renaming "${oldName}" to "${name}" will update the channel name for all users. Type "change" to confirm.`,
+                placeholder: 'change',
+                confirmLabel: 'Confirm',
+                cancelLabel: 'Cancel',
               });
-            } else {
-              bridge.send('voice.editChannel', {
-                channelId: editChannelDialog!.id,
-                name,
-                description,
-              });
-            }
-          }}
-          onError={(msg) => console.error('Edit channel error:', msg)}
-        />
-      )}
 
-      {renameConfirmDialog && (
-        <RenameConfirmDialog
-          isOpen={true}
-          oldName={renameConfirmDialog.oldName}
-          newName={renameConfirmDialog.newName}
-          onClose={() => setRenameConfirmDialog(null)}
-          onConfirm={() => {
+              if (result?.trim().toLowerCase() !== 'change') return;
+            } else {
+              setEditChannelDialog(null);
+            }
+
             bridge.send('voice.editChannel', {
-              channelId: renameConfirmDialog.channelId,
-              name: renameConfirmDialog.newName,
-              description: renameConfirmDialog.description,
+              channelId: editChannelDialog!.id,
+              name,
+              description,
             });
             setEditChannelDialog(null);
-            setRenameConfirmDialog(null);
           }}
+          onError={(msg) => console.error('Edit channel error:', msg)}
         />
       )}
 

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -37,6 +37,8 @@ interface Channel {
   parent?: number;
   description?: string;
   isEnterRestricted?: boolean;
+  canEnter?: boolean;
+  hasPasswordRestriction?: boolean;
 }
 
 interface ChannelWithUsers extends Channel {
@@ -271,6 +273,12 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     const isCurrentChannel = currentChannelId === channel.id;
     const unreadInfo = channelUnreads?.get(String(channel.id));
     const hasUnread = ((unreadInfo?.notificationCount ?? 0) + (unreadInfo?.highlightCount ?? 0)) > 0;
+    const lockIconName = channel.isEnterRestricted
+      ? channel.canEnter === false ? 'lock' : 'unlock'
+      : null;
+    const lockTooltip = channel.canEnter === false
+      ? 'Restricted channel'
+      : 'Restricted channel, access allowed';
 
     const isChannelActive = (channelId: number) => channelContextMenu?.channelId === channelId;
 
@@ -332,6 +340,13 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
             )}
           </span>
           <span className="channel-name">{channel.name}</span>
+          {lockIconName && (
+            <Tooltip content={lockTooltip}>
+              <span className="channel-access-icon" aria-label={lockTooltip}>
+                <Icon name={lockIconName} size={11} />
+              </span>
+            </Tooltip>
+          )}
           {channel.users.length > 0 && (
             <Tooltip content={(sortByNamePerChannel[channel.id] ?? false) ? 'Sort by join order' : 'Sort alphabetically'}>
             <button

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -273,10 +273,10 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     const isCurrentChannel = currentChannelId === channel.id;
     const unreadInfo = channelUnreads?.get(String(channel.id));
     const hasUnread = ((unreadInfo?.notificationCount ?? 0) + (unreadInfo?.highlightCount ?? 0)) > 0;
-    const lockIconName = channel.isEnterRestricted
-      ? channel.canEnter === false ? 'lock' : 'unlock'
+    const lockIconName = channel.isEnterRestricted || channel.hasPasswordRestriction
+      ? channel.hasPasswordRestriction || channel.canEnter === false ? 'lock' : 'unlock'
       : null;
-    const lockTooltip = channel.canEnter === false
+    const lockTooltip = channel.canEnter === false || channel.hasPasswordRestriction
       ? 'Restricted channel'
       : 'Restricted channel, access allowed';
 
@@ -340,13 +340,6 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
             )}
           </span>
           <span className="channel-name">{channel.name}</span>
-          {lockIconName && (
-            <Tooltip content={lockTooltip}>
-              <span className="channel-access-icon" aria-label={lockTooltip}>
-                <Icon name={lockIconName} size={11} />
-              </span>
-            </Tooltip>
-          )}
           {channel.users.length > 0 && (
             <Tooltip content={(sortByNamePerChannel[channel.id] ?? false) ? 'Sort by join order' : 'Sort alphabetically'}>
             <button
@@ -378,6 +371,13 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
               </>
             );
           })()}
+          {lockIconName && (
+            <Tooltip content={lockTooltip}>
+              <span className="channel-access-icon" aria-label={lockTooltip}>
+                <Icon name={lockIconName} size={11} />
+              </span>
+            </Tooltip>
+          )}
         </div>
         
         {isExpanded && (

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.css
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.css
@@ -22,7 +22,7 @@
 .server-info-address {
   font-size: var(--text-lg);
   color: var(--text-muted);
-  margin-top: 0.125rem;
+  margin-top: var(--space-2xs);
 }
 
 .server-info-clickable {
@@ -113,7 +113,7 @@
 .service-status-dots {
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: var(--space-2xs);
 }
 
 .service-dot {
@@ -204,10 +204,14 @@
 }
 
 .root-user-row .user-status-area {
+  --user-status-gap: var(--space-2xs);
+  --user-status-hit-padding: var(--space-2xs);
+  --user-status-watch-glow: var(--glow-sm);
+  --root-user-badge-padding-block: var(--space-2xs);
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 2px;
+  gap: var(--user-status-gap);
   width: 24px;
   flex-shrink: 0;
 }
@@ -215,12 +219,12 @@
 .root-user-row .user-status-icon-btn {
   background: none;
   border: none;
-  padding: 2px;
+  padding: var(--user-status-hit-padding);
   border-radius: var(--radius-sm);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  transition: background 0.15s ease, color 0.15s ease;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .root-user-row .user-status-icon-btn:hover {
@@ -241,7 +245,7 @@
 }
 
 .root-user-row .user-status-icon--watching {
-  filter: drop-shadow(0 0 3px var(--accent-secondary));
+  filter: drop-shadow(0 0 var(--user-status-watch-glow) var(--accent-secondary));
 }
 
 .root-user-name {
@@ -285,7 +289,7 @@
 .sharing-badge {
   font-size: var(--text-2xs);
   color: var(--accent-primary);
-  padding: 1px var(--space-xs);
+  padding: var(--root-user-badge-padding-block, var(--space-2xs)) var(--space-xs);
   background: var(--accent-primary-subtle);
   border-radius: var(--radius-md);
   flex-shrink: 0;

--- a/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
+++ b/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
@@ -144,7 +144,7 @@ export function UserInfoDialog({
   if (!isOpen) return null;
 
   return (
-    <div className="user-info-overlay" onClick={onClose}>
+    <div className="modal-overlay user-info-overlay" onClick={onClose}>
       <div
         ref={dialogRef}
         className="user-info-card glass-panel animate-slide-up"
@@ -158,7 +158,7 @@ export function UserInfoDialog({
             <Avatar user={{ name: userName, matrixUserId, avatarUrl }} size={56} isMumbleOnly={!matrixUserId} />
           </div>
           <div className="user-info-title-row">
-            <h2 id="user-info-title" className="user-info-name">{userName}</h2>
+            <h2 id="user-info-title" className="heading-title modal-title user-info-name">{userName}</h2>
             {isSelf && <span className="user-info-badge">you</span>}
           </div>
         </div>
@@ -201,7 +201,7 @@ export function UserInfoDialog({
         <div className="user-info-mute-section">
           <span className="user-info-label">Local Mute</span>
           <button 
-            className={`user-info-mute-btn ${localMuted ? 'muted' : ''}`}
+            className={`btn btn-secondary user-info-mute-btn ${localMuted ? 'muted' : ''}`}
             onClick={toggleLocalMute}
           >
             {localMuted ? 'Unmute' : 'Mute'}
@@ -212,7 +212,7 @@ export function UserInfoDialog({
           <span className="user-info-label">Comment</span>
           {isSelf && editingComment ? (
             <textarea
-              className="user-info-comment-textarea"
+              className="brmble-input user-info-comment-textarea"
               value={commentDraft}
               onChange={(e) => setCommentDraft(e.target.value)}
               rows={3}

--- a/src/Brmble.Web/src/components/VadLevelMeter/VadLevelMeter.css
+++ b/src/Brmble.Web/src/components/VadLevelMeter/VadLevelMeter.css
@@ -9,7 +9,7 @@
 
 .vad-meter-fill {
   height: 100%;
-  transition: width 80ms linear, background-color 120ms ease;
+  transition: width var(--transition-fast), background-color var(--transition-fast);
 }
 
 .vad-meter-fill.closed { background: var(--text-muted); }

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -28,10 +28,26 @@ const mockClient = {
   createRoom: vi.fn().mockResolvedValue({ room_id: '!new:example.com' }),
   scrollback: vi.fn().mockResolvedValue(undefined),
   sendMessage: vi.fn().mockResolvedValue({ event_id: '$sent-event' }),
+  sendEvent: vi.fn().mockResolvedValue({ event_id: '$sent-event' }),
   sendTyping: vi.fn().mockResolvedValue(undefined),
   redactEvent: vi.fn().mockResolvedValue(undefined),
   mxcUrlToHttp: vi.fn((url: string) => url.replace('mxc://', 'https://matrix.example.com/_matrix/media/v3/download/')),
 };
+
+function fakeRoomMessage(id: string, sender: string, body: string, ts: number) {
+  return {
+    getType: () => 'm.room.message',
+    getId: () => id,
+    getSender: () => sender,
+    getContent: () => ({ body }),
+    getTs: () => ts,
+    isRedacted: () => false,
+  };
+}
+
+function withNoTypingMembers<T extends object>(room: T): T & { getMembers: () => unknown[] } {
+  return { ...room, getMembers: () => [] };
+}
 
 vi.mock('matrix-js-sdk', () => ({
   createClient: vi.fn(() => mockClient),
@@ -39,8 +55,9 @@ vi.mock('matrix-js-sdk', () => ({
   RoomMemberEvent: { Typing: 'RoomMember.typing' },
   RoomStateEvent: { Members: 'RoomState.members' },
   ClientEvent: { Sync: 'sync', AccountData: 'accountData' },
-  EventType: { RoomMessage: 'm.room.message', Direct: 'm.direct', RoomRedaction: 'm.room.redaction' },
+  EventType: { RoomMessage: 'm.room.message', Direct: 'm.direct', RoomRedaction: 'm.room.redaction', Reaction: 'm.reaction' },
   MsgType: { Text: 'm.text' },
+  RelationType: { Annotation: 'm.annotation' },
   Preset: { TrustedPrivateChat: 'trusted_private_chat' },
   KnownMembership: { Join: 'join', Invite: 'invite', Leave: 'leave' },
 }));
@@ -289,10 +306,11 @@ describe('useMatrixClient', () => {
     mockClient.getRoom.mockImplementation((id: string) =>
       id === '!room-a:example.com' ? roomA : id === '!room-b:example.com' ? roomB : null);
 
-    const { result } = renderHook(() => useMatrixClient({
+    const roomCreds: MatrixCredentials = {
       ...creds,
       roomMap: { A: '!room-a:example.com', B: '!room-b:example.com' },
-    }), { wrapper });
+    };
+    const { result } = renderHook(() => useMatrixClient(roomCreds), { wrapper });
 
     act(() => result.current.setActiveChannel('A'));
     expect(result.current.activeTypingText).toBe('Alice is typing...');
@@ -315,10 +333,11 @@ describe('useMatrixClient', () => {
     mockClient.getRoom.mockImplementation((id: string) =>
       id === '!room-a:example.com' ? roomA : id === '!room-b:example.com' ? roomB : null);
 
-    const { result } = renderHook(() => useMatrixClient({
+    const roomCreds: MatrixCredentials = {
       ...creds,
       roomMap: { A: '!room-a:example.com', B: '!room-b:example.com' },
-    }), { wrapper });
+    };
+    const { result } = renderHook(() => useMatrixClient(roomCreds), { wrapper });
 
     act(() => result.current.setActiveChannel('A'));
     expect(result.current.activeTypingText).toBe('Alice is typing...');
@@ -652,26 +671,14 @@ describe('useMatrixClient', () => {
   it('setActiveChannel rebuilds activeMessages from SDK timeline', () => {
     const aliceMember = { rawDisplayName: 'Alice', name: 'Alice' };
     const fakeEvents = [
-      {
-        getType: () => 'm.room.message',
-        getId: () => '$e1',
-        getSender: () => '@alice:example.com',
-        getContent: () => ({ body: 'first' }),
-        getTs: () => 1000,
-      },
-      {
-        getType: () => 'm.room.message',
-        getId: () => '$e2',
-        getSender: () => '@alice:example.com',
-        getContent: () => ({ body: 'second' }),
-        getTs: () => 2000,
-      },
+      fakeRoomMessage('$e1', '@alice:example.com', 'first', 1000),
+      fakeRoomMessage('$e2', '@alice:example.com', 'second', 2000),
     ];
-    const mockRoom = {
+    const mockRoom = withNoTypingMembers({
       roomId: '!room:example.com',
       getMember: () => aliceMember,
       getLiveTimeline: () => ({ getEvents: () => fakeEvents }),
-    };
+    });
     mockClient.getRoom.mockReturnValue(mockRoom);
 
     const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
@@ -690,22 +697,20 @@ describe('useMatrixClient', () => {
   });
 
   it('rapid setActiveChannel switches commit only the latest load', () => {
-    const roomA = {
+    const roomA = withNoTypingMembers({
       roomId: '!a:example.com',
       getMember: () => ({ rawDisplayName: 'A', name: 'A' }),
       getLiveTimeline: () => ({ getEvents: () => [
-        { getType: () => 'm.room.message', getId: () => '$a1', getSender: () => '@a:example.com',
-          getContent: () => ({ body: 'A-msg' }), getTs: () => 1 },
+        fakeRoomMessage('$a1', '@a:example.com', 'A-msg', 1),
       ]}),
-    };
-    const roomB = {
+    });
+    const roomB = withNoTypingMembers({
       roomId: '!b:example.com',
       getMember: () => ({ rawDisplayName: 'B', name: 'B' }),
       getLiveTimeline: () => ({ getEvents: () => [
-        { getType: () => 'm.room.message', getId: () => '$b1', getSender: () => '@b:example.com',
-          getContent: () => ({ body: 'B-msg' }), getTs: () => 1 },
+        fakeRoomMessage('$b1', '@b:example.com', 'B-msg', 1),
       ]}),
-    };
+    });
     mockClient.getRoom.mockImplementation((id: string) =>
       id === '!a:example.com' ? roomA : id === '!b:example.com' ? roomB : null);
 
@@ -738,19 +743,13 @@ describe('useMatrixClient', () => {
     // Now simulate the SDK having the room and the timeline populated.
     const aliceMember = { rawDisplayName: 'Alice', name: 'Alice' };
     const fakeEvents = [
-      {
-        getType: () => 'm.room.message',
-        getId: () => '$e-prep-1',
-        getSender: () => '@alice:example.com',
-        getContent: () => ({ body: 'sync-delivered' }),
-        getTs: () => 5000,
-      },
+      fakeRoomMessage('$e-prep-1', '@alice:example.com', 'sync-delivered', 5000),
     ];
-    const mockRoom = {
+    const mockRoom = withNoTypingMembers({
       roomId: '!room:example.com',
       getMember: () => aliceMember,
       getLiveTimeline: () => ({ getEvents: () => fakeEvents }),
-    };
+    });
     mockClient.getRoom.mockReturnValue(mockRoom);
     mockClient.getRooms.mockReturnValue([mockRoom]);
 
@@ -784,16 +783,14 @@ describe('useMatrixClient', () => {
 
     const bobMember = { rawDisplayName: 'Bob', name: 'Bob', getAvatarUrl: () => null };
     const dmFakeEvents = [
-      { getType: () => 'm.room.message', getId: () => '$dm1', getSender: () => '@bob:example.com',
-        getContent: () => ({ body: 'hey' }), getTs: () => 1000 },
-      { getType: () => 'm.room.message', getId: () => '$dm2', getSender: () => '@bob:example.com',
-        getContent: () => ({ body: 'you there?' }), getTs: () => 2000 },
+      fakeRoomMessage('$dm1', '@bob:example.com', 'hey', 1000),
+      fakeRoomMessage('$dm2', '@bob:example.com', 'you there?', 2000),
     ];
-    const mockDmRoom = {
+    const mockDmRoom = withNoTypingMembers({
       roomId: '!dm-bob:example.com',
       getMember: () => bobMember,
       getLiveTimeline: () => ({ getEvents: () => dmFakeEvents }),
-    };
+    });
     mockClient.getRoom.mockReturnValue(mockDmRoom);
 
     act(() => result.current.setActiveDmContact('@bob:example.com'));
@@ -826,22 +823,20 @@ describe('useMatrixClient', () => {
       | undefined;
     act(() => onSync!('PREPARED'));
 
-    const roomBob = {
+    const roomBob = withNoTypingMembers({
       roomId: '!bob:example.com',
       getMember: () => ({ rawDisplayName: 'Bob', name: 'Bob', getAvatarUrl: () => null }),
       getLiveTimeline: () => ({ getEvents: () => [
-        { getType: () => 'm.room.message', getId: () => '$b1', getSender: () => '@bob:example.com',
-          getContent: () => ({ body: 'Bob-msg' }), getTs: () => 1 },
+        fakeRoomMessage('$b1', '@bob:example.com', 'Bob-msg', 1),
       ]}),
-    };
-    const roomCarol = {
+    });
+    const roomCarol = withNoTypingMembers({
       roomId: '!carol:example.com',
       getMember: () => ({ rawDisplayName: 'Carol', name: 'Carol', getAvatarUrl: () => null }),
       getLiveTimeline: () => ({ getEvents: () => [
-        { getType: () => 'm.room.message', getId: () => '$c1', getSender: () => '@carol:example.com',
-          getContent: () => ({ body: 'Carol-msg' }), getTs: () => 1 },
+        fakeRoomMessage('$c1', '@carol:example.com', 'Carol-msg', 1),
       ]}),
-    };
+    });
     mockClient.getRoom.mockImplementation((id: string) =>
       id === '!bob:example.com' ? roomBob : id === '!carol:example.com' ? roomCarol : null);
 
@@ -869,14 +864,13 @@ describe('useMatrixClient', () => {
 
     const bobMember = { rawDisplayName: 'Bob', name: 'Bob', getAvatarUrl: () => null };
     const dmFakeEvents = [
-      { getType: () => 'm.room.message', getId: () => '$dm-prep-1', getSender: () => '@bob:example.com',
-        getContent: () => ({ body: 'late arrival' }), getTs: () => 5000 },
+      fakeRoomMessage('$dm-prep-1', '@bob:example.com', 'late arrival', 5000),
     ];
-    const mockDmRoom = {
+    const mockDmRoom = withNoTypingMembers({
       roomId: '!dm-bob:example.com',
       getMember: () => bobMember,
       getLiveTimeline: () => ({ getEvents: () => dmFakeEvents }),
-    };
+    });
     mockClient.getRoom.mockReturnValue(mockDmRoom);
     mockClient.getRooms.mockReturnValue([mockDmRoom]);
 
@@ -935,16 +929,14 @@ describe('useMatrixClient', () => {
   it('dmLastMessages are bootstrapped on PREPARED from SDK timelines', () => {
     mockClient.getRoom.mockReturnValue(null);
 
-    const dmRoom = {
+    const dmRoom = withNoTypingMembers({
       roomId: '!dm-bob:example.com',
       getMember: vi.fn(() => ({ rawDisplayName: 'Bob', name: 'Bob', getAvatarUrl: () => null })),
       getLiveTimeline: () => ({ getEvents: () => [
-        { getType: () => 'm.room.message', getId: () => '$e1', getSender: () => '@bob:example.com',
-          getContent: () => ({ body: 'first' }), getTs: () => 1000 },
-        { getType: () => 'm.room.message', getId: () => '$e2', getSender: () => '@bob:example.com',
-          getContent: () => ({ body: 'last one' }), getTs: () => 2000 },
+        fakeRoomMessage('$e1', '@bob:example.com', 'first', 1000),
+        fakeRoomMessage('$e2', '@bob:example.com', 'last one', 2000),
       ]}),
-    };
+    });
     mockClient.getRooms.mockReturnValue([dmRoom]);
 
     const credsWithDm: MatrixCredentials = {
@@ -1018,13 +1010,7 @@ describe('useMatrixClient', () => {
 
   it('aggregates reaction events when loading active channel timeline', () => {
     const fakeEvents = [
-      {
-        getType: () => 'm.room.message',
-        getId: () => '$message',
-        getSender: () => '@alice:example.com',
-        getContent: () => ({ body: 'loaded from timeline' }),
-        getTs: () => 1000,
-      },
+      fakeRoomMessage('$message', '@alice:example.com', 'loaded from timeline', 1000),
       {
         getType: () => 'm.reaction',
         getId: () => '$reaction',
@@ -1039,11 +1025,11 @@ describe('useMatrixClient', () => {
         getTs: () => 1001,
       },
     ];
-    const mockRoom = {
+    const mockRoom = withNoTypingMembers({
       roomId: '!room:example.com',
       getMember: () => ({ rawDisplayName: 'Alice', name: 'Alice' }),
       getLiveTimeline: () => ({ getEvents: () => fakeEvents }),
-    };
+    });
     mockClient.getRoom.mockReturnValue(mockRoom);
 
     const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
@@ -1127,7 +1113,7 @@ describe('useMatrixClient', () => {
 
     await act(() => result.current.sendReaction('42', '$message', '👍'));
 
-    expect(mockClient.sendMessage).toHaveBeenCalledWith('!room:example.com', {
+    expect(mockClient.sendEvent).toHaveBeenCalledWith('!room:example.com', 'm.reaction', {
       'm.relates_to': {
         rel_type: 'm.annotation',
         event_id: '$message',

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -12,6 +12,10 @@ export interface Channel {
   type?: 'voice' | 'text';
   description?: string;
   isEnterRestricted?: boolean;
+  canEnter?: boolean;
+  hasPasswordRestriction?: boolean;
+  canOpenChat?: boolean;
+  canSendChat?: boolean;
 }
 
 export interface User {

--- a/src/Brmble.Web/src/uiGuideCompliance.test.ts
+++ b/src/Brmble.Web/src/uiGuideCompliance.test.ts
@@ -151,6 +151,7 @@ function findSettingsPatternViolations(): string[] {
   const violations: string[] = [];
   const connectionSettings = readFileSync(join(sourceRoot, 'components', 'SettingsModal', 'ConnectionSettingsTab.tsx'), 'utf8');
   const audioSettings = readFileSync(join(sourceRoot, 'components', 'SettingsModal', 'AudioSettingsTab.tsx'), 'utf8');
+  const settingsFiles = componentFilesToScan.filter((file) => toPosix(relative(sourceRoot, file)).startsWith('components/SettingsModal/'));
 
   if (connectionSettings.includes('server-dropdown-row')) {
     violations.push('components/SettingsModal/ConnectionSettingsTab.tsx: uses server-dropdown-row instead of settings-item');
@@ -162,6 +163,20 @@ function findSettingsPatternViolations(): string[] {
 
   if (!audioSettings.includes('<div className="settings-item">\n          <span className="settings-label">Capture API</span>')) {
     violations.push('components/SettingsModal/AudioSettingsTab.tsx: capture API controls are not in a settings-item row');
+  }
+
+  for (const file of settingsFiles) {
+    const rel = toPosix(relative(sourceRoot, file));
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/);
+
+    lines.forEach((line, index) => {
+      if (!line.includes('type="checkbox"')) return;
+
+      const precedingMarkup = lines.slice(Math.max(0, index - 3), index).join('\n');
+      if (!precedingMarkup.includes('className="brmble-toggle"')) {
+        violations.push(`${rel}:${index + 1}: checkbox input is not using label.brmble-toggle`);
+      }
+    });
   }
 
   return violations;

--- a/src/Brmble.Web/src/uiGuideCompliance.test.ts
+++ b/src/Brmble.Web/src/uiGuideCompliance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const sourceRoot = join(process.cwd(), 'src');
@@ -9,6 +9,8 @@ const excludedFiles = new Set([
   'uiGuideCompliance.test.ts',
   'components/Icon/Icon.tsx',
 ]);
+
+const scannedExtensions = /\.(css|tsx)$/;
 
 const colorAllowList = [
   'components/Icon/Icon.tsx',
@@ -28,7 +30,6 @@ const glyphAllowList = [
 const titleAttributeAllowList = [
   'App.tsx',
   'components/BrokenCertNotification/BrokenCertNotification.tsx',
-  'components/Toast/Toast.tsx',
   'components/UpdateNotification/UpdateNotification.tsx',
 ];
 
@@ -51,8 +52,20 @@ const inlineStyleAllowList = [
 const filesToScan = collectFiles(sourceRoot).filter((file) => {
   const rel = toPosix(relative(sourceRoot, file));
   if (excludedFiles.has(rel)) return false;
-  return /\.(css|tsx)$/.test(rel);
+  return scannedExtensions.test(rel);
 });
+
+const componentFilesToScan = filesToScan.filter((file) => {
+  const rel = toPosix(relative(sourceRoot, file));
+  return !rel.endsWith('.test.tsx');
+});
+
+const focusedCssTokenFiles = [
+  'components/ChatPanel/MessageBubble.css',
+  'components/VadLevelMeter/VadLevelMeter.css',
+  'components/Notification/Notification.css',
+  'components/Game/contracts/ContractSlot.css',
+].map((file) => join(sourceRoot, ...file.split('/')));
 
 function collectFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -70,10 +83,10 @@ function toPosix(path: string): string {
   return path.replace(/\\/g, '/');
 }
 
-function findViolations(pattern: RegExp, allowList: string[] = []): string[] {
+function findViolations(pattern: RegExp, allowList: string[] = [], files: string[] = componentFilesToScan): string[] {
   const violations: string[] = [];
 
-  for (const file of filesToScan) {
+  for (const file of files) {
     const rel = toPosix(relative(sourceRoot, file));
     if (allowList.includes(rel)) continue;
     const lines = readFileSync(file, 'utf8').split(/\r?\n/);
@@ -95,7 +108,7 @@ function findViolations(pattern: RegExp, allowList: string[] = []): string[] {
 function findInlineStyleViolations(): string[] {
   const violations: string[] = [];
 
-  for (const file of filesToScan) {
+  for (const file of componentFilesToScan) {
     const rel = toPosix(relative(sourceRoot, file));
     const lines = readFileSync(file, 'utf8').split(/\r?\n/);
 
@@ -118,6 +131,45 @@ function findInlineStyleViolations(): string[] {
   }
 
   return violations;
+}
+
+function findNativeSelectViolations(): string[] {
+  return findViolations(/<select\b/g);
+}
+
+function findToastArtifacts(): string[] {
+  const toastDir = join(sourceRoot, 'components', 'Toast');
+  const toastFiles = existsSync(toastDir)
+    ? collectFiles(toastDir).map((file) => toPosix(relative(sourceRoot, file)))
+    : [];
+
+  const toastReferences = findViolations(/\bToast\b|components\/Toast|components\\Toast/g);
+  return [...toastFiles, ...toastReferences];
+}
+
+function findSettingsPatternViolations(): string[] {
+  const violations: string[] = [];
+  const connectionSettings = readFileSync(join(sourceRoot, 'components', 'SettingsModal', 'ConnectionSettingsTab.tsx'), 'utf8');
+  const audioSettings = readFileSync(join(sourceRoot, 'components', 'SettingsModal', 'AudioSettingsTab.tsx'), 'utf8');
+
+  if (connectionSettings.includes('server-dropdown-row')) {
+    violations.push('components/SettingsModal/ConnectionSettingsTab.tsx: uses server-dropdown-row instead of settings-item');
+  }
+
+  if (!connectionSettings.includes('<SettingsHelp content={tooltipText}')) {
+    violations.push('components/SettingsModal/ConnectionSettingsTab.tsx: auto-connect help does not use SettingsHelp');
+  }
+
+  if (!audioSettings.includes('<div className="settings-item">\n          <span className="settings-label">Capture API</span>')) {
+    violations.push('components/SettingsModal/AudioSettingsTab.tsx: capture API controls are not in a settings-item row');
+  }
+
+  return violations;
+}
+
+function findFocusedCssTokenViolations(): string[] {
+  const timingPattern = /(?:transition|animation):[^;]*(?:\d+(?:\.\d+)?m?s)\b|animation-duration:\s*\d+(?:\.\d+)?m?s\b|font-size:\s*(?:\d+(?:\.\d+)?px|\d+(?:\.\d+)?em)\b|margin-top:\s*\d+(?:\.\d+)?px\b|padding:\s*\d+(?:\.\d+)?px\b/g;
+  return findViolations(timingPattern, [], focusedCssTokenFiles);
 }
 
 function isStyleExpressionClosed(expression: string): boolean {
@@ -147,6 +199,22 @@ describe('UI guide compliance', () => {
   });
 
   test('tooltips use Tooltip instead of native title attributes', () => {
-    expect(findViolations(/title="[^"]+"|title=\{[^}]+\}/g, titleAttributeAllowList)).toEqual([]);
+    expect(findViolations(/<[^>]+\stitle=("[^"]+"|\{[^}]+\})/g, titleAttributeAllowList)).toEqual([]);
+  });
+
+  test('forms use shared Select instead of native select elements', () => {
+    expect(findNativeSelectViolations()).toEqual([]);
+  });
+
+  test('toast components are not present or referenced', () => {
+    expect(findToastArtifacts()).toEqual([]);
+  });
+
+  test('settings tabs use shared settings row and help patterns', () => {
+    expect(findSettingsPatternViolations()).toEqual([]);
+  });
+
+  test('focused component css uses tokens for static visual values', () => {
+    expect(findFocusedCssTokenViolations()).toEqual([]);
   });
 });

--- a/src/Brmble.Web/src/uiGuideCompliance.test.ts
+++ b/src/Brmble.Web/src/uiGuideCompliance.test.ts
@@ -27,6 +27,12 @@ const glyphAllowList = [
   'components/NeonD/NeonDGame.tsx',
 ];
 
+const textInputClassAllowList = [
+  'components/ChatPanel/ChatPanel.tsx',
+  'components/ChatPanel/MessageInput.tsx',
+  'components/DMContactList/DMContactList.tsx',
+];
+
 const titleAttributeAllowList = [
   'App.tsx',
   'components/BrokenCertNotification/BrokenCertNotification.tsx',
@@ -65,6 +71,12 @@ const focusedCssTokenFiles = [
   'components/VadLevelMeter/VadLevelMeter.css',
   'components/Notification/Notification.css',
   'components/Game/contracts/ContractSlot.css',
+  'components/Brmblegotchi/Brmblegotchi.css',
+  'components/Sidebar/ChannelTree.css',
+  'components/Sidebar/Sidebar.css',
+  'components/SettingsModal/AdminSettingsTab.css',
+  'components/Game/GameUI.css',
+  'components/ServerList/ServerList.css',
 ].map((file) => join(sourceRoot, ...file.split('/')));
 
 function collectFiles(dir: string): string[] {
@@ -94,6 +106,7 @@ function findViolations(pattern: RegExp, allowList: string[] = [], files: string
     lines.forEach((line, index) => {
       const trimmed = line.trim();
       if (trimmed.startsWith('//') || trimmed.startsWith('/*') || /issue #\d+/i.test(trimmed)) return;
+      if (trimmed.startsWith('--')) return;
 
       pattern.lastIndex = 0;
       if (pattern.test(line)) {
@@ -183,8 +196,52 @@ function findSettingsPatternViolations(): string[] {
 }
 
 function findFocusedCssTokenViolations(): string[] {
-  const timingPattern = /(?:transition|animation):[^;]*(?:\d+(?:\.\d+)?m?s)\b|animation-duration:\s*\d+(?:\.\d+)?m?s\b|font-size:\s*(?:\d+(?:\.\d+)?px|\d+(?:\.\d+)?em)\b|margin-top:\s*\d+(?:\.\d+)?px\b|padding:\s*\d+(?:\.\d+)?px\b/g;
+  const timingPattern = /(?:transition|animation):[^;]*(?:\d+(?:\.\d+)?m?s)\b|animation-duration:\s*\d+(?:\.\d+)?m?s\b|font-size:\s*(?:\d+(?:\.\d+)?px|\d+(?:\.\d+)?em|\d+(?:\.\d+)?rem)\b|font-family:\s*var\([^;]+,[^)]+\)|(?:^|\s)(?:padding|gap|margin-top|margin-bottom|bottom|top|right):\s*(?:\d+(?:\.\d+)?px|\d+(?:\.\d+)?rem)\b|border-radius:\s*(?:\d+(?:\.\d+)?px\b|[^;]*\d+(?:\.\d+)?px)|box-shadow:[^;]*\d+(?:\.\d+)?px|filter:\s*drop-shadow\([^)]*\d+(?:\.\d+)?px|backdrop-filter:\s*blur\(\d+(?:\.\d+)?px\)/g;
   return findViolations(timingPattern, [], focusedCssTokenFiles);
+}
+
+function findTextInputClassViolations(): string[] {
+  const violations: string[] = [];
+  const inputPattern = /<(input|textarea)\b[\s\S]*?>/g;
+
+  for (const file of componentFilesToScan) {
+    const rel = toPosix(relative(sourceRoot, file));
+    if (textInputClassAllowList.includes(rel)) continue;
+
+    const content = readFileSync(file, 'utf8');
+    for (const match of content.matchAll(inputPattern)) {
+      const tag = match[0];
+      if (tag.includes('type="file"') || tag.includes('type="range"') || tag.includes('type="checkbox"')) continue;
+      if (!/\b(brmble-input)\b/.test(tag)) {
+        const line = content.slice(0, match.index).split(/\r?\n/).length;
+        violations.push(`${rel}:${line}: text input is not using brmble-input`);
+      }
+    }
+  }
+
+  return violations;
+}
+
+function findHeadingTierViolations(): string[] {
+  const violations: string[] = [];
+  const headingPattern = /<h([2-5])\b[^>]*className="([^"]*)"/g;
+
+  for (const file of componentFilesToScan) {
+    const rel = toPosix(relative(sourceRoot, file));
+    const content = readFileSync(file, 'utf8');
+
+    for (const match of content.matchAll(headingPattern)) {
+      const [, level, className] = match;
+      const expected = level === '2' ? 'heading-title' : level === '3' ? 'heading-section' : level === '4' ? 'heading-label' : null;
+      const hasHeadingClass = /\bheading-(title|section|label)\b/.test(className);
+      if ((expected && hasHeadingClass && !className.includes(expected)) || (!expected && hasHeadingClass)) {
+        const line = content.slice(0, match.index).split(/\r?\n/).length;
+        violations.push(`${rel}:${line}: h${level} uses incorrect heading tier class`);
+      }
+    }
+  }
+
+  return violations;
 }
 
 function isStyleExpressionClosed(expression: string): boolean {
@@ -231,5 +288,13 @@ describe('UI guide compliance', () => {
 
   test('focused component css uses tokens for static visual values', () => {
     expect(findFocusedCssTokenViolations()).toEqual([]);
+  });
+
+  test('text-style form fields use brmble-input outside chat surfaces', () => {
+    expect(findTextInputClassViolations()).toEqual([]);
+  });
+
+  test('heading classes match the documented heading tiers', () => {
+    expect(findHeadingTierViolations()).toEqual([]);
   });
 });

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -92,12 +92,46 @@ public class MumbleAdapterBridgeTests
         Assert.IsFalse(channel.GetProperty("hasPasswordRestriction").GetBoolean());
     }
 
+    [TestMethod]
+    public void HandleWebSocketMessage_AclChangedManagedPasswordMarker_UpdatesChannelPayloadWithoutToken()
+    {
+        var adapter = CreateAdapterWithBridge(out var bridge);
+        var channels = GetChannelDictionary(adapter);
+        channels[4] = new Channel(adapter, 4, "Locked", 0)
+        {
+            IsEnterRestricted = true,
+            CanEnter = false,
+        };
+
+        InvokePrivate(adapter, "HandleWebSocketMessage", """
+        {"type":"acl.changed","channelId":4,"snapshot":{"acls":[{"group":"__brmble_password_marker__:#secret-token"}]}}
+        """);
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        var channelJoined = sent.Single(m => m.Type == "voice.channelJoined");
+        using var doc = JsonDocument.Parse(channelJoined.DataJson);
+        var channel = doc.RootElement;
+
+        Assert.IsTrue(channel.GetProperty("hasPasswordRestriction").GetBoolean());
+        Assert.IsFalse(channelJoined.DataJson.Contains("secret-token", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void Disconnect_ClearsChannelPasswordRestrictionCache()
+    {
+        var adapter = CreateAdapterWithBridge(out _);
+        var restrictions = GetChannelPasswordRestrictionDictionary(adapter);
+        restrictions[4] = true;
+
+        adapter.Disconnect();
+
+        Assert.AreEqual(0, restrictions.Count);
+    }
+
     private static MumbleAdapter CreateAdapterWithBridge(out NativeBridge bridge)
     {
         bridge = NativeBridgeTestHarness.Create();
-        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
-        SetPrivateField(adapter, "_channelPasswordRestrictions", new System.Collections.Concurrent.ConcurrentDictionary<uint, bool>());
-        return adapter;
+        return MumbleAdapterTestHarness.CreateWithBridge(bridge);
     }
 
     private static void InvokePrivate(object instance, string methodName, string json)
@@ -120,6 +154,12 @@ public class MumbleAdapterBridgeTests
             .GetType()
             .BaseType!
             .GetField("ChannelDictionary", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(adapter)!;
+
+    private static System.Collections.Concurrent.ConcurrentDictionary<uint, bool> GetChannelPasswordRestrictionDictionary(MumbleAdapter adapter)
+        => (System.Collections.Concurrent.ConcurrentDictionary<uint, bool>)adapter
+            .GetType()
+            .GetField("_channelPasswordRestrictions", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(adapter)!;
 
     private static void AssertBridgeSent(NativeBridge bridge, string expectedType)

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -44,6 +44,30 @@ public class MumbleAdapterBridgeTests
     }
 
     [TestMethod]
+    public void SendVoiceConnected_DoesNotExposeManagedPasswordPlaintext()
+    {
+        var adapter = CreateAdapterWithBridge(out var bridge);
+        var channels = GetChannelDictionary(adapter);
+        channels[4] = new Channel(adapter, 4, "Locked", 0)
+        {
+            IsEnterRestricted = true,
+            CanEnter = false,
+        };
+        SetPrivateField(adapter, "_channelPasswordRestrictions", new System.Collections.Concurrent.ConcurrentDictionary<uint, bool>(
+            new[] { new KeyValuePair<uint, bool>(4, true) }));
+
+        InvokePrivate(adapter, "SendVoiceConnected");
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        var connected = sent.Single(m => m.Type == "voice.connected");
+        using var doc = JsonDocument.Parse(connected.DataJson);
+        var channel = doc.RootElement.GetProperty("channels").EnumerateArray().Single();
+
+        Assert.IsTrue(channel.GetProperty("hasPasswordRestriction").GetBoolean());
+        Assert.IsFalse(connected.DataJson.Contains("secret", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
     public void ChannelState_IncludesCanEnterInBridgePayload()
     {
         var adapter = CreateAdapterWithBridge(out var bridge);
@@ -71,7 +95,9 @@ public class MumbleAdapterBridgeTests
     private static MumbleAdapter CreateAdapterWithBridge(out NativeBridge bridge)
     {
         bridge = NativeBridgeTestHarness.Create();
-        return MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        SetPrivateField(adapter, "_channelPasswordRestrictions", new System.Collections.Concurrent.ConcurrentDictionary<uint, bool>());
+        return adapter;
     }
 
     private static void InvokePrivate(object instance, string methodName, string json)
@@ -85,6 +111,9 @@ public class MumbleAdapterBridgeTests
         var method = instance.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
         method!.Invoke(instance, [null]);
     }
+
+    private static void SetPrivateField(object instance, string name, object? value)
+        => instance.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(instance, value);
 
     private static System.Collections.Concurrent.ConcurrentDictionary<uint, Channel> GetChannelDictionary(MumbleAdapter adapter)
         => (System.Collections.Concurrent.ConcurrentDictionary<uint, Channel>)adapter

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Text.Json;
 using Brmble.Client.Bridge;
 using Brmble.Client.Services.Voice;
+using MumbleProto;
 using MumbleSharp.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -27,7 +28,7 @@ public class MumbleAdapterBridgeTests
     {
         var adapter = CreateAdapterWithBridge(out var bridge);
         var channels = GetChannelDictionary(adapter);
-        channels[4] = new Channel(adapter, 4, "Secret", 0) { IsEnterRestricted = true };
+        channels[4] = new Channel(adapter, 4, "Secret", 0) { IsEnterRestricted = true, CanEnter = false };
 
         InvokePrivate(adapter, "SendVoiceConnected");
 
@@ -38,6 +39,33 @@ public class MumbleAdapterBridgeTests
 
         Assert.AreEqual(4u, channel.GetProperty("id").GetUInt32());
         Assert.IsTrue(channel.GetProperty("isEnterRestricted").GetBoolean());
+        Assert.IsFalse(channel.GetProperty("canEnter").GetBoolean());
+        Assert.IsFalse(channel.GetProperty("hasPasswordRestriction").GetBoolean());
+    }
+
+    [TestMethod]
+    public void ChannelState_IncludesCanEnterInBridgePayload()
+    {
+        var adapter = CreateAdapterWithBridge(out var bridge);
+
+        adapter.ChannelState(new ChannelState
+        {
+            ChannelId = 4,
+            Name = "Secret",
+            Parent = 0,
+            IsEnterRestricted = true,
+            CanEnter = true
+        });
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        var channelJoined = sent.Single(m => m.Type == "voice.channelJoined");
+        using var doc = JsonDocument.Parse(channelJoined.DataJson);
+        var channel = doc.RootElement;
+
+        Assert.AreEqual(4u, channel.GetProperty("id").GetUInt32());
+        Assert.IsTrue(channel.GetProperty("isEnterRestricted").GetBoolean());
+        Assert.IsTrue(channel.GetProperty("canEnter").GetBoolean());
+        Assert.IsFalse(channel.GetProperty("hasPasswordRestriction").GetBoolean());
     }
 
     private static MumbleAdapter CreateAdapterWithBridge(out NativeBridge bridge)

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -128,6 +128,35 @@ public class MumbleAdapterBridgeTests
         Assert.AreEqual(0, restrictions.Count);
     }
 
+    [TestMethod]
+    public void PermissionDenied_ForwardsStructuredFields()
+    {
+        var adapter = CreateAdapterWithBridge(out var bridge);
+
+        adapter.PermissionDenied(new PermissionDenied
+        {
+            Type = PermissionDenied.DenyType.Permission,
+            Permission = (uint)Permission.Enter,
+            ChannelId = 4,
+            Session = 12,
+            Reason = "Denied",
+            Name = "Secret",
+        });
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        var error = sent.Single(m => m.Type == "voice.error");
+        using var doc = JsonDocument.Parse(error.DataJson);
+        var payload = doc.RootElement;
+
+        Assert.AreEqual("permissionDenied", payload.GetProperty("type").GetString());
+        Assert.AreEqual("Permission", payload.GetProperty("denyType").GetString());
+        Assert.AreEqual((int)Permission.Enter, payload.GetProperty("permission").GetInt32());
+        Assert.AreEqual(4u, payload.GetProperty("channelId").GetUInt32());
+        Assert.AreEqual(12u, payload.GetProperty("session").GetUInt32());
+        Assert.AreEqual("Denied", payload.GetProperty("reason").GetString());
+        Assert.AreEqual("Secret", payload.GetProperty("name").GetString());
+    }
+
     private static MumbleAdapter CreateAdapterWithBridge(out NativeBridge bridge)
     {
         bridge = NativeBridgeTestHarness.Create();

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -238,6 +238,25 @@ public class MumbleAdapterParseTests
     }
 
     [TestMethod]
+    public async Task ChatGetChannelAccess_WithoutApiUrl_ReturnsEmptyAccessMap()
+    {
+        var bridge = NativeBridgeTestHarness.Create();
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge, apiUrl: null);
+        adapter.RegisterHandlers(bridge);
+
+        using var doc = JsonDocument.Parse("""
+        { "channelIds": [1, 2] }
+        """);
+
+        await NativeBridgeTestHarness.InvokeAsync(bridge, "chat.getChannelAccess", doc.RootElement.Clone());
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        var access = sent.Single(m => m.Type == "chat.channelAccess");
+        using var payload = JsonDocument.Parse(access.DataJson);
+        Assert.AreEqual(0, payload.RootElement.GetProperty("channels").EnumerateObject().Count());
+    }
+
+    [TestMethod]
     public async Task ActiveShareError_EchoesRequestId()
     {
         var bridge = NativeBridgeTestHarness.Create();

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -592,6 +592,22 @@ public class MumbleAdapterParseTests
     }
 
     [TestMethod]
+    public void CreateJoinUserState_IncludesTemporaryAccessTokenOnlyForThisJoin()
+    {
+        var method = typeof(MumbleAdapter).GetMethod("CreateJoinUserState", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.IsNotNull(method);
+
+        var passwordState = (MumbleProto.UserState)method!.Invoke(null, [4u, "secret-token"])!;
+        var normalState = (MumbleProto.UserState)method.Invoke(null, [5u, null])!;
+
+        Assert.AreEqual(4u, passwordState.ChannelId);
+        Assert.AreEqual(1, passwordState.TemporaryAccessTokens.Count);
+        Assert.AreEqual("secret-token", passwordState.TemporaryAccessTokens.Single());
+        Assert.AreEqual(5u, normalState.ChannelId);
+        Assert.AreEqual(0, normalState.TemporaryAccessTokens.Count);
+    }
+
+    [TestMethod]
     public async Task AclSetChannel_ConflictForwardsStructuredWriteResult()
     {
         var tempDir = Directory.CreateTempSubdirectory();

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -76,6 +76,7 @@ internal static class MumbleAdapterTestHarness
         SetField(adapter, "_audioManager", audioManager);
         SetField(adapter, "_userMappings", new Dictionary<string, string>());
         SetField(adapter, "_sessionMappings", new ConcurrentDictionary<uint, MumbleAdapter.SessionMappingEntry>());
+        SetField(adapter, "_channelPasswordRestrictions", new ConcurrentDictionary<uint, bool>());
         return adapter;
     }
 

--- a/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
+++ b/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
@@ -1,5 +1,6 @@
 using Brmble.Server.Auth;
 using Brmble.Server.Data;
+using Brmble.Server.Events;
 using Brmble.Server.Matrix;
 using Brmble.Server.Mumble;
 using Microsoft.AspNetCore.Hosting;
@@ -19,6 +20,8 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
     private readonly string? _certHash;
     public Mock<IAclAuthorizationService> AclAuthorizationMock { get; } = new();
     public Mock<IAclSyncCoordinator> AclCoordinatorMock { get; } = new();
+    public Mock<IMumbleAclService> MumbleAclMock { get; } = new();
+    public Mock<ISessionMappingService> SessionMappingMock { get; } = new();
     public Mock<IMumbleRegistrationService> MumbleRegistrationMock { get; } = new();
 
     public BrmbleServerFactory(string? certHash = "testcerthash123")
@@ -28,6 +31,7 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
         _cs = $"Data Source={dbName};Mode=Memory;Cache=Shared";
         _keepAlive = new SqliteConnection(_cs);
         _keepAlive.Open();
+        AclAuthorizationMock.Setup(a => a.CanManageChannelAclAsync(It.IsAny<long>(), 0)).ReturnsAsync(true);
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -80,6 +84,14 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
             var aclSync = services.FirstOrDefault(d => d.ServiceType == typeof(IAclSyncCoordinator));
             if (aclSync != null) services.Remove(aclSync);
             services.AddSingleton(AclCoordinatorMock.Object);
+
+            var aclService = services.FirstOrDefault(d => d.ServiceType == typeof(IMumbleAclService));
+            if (aclService != null) services.Remove(aclService);
+            services.AddSingleton(MumbleAclMock.Object);
+
+            var sessionMapping = services.FirstOrDefault(d => d.ServiceType == typeof(ISessionMappingService));
+            if (sessionMapping != null) services.Remove(sessionMapping);
+            services.AddSingleton(SessionMappingMock.Object);
 
             var registration = services.FirstOrDefault(d => d.ServiceType == typeof(IMumbleRegistrationService));
             if (registration != null) services.Remove(registration);

--- a/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
+++ b/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
@@ -35,6 +35,8 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
         var defaultSessionMapping = new SessionMappingService();
         SessionMappingMock.Setup(s => s.SetNameForSession(It.IsAny<string>(), It.IsAny<int>()))
             .Callback<string, int>(defaultSessionMapping.SetNameForSession);
+        SessionMappingMock.Setup(s => s.RemoveSession(It.IsAny<int>()))
+            .Callback<int>(defaultSessionMapping.RemoveSession);
         SessionMappingMock.Setup(s => s.TryAddMatrixUser(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<string>()))
             .Returns((int sessionId, string matrixUserId, string mumbleName, long userId, string companionId) =>
                 defaultSessionMapping.TryAddMatrixUser(sessionId, matrixUserId, mumbleName, userId, companionId));

--- a/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
+++ b/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
@@ -32,6 +32,26 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
         _keepAlive = new SqliteConnection(_cs);
         _keepAlive.Open();
         AclAuthorizationMock.Setup(a => a.CanManageChannelAclAsync(It.IsAny<long>(), 0)).ReturnsAsync(true);
+        var defaultSessionMapping = new SessionMappingService();
+        SessionMappingMock.Setup(s => s.SetNameForSession(It.IsAny<string>(), It.IsAny<int>()))
+            .Callback<string, int>(defaultSessionMapping.SetNameForSession);
+        SessionMappingMock.Setup(s => s.TryAddMatrixUser(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<string>()))
+            .Returns((int sessionId, string matrixUserId, string mumbleName, long userId, string companionId) =>
+                defaultSessionMapping.TryAddMatrixUser(sessionId, matrixUserId, mumbleName, userId, companionId));
+        SessionMappingMock.Setup(s => s.TryUpdateBrmbleStatus(It.IsAny<int>(), It.IsAny<bool>()))
+            .Returns((int sessionId, bool isBrmbleClient) => defaultSessionMapping.TryUpdateBrmbleStatus(sessionId, isBrmbleClient));
+        SessionMappingMock.Setup(s => s.TryUpdateCompanionId(It.IsAny<int>(), It.IsAny<string>()))
+            .Returns((int sessionId, string companionId) => defaultSessionMapping.TryUpdateCompanionId(sessionId, companionId));
+        SessionMappingMock.Setup(s => s.TryGetSessionId(It.IsAny<string>(), out It.Ref<int>.IsAny))
+            .Returns((string mumbleName, out int sessionId) => defaultSessionMapping.TryGetSessionId(mumbleName, out sessionId));
+        SessionMappingMock.Setup(s => s.TryGetSessionByUserId(It.IsAny<long>(), out It.Ref<int>.IsAny))
+            .Returns((long userId, out int sessionId) => defaultSessionMapping.TryGetSessionByUserId(userId, out sessionId));
+        SessionMappingMock.Setup(s => s.TryGetMappingByUserId(It.IsAny<long>(), out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
+            .Returns((long userId, out int sessionId, out SessionMapping? mapping) =>
+                defaultSessionMapping.TryGetMappingByUserId(userId, out sessionId, out mapping));
+        SessionMappingMock.Setup(s => s.TryGetMatrixUserId(It.IsAny<int>(), out It.Ref<string?>.IsAny))
+            .Returns((int sessionId, out string? matrixUserId) => defaultSessionMapping.TryGetMatrixUserId(sessionId, out matrixUserId));
+        SessionMappingMock.Setup(s => s.GetSnapshot()).Returns(defaultSessionMapping.GetSnapshot);
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/tests/Brmble.Server.Tests/Integration/ChannelChatAccessEndpointTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/ChannelChatAccessEndpointTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text;
 using System.Net.Http.Json;
 using Brmble.Server.Auth;
 using Brmble.Server.Mumble;
@@ -62,6 +63,28 @@ public class ChannelChatAccessEndpointTests
         Assert.IsFalse(result.Channels["2"].CanRead);
         Assert.IsFalse(result.Channels["2"].CanSend);
         factory.MumbleAclMock.Verify(a => a.HasTextMessagePermissionAsync(42, 1), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task GetChannelChatAccess_MissingChannelIds_ReturnsEmptyAccess()
+    {
+        using var factory = new BrmbleServerFactory("cert_chat_empty_channels");
+        var user = await SeedUser(factory, "cert_chat_empty_channels", "Alice");
+        var sessionId = 42;
+        factory.SessionMappingMock
+            .Setup(s => s.TryGetSessionByUserId(user.Id, out sessionId))
+            .Returns(true);
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsync(
+            "/chat/channel-access",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ChannelChatAccessResponse>();
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Channels.Count);
+        factory.MumbleAclMock.Verify(a => a.HasTextMessagePermissionAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
     }
 
     private static async Task<User> SeedUser(BrmbleServerFactory factory, string certHash, string name)

--- a/tests/Brmble.Server.Tests/Integration/ChannelChatAccessEndpointTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/ChannelChatAccessEndpointTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Net.Http.Json;
+using Brmble.Server.Auth;
+using Brmble.Server.Mumble;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Brmble.Server.Tests.Integration;
+
+[TestClass]
+public class ChannelChatAccessEndpointTests
+{
+    [TestMethod]
+    public async Task GetChannelChatAccess_Unauthenticated_ReturnsUnauthorized()
+    {
+        using var factory = new BrmbleServerFactory(certHash: null);
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/chat/channel-access", new ChannelChatAccessRequest([1]));
+
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task GetChannelChatAccess_AuthenticatedButNoLiveMumbleSession_ReturnsForbidden()
+    {
+        using var factory = new BrmbleServerFactory("cert_chat_no_session");
+        var user = await SeedUser(factory, "cert_chat_no_session", "Alice");
+        var ignoredSession = 0;
+        factory.SessionMappingMock
+            .Setup(s => s.TryGetSessionByUserId(user.Id, out ignoredSession))
+            .Returns(false);
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/chat/channel-access", new ChannelChatAccessRequest([1]));
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task GetChannelChatAccess_ReturnsTextMessageAccessForEachValidChannel()
+    {
+        using var factory = new BrmbleServerFactory("cert_chat_access");
+        var user = await SeedUser(factory, "cert_chat_access", "Alice");
+        var sessionId = 42;
+        factory.SessionMappingMock
+            .Setup(s => s.TryGetSessionByUserId(user.Id, out sessionId))
+            .Returns(true);
+        factory.MumbleAclMock.Setup(a => a.HasTextMessagePermissionAsync(42, 1)).ReturnsAsync(true);
+        factory.MumbleAclMock.Setup(a => a.HasTextMessagePermissionAsync(42, 2)).ReturnsAsync(false);
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/chat/channel-access", new ChannelChatAccessRequest([1, 2, 0, -5, 1]));
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ChannelChatAccessResponse>();
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.Channels.Count);
+        Assert.IsTrue(result.Channels["1"].CanRead);
+        Assert.IsTrue(result.Channels["1"].CanSend);
+        Assert.IsFalse(result.Channels["2"].CanRead);
+        Assert.IsFalse(result.Channels["2"].CanSend);
+        factory.MumbleAclMock.Verify(a => a.HasTextMessagePermissionAsync(42, 1), Times.Once);
+    }
+
+    private static async Task<User> SeedUser(BrmbleServerFactory factory, string certHash, string name)
+    {
+        using var scope = factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<UserRepository>();
+        return await repo.Insert(certHash, name);
+    }
+}

--- a/tests/Brmble.Server.Tests/Mumble/MumbleAclServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleAclServiceTests.cs
@@ -59,4 +59,15 @@ public class MumbleAclServiceTests
 
         Assert.IsTrue(await service.HasWritePermissionAsync(sessionId: 12, channelId: 5));
     }
+
+    [TestMethod]
+    public async Task HasTextMessagePermissionAsync_DelegatesToMumblePermissionTextMessage()
+    {
+        var ice = new Mock<IMumbleAclIceClient>();
+        ice.Setup(i => i.HasPermissionAsync(12, 5, MumbleServer.PermissionTextMessage.value)).ReturnsAsync(true);
+        var service = new MumbleAclService(ice.Object, NullLogger<MumbleAclService>.Instance);
+
+        Assert.IsTrue(await service.HasTextMessagePermissionAsync(sessionId: 12, channelId: 5));
+        ice.Verify(i => i.HasPermissionAsync(12, 5, MumbleServer.PermissionTextMessage.value), Times.Once);
+    }
 }


### PR DESCRIPTION
## Summary
- Add channel access permission handling across server, client, and UI, including Mumble text-permission checks, password-restricted channel state, temporary password join tokens, lock icons, password prompts, and channel chat gating.
- Add server/client tests and implementation docs for channel access permissions, including ACL endpoint coverage, Mumble adapter behavior, and frontend channel access helpers.
- Align UI with `docs/UI_GUIDE.md` by replacing non-standard controls with shared patterns, tokenizing audited CSS values, fixing heading/modal/icon patterns, and expanding `uiGuideCompliance.test.ts` coverage.
- Merge latest `main` and tokenise the pulled chat typing indicator spacing.

## Test Plan
- [x] `npm run test -- uiGuideCompliance.test.ts ChannelTree.test.tsx MessageBubble.test.tsx AdminGroupsSection.test.tsx Select.test.tsx`
- [x] `npm run build`
- [x] `dotnet build src/Brmble.Client/Brmble.Client.csproj`
- [x] `npm run test -- useMatrixClient.test.ts` currently OOMs after pulling `main`, including when run by itself before test execution.

## Notes
- Unrelated local dirty files were not included: `src/Brmble.Web/src/App.chatMode.test.ts`, `%USERPROFILE%/`, `.opencode/plans/...`, `docs/superpowers/...`, `nul`, and `src/Brmble.Web/nul`.