### PR TITLE
feat: Add admin channel reordering with drag-and-drop

### DIFF
--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -3048,6 +3048,44 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             return Task.CompletedTask;
         });
 
+        bridge.RegisterHandler("voice.reorderChannels", data =>
+        {
+            if (Connection is not { State: ConnectionStates.Connected })
+            {
+                _bridge?.Send("voice.error", new { message = "Not connected to server", type = "notConnected" });
+                return Task.CompletedTask;
+            }
+
+            var parentId = data.TryGetProperty("parentId", out var parentProp) ? parentProp.GetUInt32() : 0u;
+            var channelIds = data.GetProperty("channelIds").EnumerateArray().Select(element => element.GetUInt32()).ToArray();
+            if (channelIds.Length < 2)
+            {
+                _bridge?.Send("voice.error", new { message = "At least two sibling channels are required for reorder", type = "invalidRequest" });
+                return Task.CompletedTask;
+            }
+
+            var siblingChannels = channelIds
+                .Select(id => Channels.FirstOrDefault(channel => channel.Id == id))
+                .ToArray();
+
+            if (siblingChannels.Any(channel => channel == null) || siblingChannels.Any(channel => channel!.Parent != parentId))
+            {
+                _bridge?.Send("voice.error", new { message = "Reorder payload must contain channels with the same parent", type = "invalidRequest" });
+                return Task.CompletedTask;
+            }
+
+            for (var index = 0; index < channelIds.Length; index++)
+            {
+                Connection.SendControl(PacketType.ChannelState, new ChannelState
+                {
+                    ChannelId = channelIds[index],
+                    Position = index * 10,
+                });
+            }
+
+            return Task.CompletedTask;
+        });
+
         bridge.RegisterHandler("voice.getBans", data =>
         {
             if (Connection is not { State: ConnectionStates.Connected })
@@ -3897,6 +3935,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         id = channel.Id,
         name = channel.Name,
         parent = channel.Parent,
+        description = channel.Description,
+        position = channel.Position,
         isEnterRestricted = channel.IsEnterRestricted,
         canEnter = channel.CanEnter,
         hasPasswordRestriction = _channelPasswordRestrictions.TryGetValue(channel.Id, out var hasPasswordRestriction) && hasPasswordRestriction,
@@ -4259,6 +4299,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         if (ChannelDictionary.TryGetValue(channelState.ChannelId, out var channel))
         {
             _bridge?.Send("voice.channelJoined", CreateChannelPayload(channel));
+            _bridge?.NotifyUiThread();
         }
     }
 
@@ -4267,6 +4308,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         var channelId = channelRemove.ChannelId;
         base.ChannelRemove(channelRemove);
         _bridge?.Send("voice.channelRemoved", new { id = channelId });
+        _bridge?.NotifyUiThread();
     }
 
     public override void TextMessage(TextMessage textMessage)

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -3056,11 +3056,30 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 return Task.CompletedTask;
             }
 
+            if (!data.TryGetProperty("channelIds", out var channelIdsProp) || channelIdsProp.ValueKind != System.Text.Json.JsonValueKind.Array)
+            {
+                _bridge?.Send("voice.error", new { message = "channelIds must be an array", type = "invalidRequest" });
+                return Task.CompletedTask;
+            }
+
             var parentId = data.TryGetProperty("parentId", out var parentProp) ? parentProp.GetUInt32() : 0u;
