### PR TITLE
NeonD: Star ratings & offline catch-up

### DIFF
--- a/src/Brmble.Web/src/components/NeonD/NeonD.module.css
+++ b/src/Brmble.Web/src/components/NeonD/NeonD.module.css
@@ -214,6 +214,19 @@
   max-width: 500px;
 }
 
+.offlineSummaryModal {
+  padding: var(--space-xl);
+  max-width: 420px;
+  display: grid;
+  gap: var(--space-md);
+}
+
+.offlineSummaryText {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
 .equipmentOptions {
   display: grid;
   gap: var(--space-xs);

--- a/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
+++ b/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
@@ -80,6 +80,18 @@ function formatMoney(value: number) {
   return `$${Math.round(value).toLocaleString()}`;
 }
 
+function formatAwayDuration(awayMs: number) {
+  const totalMinutes = Math.floor(awayMs / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  return `${minutes}m`;
+}
+
 export function NeonDGame({ onClose }: { onClose?: () => void }) {
   const {
     state,
@@ -95,6 +107,7 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
     buyEquipment,
     toggleDealerProtection,
     payDealerBail,
+    dismissOfflineEarningsSummary,
   } = useGameEngine();
   const [upgradingDealerId, setUpgradingDealerId] = useState<string | null>(null);
 
@@ -494,6 +507,23 @@ export function NeonDGame({ onClose }: { onClose?: () => void }) {
                 </button>
               ))}
             </div>
+          </div>
+        </div>
+      )}
+
+      {state.offlineEarningsSummary && (
+        <div className={styles.equipmentModalOverlay}>
+          <div className={`glass-panel animate-slide-up ${styles.offlineSummaryModal}`}>
+            <h3 className={`heading-section ${styles.columnHeader}`}>Welcome back</h3>
+            <p className={styles.offlineSummaryText}>
+              You've been away for {formatAwayDuration(state.offlineEarningsSummary.awayMs)}.
+            </p>
+            <p className={styles.offlineSummaryText}>
+              In that time, you've earned {formatMoney(state.offlineEarningsSummary.earned)}.
+            </p>
+            <button className={styles.buyButton} onClick={dismissOfflineEarningsSummary}>
+              Accept
+            </button>
           </div>
         </div>
       )}

--- a/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
+++ b/src/Brmble.Web/src/components/NeonD/NeonDGame.tsx
@@ -12,13 +12,13 @@ import styles from './NeonD.module.css';
 
 function StarRating({ rating, label, tooltipText }: { rating: number; label?: string; tooltipText?: string }) {
   const clampedRating = Math.min(5, Math.max(0, Math.round(rating)));
-  const stars = `${clampedRating}/5`;
+  const stars = `${'★'.repeat(clampedRating)}${'☆'.repeat(5 - clampedRating)}`;
   const text = tooltipText || (label ? `${label}: ${clampedRating}/5` : `Rating: ${clampedRating}/5`);
   return (
     <Tooltip content={text}>
       <button 
         tabIndex={0}
-        aria-label={`Rating: ${clampedRating}/5`} 
+        aria-label={`Rating: ${clampedRating} of 5 stars`} 
         className={styles.ratingButton}
       >
         <span className={styles.ratingValue} aria-hidden="true">{stars}</span>

--- a/src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+++ b/src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
@@ -48,6 +48,7 @@ const mockNeonD = vi.hoisted(() => {
     lastRefreshTime: 0,
     lastEarningsPerDealer: { 'dealer-ui': 8.5 },
     lastTickAt: Date.now(),
+    offlineEarningsSummary: null,
     ...overrides,
   });
 
@@ -83,6 +84,7 @@ const mockNeonD = vi.hoisted(() => {
       toggleDealerProtection: vi.fn(),
       payDealerBail: vi.fn(),
       forceArrestDealer: vi.fn(),
+      dismissOfflineEarningsSummary: vi.fn(),
     }),
   };
 });
@@ -229,4 +231,41 @@ it('shows bail and fire actions for arrested dealers', () => {
   expect(screen.getAllByText(/arrested/i).length).toBeGreaterThan(0);
   expect(screen.getByRole('button', { name: /pay bail \(\$900\)/i })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /fire dealer/i })).toBeInTheDocument();
+});
+
+it('shows an offline earnings popup after a long enough break and dismisses it on accept', async () => {
+  const user = userEvent.setup();
+  const dismissOfflineEarningsSummary = vi.fn();
+
+  mockNeonD.useGameEngine = () => ({
+    state: mockNeonD.createState({
+      offlineEarningsSummary: {
+        awayMs: 65 * 60 * 1000,
+        earned: 12345,
+      },
+    }),
+    upgrade: vi.fn(),
+    unlockProduction: vi.fn(),
+    hireDealer: vi.fn(),
+    fireDealer: vi.fn(),
+    refreshPool: vi.fn(),
+    resetGame: vi.fn(),
+    unlockSlot: vi.fn(),
+    setDealerSelling: vi.fn(),
+    startDealerUpgrade: mockNeonD.startDealerUpgradeMock,
+    buyEquipment: mockNeonD.buyEquipmentMock,
+    toggleDealerProtection: vi.fn(),
+    payDealerBail: vi.fn(),
+    forceArrestDealer: vi.fn(),
+    dismissOfflineEarningsSummary,
+  });
+
+  render(<NeonDGame />);
+
+  expect(screen.getByText(/welcome back/i)).toBeInTheDocument();
+  expect(screen.getByText(/you've been away for 1h 5m/i)).toBeInTheDocument();
+  expect(screen.getByText(/you've earned \$12[.,]345/i)).toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: /accept/i }));
+  expect(dismissOfflineEarningsSummary).toHaveBeenCalled();
 });

--- a/src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
+++ b/src/Brmble.Web/src/components/NeonD/__tests__/NeonDGame.test.tsx
@@ -47,6 +47,7 @@ const mockNeonD = vi.hoisted(() => {
     unlockedSlots: 1,
     lastRefreshTime: 0,
     lastEarningsPerDealer: { 'dealer-ui': 8.5 },
+    lastTickAt: Date.now(),
     ...overrides,
   });
 
@@ -102,6 +103,13 @@ it('shows protection state and risk label on an active dealer card', () => {
   expect(screen.getByText(/-15% income/i)).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /pay off cops/i })).toBeInTheDocument();
   expect(screen.getByLabelText(/production and dealer sales are balanced/i)).toBeInTheDocument();
+});
+
+it('renders dealer volume and margin as star ratings instead of fractions', () => {
+  render(<NeonDGame />);
+
+  expect(screen.queryByText('3/5')).not.toBeInTheDocument();
+  expect(screen.getAllByText('★★★☆☆').length).toBeGreaterThan(0);
 });
 
 it('reopens stored dealer upgrade options without rerolling and uses the engine flow', async () => {

--- a/src/Brmble.Web/src/components/NeonD/constants.ts
+++ b/src/Brmble.Web/src/components/NeonD/constants.ts
@@ -385,7 +385,8 @@ export const INITIAL_GAME_STATE: GameState = {
   availableDealers: [],
   unlockedSlots: 1,
   lastRefreshTime: 0,
-  lastEarningsPerDealer: {}
+  lastEarningsPerDealer: {},
+  lastTickAt: Date.now(),
 };
 
 // Star-based dealer stat ranges (rolled once at generation)

--- a/src/Brmble.Web/src/components/NeonD/constants.ts
+++ b/src/Brmble.Web/src/components/NeonD/constants.ts
@@ -387,6 +387,7 @@ export const INITIAL_GAME_STATE: GameState = {
   lastRefreshTime: 0,
   lastEarningsPerDealer: {},
   lastTickAt: Date.now(),
+  offlineEarningsSummary: null,
 };
 
 // Star-based dealer stat ranges (rolled once at generation)

--- a/src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
@@ -592,4 +592,43 @@ describe('useGameEngine', () => {
     expect(dealer?.hasPendingUpgrade).toBe(false);
     expect(dealer?.pendingUpgradeOptions).toEqual([]);
   });
+
+  it('catches up production and earnings after the game was closed for a few seconds', () => {
+    localStorage.setItem('brmble_neon_d_save', JSON.stringify({
+      money: 100,
+      totalEarned: 0,
+      researchSpeed: 1,
+      production: {
+        weed: {
+          id: 'weed',
+          name: 'Weed',
+          stock: 0,
+          rate: 2,
+          yieldPerLevel: 0.2,
+          costMultiplier: 1.12,
+          level: 1,
+          upgradeCost: 16,
+        },
+      },
+      unlockedProduction: ['weed'],
+      activeDealers: [makeDealer({
+        id: 'offline-earner',
+        volume: 1,
+        margin: 1,
+        sideVolume: 0,
+      }), null, null],
+      availableDealers: [],
+      unlockedSlots: 1,
+      lastRefreshTime: 0,
+      lastEarningsPerDealer: {},
+      lastTickAt: Date.now() - 5_000,
+    }));
+
+    const { result } = renderHook(() => useGameEngine());
+
+    expect(result.current.state.money).toBeCloseTo(121, 5);
+    expect(result.current.state.totalEarned).toBeCloseTo(21, 5);
+    expect(result.current.state.production.weed.stock).toBeCloseTo(5, 5);
+    expect(result.current.state.lastEarningsPerDealer['offline-earner']).toBeCloseTo(4.2, 5);
+  });
 });

--- a/src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/__tests__/useGameEngine.test.ts
@@ -622,6 +622,7 @@ describe('useGameEngine', () => {
       lastRefreshTime: 0,
       lastEarningsPerDealer: {},
       lastTickAt: Date.now() - 5_000,
+      offlineEarningsSummary: null,
     }));
 
     const { result } = renderHook(() => useGameEngine());