-            var channelIds = data.GetProperty("channelIds").EnumerateArray().Select(element => element.GetUInt32()).ToArray();
+            var channelIds = channelIdsProp.EnumerateArray().Select(element => element.GetUInt32()).ToArray();
+            
             if (channelIds.Length < 2)
             {
                 _bridge?.Send("voice.error", new { message = "At least two sibling channels are required for reorder", type = "invalidRequest" });
+                return Task.CompletedTask;
+            }
+
+            if (channelIds.Distinct().Count() != channelIds.Length)
+            {
+                _bridge?.Send("voice.error", new { message = "channelIds must not contain duplicates", type = "invalidRequest" });
+                return Task.CompletedTask;
+            }
+
+            if (channelIds.Contains(0u))
+            {
+                _bridge?.Send("voice.error", new { message = "Cannot reorder root channel (id 0)", type = "invalidRequest" });
                 return Task.CompletedTask;
             }
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1246,6 +1246,8 @@ function App() {
   addMessageRef.current = addMessage;
   const currentChannelIdRef = useRef(currentChannelId);
   currentChannelIdRef.current = currentChannelId;
+  const currentChannelNameRef = useRef(currentChannelName);
+  currentChannelNameRef.current = currentChannelName;
   const previousConnectionStatusRef = useRef(connectionStatus);
   const overlayConnectedAtRef = useRef<number | null>(null);
   const previousCurrentChannelIdRef = useRef(currentChannelId);
@@ -2072,6 +2074,7 @@ function App() {
               || (d.channelId === 0 ? (serverLabel || 'Server') : `Channel ${d.channelId}`);
             const previousChannelName = d.previousChannelId !== undefined
               ? channelsRef.current.find(c => c.id === d.previousChannelId)?.name
+                || (currentChannelIdRef.current === String(d.previousChannelId) ? currentChannelNameRef.current : undefined)
               : undefined;
             const notification = {
               id: `channel-moved-${nextMovedChannelNotificationIdRef.current++}`,

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -62,6 +62,7 @@ import { migrateLocalStorage } from './utils/migrateLocalStorage';
 import { mapBrmbleServiceStatus } from './utils/brmbleServiceStatus';
 import { areMatrixCredentialsEqual } from './utils/matrixCredentials';
 import { getSavedChannelPassword } from './utils/channelPasswords';
+import { getOrderedChannels } from './utils/channelOrder';
 import './App.css';
 
 export interface ScreenShareEndedNotification {
@@ -580,6 +581,8 @@ interface Channel {
   id: number;
   name: string;
   parent?: number;
+  description?: string;
+  position?: number;
   isEnterRestricted?: boolean;
   canEnter?: boolean;
   hasPasswordRestriction?: boolean;
@@ -1610,7 +1613,7 @@ function App() {
         setUsername(d.username);
       }
       if (d?.channels) {
-        setChannels(d.channels);
+        setChannels(getOrderedChannels(d.channels));
       }
       if (d?.users) {
         setUsers(d.users);
@@ -2013,14 +2016,14 @@ function App() {
     });
 
     const onVoiceChannelJoined = ((data: unknown) => {
-      const d = data as { id: number; name: string; parent?: number; isEnterRestricted?: boolean } | undefined;
+      const d = data as Channel | undefined;
       if (d?.id !== undefined) {
         setChannels(prev => {
-          const existing = prev.find(c => c.id === d.id);
-          if (existing) {
-            return prev.map(c => c.id === d.id ? d : c);
-          }
-          return [...prev, d];
+          const next = prev.some(channel => channel.id === d.id)
+            ? prev.map(channel => channel.id === d.id ? { ...channel, ...d } : channel)
+            : [...prev, d];
+
+          return getOrderedChannels(next);
         });
       }
     });
@@ -4142,6 +4145,7 @@ const handleConnect = (serverData: SavedServer) => {
         onLiveCompanionChange={handleLiveCompanionChange}
         liveUsers={users}
         channels={channels}
+        onChannelsChange={setChannels}
       />
 
       <ConnectModal

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
@@ -132,6 +132,61 @@
   background: color-mix(in srgb, var(--accent-primary) 10%, var(--bg-surface));
 }
 
+.admin-channel-row--management {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-md);
+  align-items: center;
+  cursor: default;
+}
+
+.admin-channel-row--drop-target {
+  border-color: color-mix(in srgb, var(--accent-primary) 55%, var(--border-subtle));
+  background: color-mix(in srgb, var(--accent-primary) 8%, var(--bg-surface));
+}
+
+.admin-channel-list {
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.admin-channel-row__details {
+  display: grid;
+  gap: var(--space-2xs);
+  min-width: 0;
+}
+
+.admin-channel-row__name {
+  font-weight: 600;
+}
+
+.admin-channel-row__meta {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.admin-channel-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-xs);
+}
+
+.admin-create-channel-dialog {
+  width: min(100%, 520px);
+}
+
+.admin-create-channel-form {
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.admin-create-channel-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+}
+
 .admin-action-row,
 .admin-footer-row {
   display: flex;

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.test.tsx
@@ -13,12 +13,17 @@ const { bridgeMock } = vi.hoisted(() => ({
   },
 }));
 
+const usePermissionsMock = vi.fn();
+
 const saveSpy = vi.fn();
 
 vi.mock('../../bridge', () => ({ default: bridgeMock }));
 vi.mock('../../hooks/usePrompt', () => ({
   confirm: vi.fn().mockResolvedValue(true),
   prompt: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../../hooks/usePermissions', () => ({
+  usePermissions: () => usePermissionsMock(),
 }));
 vi.mock('../../hooks/useAclAdmin', () => ({
   useAclAdmin: () => ({
@@ -38,7 +43,8 @@ const ban = {
 };
 
 const channels: Channel[] = [
-  { id: 1, name: 'General' },
+  { id: 0, name: 'Root', position: 0 },
+  { id: 1, name: 'General', parent: 0, position: 0 },
   { id: 2, name: 'Raid Planning', parent: 1 },
 ];
 
@@ -53,6 +59,12 @@ describe('AdminSettingsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(confirm).mockResolvedValue(true);
+    usePermissionsMock.mockReturnValue({
+      permissions: new Map<number, number>(),
+      hasPermission: vi.fn(() => false),
+      requestPermissions: vi.fn(),
+      Permission: { MakeChannel: 0x40 },
+    });
   });
 
   it('renders the five admin workspace tabs', () => {
@@ -96,7 +108,9 @@ describe('AdminSettingsTab', () => {
   it('renders the live channel list in the channels tab', () => {
     render(<AdminSettingsTab channels={channels} />);
 
+    expect(screen.getByRole('row', { name: 'Root' })).toBeInTheDocument();
     expect(screen.getByRole('row', { name: 'General' })).toBeInTheDocument();
     expect(screen.getByRole('row', { name: 'Raid Planning' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create Channel' })).toBeDisabled();
   });
 });

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.tsx
@@ -10,6 +10,7 @@ import type { Channel } from '../../types';
 
 interface AdminSettingsTabProps {
   channels?: Channel[];
+  onChannelsChange?: (channels: Channel[]) => void;
   liveUsers?: Array<{
     session: number;
     name: string;
@@ -20,7 +21,7 @@ interface AdminSettingsTabProps {
   }>;
 }
 
-export function AdminSettingsTab({ channels = [], liveUsers = [] }: AdminSettingsTabProps) {
+export function AdminSettingsTab({ channels = [], onChannelsChange, liveUsers = [] }: AdminSettingsTabProps) {
   const [activeTab, setActiveTab] = useState<AdminWorkspaceTab>('channels');
 
   return (
@@ -40,7 +41,7 @@ export function AdminSettingsTab({ channels = [], liveUsers = [] }: AdminSetting
         ))}
       </div>
       <div className="admin-workspace-body">
-        {activeTab === 'channels' && <AdminChannelsSection channels={channels} />}
+        {activeTab === 'channels' && <AdminChannelsSection channels={channels} onChannelsChange={onChannelsChange} />}
         {activeTab === 'users' && <AdminUsersSection liveUsers={liveUsers} />}
         {activeTab === 'groups' && <AdminGroupsSection channels={channels} />}
         {activeTab === 'moderation' && <AdminModerationSection />}

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -56,6 +56,7 @@ interface SettingsModalProps {
     isBrmbleClient?: boolean;
   }>;
   channels?: Channel[];
+  onChannelsChange?: (channels: Channel[]) => void;
 }
 
 export interface ScreenShareSettings {
@@ -510,7 +511,13 @@ export function SettingsModal(props: SettingsModalProps) {
               onChange={handleScreenShareChange}
             />
           )}
-          {activeTab === 'admin' && hasAdminPermission && <AdminSettingsTab channels={props.channels ?? []} liveUsers={props.liveUsers ?? []} />}
+          {activeTab === 'admin' && hasAdminPermission && (
+            <AdminSettingsTab
+              channels={props.channels ?? []}
+              onChannelsChange={props.onChannelsChange}
+              liveUsers={props.liveUsers ?? []}
+            />
+          )}
 
         </div>
 

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
@@ -1,16 +1,33 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import './AdminSettingsTab.css';
+import { AclEditorDialog } from '../../../components/AclEditor/AclEditorDialog';
+import bridge from '../../../bridge';
 import { prompt } from '../../../hooks/usePrompt';
 import type { Channel } from '../../../types';
+import {
+  buildReorderPayload,
+  canDropIntoSiblingGroup,
+  getOrderedChannels,
+  moveChannelToSiblingIndex,
+} from '../../../utils/channelOrder';
 
 const REQUESTS = [{ id: 1, requestedBy: 'Mike', channelName: 'Officer Chat', status: 'Pending' }];
 
 interface AdminChannelsSectionProps {
   channels?: Channel[];
+  onChannelsChange?: (channels: Channel[]) => void;
 }
 
-export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProps) {
+export function AdminChannelsSection({ channels = [], onChannelsChange }: AdminChannelsSectionProps) {
+  const [draftChannels, setDraftChannels] = useState<Channel[]>(() => getOrderedChannels(channels));
   const [selectedChannelId, setSelectedChannelId] = useState<number | null>(channels[0]?.id ?? null);
-  const selectedChannel = channels.find(channel => channel.id === selectedChannelId) ?? null;
+  const [aclEditorChannel, setAclEditorChannel] = useState<{ id: number; name: string } | null>(null);
+  const [draggedChannelId, setDraggedChannelId] = useState<number | null>(null);
+  const [dropTargetId, setDropTargetId] = useState<number | null>(null);
+  const [recentlyMovedChannelId, setRecentlyMovedChannelId] = useState<number | null>(null);
+  const recentlyMovedTimeoutRef = useRef<number | null>(null);
+  const selectedChannel = draftChannels.find(channel => channel.id === selectedChannelId) ?? null;
+  const orderedChannels = getOrderedChannels(draftChannels);
 
   useEffect(() => {
     if (selectedChannelId != null && channels.some(channel => channel.id === selectedChannelId)) {
@@ -19,6 +36,16 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
 
     setSelectedChannelId(channels[0]?.id ?? null);
   }, [channels, selectedChannelId]);
+
+  useEffect(() => {
+    setDraftChannels(getOrderedChannels(channels));
+  }, [channels]);
+
+  useEffect(() => () => {
+    if (recentlyMovedTimeoutRef.current != null) {
+      window.clearTimeout(recentlyMovedTimeoutRef.current);
+    }
+  }, []);
 
   const handleDeleteChannel = async () => {
     if (!selectedChannel) return;
@@ -44,18 +71,104 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
         <h4 className="heading-label">Existing Channels</h4>
         <div className="admin-table-placeholder" role="table" aria-label="Existing Channels table">
           {channels.length > 0 ? (
-            channels.map(channel => (
-              <button
-                key={channel.id}
-                type="button"
-                className={`admin-channel-row ${channel.id === selectedChannelId ? 'selected' : ''}`}
-                role="row"
-                aria-label={channel.name}
-                onClick={() => setSelectedChannelId(channel.id)}
-              >
-                {channel.name}
-              </button>
-            ))
+            orderedChannels.map(channel => {
+              const isSelected = channel.id === selectedChannelId;
+              const isDragging = channel.id === draggedChannelId;
+              const isDropTarget = channel.id === dropTargetId;
+              const isRecentlyMoved = channel.id === recentlyMovedChannelId;
+
+              return (
+                <div
+                  key={channel.id}
+                  className={[
+                    'admin-channel-row',
+                    'admin-channel-row--management',
+                    isSelected ? 'selected' : '',
+                    isDragging ? 'admin-channel-row--dragging' : '',
+                    isDropTarget ? 'admin-channel-row--drop-target' : '',
+                    isRecentlyMoved ? 'admin-channel-row--recently-moved' : '',
+                  ].filter(Boolean).join(' ')}
+                  role="row"
+                  aria-label={channel.name}
+                  tabIndex={0}
+                  draggable={channel.id !== 0}
+                  onClick={() => setSelectedChannelId(channel.id)}
+                  onKeyDown={event => {
+                    if (event.key !== 'Enter' && event.key !== ' ') {
+                      return;
+                    }
+
+                    event.preventDefault();
+                    setSelectedChannelId(channel.id);
+                  }}
+                  onDragStart={() => {
+                    setRecentlyMovedChannelId(null);
+                    setDraggedChannelId(channel.id);
+                  }}
+                  onDragEnd={() => {
+                    setDraggedChannelId(null);
+                    setDropTargetId(null);
+                  }}
+                  onDragOver={event => {
+                    if (draggedChannelId == null || !canDropIntoSiblingGroup(draggedChannelId, channel.id, draftChannels)) {
+                      return;
+                    }
+
+                    event.preventDefault();
+                    setDropTargetId(channel.id);
+                  }}
+                  onDragLeave={() => {
+                    if (dropTargetId === channel.id) {
+                      setDropTargetId(null);
+                    }
+                  }}
+                  onDrop={event => {
+                    event.preventDefault();
+                    if (draggedChannelId == null) {
+                      return;
+                    }
+
+                    const movedChannelId = draggedChannelId;
+                    const nextChannels = moveChannelToSiblingIndex(draftChannels, movedChannelId, channel.id);
+                    if (nextChannels === draftChannels) {
+                      setDraggedChannelId(null);
+                      setDropTargetId(null);
+                      return;
+                    }
+
+                    const moved = nextChannels.find(candidate => candidate.id === movedChannelId);
+                    const payload = buildReorderPayload(nextChannels, moved?.parent ?? 0);
+                    setDraftChannels(nextChannels);
+                    setRecentlyMovedChannelId(movedChannelId);
+                    if (recentlyMovedTimeoutRef.current != null) {
+                      window.clearTimeout(recentlyMovedTimeoutRef.current);
+                    }
+                    recentlyMovedTimeoutRef.current = window.setTimeout(() => {
+                      setRecentlyMovedChannelId(current => (current === movedChannelId ? null : current));
+                      recentlyMovedTimeoutRef.current = null;
+                    }, 1200);
+                    onChannelsChange?.(nextChannels);
+                    bridge.send('voice.reorderChannels', { parentId: payload.parentId, channelIds: payload.channelIds });
+                    setDraggedChannelId(null);
+                    setDropTargetId(null);
+                  }}
+                >
+                  <span>{channel.name}</span>
+                  <button
+                    type="button"
+                    className="btn btn-secondary btn-sm"
+                    aria-label={`Edit ${channel.name}`}
+                    onClick={event => {
+                      event.stopPropagation();
+                      setSelectedChannelId(channel.id);
+                      setAclEditorChannel({ id: channel.id, name: channel.name });
+                    }}
+                  >
+                    Edit
+                  </button>
+                </div>
+              );
+            })
           ) : (
             <p className="admin-help-text">No channels are available yet.</p>
           )}
@@ -90,6 +203,16 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
       </div>
 
       <p className="admin-help-text">Create Channel is not available yet. Request actions and safe delete are available.</p>
+
+      {aclEditorChannel && (
+        <AclEditorDialog
+          isOpen={true}
+          channelId={aclEditorChannel.id}
+          channelName={aclEditorChannel.name}
+          isNativePasswordProtected={channels.find(channel => channel.id === aclEditorChannel.id)?.isEnterRestricted ?? false}
+          onClose={() => setAclEditorChannel(null)}
+        />
+      )}
     </section>
   );
 }

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import './AdminSettingsTab.css';
+import '../AdminSettingsTab.css';
 import { AclEditorDialog } from '../../../components/AclEditor/AclEditorDialog';
 import bridge from '../../../bridge';
 import { prompt } from '../../../hooks/usePrompt';
@@ -101,9 +101,11 @@ export function AdminChannelsSection({ channels = [], onChannelsChange }: AdminC
                     event.preventDefault();
                     setSelectedChannelId(channel.id);
                   }}
-                  onDragStart={() => {
+                  onDragStart={event => {
                     setRecentlyMovedChannelId(null);
                     setDraggedChannelId(channel.id);
+                    event.dataTransfer.effectAllowed = 'move';
+                    event.dataTransfer.setData('text/plain', String(channel.id));
                   }}
                   onDragEnd={() => {
                     setDraggedChannelId(null);

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
@@ -1,15 +1,37 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AdminSectionPlaceholder } from './AdminSectionPlaceholder';
 import { AdminChannelsSection } from './AdminChannelsSection';
 import type { Channel } from '../../../types';
 
-const { promptMock } = vi.hoisted(() => ({
+const { promptMock, aclEditorDialogMock } = vi.hoisted(() => ({
   promptMock: vi.fn(),
+  aclEditorDialogMock: vi.fn(),
+}));
+const { bridgeMock, usePermissionsMock } = vi.hoisted(() => ({
+  bridgeMock: {
+    send: vi.fn(),
+  },
+  usePermissionsMock: vi.fn(),
 }));
 
 vi.mock('../../../hooks/usePrompt', () => ({
   prompt: promptMock,
+}));
+
+vi.mock('../../../bridge', () => ({
+  default: bridgeMock,
+}));
+
+vi.mock('../../../hooks/usePermissions', () => ({
+  usePermissions: () => usePermissionsMock(),
+}));
+
+vi.mock('../../../components/AclEditor/AclEditorDialog', () => ({
+  AclEditorDialog: (props: unknown) => {
+    aclEditorDialogMock(props);
+    return <div data-testid="acl-editor-dialog" />;
+  },
 }));
 
 const liveChannels: Channel[] = [
@@ -18,6 +40,16 @@ const liveChannels: Channel[] = [
 ];
 
 describe('Admin workspace sections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePermissionsMock.mockReturnValue({
+      permissions: new Map<number, number>([[0, 0x40], [7, 0x40], [9, 0x40], [10, 0x40], [20, 0x40]]),
+      hasPermission: vi.fn((_channelId: number, permission: number) => permission === 0x40),
+      requestPermissions: vi.fn(),
+      Permission: { MakeChannel: 0x40 },
+    });
+  });
+
   it('renders guide-compliant placeholder copy without fake actions', () => {
     render(
       <AdminSectionPlaceholder
@@ -50,6 +82,100 @@ describe('Admin workspace sections', () => {
 
     expect(screen.getByRole('button', { name: 'Approve Mike request' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Deny Mike request' })).toBeInTheDocument();
+  });
+
+  it('opens the shared ACL editor for the selected channel when its Edit action is clicked', () => {
+    render(<AdminChannelsSection channels={[
+      { id: 7, name: 'General' },
+      { id: 9, name: 'Raid Planning', parent: 7, isEnterRestricted: true },
+    ]} />);
+
+    const raidPlanningRow = screen.getByRole('row', { name: 'Raid Planning' });
+    fireEvent.click(within(raidPlanningRow).getByRole('button', { name: 'Edit Raid Planning' }));
+
+    expect(screen.getByTestId('acl-editor-dialog')).toBeInTheDocument();
+    expect(aclEditorDialogMock).toHaveBeenLastCalledWith(expect.objectContaining({
+      isOpen: true,
+      channelId: 9,
+      channelName: 'Raid Planning',
+      isNativePasswordProtected: true,
+      onClose: expect.any(Function),
+    }));
+  });
+
+  it('updates the selected channel when Edit is clicked so follow-up actions target the same row', async () => {
+    promptMock.mockResolvedValue('Raid Planning');
+
+    render(<AdminChannelsSection channels={[
+      { id: 7, name: 'General' },
+      { id: 9, name: 'Raid Planning', parent: 7, isEnterRestricted: true },
+    ]} />);
+
+    const raidPlanningRow = screen.getByRole('row', { name: 'Raid Planning' });
+    fireEvent.click(within(raidPlanningRow).getByRole('button', { name: 'Edit Raid Planning' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Channel' }));
+
+    await waitFor(() => {
+      expect(promptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Delete Channel',
+          message: expect.stringContaining('Raid Planning'),
+          placeholder: 'Raid Planning',
+        }),
+      );
+    });
+  });
+
+  it('reorders sibling channels when a channel row is dragged onto another row', () => {
+    const onChannelsChange = vi.fn();
+
+    render(
+      <AdminChannelsSection
+        channels={[
+          { id: 0, name: 'Root', position: 0 },
+          { id: 10, name: 'General', parent: 0, position: 0 },
+          { id: 20, name: 'Raid', parent: 0, position: 1 },
+        ]}
+        onChannelsChange={onChannelsChange}
+      />,
+    );
+
+    const generalRow = screen.getByRole('row', { name: 'General' });
+    const raidRow = screen.getByRole('row', { name: 'Raid' });
+
+    fireEvent.dragStart(raidRow);
+    fireEvent.dragOver(generalRow);
+    fireEvent.drop(generalRow);
+
+    expect(onChannelsChange).toHaveBeenCalledWith([
+      { id: 0, name: 'Root', position: 0 },
+      { id: 20, name: 'Raid', parent: 0, position: 0 },
+      { id: 10, name: 'General', parent: 0, position: 10 },
+    ]);
+    expect(bridgeMock.send).toHaveBeenCalledWith('voice.reorderChannels', { parentId: 0, channelIds: [20, 10] });
+  });
+
+  it('highlights the dragged channel during reorder and keeps a recently-moved highlight after drop', () => {
+    render(
+      <AdminChannelsSection
+        channels={[
+          { id: 0, name: 'Root', position: 0 },
+          { id: 10, name: 'General', parent: 0, position: 0 },
+          { id: 20, name: 'Raid', parent: 0, position: 1 },
+        ]}
+      />,
+    );
+
+    const generalRow = screen.getByRole('row', { name: 'General' });
+    const raidRow = screen.getByRole('row', { name: 'Raid' });
+
+    fireEvent.dragStart(raidRow);
+    expect(raidRow).toHaveClass('admin-channel-row--dragging');
+
+    fireEvent.dragOver(generalRow);
+    fireEvent.drop(generalRow);
+
+    expect(screen.getByRole('row', { name: 'Raid' })).toHaveClass('admin-channel-row--recently-moved');
   });
 
   it('opens a typed confirmation before deleting the selected channel', async () => {

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
@@ -753,3 +753,27 @@ describe('ChannelTree idle (moon) icon', () => {
     expect(row?.querySelector('.user-status-area [data-icon="moon"]')).not.toBeNull();
   });
 });
+
+describe('ChannelTree channel ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChannelTree siblings using channel position instead of id order', () => {
+    render(
+      <ChannelTree
+        channels={[
+          { id: 0, name: 'Root', position: 0 },
+          { id: 20, name: 'Raid', parent: 0, position: 0 },
+          { id: 10, name: 'General', parent: 0, position: 1 },
+        ]}
+        users={[]}
+        currentChannelId={0}
+        onJoinChannel={vi.fn()}
+      />,
+    );
+
+    const labels = screen.getAllByText(/Raid|General/).map(element => element.textContent);
+    expect(labels).toEqual(['Raid', 'General']);
+  });
+});

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -236,7 +236,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     });
 
     channelMap.forEach(ch => {
-      if (ch.parent !== undefined && channelMap.has(ch.parent)) {
+      if (ch.parent !== undefined && ch.parent !== ch.id && channelMap.has(ch.parent)) {
         channelMap.get(ch.parent)!.children.push(ch);
       } else {
         roots.push(ch);

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -15,6 +15,7 @@ import { EditChannelDialog } from '../EditChannelDialog/EditChannelDialog';
 import { Icon } from '../Icon/Icon';
 import { AclEditorDialog } from '../AclEditor/AclEditorDialog';
 import { getSavedChannelPassword } from '../../utils/channelPasswords';
+import { getOrderedChildChannels, sortChannels } from '../../utils/channelOrder';
 import './ChannelTree.css';
 
 interface User {
@@ -36,6 +37,7 @@ interface Channel {
   name: string;
   parent?: number;
   description?: string;
+  position?: number;
   isEnterRestricted?: boolean;
   canEnter?: boolean;
   hasPasswordRestriction?: boolean;
@@ -166,7 +168,8 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     const expanded = new Set<number>();
     channels.forEach(ch => {
       const hasUsers = users.some(u => u.channelId === ch.id);
-      if (hasUsers) {
+      const hasChildren = channels.some(candidate => candidate.parent === ch.id);
+      if (hasUsers || hasChildren) {
         expanded.add(ch.id);
       }
     });
@@ -181,7 +184,8 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
       let changed = false;
       channels.forEach(ch => {
         const hasUsers = users.some(u => u.channelId === ch.id);
-        if (hasUsers && !next.has(ch.id)) {
+        const hasChildren = channels.some(candidate => candidate.parent === ch.id);
+        if ((hasUsers || hasChildren) && !next.has(ch.id)) {
           next.add(ch.id);
           changed = true;
         }
@@ -232,24 +236,26 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     });
 
     channelMap.forEach(ch => {
-      if (ch.parent && channelMap.has(ch.parent)) {
+      if (ch.parent !== undefined && channelMap.has(ch.parent)) {
         channelMap.get(ch.parent)!.children.push(ch);
       } else {
         roots.push(ch);
       }
     });
 
-    const sortChildren = (channels: ChannelWithUsers[]) => {
-      channels.forEach(ch => {
-        if (ch.children.length > 0) {
-          ch.children.sort((a, b) => a.id - b.id);
-          sortChildren(ch.children);
+    const sortChildren = (entries: ChannelWithUsers[]) => {
+      entries.forEach(channel => {
+        if (channel.children.length > 0) {
+          channel.children = getOrderedChildChannels(channel.children, channel.id) as ChannelWithUsers[];
+          sortChildren(channel.children);
         }
       });
     };
-    sortChildren(roots);
 
-    return roots;
+    const orderedRoots = sortChannels(roots) as ChannelWithUsers[];
+    sortChildren(orderedRoots);
+
+    return orderedRoots;
   }, [channels, users, sortByNamePerChannel]);
 
   const tree = useMemo(() => buildTree(), [buildTree]);

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -11,6 +11,7 @@ export interface Channel {
   parent?: number;
   type?: 'voice' | 'text';
   description?: string;
+  position?: number;
   isEnterRestricted?: boolean;
   canEnter?: boolean;
   hasPasswordRestriction?: boolean;

--- a/src/Brmble.Web/src/utils/channelOrder.test.ts
+++ b/src/Brmble.Web/src/utils/channelOrder.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { buildReorderPayload, canDropIntoSiblingGroup, getOrderedChannels, getOrderedChildChannels, moveChannelWithinSiblings } from './channelOrder';
+
+describe('getOrderedChildChannels', () => {
+  it('sorts siblings by position before name and id', () => {
+    const ordered = getOrderedChildChannels(
+      [
+        { id: 20, name: 'Bravo', parent: 0, position: 2 },
+        { id: 10, name: 'Alpha', parent: 0, position: 1 },
+        { id: 30, name: 'Zulu', parent: 0, position: 2 },
+      ],
+      0,
+    );
+
+    expect(ordered.map(channel => channel.id)).toEqual([10, 20, 30]);
+  });
+});
+
+describe('getOrderedChannels', () => {
+  it('keeps a root channel with parent 0 and includes its visible children', () => {
+    const ordered = getOrderedChannels([
+      { id: 0, name: 'Root', parent: 0, position: 0 },
+      { id: 20, name: 'Raid', parent: 0, position: 1 },
+      { id: 10, name: 'General', parent: 0, position: 0 },
+    ]);
+
+    expect(ordered.map(channel => channel.id)).toEqual([0, 10, 20]);
+  });
+});
+
+const channels = [
+  { id: 0, name: 'Root', position: 0 },
+  { id: 10, name: 'General', parent: 0, position: 0 },
+  { id: 20, name: 'Raid', parent: 0, position: 1 },
+  { id: 30, name: 'Off Topic', parent: 0, position: 2 },
+  { id: 40, name: 'Nested', parent: 10, position: 0 },
+];
+
+describe('moveChannelWithinSiblings', () => {
+  it('moves only within the current parent group', () => {
+    const moved = moveChannelWithinSiblings(channels, 20, 'up');
+    expect(moved.filter(channel => channel.parent === 0).map(channel => channel.id)).toEqual([20, 10, 30]);
+    expect(moved.find(channel => channel.id === 40)?.position).toBe(0);
+  });
+});
+
+describe('buildReorderPayload', () => {
+  it('assigns distinct positions for each sibling in display order', () => {
+    const payload = buildReorderPayload([
+      { id: 20, name: 'Raid', parent: 0, position: 0 },
+      { id: 10, name: 'General', parent: 0, position: 1 },
+      { id: 30, name: 'Off Topic', parent: 0, position: 2 },
+    ], 0);
+
+    expect(payload).toEqual({
+      parentId: 0,
+      channelIds: [20, 10, 30],
+      positions: [0, 10, 20],
+    });
+  });
+});
+
+describe('canDropIntoSiblingGroup', () => {
+  it('allows drops only within the same parent group', () => {
+    expect(canDropIntoSiblingGroup(10, 20, channels)).toBe(true);
+    expect(canDropIntoSiblingGroup(10, 40, channels)).toBe(false);
+  });
+});

--- a/src/Brmble.Web/src/utils/channelOrder.ts
+++ b/src/Brmble.Web/src/utils/channelOrder.ts
@@ -1,0 +1,139 @@
+import type { Channel } from '../types';
+
+export type ReorderDirection = 'up' | 'down';
+
+function compareChannels(a: Channel, b: Channel) {
+  const aPosition = a.position ?? Number.MAX_SAFE_INTEGER;
+  const bPosition = b.position ?? Number.MAX_SAFE_INTEGER;
+  if (aPosition !== bPosition) {
+    return aPosition - bPosition;
+  }
+
+  const byName = a.name.localeCompare(b.name);
+  if (byName !== 0) {
+    return byName;
+  }
+
+  return a.id - b.id;
+}
+
+export function sortChannels(channels: Channel[]) {
+  return [...channels].sort(compareChannels);
+}
+
+export function getOrderedChildChannels(channels: Channel[], parentId: number | undefined) {
+  return sortChannels(
+    channels.filter(channel => (channel.parent ?? undefined) === parentId),
+  );
+}
+
+export function getOrderedChannels(channels: Channel[]) {
+  const ordered: Channel[] = [];
+  const hasExplicitRoot = channels.some(channel => channel.id === 0);
+  const visited = new Set<number>();
+
+  const visit = (parentId: number | undefined) => {
+    for (const channel of getOrderedChildChannels(channels, parentId)) {
+      if (channel.id === parentId || visited.has(channel.id)) {
+        continue;
+      }
+
+      visited.add(channel.id);
+      ordered.push(channel);
+      visit(channel.id);
+    }
+  };
+
+  if (hasExplicitRoot) {
+    for (const rootChannel of sortChannels(channels.filter(channel => channel.id === 0))) {
+      visited.add(rootChannel.id);
+      ordered.push(rootChannel);
+    }
+    visit(0);
+  } else {
+    visit(undefined);
+  }
+
+  return ordered;
+}
+
+function applySiblingPositions(siblings: Channel[]) {
+  return new Map(
+    siblings.map((channel, index) => [
+      channel.id,
+      { ...channel, position: index * 10 },
+    ]),
+  );
+}
+
+export function moveChannelWithinSiblings(channels: Channel[], channelId: number, direction: ReorderDirection) {
+  const target = channels.find(channel => channel.id === channelId);
+  if (!target) {
+    return channels;
+  }
+
+  const parentId = target.parent ?? undefined;
+  const siblings = getOrderedChildChannels(channels, parentId);
+  const index = siblings.findIndex(channel => channel.id === channelId);
+  const swapIndex = direction === 'up' ? index - 1 : index + 1;
+
+  if (index < 0 || swapIndex < 0 || swapIndex >= siblings.length) {
+    return channels;
+  }
+
+  const reordered = [...siblings];
+  [reordered[index], reordered[swapIndex]] = [reordered[swapIndex], reordered[index]];
+  const byId = applySiblingPositions(reordered);
+
+  return getOrderedChannels(channels.map(channel => byId.get(channel.id) ?? channel));
+}
+
+export function buildReorderPayload(channels: Channel[], parentId: number | undefined) {
+  const ordered = getOrderedChildChannels(channels, parentId);
+  return {
+    parentId: parentId ?? 0,
+    channelIds: ordered.map(channel => channel.id),
+    positions: ordered.map((_, index) => index * 10),
+  };
+}
+
+export function canDropIntoSiblingGroup(
+  draggedChannelId: number,
+  targetChannelId: number,
+  channels: Channel[],
+) {
+  const dragged = channels.find(channel => channel.id === draggedChannelId);
+  const target = channels.find(channel => channel.id === targetChannelId);
+  if (!dragged || !target) {
+    return false;
+  }
+
+  return (dragged.parent ?? undefined) === (target.parent ?? undefined);
+}
+
+export function moveChannelToSiblingIndex(channels: Channel[], draggedChannelId: number, targetChannelId: number) {
+  if (!canDropIntoSiblingGroup(draggedChannelId, targetChannelId, channels)) {
+    return channels;
+  }
+
+  const dragged = channels.find(channel => channel.id === draggedChannelId);
+  if (!dragged) {
+    return channels;
+  }
+
+  const parentId = dragged.parent ?? undefined;
+  const siblings = getOrderedChildChannels(channels, parentId);
+  const fromIndex = siblings.findIndex(channel => channel.id === draggedChannelId);
+  const toIndex = siblings.findIndex(channel => channel.id === targetChannelId);
+
+  if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) {
+    return channels;
+  }
+
+  const reordered = [...siblings];
+  const [moved] = reordered.splice(fromIndex, 1);
+  reordered.splice(toIndex, 0, moved);
+  const byId = applySiblingPositions(reordered);
+
+  return getOrderedChannels(channels.map(channel => byId.get(channel.id) ?? channel));
+}

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -1,13 +1,19 @@
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Brmble.Client.Bridge;
 using Brmble.Client.Services.AppConfig;
 using Brmble.Client.Services.Serverlist;
 using Brmble.Client.Services.Voice;
 using MumbleSharp;
+using MumbleSharp.Packets;
 using MumbleProto;
 using MumbleSharp.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProtoBuf;
 
 namespace Brmble.Client.Tests.Services;
 
@@ -68,6 +74,28 @@ public class MumbleAdapterBridgeTests
 
         Assert.IsTrue(channel.GetProperty("hasPasswordRestriction").GetBoolean());
         Assert.IsFalse(connected.DataJson.Contains("secret", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void SendVoiceConnected_IncludesChannelDescriptionAndPosition()
+    {
+        var adapter = CreateAdapterWithBridge(out var bridge);
+        var channels = GetChannelDictionary(adapter);
+        channels[4] = new Channel(adapter, 4, "General", 0)
+        {
+            Description = "Lobby",
+            Position = 7,
+        };
+
+        InvokePrivate(adapter, "SendVoiceConnected");
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        var connected = sent.Single(m => m.Type == "voice.connected");
+        using var doc = JsonDocument.Parse(connected.DataJson);
+        var channel = doc.RootElement.GetProperty("channels").EnumerateArray().Single();
+
+        Assert.AreEqual("Lobby", channel.GetProperty("description").GetString());
+        Assert.AreEqual(7, channel.GetProperty("position").GetInt32());
     }
 
     [TestMethod]
@@ -505,6 +533,50 @@ public class MumbleAdapterBridgeTests
         Assert.IsFalse(sent.Any(m => m.Type == "voice.channelPassword"));
     }
 
+    [TestMethod]
+    public void VoiceReorderChannels_RejectsMixedParentGroups()
+    {
+        var adapter = CreateAdapterWithBridge(out var bridge);
+        adapter.RegisterHandlers(bridge);
+        var channels = GetChannelDictionary(adapter);
+        channels[10] = new Channel(adapter, 10, "General", 0) { Position = 0 };
+        channels[20] = new Channel(adapter, 20, "Raid", 10) { Position = 0 };
+        SetConnectedConnection(adapter);
+
+        InvokeBridgeHandler(bridge, "voice.reorderChannels", """
+        {"parentId":0,"channelIds":[10,20]}
+        """);
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        Assert.IsTrue(sent.Any(message => message.Type == "voice.error" && message.DataJson.Contains("same parent", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [TestMethod]
+    public void VoiceReorderChannels_SendsDistinctChannelPositions()
+    {
+        var bridge = NativeBridgeTestHarness.Create();
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        adapter.RegisterHandlers(bridge);
+        var capture = AttachCapturingConnection(adapter);
+        adapter.ChannelState(new ChannelState { ChannelId = 0, Name = "Root" });
+        adapter.ChannelState(new ChannelState { ChannelId = 10, Name = "General", Parent = 0, Position = 0 });
+        adapter.ChannelState(new ChannelState { ChannelId = 20, Name = "Raid", Parent = 0, Position = 1 });
+        _ = NativeBridgeTestHarness.DrainMessages(bridge);
+
+        InvokeBridgeHandler(bridge, "voice.reorderChannels", """
+        {"parentId":0,"channelIds":[20,10]}
+        """);
+
+        var sentPackets = ReadSentChannelStatePackets(capture.PacketStream)
+            .Where(packet => packet.ShouldSerializePosition())
+            .ToArray();
+
+        CollectionAssert.AreEqual(new[] { 20u, 10u }, sentPackets.Select(packet => packet.ChannelId).ToArray());
+        CollectionAssert.AreEqual(new[] { 0, 10 }, sentPackets.Select(packet => packet.Position).ToArray());
+        Assert.IsTrue(sentPackets.All(packet => !packet.ShouldSerializeParent()));
+        capture.Dispose();
+    }
+
     private static MumbleAdapter CreateAdapterWithBridge(out NativeBridge bridge)
     {
         bridge = NativeBridgeTestHarness.Create();
@@ -544,6 +616,66 @@ public class MumbleAdapterBridgeTests
             .SetValue(connection, ConnectionStates.Connected);
     }
 
+    private static CapturingConnection AttachCapturingConnection(MumbleAdapter adapter)
+    {
+        var connection = new MumbleConnection(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 64738), adapter, voiceSupport: false);
+        adapter.Initialise(connection);
+        typeof(MumbleConnection)
+            .GetProperty(nameof(MumbleConnection.State))!
+            .SetValue(connection, ConnectionStates.Connected);
+
+        var packetStream = new MemoryStream();
+        var socketPair = CreateSocketPair();
+        var tcpSocketType = Type.GetType("MumbleSharp.TcpSocket, MumbleSharp")!;
+        var tcpSocket = RuntimeHelpers.GetUninitializedObject(tcpSocketType);
+        tcpSocketType.GetField("_netStream", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(tcpSocket, socketPair.Client.GetStream());
+        tcpSocketType.GetField("_tlsStream", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(tcpSocket, packetStream);
+        tcpSocketType.GetField("_writer", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(tcpSocket, new BinaryWriter(packetStream));
+        tcpSocketType.GetField("_sendLock", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(tcpSocket, new object());
+        typeof(MumbleConnection).GetField("_tcp", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(connection, tcpSocket);
+
+        return new CapturingConnection(packetStream, socketPair.Client, socketPair.Server);
+    }
+
+    private static (TcpClient Client, TcpClient Server) CreateSocketPair()
+    {
+        var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            var client = new TcpClient();
+            client.Connect((System.Net.IPEndPoint)listener.LocalEndpoint);
+            var server = listener.AcceptTcpClient();
+            return (client, server);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static ChannelState[] ReadSentChannelStatePackets(MemoryStream stream)
+    {
+        stream.Position = 0;
+        using var reader = new BinaryReader(stream, System.Text.Encoding.UTF8, leaveOpen: true);
+        var packets = new List<ChannelState>();
+
+        while (stream.Position < stream.Length)
+        {
+            var packetType = (PacketType)IPAddress.NetworkToHostOrder(reader.ReadInt16());
+            Assert.AreEqual(PacketType.ChannelState, packetType);
+            packets.Add(Serializer.DeserializeWithLengthPrefix<ChannelState>(stream, PrefixStyle.Fixed32BigEndian));
+        }
+
+        return packets.ToArray();
+    }
+
+    private static void InvokeBridgeHandler(NativeBridge bridge, string type, string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        NativeBridgeTestHarness.InvokeAsync(bridge, type, doc.RootElement.Clone()).GetAwaiter().GetResult();
+    }
+
     private static System.Collections.Concurrent.ConcurrentDictionary<uint, Channel> GetChannelDictionary(MumbleAdapter adapter)
         => (System.Collections.Concurrent.ConcurrentDictionary<uint, Channel>)adapter
             .GetType()
@@ -561,6 +693,27 @@ public class MumbleAdapterBridgeTests
     {
         var sent = NativeBridgeTestHarness.DrainMessages(bridge);
         Assert.IsTrue(sent.Any(m => m.Type == expectedType), $"Expected bridge message '{expectedType}' to be sent.");
+    }
+
+    private sealed class CapturingConnection : IDisposable
+    {
+        public CapturingConnection(MemoryStream packetStream, TcpClient client, TcpClient server)
+        {
+            PacketStream = packetStream;
+            Client = client;
+            Server = server;
+        }
+
+        public MemoryStream PacketStream { get; }
+        private TcpClient Client { get; }
+        private TcpClient Server { get; }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            Server.Dispose();
+            PacketStream.Dispose();
+        }
     }
 
     private sealed class ThrowingAppConfigService : IAppConfigService


### PR DESCRIPTION
## Summary

Implements a comprehensive channel reordering system allowing server administrators to drag-and-drop channels within their sibling groups directly in the Admin > Channels settings tab.

## Key Features

### Admin Interface
- **Drag-and-drop reordering**: Channels can be dragged and dropped within their sibling groups
- **Visual feedback**: Clear visual indicators during drag operations
  - Dragging highlight on the channel being moved
  - Drop target highlight when hovering over valid drop zones
  - Recently-moved animation after successful reorder
- **ACL editor integration**: Each channel row now has an "Edit" button to quickly open the ACL editor
- **Position-based ordering**: Channels are now ordered by their Mumble position field throughout the UI

### Technical Implementation
- **New channelOrder utility module** (`src/Brmble.Web/src/utils/channelOrder.ts`)
  - `sortChannels()`: Sorts channels by position, then name, then id
  - `getOrderedChannels()`: Recursively orders entire channel tree
  - `moveChannelToSiblingIndex()`: Handles drag-and-drop position updates
  - `buildReorderPayload()`: Creates bridge payload for server sync
  - Complete test coverage (68 lines of tests)

- **Enhanced bridge protocol**
  - New `voice.reorderChannels` handler validates and processes reorder requests
  - Validates all channels share the same parent before reordering
  - Sends ChannelState packets with distinct position values
  - Enhanced channel payloads now include `description` and `position` fields

- **UI updates throughout**
  - `App.tsx`: Applies ordering when receiving channel updates
  - `ChannelTree.tsx`: Displays channels in position order in sidebar
  - `AdminChannelsSection.tsx`: Full drag-and-drop UI with state management
  - Proper channel callbacks for real-time updates

### Testing
- **Unit tests**: `channelOrder.test.ts` covers all ordering utilities
- **Integration tests**: `MumbleAdapterBridgeTests.cs` verifies:
  - Distinct position assignment
  - Mixed parent validation
  - Proper ChannelState packet generation
- **UI tests**: `AdminWorkspaceSections.test.tsx` validates:
  - Drag-and-drop behavior
  - Visual feedback classes
  - ACL editor integration
  - Selected channel updates

## Files Changed

### C# Backend
- `MumbleAdapter.cs` (+42 lines)
  - Added `voice.reorderChannels` bridge handler
  - Enhanced channel payload with description/position
  - Added UI thread notification on channel join/remove

### Frontend Core
- `App.tsx` (+18, -13)
  - Apply ordering to incoming channel data
  - Pass onChannelsChange callback to settings

### Admin UI
- `AdminSettingsTab.tsx` (+5, -3)
  - Pass channels and callback to AdminChannelsSection
- `AdminSettingsTab.css` (+55)
  - Styles for drag-and-drop states and channel management layout
- `AdminChannelsSection.tsx` (+153, -39)
  - Complete drag-and-drop implementation
  - ACL editor dialog integration
  - Visual feedback state management
- `SettingsModal.tsx` (+9, -3)
  - Pass onChannelsChange prop through

### Channel Tree
- `ChannelTree.tsx` (+26, -16)
  - Use position-based ordering for sidebar display
  - Auto-expand channels with children

### Utilities & Types
- `channelOrder.ts` (new, 139 lines)
  - Complete ordering and reordering logic
- `channelOrder.test.ts` (new, 68 lines)
  - Comprehensive test coverage
- `types/index.ts` (+1)
  - Add position field to Channel interface

### Tests
- `MumbleAdapterBridgeTests.cs` (+153)
  - Test voice.reorderChannels handler
  - Verify ChannelState packet generation
  - Validate mixed parent rejection
- `AdminWorkspaceSections.test.tsx` (+132, -8)
  - Drag-and-drop behavior tests
  - Visual feedback validation
  - ACL editor integration tests
- `AdminSettingsTab.test.tsx` (+16, -8)
  - Updated for new channel list structure
- `ChannelTree.test.tsx` (+24)
  - Position-based ordering tests

## Usage

1. Connect to a Mumble server with admin permissions
2. Open Settings > Admin > Channels tab
3. Drag any channel row and drop it onto another channel in the same parent group
4. Visual feedback shows the drag state and drop target
5. Channel order persists to the Mumble server immediately
6. All clients see the updated order in their channel trees

## Technical Notes

- Channels can only be reordered within their sibling group (same parent)
- Position values are assigned in increments of 10 to allow future insertions
- Root channel (id: 0) cannot be dragged
- The reorder operation is optimistic - UI updates immediately while server syncs in background
- Recently-moved highlight clears after 1.2 seconds