@@ -630,5 +631,80 @@ describe('useGameEngine', () => {
     expect(result.current.state.totalEarned).toBeCloseTo(21, 5);
     expect(result.current.state.production.weed.stock).toBeCloseTo(5, 5);
     expect(result.current.state.lastEarningsPerDealer['offline-earner']).toBeCloseTo(4.2, 5);
+  });
+
+  it('stores an offline earnings summary after 10 minutes away', () => {
+    localStorage.setItem('brmble_neon_d_save', JSON.stringify({
+      money: 100,
+      totalEarned: 0,
+      researchSpeed: 1,
+      production: {
+        weed: {
+          id: 'weed',
+          name: 'Weed',
+          stock: 0,
+          rate: 2,
+          yieldPerLevel: 0.2,
+          costMultiplier: 1.12,
+          level: 1,
+          upgradeCost: 16,
+        },
+      },
+      unlockedProduction: ['weed'],
+      activeDealers: [makeDealer({
+        id: 'offline-summary',
+        volume: 1,
+        margin: 1,
+        sideVolume: 0,
+      }), null, null],
+      availableDealers: [],
+      unlockedSlots: 1,
+      lastRefreshTime: 0,
+      lastEarningsPerDealer: {},
+      lastTickAt: Date.now() - 10 * 60 * 1000,
+      offlineEarningsSummary: null,
+    }));
+
+    const { result } = renderHook(() => useGameEngine());
+
+    expect(result.current.state.offlineEarningsSummary?.awayMs).toBe(10 * 60 * 1000);
+    expect(result.current.state.offlineEarningsSummary?.earned).toBeCloseTo(2520, 5);
+  });
+
+  it('does not store an offline earnings summary before 10 minutes away', () => {
+    localStorage.setItem('brmble_neon_d_save', JSON.stringify({
+      money: 100,
+      totalEarned: 0,
+      researchSpeed: 1,
+      production: {
+        weed: {
+          id: 'weed',
+          name: 'Weed',
+          stock: 0,
+          rate: 2,
+          yieldPerLevel: 0.2,
+          costMultiplier: 1.12,
+          level: 1,
+          upgradeCost: 16,
+        },
+      },
+      unlockedProduction: ['weed'],
+      activeDealers: [makeDealer({
+        id: 'offline-short',
+        volume: 1,
+        margin: 1,
+        sideVolume: 0,
+      }), null, null],
+      availableDealers: [],
+      unlockedSlots: 1,
+      lastRefreshTime: 0,
+      lastEarningsPerDealer: {},
+      lastTickAt: Date.now() - (9 * 60 * 1000 + 59 * 1000),
+      offlineEarningsSummary: null,
+    }));
+
+    const { result } = renderHook(() => useGameEngine());
+
+    expect(result.current.state.offlineEarningsSummary).toBeNull();
   });
 });

--- a/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
@@ -151,6 +151,109 @@ const normalizeDealerRiskState = (dealer: Dealer): Dealer => ({
   pendingUpgradeOptions: dealer.pendingUpgradeOptions ?? [],
 });
 
+const simulateSingleSecond = (state: GameState, now: number): GameState => {
+  const nextProduction = { ...state.production };
+  const nextEarnings: Record<string, number> = {};
+  let totalEarnedThisTick = 0;
+
+  Object.keys(nextProduction).forEach(key => {
+    if (nextProduction[key].rate > 0) {
+      nextProduction[key] = {
+        ...nextProduction[key],
+        stock: nextProduction[key].stock + nextProduction[key].rate
+      };
+    }
+  });
+
+  state.activeDealers.forEach((dealer) => {
+    if (!dealer) return;
+    if (dealer.isArrested) {
+      nextEarnings[dealer.id] = 0;
+      return;
+    }
+    let dealerGross = 0;
+
+    const effectiveVolume = dealer.volume * (1 + dealer.volumeBonus);
+    const effectiveMargin = dealer.margin * (1 + dealer.marginBonus);
+
+    const primaryProd = nextProduction[dealer.selling];
+    if (primaryProd) {
+      const primarySold = Math.min(primaryProd.stock, effectiveVolume);
+      nextProduction[dealer.selling] = {
+        ...primaryProd,
+        stock: Math.max(0, primaryProd.stock - primarySold)
+      };
+      dealerGross += primarySold * (effectiveMargin * (PRODUCT_TIERS[dealer.selling] || 1));
+    }
+
+    if (dealer.sideVolume > 0) {
+      const bleedAmount = effectiveVolume * dealer.sideVolume;
+      for (const product of state.unlockedProduction) {
+        if (product !== dealer.selling) {
+          const sideProd = nextProduction[product];
+          if (!sideProd) continue;
+          const sold = Math.min(sideProd.stock, bleedAmount);
+          nextProduction[product] = { ...sideProd, stock: Math.max(0, sideProd.stock - sold) };
+          dealerGross += sold * (effectiveMargin * (PRODUCT_TIERS[product] || 1));
+        }
+      }
+    }
+
+    if (dealer.isProtected) {
+      dealerGross *= DEALER_PROTECTION_INCOME_MULTIPLIER;
+    }
+
+    nextEarnings[dealer.id] = dealerGross;
+    totalEarnedThisTick += dealerGross;
+  });
+
+  let nextDealers = state.activeDealers.map(dealer => dealer ? { ...dealer } : null);
+  nextDealers = nextDealers.map(dealer => {
+    if (!dealer || dealer.isArrested || dealer.isProtected) return dealer;
+    if (dealer.nextArrestCheckAt > now) return dealer;
+
+    const risk = getDealerRisk(dealer.selling);
+    const rolledArrest = Math.random() < risk.chance;
+
+    if (rolledArrest) {
+      return {
+        ...dealer,
+        isArrested: true,
+        isProtected: false,
+      };
+    }
+
+    return {
+      ...dealer,
+      nextArrestCheckAt: scheduleNextArrestCheck(now),
+    };
+  });
+
+  return {
+    ...state,
+    money: state.money + totalEarnedThisTick,
+    totalEarned: state.totalEarned + totalEarnedThisTick,
+    production: nextProduction,
+    activeDealers: nextDealers,
+    lastEarningsPerDealer: nextEarnings,
+    lastTickAt: now,
+  };
+};
+
+const advanceGameState = (state: GameState, now: number): GameState => {
+  const lastTickAt = state.lastTickAt ?? now;
+  const elapsedSeconds = Math.floor((now - lastTickAt) / 1000);
+  if (elapsedSeconds <= 0) return state;
+
+  let nextState = state;
+  for (let tickIndex = 0; tickIndex < elapsedSeconds; tickIndex += 1) {
+    const tickTime = lastTickAt + ((tickIndex + 1) * 1000);
+    nextState = simulateSingleSecond(nextState, tickTime);
+  }
+
+  return nextState;
+};
+
 export const useGameEngine = () => {
   const [state, setState, clearStorage] = usePersistedGameState<GameState>('brmble_neon_d_save', () => {
     const initial = INITIAL_GAME_STATE;
@@ -181,7 +284,7 @@ export const useGameEngine = () => {
         dealer.hasPendingUpgrade === undefined ||
         dealer.pendingUpgradeOptions === undefined
       )
-    );
+    ) || state.lastTickAt === undefined;
 
     if (!needsMigration) return;
 
@@ -189,100 +292,17 @@ export const useGameEngine = () => {
       ...prev,
       activeDealers: prev.activeDealers.map(dealer => (dealer ? normalizeDealerRiskState(dealer) : null)),
       availableDealers: prev.availableDealers.map(dealer => normalizeDealerRiskState(dealer)),
+      lastTickAt: prev.lastTickAt ?? Date.now(),
     }));
   }, [state.activeDealers, state.availableDealers, setState]);
 
   const tick = () => {
-    setState(prev => {
-      const nextProduction = { ...prev.production };
-      const nextEarnings: Record<string, number> = {};
-      let totalEarnedThisTick = 0;
-
-      Object.keys(nextProduction).forEach(key => {
-        if (nextProduction[key].rate > 0) {
-          nextProduction[key] = {
-            ...nextProduction[key],
-            stock: nextProduction[key].stock + nextProduction[key].rate
-          };
-        }
-      });
-
-      prev.activeDealers.forEach((dealer) => {
-        if (!dealer) return;
-        if (dealer.isArrested) {
-          nextEarnings[dealer.id] = 0;
-          return;
-        }
-        let dealerGross = 0;
-
-        const effectiveVolume = dealer.volume * (1 + dealer.volumeBonus);
-        const effectiveMargin = dealer.margin * (1 + dealer.marginBonus);
-
-        const primaryProd = nextProduction[dealer.selling];
-        if (primaryProd) {
-          const primarySold = Math.min(primaryProd.stock, effectiveVolume);
-          nextProduction[dealer.selling] = { 
-            ...primaryProd, 
-            stock: Math.max(0, primaryProd.stock - primarySold) 
-          };
-          dealerGross += primarySold * (effectiveMargin * (PRODUCT_TIERS[dealer.selling] || 1));
-        }
-
-        if (dealer.sideVolume > 0) {
-          const bleedAmount = effectiveVolume * dealer.sideVolume;
-          // Side volume only applies to other UNLOCKED products
-          for (const product of prev.unlockedProduction) {
-            if (product !== dealer.selling) {
-              const sideProd = nextProduction[product];
-              if (!sideProd) continue;
-              const sold = Math.min(sideProd.stock, bleedAmount);
-              nextProduction[product] = { ...sideProd, stock: Math.max(0, sideProd.stock - sold) };
-              dealerGross += sold * (effectiveMargin * (PRODUCT_TIERS[product] || 1));
-            }
-          }
-        }
-
-        if (dealer.isProtected) {
-          dealerGross *= DEALER_PROTECTION_INCOME_MULTIPLIER;
-        }
-
-        nextEarnings[dealer.id] = dealerGross;
-        totalEarnedThisTick += dealerGross;
-      });
-
-      const now = Date.now();
-      let nextDealers = prev.activeDealers.map(dealer => dealer ? { ...dealer } : null);
-      nextDealers = nextDealers.map(dealer => {
-        if (!dealer || dealer.isArrested || dealer.isProtected) return dealer;
-        if (dealer.nextArrestCheckAt > now) return dealer;
-
-        const risk = getDealerRisk(dealer.selling);
-        const rolledArrest = Math.random() < risk.chance;
-
-        if (rolledArrest) {
-          return {
-            ...dealer,
-            isArrested: true,
-            isProtected: false,
-          };
-        }
-
-        return {
-          ...dealer,
-          nextArrestCheckAt: scheduleNextArrestCheck(now),
-        };
-      });
-
-      return {
-        ...prev,
-        money: prev.money + totalEarnedThisTick,
-        totalEarned: prev.totalEarned + totalEarnedThisTick,
-        production: nextProduction,
-        activeDealers: nextDealers,
-        lastEarningsPerDealer: nextEarnings
-      };
-    });
+    setState(prev => advanceGameState(prev, Date.now()));
   };
+
+  useEffect(() => {
+    setState(prev => advanceGameState(prev, Date.now()));
+  }, [setState]);
 
   const upgrade = (id: string) => {
     setState(prev => {

--- a/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
+++ b/src/Brmble.Web/src/components/NeonD/hooks/useGameEngine.ts
@@ -5,6 +5,8 @@ import type { GameState, Dealer, DealerUpgrade } from '../types';
 import { INITIAL_GAME_STATE, UNLOCK_COSTS, PRODUCT_TIERS, DEALER_FIRST_NAMES, DEALER_LAST_NAMES, SLOT_UNLOCK_COSTS, VOLUME_RANGES, MARGIN_RANGES, ARREST_CHECK_INTERVAL_MS, DEALER_PROTECTION_INCOME_MULTIPLIER, PRODUCT_ARREST_RISK } from '../constants';
 import { getBailCost } from '../economy';
 
+const OFFLINE_EARNINGS_POPUP_THRESHOLD_MS = 10 * 60 * 1000;
+
 // Roll a random value within a given range
 function rollWithinRange(min: number, max: number): number {
   return min + Math.random() * (max - min);
@@ -245,10 +247,22 @@ const advanceGameState = (state: GameState, now: number): GameState => {
   const elapsedSeconds = Math.floor((now - lastTickAt) / 1000);
   if (elapsedSeconds <= 0) return state;
 
+  const moneyBefore = state.money;
   let nextState = state;
   for (let tickIndex = 0; tickIndex < elapsedSeconds; tickIndex += 1) {
     const tickTime = lastTickAt + ((tickIndex + 1) * 1000);
     nextState = simulateSingleSecond(nextState, tickTime);
+  }
+
+  const awayMs = now - lastTickAt;
+  if (awayMs >= OFFLINE_EARNINGS_POPUP_THRESHOLD_MS) {
+    nextState = {
+      ...nextState,
+      offlineEarningsSummary: {
+        awayMs,
+        earned: nextState.money - moneyBefore,
+      },
+    };
   }
 
   return nextState;
@@ -293,6 +307,7 @@ export const useGameEngine = () => {
       activeDealers: prev.activeDealers.map(dealer => (dealer ? normalizeDealerRiskState(dealer) : null)),
       availableDealers: prev.availableDealers.map(dealer => normalizeDealerRiskState(dealer)),
       lastTickAt: prev.lastTickAt ?? Date.now(),
+      offlineEarningsSummary: prev.offlineEarningsSummary ?? null,
     }));
   }, [state.activeDealers, state.availableDealers, setState]);
 
@@ -515,6 +530,13 @@ export const useGameEngine = () => {
     });
   };
 
+  const dismissOfflineEarningsSummary = () => {
+    setState(prev => ({
+      ...prev,
+      offlineEarningsSummary: null,
+    }));
+  };
+
   const resetGame = useCallback(() => {
     clearStorage();
     setState({
@@ -544,5 +566,6 @@ export const useGameEngine = () => {
     toggleDealerProtection,
     forceArrestDealer,
     payDealerBail,
+    dismissOfflineEarningsSummary,
   };
 };

--- a/src/Brmble.Web/src/components/NeonD/types.ts
+++ b/src/Brmble.Web/src/components/NeonD/types.ts
@@ -43,6 +43,11 @@ export interface Dealer {
   pendingUpgradeOptions: DealerUpgrade[];
 }
 
+export interface OfflineEarningsSummary {
+  awayMs: number;
+  earned: number;
+}
+
 export interface GameState {
   money: number;
   totalEarned: number;
@@ -55,4 +60,5 @@ export interface GameState {
   lastRefreshTime: number;
   lastEarningsPerDealer: Record<string, number>;
   lastTickAt: number;
+  offlineEarningsSummary: OfflineEarningsSummary | null;
 }

--- a/src/Brmble.Web/src/components/NeonD/types.ts
+++ b/src/Brmble.Web/src/components/NeonD/types.ts
@@ -54,4 +54,5 @@ export interface GameState {
   unlockedSlots: number;
   lastRefreshTime: number;
   lastEarningsPerDealer: Record<string, number>;
+  lastTickAt: number;
 }


### PR DESCRIPTION
Display dealer volume and margin stats as star ratings instead of fractions (★★★☆☆), and add offline catch-up to simulate missed game ticks when app was closed.