### PR TITLE
fix: channel ordering, version display, position persistence, shortcut recorder, admin UI refinements, and UI guide compliance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,12 @@
 **/obj/
 **/.vs/
 **/.git/
+!.git/
+!.git/HEAD
+!.git/refs/
+!.git/refs/heads/
+!.git/refs/heads/**
+!.git/packed-refs
 .worktrees/
 src/Brmble.Web/
 src/Brmble.Client/

--- a/.github/workflows/docker-server.yml
+++ b/.github/workflows/docker-server.yml
@@ -40,5 +40,7 @@ jobs:
           context: .
           file: src/Brmble.Server/Dockerfile
           push: true
+          build-args: |
+            SOURCE_REVISION_ID=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,5 +128,6 @@ jobs:
           push: true
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
+            SOURCE_REVISION_ID=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-local/docker-compose.yml
+++ b/docker-local/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     build:
       context: ..
       dockerfile: src/Brmble.Server/Dockerfile
+      args:
+        SOURCE_REVISION_ID: ${SOURCE_REVISION_ID:-}
     ports:
       - "1912:8080"
       - "7881:7881"

--- a/docs/superpowers/plans/2026-05-25-admin-channel-position-feedback.md
+++ b/docs/superpowers/plans/2026-05-25-admin-channel-position-feedback.md
@@ -1,0 +1,348 @@
+# Admin Channel Position Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show Mumble channel positions in the admin channel list and notify admins when a position save fails.
+
+**Architecture:** Keep the position display local to `AdminChannelsSection`, which already receives channel metadata. Route `admin.channelUpdateError` through `App.tsx` because top-right notifications are centralized there.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, existing Brmble bridge and `<Notification>` system.
+
+---
+
+## File Structure
+
+- Modify `src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx` to render a right-aligned position pill in each admin channel row.
+- Modify `src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css` to style the channel row as a left/right flex row and style the position pill with existing CSS tokens.
+- Modify `src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx` to assert position pills render, including default `Position 0`.
+- Modify `src/Brmble.Web/src/App.tsx` to listen for `admin.channelUpdateError`, register an info notification, and render it in the existing notification stack.
+- Modify or add an app-level test in `src/Brmble.Web/src/App.*.test.tsx` for the notification event.
+
+---
+
+### Task 1: Render Position Pills In Admin Channel Rows
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx`
+- Modify: `src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx`
+- Modify: `src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx`, add assertions to the existing channels overview test, or add this focused test near the existing channel tests:
+
+```tsx
+it('shows each admin channel position in a right-side label', () => {
+  render(<AdminChannelsSection channels={[
+    { id: 1, name: 'Root', position: 0 },
+    { id: 2, name: 'Raid', position: 12 },
+    { id: 3, name: 'No Position' },
+  ]} />);
+
+  expect(screen.getByRole('row', { name: 'Root Position 0' })).toBeInTheDocument();
+  expect(screen.getByRole('row', { name: 'Raid Position 12' })).toBeInTheDocument();
+  expect(screen.getByRole('row', { name: 'No Position Position 0' })).toBeInTheDocument();
+  expect(screen.getAllByText('Position 0')).toHaveLength(2);
+  expect(screen.getByText('Position 12')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```powershell
+npm test -- --run src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
+```
+
+Expected: FAIL because `Position 0` and `Position 12` are not rendered in admin channel rows.
+
+- [ ] **Step 3: Implement the position pill markup**
+
+In `src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx`, replace the row content:
+
+```tsx
+{channel.name}
+```
+
+with:
+
+```tsx
+<span className="admin-channel-row-name">{channel.name}</span>
+<span className="admin-channel-position-pill">Position {channel.position ?? 0}</span>
+```
+
+Update the row `aria-label` from:
+
+```tsx
+aria-label={channel.name}
+```
+
+to:
+
+```tsx
+aria-label={`${channel.name} Position ${channel.position ?? 0}`}
+```
+
+- [ ] **Step 4: Implement token-based styling**
+
+In `src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css`, update `.admin-channel-row`:
+
+```css
+.admin-channel-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  width: 100%;
+  min-width: 0;
+  text-align: left;
+  padding: var(--space-sm);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: inherit;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+```
+
+Add these rules near `.admin-channel-row`:
+
+```css
+.admin-channel-row-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-channel-position-pill {
+  flex: 0 0 auto;
+  padding: var(--space-2xs) var(--space-xs);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run:
+
+```powershell
+npm test -- --run src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```powershell
+git add -- src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
+git commit -m "fix: show admin channel positions"
+```
+
+---
+
+### Task 2: Show Notification When Admin Channel Update Fails
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Modify or create test: `src/Brmble.Web/src/App.adminChannelUpdate.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/Brmble.Web/src/App.adminChannelUpdate.test.tsx` with the same bridge mock style used by existing `App.*.test.tsx` files. The test should render `<App />`, emit `admin.channelUpdateError`, and assert notification copy appears:
+
+```tsx
+import { render, screen, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+import bridge from './bridge';
+
+vi.mock('./bridge', () => {
+  const handlers = new Map<string, Set<(data: unknown) => void>>();
+  return {
+    default: {
+      send: vi.fn(),
+      on: vi.fn((event: string, handler: (data: unknown) => void) => {
+        if (!handlers.has(event)) handlers.set(event, new Set());
+        handlers.get(event)!.add(handler);
+      }),
+      off: vi.fn((event: string, handler: (data: unknown) => void) => {
+        handlers.get(event)?.delete(handler);
+      }),
+      __emit: (event: string, data?: unknown) => {
+        handlers.get(event)?.forEach(handler => handler(data));
+      },
+      __reset: () => handlers.clear(),
+    },
+  };
+});
+
+describe('admin channel update notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (bridge as unknown as { __reset: () => void }).__reset();
+  });
+
+  it('shows an info notification when admin channel updates fail', async () => {
+    render(<App />);
+
+    await act(async () => {
+      (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('admin.channelUpdateError', { channelId: 7, statusCode: 403 });
+    });
+
+    expect(await screen.findByText('Channel position was not saved')).toBeInTheDocument();
+    expect(screen.getByText('You need Write permission on that channel. Check the channel ACL if inheritance is disabled.')).toBeInTheDocument();
+  });
+});
+```
+
+If the project has required mocks for `App` tests, copy only the required setup from the nearest existing `App.*.test.tsx` file rather than broadening production code.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```powershell
+npm test -- --run src/App.adminChannelUpdate.test.tsx
+```
+
+Expected: FAIL because `App.tsx` does not listen for `admin.channelUpdateError` or render this notification yet.
+
+- [ ] **Step 3: Add notification state and bridge handler**
+
+In `src/Brmble.Web/src/App.tsx`, add a notification state near the other notification states:
+
+```tsx
+const [adminChannelUpdateErrorVisible, setAdminChannelUpdateErrorVisible] = useState(false);
+```
+
+Inside the main bridge subscription effect, add a handler before registrations:
+
+```tsx
+const onAdminChannelUpdateError = () => {
+  setAdminChannelUpdateErrorVisible(true);
+  notifQueue.register('admin-channel-update-error', 'info');
+};
+```
+
+Register it with the other bridge handlers:
+
+```tsx
+bridge.on('admin.channelUpdateError', onAdminChannelUpdateError);
+```
+
+Unregister it in the cleanup block:
+
+```tsx
+bridge.off('admin.channelUpdateError', onAdminChannelUpdateError);
+```
+
+- [ ] **Step 4: Render the notification**
+
+In the existing `<div className="notification-stack">`, add this notification near other general app notifications:
+
+```tsx
+{adminChannelUpdateErrorVisible && notifQueue.isVisible('admin-channel-update-error') && (
+  <Notification
+    status="info"
+    position="top-right"
+    visible={adminChannelUpdateErrorVisible}
+    title="Channel position was not saved"
+    detail="You need Write permission on that channel. Check the channel ACL if inheritance is disabled."
+    onDismiss={() => {
+      setAdminChannelUpdateErrorVisible(false);
+    }}
+    onExited={() => {
+      notifQueue.unregister('admin-channel-update-error');
+    }}
+  />
+)}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run:
+
+```powershell
+npm test -- --run src/App.adminChannelUpdate.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused frontend tests**
+
+Run:
+
+```powershell
+npm test -- --run src/App.adminChannelUpdate.test.tsx src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```powershell
+git add -- src/Brmble.Web/src/App.tsx src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
+git commit -m "fix: notify when admin channel position save fails"
+```
+
+---
+
+### Task 3: Final Verification
+
+**Files:**
+- Verify all frontend files touched in Tasks 1 and 2.
+
+- [ ] **Step 1: Run type check**
+
+Run:
+
+```powershell
+npm run type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend tests**
+
+Run:
+
+```powershell
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Build frontend**
+
+Run:
+
+```powershell
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Check git status**
+
+Run:
+
+```powershell
+git status --short
+```
+
+Expected: only unrelated pre-existing untracked files may remain; all implementation files should be committed.

--- a/docs/superpowers/specs/2026-05-25-admin-channel-position-feedback-design.md
+++ b/docs/superpowers/specs/2026-05-25-admin-channel-position-feedback-design.md
@@ -1,0 +1,52 @@
+# Admin Channel Position Feedback Design
+
+## Summary
+
+Improve the admin channel management panel so admins can see the numeric Mumble position that drives channel ordering and receive clear feedback when a position update is rejected.
+
+## Goals
+
+- Show each channel's effective `position` value in `Settings > Admin > Channels`.
+- Keep the channel list compact and easy to scan.
+- Notify admins when an `admin.updateChannel` save fails, especially when the likely cause is missing Mumble `Write` permission after ACL inheritance is disabled.
+
+## Non-Goals
+
+- Do not change normal sidebar channel rows.
+- Do not add inline error state to the edit dialog.
+- Do not keep the edit dialog open after a failed save.
+- Do not change Mumble ACL authorization rules.
+
+## UX
+
+Admin channel rows will render the channel name on the left and a small right-aligned pill on the right: `Position N`.
+
+If a channel has no explicit `position`, the pill shows `Position 0`, matching Mumble's default ordering value.
+
+When `admin.channelUpdateError` is received, Brmble shows a top-right info notification:
+
+- Title: `Channel position was not saved`
+- Detail: `You need Write permission on that channel. Check the channel ACL if inheritance is disabled.`
+
+The notification uses the existing `<Notification>` system and `useNotificationQueue`; no toast or new notification system is introduced.
+
+## Data Flow
+
+`AdminChannelsSection` already receives `channels` with optional `position` metadata. It will render `channel.position ?? 0` in each admin channel row.
+
+`MumbleAdapter` already emits `admin.channelUpdateError` when the server rejects or cannot complete an update. `App.tsx` will listen for this event, register a queued info notification, and render it in the existing notification stack.
+
+## Error Handling
+
+The notification is intentionally informational rather than blocking. A failed save means the attempted channel state change did not persist; the dialog remains closed to preserve the current save flow.
+
+The copy names the most likely cause based on current authorization: the server requires Mumble `Write` permission on the target channel.
+
+## Styling
+
+Use existing admin row styling and CSS custom property tokens only. The pill should be subtle, right-aligned, and not compete with the selected-row state.
+
+## Tests
+
+- Add or update admin channel section tests to assert `Position N` pills render, including default `Position 0`.
+- Add or update app-level bridge event tests to assert `admin.channelUpdateError` displays the info notification copy.

--- a/docs/superpowers/specs/2026-05-25-admin-channel-position-feedback-design.md
+++ b/docs/superpowers/specs/2026-05-25-admin-channel-position-feedback-design.md
@@ -23,7 +23,7 @@ Admin channel rows will render the channel name on the left and a small right-al
 
 If a channel has no explicit `position`, the pill shows `Position 0`, matching Mumble's default ordering value.
 
-When `admin.channelUpdateError` is received, Brmble shows a top-right info notification:
+When `admin.channelUpdateError` is received, Brmble shows a top-right warning notification:
 
 - Title: `Channel position was not saved`
 - Detail: `You need Write permission on that channel. Check the channel ACL if inheritance is disabled.`
@@ -34,7 +34,7 @@ The notification uses the existing `<Notification>` system and `useNotificationQ
 
 `AdminChannelsSection` already receives `channels` with optional `position` metadata. It will render `channel.position ?? 0` in each admin channel row.
 
-`MumbleAdapter` already emits `admin.channelUpdateError` when the server rejects or cannot complete an update. `App.tsx` will listen for this event, register a queued info notification, and render it in the existing notification stack.
+`MumbleAdapter` already emits `admin.channelUpdateError` when the server rejects or cannot complete an update. `App.tsx` will listen for this event, register a queued warning notification, and render it in the existing notification stack.
 
 ## Error Handling
 
@@ -49,4 +49,4 @@ Use existing admin row styling and CSS custom property tokens only. The pill sho
 ## Tests
 
 - Add or update admin channel section tests to assert `Position N` pills render, including default `Position 0`.
-- Add or update app-level bridge event tests to assert `admin.channelUpdateError` displays the info notification copy.
+- Add or update app-level bridge event tests to assert `admin.channelUpdateError` displays the warning notification copy.

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1442,6 +1442,20 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         int? delayMs = null)
         => new(service, state, reason, attempt, delayMs);
 
+    internal static ChannelState CreateEditChannelState(
+        uint channelId,
+        Channel channel,
+        string name,
+        string? description,
+        int? position)
+        => new()
+        {
+            ChannelId = channelId,
+            Name = name,
+            Description = description ?? string.Empty,
+            Position = position ?? channel.Position,
+        };
+
     internal static bool ShouldRefreshCredentialsAfterHealthSuccess(
         bool credentialsAlreadyFetched,
         bool previousHealthWasConnected,
@@ -3015,16 +3029,16 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 return Task.CompletedTask;
             }
 
-            var position = channel.Position;
-            var hasPosition = data.TryGetProperty("position", out var pos) && pos.TryGetInt32(out position);
+            var position = data.TryGetProperty("position", out var pos) && pos.TryGetInt32(out var parsedPosition)
+                ? parsedPosition
+                : (int?)null;
 
-            Connection.SendControl(PacketType.ChannelState, new ChannelState
-            {
-                ChannelId = channelId,
-                Name = name,
-                Description = description ?? string.Empty,
-                Position = hasPosition ? position : channel.Position,
-            });
+            Connection.SendControl(PacketType.ChannelState, CreateEditChannelState(
+                channelId,
+                channel,
+                name,
+                description,
+                position));
 
             return Task.CompletedTask;
         });

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -3015,11 +3015,15 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 return Task.CompletedTask;
             }
 
+            var position = channel.Position;
+            var hasPosition = data.TryGetProperty("position", out var pos) && pos.TryGetInt32(out position);
+
             Connection.SendControl(PacketType.ChannelState, new ChannelState
             {
                 ChannelId = channelId,
                 Name = name,
                 Description = description ?? string.Empty,
+                Position = hasPosition ? position : channel.Position,
             });
 
             return Task.CompletedTask;
@@ -3897,6 +3901,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         id = channel.Id,
         name = channel.Name,
         parent = channel.Parent,
+        position = channel.Position,
         isEnterRestricted = channel.IsEnterRestricted,
         canEnter = channel.CanEnter,
         hasPasswordRestriction = _channelPasswordRestrictions.TryGetValue(channel.Id, out var hasPasswordRestriction) && hasPasswordRestriction,

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1382,6 +1382,14 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         return await SendViaBcTls(cert, uri, httpRequest);
     }
 
+    private static async Task<TlsResult> PatchViaBcTls(X509Certificate2 cert, Uri uri, string jsonBody)
+    {
+        var hostHeader = uri.IsDefaultPort ? uri.Host : $"{uri.Host}:{uri.Port}";
+        var contentLength = System.Text.Encoding.UTF8.GetByteCount(jsonBody);
+        var httpRequest = $"PATCH {uri.PathAndQuery} HTTP/1.1\r\nHost: {hostHeader}\r\nContent-Type: application/json\r\nContent-Length: {contentLength}\r\nConnection: close\r\n\r\n{jsonBody}";
+        return await SendViaBcTls(cert, uri, httpRequest);
+    }
+
     internal static string CreateLiveKitTokenRequestBody(string roomName, string accessMode)
     {
         var normalizedAccessMode = accessMode.Trim().ToLowerInvariant() switch
@@ -3545,6 +3553,38 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             var result = await PutViaBcTls(cert, uri, requestJson);
             var eventType = result.Success || result.StatusCode == 409 ? "acl.writeResult" : "acl.error";
             _bridge?.Send(eventType, new { channelId, body = result.Body, statusCode = result.StatusCode, error = result.Error });
+            _bridge?.NotifyUiThread();
+        });
+
+        bridge.RegisterHandler("admin.updateChannel", async data =>
+        {
+            var channelId = data.TryGetProperty("channelId", out var cid) && cid.ValueKind == System.Text.Json.JsonValueKind.Number
+                ? cid.GetInt32()
+                : 0;
+            if (channelId <= 0 || _apiUrl is null)
+            {
+                _bridge?.Send("admin.channelUpdateError", new { channelId, error = "Not connected or invalid channel" });
+                _bridge?.NotifyUiThread();
+                return;
+            }
+
+            using var cert = _certService?.GetExportableCertificate();
+            if (cert is null)
+            {
+                _bridge?.Send("admin.channelUpdateError", new { channelId, error = "No client certificate" });
+                _bridge?.NotifyUiThread();
+                return;
+            }
+
+            var name = data.TryGetProperty("name", out var nameEl) ? nameEl.GetString() : string.Empty;
+            var description = data.TryGetProperty("description", out var descEl) ? descEl.GetString() : string.Empty;
+            var position = data.TryGetProperty("position", out var posEl) && posEl.TryGetInt32(out var parsedPosition)
+                ? parsedPosition
+                : 0;
+            var requestJson = System.Text.Json.JsonSerializer.Serialize(new { name, description, position });
+            var uri = new Uri(new Uri(_apiUrl, UriKind.Absolute), $"acl/channels/{channelId}/state");
+            var result = await PatchViaBcTls(cert, uri, requestJson);
+            _bridge?.Send(result.Success ? "admin.channelUpdated" : "admin.channelUpdateError", new { channelId, body = result.Body, statusCode = result.StatusCode, error = result.Error });
             _bridge?.NotifyUiThread();
         });
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1451,6 +1451,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         => new()
         {
             ChannelId = channelId,
+            Parent = channel.Parent,
             Name = name,
             Description = description ?? string.Empty,
             Position = position ?? channel.Position,

--- a/src/Brmble.Server/Dockerfile
+++ b/src/Brmble.Server/Dockerfile
@@ -26,6 +26,7 @@ RUN curl -fsSL -o /usr/local/bin/continuwuity \
 # ── Stage 2: Build Brmble.Server ─────────────────────────────────────────────
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG VERSION=0.0.0-dev
+ARG SOURCE_REVISION_ID=
 WORKDIR /src
 
 COPY Directory.Build.props .
@@ -36,6 +37,7 @@ RUN dotnet publish src/Brmble.Server/Brmble.Server.csproj \
     -r linux-x64 \
     --no-self-contained \
     -p:Version=${VERSION} \
+    -p:SourceRevisionId=${SOURCE_REVISION_ID} \
     -o /app/publish
 
 # ── Stage 3: Runtime image ────────────────────────────────────────────────────

--- a/src/Brmble.Server/Dockerfile
+++ b/src/Brmble.Server/Dockerfile
@@ -30,14 +30,25 @@ ARG SOURCE_REVISION_ID=
 WORKDIR /src
 
 COPY Directory.Build.props .
+COPY .git/ .git/
 COPY src/Brmble.Server/ src/Brmble.Server/
 
-RUN dotnet publish src/Brmble.Server/Brmble.Server.csproj \
+RUN source_revision_id="$SOURCE_REVISION_ID"; \
+    if [ -z "$source_revision_id" ] && [ -f .git/HEAD ]; then \
+        head_ref="$(cat .git/HEAD)"; \
+        case "$head_ref" in \
+          ref:\ *) ref_path="${head_ref#ref: }"; \
+                   if [ -f ".git/$ref_path" ]; then source_revision_id="$(cat ".git/$ref_path")"; \
+                   elif [ -f .git/packed-refs ]; then source_revision_id="$(awk -v ref="$ref_path" '$2 == ref { print $1; exit }' .git/packed-refs)"; fi ;; \
+          *) source_revision_id="$head_ref" ;; \
+        esac; \
+    fi && \
+    dotnet publish src/Brmble.Server/Brmble.Server.csproj \
     -c Release \
     -r linux-x64 \
     --no-self-contained \
     -p:Version=${VERSION} \
-    -p:SourceRevisionId=${SOURCE_REVISION_ID} \
+    -p:SourceRevisionId=${source_revision_id} \
     -o /app/publish
 
 # ── Stage 3: Runtime image ────────────────────────────────────────────────────

--- a/src/Brmble.Server/Mumble/AclAdminEndpoints.cs
+++ b/src/Brmble.Server/Mumble/AclAdminEndpoints.cs
@@ -28,6 +28,33 @@ public static class AclAdminEndpoints
             return Results.Ok(new { snapshot = canonical, cached });
         });
 
+        group.MapPatch("state", async (
+            int channelId,
+            ChannelUpdateRequest request,
+            HttpContext httpContext,
+            ICertificateHashExtractor certHashExtractor,
+            UserRepository userRepo,
+            IAclAuthorizationService authorization,
+            IMumbleAclService mumbleAcl,
+            ILoggerFactory loggerFactory) =>
+        {
+            var auth = await ResolveAuthorizedUser(httpContext, certHashExtractor, userRepo, authorization, channelId);
+            if (auth.Result is not null)
+            {
+                return auth.Result;
+            }
+
+            if (string.IsNullOrWhiteSpace(request.Name))
+            {
+                return Results.BadRequest(new { error = "Channel name is required." });
+            }
+
+            await mumbleAcl.UpdateChannelStateAsync(channelId, request);
+            loggerFactory.CreateLogger("Brmble.Server.Mumble.AclAudit")
+                .LogInformation("Channel state update actor={UserId} channel={ChannelId}", auth.User!.Id, channelId);
+            return Results.NoContent();
+        });
+
         group.MapPut("", async (
             int channelId,
             AclUpdateRequest request,

--- a/src/Brmble.Server/Mumble/AclDtos.cs
+++ b/src/Brmble.Server/Mumble/AclDtos.cs
@@ -36,6 +36,8 @@ public sealed record AclUpdateRequest(
 
 public sealed record AclGroupMemberRequest(int Session, string Group);
 
+public sealed record ChannelUpdateRequest(string Name, string? Description, int Position);
+
 public sealed record AclWriteResult(
     bool Success,
     AclChannelSnapshotDto? Snapshot,

--- a/src/Brmble.Server/Mumble/IMumbleAclService.cs
+++ b/src/Brmble.Server/Mumble/IMumbleAclService.cs
@@ -3,6 +3,7 @@ namespace Brmble.Server.Mumble;
 public interface IMumbleAclService
 {
     Task<AclChannelSnapshotDto> GetChannelAclAsync(int channelId);
+    Task UpdateChannelStateAsync(int channelId, ChannelUpdateRequest request);
     Task SetChannelAclAsync(int channelId, AclUpdateRequest request);
     Task AddUserToGroupAsync(int channelId, int sessionId, string group);
     Task RemoveUserFromGroupAsync(int channelId, int sessionId, string group);
@@ -13,6 +14,8 @@ public interface IMumbleAclService
 public interface IMumbleAclIceClient
 {
     Task<MumbleServer.Server_GetACLResult> GetAclAsync(int channelId);
+    Task<MumbleServer.Channel> GetChannelStateAsync(int channelId);
+    Task SetChannelStateAsync(MumbleServer.Channel channel);
     Task SetAclAsync(int channelId, MumbleServer.ACL[] acls, MumbleServer.Group[] groups, bool inherit);
     Task AddUserToGroupAsync(int channelId, int sessionId, string group);
     Task RemoveUserFromGroupAsync(int channelId, int sessionId, string group);

--- a/src/Brmble.Server/Mumble/MumbleAclIceClient.cs
+++ b/src/Brmble.Server/Mumble/MumbleAclIceClient.cs
@@ -14,6 +14,12 @@ public sealed class MumbleAclIceClient : IMumbleAclIceClient
     public Task<MumbleServer.Server_GetACLResult> GetAclAsync(int channelId)
         => GetProxy().getACLAsync(channelId);
 
+    public Task<MumbleServer.Channel> GetChannelStateAsync(int channelId)
+        => GetProxy().getChannelStateAsync(channelId);
+
+    public Task SetChannelStateAsync(MumbleServer.Channel channel)
+        => GetProxy().setChannelStateAsync(channel);
+
     public Task SetAclAsync(int channelId, MumbleServer.ACL[] acls, MumbleServer.Group[] groups, bool inherit)
         => GetProxy().setACLAsync(channelId, acls, groups, inherit);
 

--- a/src/Brmble.Server/Mumble/MumbleAclService.cs
+++ b/src/Brmble.Server/Mumble/MumbleAclService.cs
@@ -40,6 +40,29 @@ public sealed class MumbleAclService : IMumbleAclService
         }
     }
 
+    public async Task UpdateChannelStateAsync(int channelId, ChannelUpdateRequest request)
+    {
+        try
+        {
+            var current = await _iceClient.GetChannelStateAsync(channelId);
+            var updated = new MumbleServer.Channel(
+                current.id,
+                request.Name.Trim(),
+                current.parent,
+                current.links,
+                request.Description ?? string.Empty,
+                current.temporary,
+                request.Position);
+
+            await _iceClient.SetChannelStateAsync(updated);
+        }
+        catch (Exception ex) when (ex is not MumbleAclUnavailableException and not MumbleAclException)
+        {
+            _logger.LogWarning(ex, "Failed to update channel state for channel {ChannelId}", channelId);
+            throw new MumbleAclException($"Failed to update channel {channelId}.", ex);
+        }
+    }
+
     public async Task AddUserToGroupAsync(int channelId, int sessionId, string group)
     {
         try

--- a/src/Brmble.Server/Mumble/MumbleAclService.cs
+++ b/src/Brmble.Server/Mumble/MumbleAclService.cs
@@ -50,7 +50,7 @@ public sealed class MumbleAclService : IMumbleAclService
                 request.Name.Trim(),
                 current.parent,
                 current.links,
-                request.Description ?? string.Empty,
+                request.Description ?? current.description,
                 current.temporary,
                 request.Position);
 

--- a/src/Brmble.Server/ServerInfo/ServerVersionProvider.cs
+++ b/src/Brmble.Server/ServerInfo/ServerVersionProvider.cs
@@ -11,6 +11,26 @@ public sealed class ServerVersionProvider : IServerVersionProvider
 {
     public string Version { get; } = ReadVersion();
 
+    internal static string FormatVersion(string version, string? sourceRevisionId)
+    {
+        var releaseMatch = System.Text.RegularExpressions.Regex.Match(version, @"^(\d+\.\d+\.\d+)(?:\+[0-9a-f]{7,40})?$", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        if (releaseMatch.Success)
+        {
+            return releaseMatch.Groups[1].Value;
+        }
+
+        var sha = sourceRevisionId;
+        if (string.IsNullOrWhiteSpace(sha))
+        {
+            var match = System.Text.RegularExpressions.Regex.Match(version, @"\+([0-9a-f]{7,40})$", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            sha = match.Success ? match.Groups[1].Value : null;
+        }
+
+        return string.IsNullOrWhiteSpace(sha)
+            ? version
+            : $"Dev main {sha[..Math.Min(7, sha.Length)]}";
+    }
+
     private static string ReadVersion()
     {
         var informational = typeof(ServerVersionProvider).Assembly
@@ -19,7 +39,7 @@ public sealed class ServerVersionProvider : IServerVersionProvider
 
         if (!string.IsNullOrWhiteSpace(informational))
         {
-            return informational;
+            return FormatVersion(informational, null);
         }
 
         var fileVersion = typeof(ServerVersionProvider).Assembly

--- a/src/Brmble.Server/ServerInfo/ServerVersionProvider.cs
+++ b/src/Brmble.Server/ServerInfo/ServerVersionProvider.cs
@@ -19,6 +19,13 @@ public sealed class ServerVersionProvider : IServerVersionProvider
             return releaseMatch.Groups[1].Value;
         }
 
+        if (System.Text.RegularExpressions.Regex.IsMatch(version, @"^0\.0\.0(?:[-+]|$)", System.Text.RegularExpressions.RegexOptions.IgnoreCase)
+            && string.IsNullOrWhiteSpace(sourceRevisionId)
+            && !System.Text.RegularExpressions.Regex.IsMatch(version, @"\+[0-9a-f]{7,40}$", System.Text.RegularExpressions.RegexOptions.IgnoreCase))
+        {
+            return "Dev main";
+        }
+
         var sha = sourceRevisionId;
         if (string.IsNullOrWhiteSpace(sha))
         {

--- a/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
+++ b/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
@@ -228,9 +228,9 @@ function renderApp() {
   );
 }
 
-async function emitAdminChannelUpdateError() {
+async function emitAdminChannelUpdateError(payload?: object) {
   await act(async () => {
-    (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('admin.channelUpdateError', { channelId: 7, statusCode: 403 });
+    (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('admin.channelUpdateError', payload ?? { channelId: 7, statusCode: 403 });
   });
 }
 
@@ -242,14 +242,33 @@ describe('admin channel update notifications', () => {
     (bridge as unknown as { __reset: () => void }).__reset();
   });
 
-  it('shows a warning notification when admin channel updates fail', async () => {
+  it('shows a warning notification with Write-permission guidance for 403 errors', async () => {
     renderApp();
 
-    await emitAdminChannelUpdateError();
+    await emitAdminChannelUpdateError({ channelId: 7, statusCode: 403 });
 
     expect(mockValues.notificationQueue.register).toHaveBeenCalledWith('admin-channel-update-error', 'warning');
     expect(await screen.findByText('Channel position was not saved')).toBeInTheDocument();
     expect(screen.getByText('You need Write permission on that channel. Check the channel ACL if inheritance is disabled.')).toBeInTheDocument();
+  });
+
+  it('shows a generic failure notification for non-403 errors', async () => {
+    renderApp();
+
+    await emitAdminChannelUpdateError({ channelId: 7, statusCode: 400, body: 'Bad request' });
+
+    expect(mockValues.notificationQueue.register).toHaveBeenCalledWith('admin-channel-update-error', 'warning');
+    expect(await screen.findByText('Channel update failed')).toBeInTheDocument();
+    expect(screen.getByText('Request failed (400). Please try again.')).toBeInTheDocument();
+  });
+
+  it('shows a generic failure notification when no status code is present', async () => {
+    renderApp();
+
+    await emitAdminChannelUpdateError({ channelId: 7, error: 'Not connected or invalid channel' });
+
+    expect(await screen.findByText('Channel update failed')).toBeInTheDocument();
+    expect(screen.getByText('Request failed (Not connected or invalid channel). Please try again.')).toBeInTheDocument();
   });
 
   it('unregisters the queue entry when dismissed', async () => {
@@ -272,7 +291,7 @@ describe('admin channel update notifications', () => {
       await act(async () => {
         vi.advanceTimersByTime(4900);
       });
-      await emitAdminChannelUpdateError();
+      await emitAdminChannelUpdateError({ channelId: 7, statusCode: 403 });
       await act(async () => {
         vi.advanceTimersByTime(5200);
       });

--- a/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
+++ b/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
@@ -242,11 +242,12 @@ describe('admin channel update notifications', () => {
     (bridge as unknown as { __reset: () => void }).__reset();
   });
 
-  it('shows an info notification when admin channel updates fail', async () => {
+  it('shows a warning notification when admin channel updates fail', async () => {
     renderApp();
 
     await emitAdminChannelUpdateError();
 
+    expect(mockValues.notificationQueue.register).toHaveBeenCalledWith('admin-channel-update-error', 'warning');
     expect(await screen.findByText('Channel position was not saved')).toBeInTheDocument();
     expect(screen.getByText('You need Write permission on that channel. Check the channel ACL if inheritance is disabled.')).toBeInTheDocument();
   });
@@ -260,7 +261,7 @@ describe('admin channel update notifications', () => {
     expect(mockValues.notificationQueue.unregister).toHaveBeenCalledWith('admin-channel-update-error');
   });
 
-  it('refreshes the notification timer for repeated failures while visible', async () => {
+  it('keeps the warning visible for repeated failures', async () => {
     vi.useFakeTimers();
     try {
       renderApp();
@@ -273,16 +274,11 @@ describe('admin channel update notifications', () => {
       });
       await emitAdminChannelUpdateError();
       await act(async () => {
-        vi.advanceTimersByTime(200);
+        vi.advanceTimersByTime(5200);
       });
 
       expect(screen.getByText('Channel position was not saved')).toBeInTheDocument();
-
-      await act(async () => {
-        vi.advanceTimersByTime(5000);
-      });
-
-      expect(screen.queryByText('Channel position was not saved')).not.toBeInTheDocument();
+      expect(mockValues.notificationQueue.register).toHaveBeenCalledWith('admin-channel-update-error', 'warning');
     } finally {
       vi.useRealTimers();
     }

--- a/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
+++ b/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+import bridge from './bridge';
+import { ServiceStatusProvider } from './hooks/useServiceStatus';
+
+const mockValues = vi.hoisted(() => {
+  const matrixClient = {
+    lastMessages: new Map(),
+    activeMessages: [],
+    setActiveChannel: vi.fn(),
+    sendMessage: vi.fn(),
+    sendImageMessage: vi.fn(),
+    uploadContent: vi.fn(),
+    fetchHistory: vi.fn(),
+    sendReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    dmLastMessages: new Map(),
+    activeDmMessages: [],
+    setActiveDmContact: vi.fn(),
+    dmRoomMap: new Map(),
+    dmUserDisplayNames: new Map(),
+    dmUserAvatarUrls: new Map(),
+    sendDMMessage: vi.fn(),
+    fetchDMHistory: vi.fn(),
+    fetchAvatarUrl: vi.fn(),
+    client: null,
+    activeTypingText: null,
+    startTyping: vi.fn(),
+    stopTyping: vi.fn(),
+  };
+
+  const dmStore = {
+    contacts: [],
+    selectedContact: null,
+    messages: [],
+    appMode: 'channels' as const,
+    selectContact: vi.fn(),
+    sendMessage: vi.fn(),
+    startDM: vi.fn(),
+    clearSelection: vi.fn(),
+    toggleMode: vi.fn(),
+    closeDM: vi.fn(),
+    appModeRef: { current: 'channels' as const },
+    selectedContactIdRef: { current: null },
+    receiveMumbleDM: vi.fn(),
+    updateMumbleSession: vi.fn(),
+    clearMumbleContacts: vi.fn(),
+    startMumbleDM: vi.fn(),
+  };
+
+  const unreadTracker = {
+    roomUnreads: new Map(),
+    getRoomUnread: vi.fn(() => ({ notificationCount: 0, highlightCount: 0, fullyReadEventId: null })),
+    markRoomRead: vi.fn(),
+    getFullyReadEventId: vi.fn(() => null),
+    getMarkerTimestamp: vi.fn(() => null),
+    totalUnreadCount: 0,
+    totalDmUnreadCount: 0,
+  };
+
+  const idleActions = {
+    autoLeftAt: null,
+    preLeaveStartedAt: null,
+    preLeaveCancelledAt: null,
+    dismissNotification: vi.fn(),
+    dismissPreLeaveCancelled: vi.fn(),
+  };
+
+  const screenShare = {
+    isSharing: false,
+    startSharing: vi.fn(),
+    stopSharing: vi.fn(),
+    markLocalShareTeardownIntent: vi.fn(),
+    error: null,
+    activeShare: null,
+    activeShares: [],
+    watchingShare: null,
+    watchingShares: [],
+    isViewerConnectPending: false,
+    focusedShare: null,
+    setFocusedShare: vi.fn(),
+    setDiscoveryTarget: vi.fn(),
+    remoteVideoEl: null,
+    remoteVideoEls: new Map(),
+    roomQuality: undefined,
+    shareQualities: new Map(),
+    addWatchingShare: vi.fn(),
+    removeWatchingShare: vi.fn(),
+    disconnectViewer: vi.fn(),
+    connectAsViewer: vi.fn(),
+    handleScreenShareServiceUnavailable: vi.fn(),
+  };
+
+  return { matrixClient, dmStore, unreadTracker, idleActions, screenShare };
+});
+
+vi.mock('./bridge', () => {
+  const handlers = new Map<string, Set<(data: unknown) => void>>();
+  return {
+    default: {
+      send: vi.fn(),
+      on: vi.fn((event: string, handler: (data: unknown) => void) => {
+        if (!handlers.has(event)) handlers.set(event, new Set());
+        handlers.get(event)!.add(handler);
+      }),
+      off: vi.fn((event: string, handler: (data: unknown) => void) => {
+        handlers.get(event)?.delete(handler);
+      }),
+      __emit: (event: string, data?: unknown) => {
+        handlers.get(event)?.forEach(handler => handler(data));
+      },
+      __reset: () => handlers.clear(),
+    },
+  };
+});
+
+vi.mock('./components/Header/Header', () => ({
+  Header: () => <header data-testid="header" />,
+}));
+
+vi.mock('./components/Sidebar/Sidebar', () => ({
+  Sidebar: () => <aside data-testid="sidebar" />,
+}));
+
+vi.mock('./components/ChatPanel/ChatPanel', () => ({
+  ChatPanel: () => <section data-testid="chat-panel" />,
+}));
+
+vi.mock('./components/ServerList/ServerList', () => ({
+  ServerList: () => <section data-testid="server-list" />,
+}));
+
+vi.mock('./components/ConnectionState/ConnectionState', () => ({
+  ConnectionState: () => <section data-testid="connection-state" />,
+}));
+
+vi.mock('./components/DMContactList/DMContactList', () => ({
+  DMContactList: () => null,
+}));
+
+vi.mock('./components/NeonD/NeonDGame', () => ({
+  NeonDGame: () => null,
+}));
+
+vi.mock('./components/SettingsModal/SettingsModal', () => ({
+  DEFAULT_SCREEN_SHARE: {
+    captureAudio: false,
+    resolution: '1080p',
+    fps: 30,
+    systemAudio: false,
+    viewerMode: 'in-app',
+  },
+  SettingsModal: () => null,
+}));
+
+vi.mock('./hooks/useMatrixClient', () => ({
+  useMatrixClient: () => mockValues.matrixClient,
+}));
+
+vi.mock('./hooks/useChatStore', () => ({
+  useChatStore: () => ({ messages: [], addMessage: vi.fn() }),
+  addMessageToStore: vi.fn(),
+  clearChatStorage: vi.fn(),
+  purgeEphemeralMessages: vi.fn(),
+}));
+
+vi.mock('./hooks/useDMStore', () => ({
+  useDMStore: () => mockValues.dmStore,
+}));
+
+vi.mock('./hooks/useUnreadTracker', () => ({
+  resetMarkersCache: vi.fn(),
+  useUnreadTracker: () => mockValues.unreadTracker,
+}));
+
+vi.mock('./hooks/useBrmbleIdle', () => ({
+  useBrmbleIdle: () => 0,
+}));
+
+vi.mock('./hooks/useIdleStatus', () => ({
+  useIdleStatus: () => ({ voiceIdle: {}, systemIdle: 0, isLocked: false }),
+}));
+
+vi.mock('./hooks/useIdleActions', () => ({
+  AFK_THRESHOLD_SEC: 600,
+  useIdleActions: () => mockValues.idleActions,
+}));
+
+vi.mock('./hooks/useServerHealth', () => ({
+  useServerHealth: () => undefined,
+}));
+
+vi.mock('./hooks/useCompanionOverlayPublisher', () => ({
+  useCompanionOverlayPublisher: () => undefined,
+}));
+
+vi.mock('./hooks/useLeaveVoiceCooldown', () => ({
+  useLeaveVoiceCooldown: () => ({ isOnCooldown: false, trigger: vi.fn() }),
+}));
+
+vi.mock('./hooks/useScreenShare', () => ({
+  useScreenShare: () => mockValues.screenShare,
+}));
+
+describe('admin channel update notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    (bridge as unknown as { __reset: () => void }).__reset();
+  });
+
+  it('shows an info notification when admin channel updates fail', async () => {
+    render(
+      <ServiceStatusProvider>
+        <App />
+      </ServiceStatusProvider>,
+    );
+
+    await act(async () => {
+      (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('admin.channelUpdateError', { channelId: 7, statusCode: 403 });
+    });
+
+    expect(await screen.findByText('Channel position was not saved')).toBeInTheDocument();
+    expect(screen.getByText('You need Write permission on that channel. Check the channel ACL if inheritance is disabled.')).toBeInTheDocument();
+  });
+});

--- a/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
+++ b/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
 import bridge from './bridge';
@@ -92,7 +92,20 @@ const mockValues = vi.hoisted(() => {
     handleScreenShareServiceUnavailable: vi.fn(),
   };
 
-  return { matrixClient, dmStore, unreadTracker, idleActions, screenShare };
+  const notificationQueueIds = new Set<string>();
+  const notificationQueue = {
+    register: vi.fn((id: string) => {
+      notificationQueueIds.add(id);
+    }),
+    unregister: vi.fn((id: string) => {
+      notificationQueueIds.delete(id);
+    }),
+    isVisible: vi.fn((id: string) => notificationQueueIds.has(id)),
+    visibleCount: 0,
+    totalCount: 0,
+  };
+
+  return { matrixClient, dmStore, unreadTracker, idleActions, screenShare, notificationQueue, notificationQueueIds };
 });
 
 vi.mock('./bridge', () => {
@@ -199,29 +212,51 @@ vi.mock('./hooks/useLeaveVoiceCooldown', () => ({
   useLeaveVoiceCooldown: () => ({ isOnCooldown: false, trigger: vi.fn() }),
 }));
 
+vi.mock('./hooks/useNotificationQueue', () => ({
+  useNotificationQueue: () => mockValues.notificationQueue,
+}));
+
 vi.mock('./hooks/useScreenShare', () => ({
   useScreenShare: () => mockValues.screenShare,
 }));
 
+function renderApp() {
+  render(
+    <ServiceStatusProvider>
+      <App />
+    </ServiceStatusProvider>,
+  );
+}
+
+async function emitAdminChannelUpdateError() {
+  await act(async () => {
+    (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('admin.channelUpdateError', { channelId: 7, statusCode: 403 });
+  });
+}
+
 describe('admin channel update notifications', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockValues.notificationQueueIds.clear();
     localStorage.clear();
     (bridge as unknown as { __reset: () => void }).__reset();
   });
 
   it('shows an info notification when admin channel updates fail', async () => {
-    render(
-      <ServiceStatusProvider>
-        <App />
-      </ServiceStatusProvider>,
-    );
+    renderApp();
 
-    await act(async () => {
-      (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('admin.channelUpdateError', { channelId: 7, statusCode: 403 });
-    });
+    await emitAdminChannelUpdateError();
 
     expect(await screen.findByText('Channel position was not saved')).toBeInTheDocument();
     expect(screen.getByText('You need Write permission on that channel. Check the channel ACL if inheritance is disabled.')).toBeInTheDocument();
+  });
+
+  it('unregisters the queue entry when dismissed', async () => {
+    renderApp();
+    await emitAdminChannelUpdateError();
+
+    fireEvent.click(await screen.findByLabelText('Dismiss notification'));
+
+    expect(mockValues.notificationQueue.unregister).toHaveBeenCalledWith('admin-channel-update-error');
   });
 });

--- a/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
+++ b/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
@@ -259,4 +259,32 @@ describe('admin channel update notifications', () => {
 
     expect(mockValues.notificationQueue.unregister).toHaveBeenCalledWith('admin-channel-update-error');
   });
+
+  it('refreshes the notification timer for repeated failures while visible', async () => {
+    vi.useFakeTimers();
+    try {
+      renderApp();
+      await emitAdminChannelUpdateError();
+
+      expect(screen.getByText('Channel position was not saved')).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(4900);
+      });
+      await emitAdminChannelUpdateError();
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByText('Channel position was not saved')).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(screen.queryByText('Channel position was not saved')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -73,7 +73,7 @@ const {
   };
   let idleActionsArgs: { onBeforeAutoLeave?: () => void | Promise<void> } | null = null;
   let localShareEndedHandler: ((reason: 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel') => void) | null = null;
-  let latestSidebarProps: { channels?: Array<{ id: number; canEnter?: boolean; hasPasswordRestriction?: boolean }> } = {};
+  let latestSidebarProps: { channels?: Array<{ id: number; canEnter?: boolean; hasPasswordRestriction?: boolean; position?: number; description?: string }> } = {};
   const mockBridge = {
     send: vi.fn(),
     on: vi.fn((type: string, handler: BridgeHandler) => {
@@ -103,7 +103,7 @@ const {
     bridge: mockBridge,
     sidebarProps: {
       get current() { return latestSidebarProps; },
-      set current(value: { channels?: Array<{ id: number; canEnter?: boolean; hasPasswordRestriction?: boolean }> }) { latestSidebarProps = value; },
+      set current(value: { channels?: Array<{ id: number; canEnter?: boolean; hasPasswordRestriction?: boolean; position?: number; description?: string }> }) { latestSidebarProps = value; },
     },
     disconnectViewer: disconnect,
     setDiscoveryTarget: setTarget,
@@ -287,7 +287,7 @@ vi.mock('./components/Sidebar/Sidebar', () => ({
     onDisconnect?: () => void;
     onWatchScreenShare?: (roomName: string, userId?: number, matrixUserId?: string) => void;
     onJoinChannel?: (channelId: number) => void;
-    channels?: Array<{ id: number; canEnter?: boolean; hasPasswordRestriction?: boolean }>;
+    channels?: Array<{ id: number; canEnter?: boolean; hasPasswordRestriction?: boolean; position?: number; description?: string }>;
   }) => {
     sidebarProps.current = props;
     return React.createElement(React.Fragment, null,
@@ -2367,6 +2367,32 @@ describe('active share discovery', () => {
     expect(channel?.canEnter).toBeUndefined();
     expect(channel?.hasPasswordRestriction).toBe(true);
     expect(bridge.send).toHaveBeenCalledWith('voice.reconnect', { channelId: 2 });
+  });
+
+  it('preserves channel metadata when a channel update omits unchanged fields', async () => {
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [
+          { id: 1, name: 'General', position: 1, description: 'Lobby' },
+          { id: 2, name: 'Gaming', position: 3, description: 'Games' },
+        ],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    act(() => {
+      bridge.emit('voice.channelJoined', { id: 2, name: 'Gaming' });
+    });
+
+    await waitFor(() => {
+      const channel = sidebarProps.current.channels?.find(c => c.id === 2);
+      expect(channel?.position).toBe(3);
+      expect(channel?.description).toBe('Games');
+    });
   });
 
   it('prompts for a channel password when a password-denial reason reveals an uncached password ACL', async () => {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4317,6 +4317,7 @@ const handleConnect = (serverData: SavedServer) => {
             title="Channel position was not saved"
             detail="You need Write permission on that channel. Check the channel ACL if inheritance is disabled."
             onDismiss={() => {
+              notifQueue.unregister('admin-channel-update-error');
               setAdminChannelUpdateErrorVisible(false);
             }}
             onExited={() => {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2569,6 +2569,7 @@ function App() {
     };
 
     const onAdminChannelUpdateError = () => {
+      setAdminChannelUpdateErrorSequence(sequence => sequence + 1);
       setAdminChannelUpdateErrorVisible(true);
       notifQueue.register('admin-channel-update-error', 'info');
     };
@@ -3329,6 +3330,7 @@ const handleConnect = (serverData: SavedServer) => {
   const [serverRemovalNotification, setServerRemovalNotification] = useState<ServerRemovalNotification | null>(null);
   const [brmbleServiceWarningNotification, setBrmbleServiceWarningNotification] = useState<typeof BRMBLE_SERVICE_DISCONNECTED_NOTIFICATION | null>(null);
   const [adminChannelUpdateErrorVisible, setAdminChannelUpdateErrorVisible] = useState(false);
+  const [adminChannelUpdateErrorSequence, setAdminChannelUpdateErrorSequence] = useState(0);
   const brmbleServiceWarningDismissedForOutageRef = useRef(false);
   const nextScreenShareEndedNotificationIdRef = useRef(0);
   const nextWatchedShareEndedNotificationIdRef = useRef(0);
@@ -4311,6 +4313,7 @@ const handleConnect = (serverData: SavedServer) => {
         )}
         {adminChannelUpdateErrorVisible && notifQueue.isVisible('admin-channel-update-error') && (
           <Notification
+            key={adminChannelUpdateErrorSequence}
             status="info"
             position="top-right"
             visible={adminChannelUpdateErrorVisible}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -580,6 +580,7 @@ interface Channel {
   id: number;
   name: string;
   parent?: number;
+  position?: number;
   isEnterRestricted?: boolean;
   canEnter?: boolean;
   hasPasswordRestriction?: boolean;

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2014,12 +2014,12 @@ function App() {
     });
 
     const onVoiceChannelJoined = ((data: unknown) => {
-      const d = data as { id: number; name: string; parent?: number; isEnterRestricted?: boolean } | undefined;
+      const d = data as Channel | undefined;
       if (d?.id !== undefined) {
         setChannels(prev => {
           const existing = prev.find(c => c.id === d.id);
           if (existing) {
-            return prev.map(c => c.id === d.id ? d : c);
+            return prev.map(c => c.id === d.id ? { ...c, ...d } : c);
           }
           return [...prev, d];
         });

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2571,7 +2571,7 @@ function App() {
     const onAdminChannelUpdateError = () => {
       setAdminChannelUpdateErrorSequence(sequence => sequence + 1);
       setAdminChannelUpdateErrorVisible(true);
-      notifQueue.register('admin-channel-update-error', 'info');
+      notifQueue.register('admin-channel-update-error', 'warning');
     };
 
     bridge.on('brmble.serviceStatus', onBrmbleServiceStatus);
@@ -4314,7 +4314,7 @@ const handleConnect = (serverData: SavedServer) => {
         {adminChannelUpdateErrorVisible && notifQueue.isVisible('admin-channel-update-error') && (
           <Notification
             key={adminChannelUpdateErrorSequence}
-            status="info"
+            status="warning"
             position="top-right"
             visible={adminChannelUpdateErrorVisible}
             title="Channel position was not saved"

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2568,9 +2568,19 @@ function App() {
       setChannels(prev => mergeChannelChatAccess(prev, getResolvedChannelChatAccess(getChannelChatAccessRequestIds(prev))));
     };
 
-    const onAdminChannelUpdateError = () => {
-      setAdminChannelUpdateErrorSequence(sequence => sequence + 1);
-      setAdminChannelUpdateErrorVisible(true);
+    const onAdminChannelUpdateError = (payload?: { statusCode?: number; body?: string; error?: string }) => {
+      if (payload?.statusCode === 403) {
+        setAdminChannelUpdateError({
+          title: 'Channel position was not saved',
+          detail: 'You need Write permission on that channel. Check the channel ACL if inheritance is disabled.',
+        });
+      } else {
+        const code = payload?.statusCode ?? payload?.error ?? 'unknown';
+        setAdminChannelUpdateError({
+          title: 'Channel update failed',
+          detail: `Request failed (${code}). Please try again.`,
+        });
+      }
       notifQueue.register('admin-channel-update-error', 'warning');
     };
 
@@ -3329,8 +3339,7 @@ const handleConnect = (serverData: SavedServer) => {
   const [movedChannelNotification, setMovedChannelNotification] = useState<QueuedMovedChannelNotification | null>(null);
   const [serverRemovalNotification, setServerRemovalNotification] = useState<ServerRemovalNotification | null>(null);
   const [brmbleServiceWarningNotification, setBrmbleServiceWarningNotification] = useState<typeof BRMBLE_SERVICE_DISCONNECTED_NOTIFICATION | null>(null);
-  const [adminChannelUpdateErrorVisible, setAdminChannelUpdateErrorVisible] = useState(false);
-  const [adminChannelUpdateErrorSequence, setAdminChannelUpdateErrorSequence] = useState(0);
+  const [adminChannelUpdateError, setAdminChannelUpdateError] = useState<{ title: string; detail: string } | null>(null);
   const brmbleServiceWarningDismissedForOutageRef = useRef(false);
   const nextScreenShareEndedNotificationIdRef = useRef(0);
   const nextWatchedShareEndedNotificationIdRef = useRef(0);
@@ -4311,17 +4320,17 @@ const handleConnect = (serverData: SavedServer) => {
             }}
           />
         )}
-        {adminChannelUpdateErrorVisible && notifQueue.isVisible('admin-channel-update-error') && (
+        {adminChannelUpdateError && notifQueue.isVisible('admin-channel-update-error') && (
           <Notification
-            key={adminChannelUpdateErrorSequence}
+            key={adminChannelUpdateError.title}
             status="warning"
             position="top-right"
-            visible={adminChannelUpdateErrorVisible}
-            title="Channel position was not saved"
-            detail="You need Write permission on that channel. Check the channel ACL if inheritance is disabled."
+            visible={true}
+            title={adminChannelUpdateError.title}
+            detail={adminChannelUpdateError.detail}
             onDismiss={() => {
               notifQueue.unregister('admin-channel-update-error');
-              setAdminChannelUpdateErrorVisible(false);
+              setAdminChannelUpdateError(null);
             }}
             onExited={() => {
               notifQueue.unregister('admin-channel-update-error');

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2568,7 +2568,8 @@ function App() {
       setChannels(prev => mergeChannelChatAccess(prev, getResolvedChannelChatAccess(getChannelChatAccessRequestIds(prev))));
     };
 
-    const onAdminChannelUpdateError = (payload?: { statusCode?: number; body?: string; error?: string }) => {
+    const onAdminChannelUpdateError = (data: unknown) => {
+      const payload = data as { statusCode?: number; body?: string; error?: string } | undefined;
       if (payload?.statusCode === 403) {
         setAdminChannelUpdateError({
           title: 'Channel position was not saved',

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2568,7 +2568,13 @@ function App() {
       setChannels(prev => mergeChannelChatAccess(prev, getResolvedChannelChatAccess(getChannelChatAccessRequestIds(prev))));
     };
 
+    const onAdminChannelUpdateError = () => {
+      setAdminChannelUpdateErrorVisible(true);
+      notifQueue.register('admin-channel-update-error', 'info');
+    };
+
     bridge.on('brmble.serviceStatus', onBrmbleServiceStatus);
+    bridge.on('admin.channelUpdateError', onAdminChannelUpdateError);
     bridge.on('voice.connected', onVoiceConnected);
     bridge.on('voice.disconnected', onVoiceDisconnected);
     bridge.on('voice.error', onVoiceError);
@@ -2657,6 +2663,7 @@ function App() {
       bridge.off('app.updateAvailable', onUpdateAvailable);
       bridge.off('app.updateProgress', onUpdateProgress);
       bridge.off('brmble.serviceStatus', onBrmbleServiceStatus);
+      bridge.off('admin.channelUpdateError', onAdminChannelUpdateError);
       bridge.off('voice.connected', onVoiceConnected);
       bridge.off('voice.disconnected', onVoiceDisconnected);
       bridge.off('voice.error', onVoiceError);
@@ -3321,6 +3328,7 @@ const handleConnect = (serverData: SavedServer) => {
   const [movedChannelNotification, setMovedChannelNotification] = useState<QueuedMovedChannelNotification | null>(null);
   const [serverRemovalNotification, setServerRemovalNotification] = useState<ServerRemovalNotification | null>(null);
   const [brmbleServiceWarningNotification, setBrmbleServiceWarningNotification] = useState<typeof BRMBLE_SERVICE_DISCONNECTED_NOTIFICATION | null>(null);
+  const [adminChannelUpdateErrorVisible, setAdminChannelUpdateErrorVisible] = useState(false);
   const brmbleServiceWarningDismissedForOutageRef = useRef(false);
   const nextScreenShareEndedNotificationIdRef = useRef(0);
   const nextWatchedShareEndedNotificationIdRef = useRef(0);
@@ -4298,6 +4306,21 @@ const handleConnect = (serverData: SavedServer) => {
             }}
             onExited={() => {
               notifQueue.unregister(serverRemovalNotification.id);
+            }}
+          />
+        )}
+        {adminChannelUpdateErrorVisible && notifQueue.isVisible('admin-channel-update-error') && (
+          <Notification
+            status="info"
+            position="top-right"
+            visible={adminChannelUpdateErrorVisible}
+            title="Channel position was not saved"
+            detail="You need Write permission on that channel. Check the channel ACL if inheritance is disabled."
+            onDismiss={() => {
+              setAdminChannelUpdateErrorVisible(false);
+            }}
+            onExited={() => {
+              notifQueue.unregister('admin-channel-update-error');
             }}
           />
         )}

--- a/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.css
+++ b/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.css
@@ -55,6 +55,50 @@
   min-height: 60px;
 }
 
+.position-stepper {
+  position: relative;
+}
+
+.position-stepper-input {
+  width: 100%;
+  padding-right: var(--space-2xl);
+}
+
+.position-stepper-controls {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  display: grid;
+  width: var(--space-xl);
+  border-left: 1px solid var(--border-subtle);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  overflow: hidden;
+}
+
+.position-stepper-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 0;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.position-stepper-button:hover,
+.position-stepper-button:focus-visible {
+  background: var(--bg-hover);
+  color: var(--accent-primary);
+}
+
+.position-stepper-button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--accent-primary);
+}
+
 .edit-channel-hint {
   font-size: var(--text-xs);
   color: var(--text-muted);

--- a/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.test.tsx
+++ b/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { EditChannelDialog } from './EditChannelDialog';
 
 vi.mock('../Icon/Icon', () => ({
-  Icon: () => null,
+  Icon: ({ name }: { name: string }) => <span data-icon-name={name} />,
 }));
 
 describe('EditChannelDialog', () => {
@@ -59,5 +59,50 @@ describe('EditChannelDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(onSave).toHaveBeenCalledWith('Main channel', '', 9, '');
+  });
+
+  it('uses themed icon stepper controls for the position field', () => {
+    render(
+      <EditChannelDialog
+        isOpen
+        initialName="Main channel"
+        initialDescription=""
+        initialPassword=""
+        initialPosition={4}
+        showPosition
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Position')).toHaveAttribute('type', 'text');
+    expect(screen.getByRole('button', { name: 'Increase channel position' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Decrease channel position' })).toBeInTheDocument();
+    expect(screen.getByTestId('position-stepper')).toBeInTheDocument();
+    expect(screen.getByText((_, node) => node?.getAttribute('data-icon-name') === 'chevron-up')).toBeInTheDocument();
+    expect(screen.getByText((_, node) => node?.getAttribute('data-icon-name') === 'chevron-down')).toBeInTheDocument();
+  });
+
+  it('updates the position using the themed stepper buttons', () => {
+    const onSave = vi.fn();
+    render(
+      <EditChannelDialog
+        isOpen
+        initialName="Main channel"
+        initialDescription=""
+        initialPassword=""
+        initialPosition={4}
+        showPosition
+        onClose={vi.fn()}
+        onSave={onSave}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Increase channel position' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Decrease channel position' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Decrease channel position' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).toHaveBeenCalledWith('Main channel', '', 3, '');
   });
 });

--- a/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.test.tsx
+++ b/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.test.tsx
@@ -7,7 +7,7 @@ vi.mock('../Icon/Icon', () => ({
 }));
 
 describe('EditChannelDialog', () => {
-  it('explains that channel password management lives in the ACL editor', () => {
+  it('does not render password access help text', () => {
     const onSave = vi.fn();
     render(
       <EditChannelDialog
@@ -20,10 +20,27 @@ describe('EditChannelDialog', () => {
       />
     );
 
-    expect(screen.getByText(/Permissions.*ACL editor/i)).toBeInTheDocument();
+    expect(screen.queryByText('Password Access')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Permissions.*ACL editor/i)).not.toBeInTheDocument();
   });
 
-  it('allows admins to edit the Mumble channel position', () => {
+  it('hides the Mumble channel position by default', () => {
+    render(
+      <EditChannelDialog
+        isOpen
+        initialName="Main channel"
+        initialDescription=""
+        initialPassword=""
+        initialPosition={4}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByLabelText('Position')).not.toBeInTheDocument();
+  });
+
+  it('allows admins to edit the Mumble channel position when enabled', () => {
     const onSave = vi.fn();
     render(
       <EditChannelDialog
@@ -32,6 +49,7 @@ describe('EditChannelDialog', () => {
         initialDescription=""
         initialPassword=""
         initialPosition={4}
+        showPosition
         onClose={vi.fn()}
         onSave={onSave}
       />

--- a/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.test.tsx
+++ b/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { EditChannelDialog } from './EditChannelDialog';
 
@@ -21,5 +21,25 @@ describe('EditChannelDialog', () => {
     );
 
     expect(screen.getByText(/Permissions.*ACL editor/i)).toBeInTheDocument();
+  });
+
+  it('allows admins to edit the Mumble channel position', () => {
+    const onSave = vi.fn();
+    render(
+      <EditChannelDialog
+        isOpen
+        initialName="Main channel"
+        initialDescription=""
+        initialPassword=""
+        initialPosition={4}
+        onClose={vi.fn()}
+        onSave={onSave}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Position'), { target: { value: '9' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).toHaveBeenCalledWith('Main channel', '', 9, '');
   });
 });

--- a/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.tsx
+++ b/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.tsx
@@ -7,8 +7,9 @@ interface EditChannelDialogProps {
   initialName: string;
   initialDescription?: string;
   initialPassword?: string;
+  initialPosition?: number;
   onClose: () => void;
-  onSave: (name: string, description: string, password: string) => void;
+  onSave: (name: string, description: string, position: number, password: string) => void;
   onError?: (message: string) => void;
 }
 
@@ -17,25 +18,30 @@ export function EditChannelDialog({
   initialName,
   initialDescription = '',
   initialPassword = '',
+  initialPosition = 0,
   onClose,
   onSave,
 }: EditChannelDialogProps) {
   const [name, setName] = useState(initialName);
   const [description, setDescription] = useState(initialDescription);
+  const [position, setPosition] = useState(String(initialPosition));
 
   useEffect(() => {
     setName(initialName);
     setDescription(initialDescription);
-  }, [initialName, initialDescription, initialPassword, isOpen]);
+    setPosition(String(initialPosition));
+  }, [initialName, initialDescription, initialPassword, initialPosition, isOpen]);
 
   if (!isOpen) return null;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSave(name, description, initialPassword);
+    onSave(name, description, Number.parseInt(position, 10) || 0, initialPassword);
   };
 
-  const hasChanges = name !== initialName || description !== initialDescription;
+  const hasChanges = name !== initialName
+    || description !== initialDescription
+    || (Number.parseInt(position, 10) || 0) !== initialPosition;
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -74,6 +80,17 @@ export function EditChannelDialog({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="channel-position">Position</label>
+            <input
+              id="channel-position"
+              className="brmble-input"
+              type="number"
+              value={position}
+              onChange={(e) => setPosition(e.target.value)}
             />
           </div>
 

--- a/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.tsx
+++ b/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.tsx
@@ -8,6 +8,7 @@ interface EditChannelDialogProps {
   initialDescription?: string;
   initialPassword?: string;
   initialPosition?: number;
+  showPosition?: boolean;
   onClose: () => void;
   onSave: (name: string, description: string, position: number, password: string) => void;
   onError?: (message: string) => void;
@@ -19,6 +20,7 @@ export function EditChannelDialog({
   initialDescription = '',
   initialPassword = '',
   initialPosition = 0,
+  showPosition = false,
   onClose,
   onSave,
 }: EditChannelDialogProps) {
@@ -41,7 +43,7 @@ export function EditChannelDialog({
 
   const hasChanges = name !== initialName
     || description !== initialDescription
-    || (Number.parseInt(position, 10) || 0) !== initialPosition;
+    || (showPosition && (Number.parseInt(position, 10) || 0) !== initialPosition);
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -83,23 +85,18 @@ export function EditChannelDialog({
             />
           </div>
 
-          <div className="form-group">
-            <label htmlFor="channel-position">Position</label>
-            <input
-              id="channel-position"
-              className="brmble-input"
-              type="number"
-              value={position}
-              onChange={(e) => setPosition(e.target.value)}
-            />
-          </div>
-
-          <div className="form-group">
-            <label>Password Access</label>
-            <p className="edit-channel-hint">
-              Channel password access is managed from the Permissions ACL editor so it stays visible alongside other group access rules.
-            </p>
-          </div>
+          {showPosition && (
+            <div className="form-group">
+              <label htmlFor="channel-position">Position</label>
+              <input
+                id="channel-position"
+                className="brmble-input"
+                type="number"
+                value={position}
+                onChange={(e) => setPosition(e.target.value)}
+              />
+            </div>
+          )}
 
           <div className="edit-channel-footer">
             <button type="button" className="btn btn-secondary" onClick={onClose}>

--- a/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.tsx
+++ b/src/Brmble.Web/src/components/EditChannelDialog/EditChannelDialog.tsx
@@ -41,6 +41,10 @@ export function EditChannelDialog({
     onSave(name, description, Number.parseInt(position, 10) || 0, initialPassword);
   };
 
+  const adjustPosition = (delta: number) => {
+    setPosition(current => String((Number.parseInt(current, 10) || 0) + delta));
+  };
+
   const hasChanges = name !== initialName
     || description !== initialDescription
     || (showPosition && (Number.parseInt(position, 10) || 0) !== initialPosition);
@@ -88,13 +92,35 @@ export function EditChannelDialog({
           {showPosition && (
             <div className="form-group">
               <label htmlFor="channel-position">Position</label>
-              <input
-                id="channel-position"
-                className="brmble-input"
-                type="number"
-                value={position}
-                onChange={(e) => setPosition(e.target.value)}
-              />
+              <div className="position-stepper" data-testid="position-stepper">
+                <input
+                  id="channel-position"
+                  className="brmble-input position-stepper-input"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="-?[0-9]*"
+                  value={position}
+                  onChange={(e) => setPosition(e.target.value)}
+                />
+                <div className="position-stepper-controls">
+                  <button
+                    type="button"
+                    className="position-stepper-button"
+                    aria-label="Increase channel position"
+                    onClick={() => adjustPosition(1)}
+                  >
+                    <Icon name="chevron-up" size={12} />
+                  </button>
+                  <button
+                    type="button"
+                    className="position-stepper-button"
+                    aria-label="Decrease channel position"
+                    onClick={() => adjustPosition(-1)}
+                  >
+                    <Icon name="chevron-down" size={12} />
+                  </button>
+                </div>
+              </div>
             </div>
           )}
 

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
@@ -97,7 +97,10 @@
 }
 
 .admin-channel-row {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
   width: 100%;
   min-width: 0;
   text-align: left;
@@ -112,6 +115,25 @@
     border-color var(--transition-fast),
     box-shadow var(--transition-fast),
     transform var(--transition-fast);
+}
+
+.admin-channel-row-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.admin-channel-position-pill {
+  flex: 0 0 auto;
+  padding: var(--space-2xs) var(--space-xs);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--bg-overlay);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .admin-channel-row:hover,

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
@@ -128,7 +128,7 @@
   flex: 0 0 auto;
   padding: var(--space-2xs) var(--space-xs);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-full);
   background: var(--bg-overlay);
   color: var(--text-secondary);
   font-size: var(--text-xs);

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.test.tsx
@@ -96,7 +96,7 @@ describe('AdminSettingsTab', () => {
   it('renders the live channel list in the channels tab', () => {
     render(<AdminSettingsTab channels={channels} />);
 
-    expect(screen.getByRole('row', { name: 'General' })).toBeInTheDocument();
-    expect(screen.getByRole('row', { name: 'Raid Planning' })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: 'General Position 0' })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: 'Raid Planning Position 0' })).toBeInTheDocument();
   });
 });

--- a/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.test.tsx
@@ -125,6 +125,32 @@ describe('ShortcutsSettingsTab', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ toggleLeaveVoiceKey: 'KeyM' }));
   });
 
+  it('keeps showing the captured key when parent settings rerender before key release', () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <ShortcutsSettingsTab
+        settings={baseSettings}
+        onChange={onChange}
+        allBindings={{}}
+        onClearBinding={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Not bound' })[0]);
+    fireEvent.keyDown(window, { code: 'KeyM' });
+    rerender(
+      <ShortcutsSettingsTab
+        settings={{ ...baseSettings, toggleLeaveVoiceKey: 'KeyM' }}
+        onChange={onChange}
+        allBindings={{ toggleLeaveVoiceKey: 'KeyM' }}
+        onClearBinding={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'KeyM' })).toHaveClass('btn-primary');
+    expect(screen.queryByRole('button', { name: 'Press any key...' })).not.toBeInTheDocument();
+  });
+
   it('keeps hotkeys suspended until the recorded keyboard input is released', () => {
     render(
       <ShortcutsSettingsTab

--- a/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.test.tsx
@@ -105,6 +105,26 @@ describe('ShortcutsSettingsTab', () => {
     }
   });
 
+  it('shows a newly recorded shortcut key immediately after successful capture', () => {
+    const onChange = vi.fn();
+
+    render(
+      <ShortcutsSettingsTab
+        settings={baseSettings}
+        onChange={onChange}
+        allBindings={{}}
+        onClearBinding={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Not bound' })[0]);
+    fireEvent.keyDown(window, { code: 'KeyM' });
+
+    expect(screen.getByRole('button', { name: 'KeyM' })).toHaveClass('btn-primary');
+    expect(screen.queryByRole('button', { name: 'Press any key...' })).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ toggleLeaveVoiceKey: 'KeyM' }));
+  });
+
   it('keeps hotkeys suspended until the recorded keyboard input is released', () => {
     render(
       <ShortcutsSettingsTab

--- a/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.tsx
@@ -33,6 +33,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
   const [recordingKey, setRecordingKey] = useState<keyof ShortcutsSettings | null>(null);
   const [localSettings, setLocalSettings] = useState<ShortcutsSettings>(settings);
   const [isPromptOpen, setIsPromptOpen] = useState(false);
+  const [capturedBindingKey, setCapturedBindingKey] = useState<keyof ShortcutsSettings | null>(null);
   const capturedInputRef = useRef<string | null>(null);
   const hotkeysSuspendedRef = useRef(false);
 
@@ -46,7 +47,13 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
   };
 
   const keyButtonClass = (bindingId: keyof ShortcutsSettings) => (
-    `btn ${localSettings[bindingId] && recordingKey !== bindingId ? 'btn-primary' : 'btn-secondary'} key-binding-btn ${recordingKey === bindingId ? 'recording' : ''}`
+    `btn ${localSettings[bindingId] && (recordingKey !== bindingId || capturedBindingKey === bindingId) ? 'btn-primary' : 'btn-secondary'} key-binding-btn ${recordingKey === bindingId && capturedBindingKey !== bindingId ? 'recording' : ''}`
+  );
+
+  const keyButtonLabel = (bindingId: keyof ShortcutsSettings) => (
+    recordingKey === bindingId && capturedBindingKey !== bindingId
+      ? 'Press any key...'
+      : (localSettings[bindingId] || 'Not bound')
   );
 
   const handleInput = useCallback(async (key: string) => {
@@ -70,6 +77,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
       
       if (!confirmed) {
         capturedInputRef.current = null;
+        setCapturedBindingKey(null);
         setRecordingKey(null);
         return;
       }
@@ -88,6 +96,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
         return newSettings;
       });
       capturedInputRef.current = null;
+      setCapturedBindingKey(null);
       setRecordingKey(null);
       return;
     }
@@ -99,6 +108,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
       return newSettings;
     });
     capturedInputRef.current = key;
+    setCapturedBindingKey(recordingKey);
   }, [recordingKey, allBindings, onChange, onClearBinding]);
 
   useEffect(() => {
@@ -134,6 +144,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
       const finishRecording = () => {
         if (!capturedInputRef.current) return;
         capturedInputRef.current = null;
+        setCapturedBindingKey(null);
         setRecordingKey(null);
       };
       window.addEventListener('keydown', onKey, true);
@@ -150,6 +161,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
           hotkeysSuspendedRef.current = false;
         }
         capturedInputRef.current = null;
+        setCapturedBindingKey(null);
       };
     }
   }, [recordingKey, isPromptOpen, handleInput]);
@@ -166,7 +178,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
               className={keyButtonClass('toggleLeaveVoiceKey')}
               onClick={() => setRecordingKey(recordingKey === 'toggleLeaveVoiceKey' ? null : 'toggleLeaveVoiceKey')}
             >
-              {recordingKey === 'toggleLeaveVoiceKey' ? 'Press any key...' : (localSettings.toggleLeaveVoiceKey || 'Not bound')}
+                  {keyButtonLabel('toggleLeaveVoiceKey')}
             </button>
           </div>
         </div>
@@ -179,7 +191,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
               className={keyButtonClass('toggleMuteDeafenKey')}
               onClick={() => setRecordingKey(recordingKey === 'toggleMuteDeafenKey' ? null : 'toggleMuteDeafenKey')}
             >
-              {recordingKey === 'toggleMuteDeafenKey' ? 'Press any key...' : (localSettings.toggleMuteDeafenKey || 'Not bound')}
+                  {keyButtonLabel('toggleMuteDeafenKey')}
             </button>
           </div>
         </div>
@@ -192,7 +204,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
               className={keyButtonClass('toggleMuteKey')}
               onClick={() => setRecordingKey(recordingKey === 'toggleMuteKey' ? null : 'toggleMuteKey')}
             >
-              {recordingKey === 'toggleMuteKey' ? 'Press any key...' : (localSettings.toggleMuteKey || 'Not bound')}
+                  {keyButtonLabel('toggleMuteKey')}
             </button>
           </div>
         </div>
@@ -208,7 +220,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
               className={keyButtonClass('toggleDMScreenKey')}
               onClick={() => setRecordingKey(recordingKey === 'toggleDMScreenKey' ? null : 'toggleDMScreenKey')}
             >
-              {recordingKey === 'toggleDMScreenKey' ? 'Press any key...' : (localSettings.toggleDMScreenKey || 'Not bound')}
+                  {keyButtonLabel('toggleDMScreenKey')}
             </button>
           </div>
         </div>
@@ -224,7 +236,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
               className={keyButtonClass('toggleScreenShareKey')}
               onClick={() => setRecordingKey(recordingKey === 'toggleScreenShareKey' ? null : 'toggleScreenShareKey')}
             >
-              {recordingKey === 'toggleScreenShareKey' ? 'Press any key...' : (localSettings.toggleScreenShareKey || 'Not bound')}
+                  {keyButtonLabel('toggleScreenShareKey')}
             </button>
           </div>
         </div>
@@ -240,7 +252,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
               className={keyButtonClass('toggleGameKey')}
               onClick={() => setRecordingKey(recordingKey === 'toggleGameKey' ? null : 'toggleGameKey')}
             >
-              {recordingKey === 'toggleGameKey' ? 'Press any key...' : (localSettings.toggleGameKey || 'Not bound')}
+                  {keyButtonLabel('toggleGameKey')}
             </button>
           </div>
         </div>

--- a/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.tsx
@@ -162,10 +162,6 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
         window.removeEventListener('mousedown', onMouse, true);
         window.removeEventListener('keyup', finishRecording, true);
         window.removeEventListener('mouseup', finishRecording, true);
-        if (hotkeysSuspendedRef.current && (!capturedInputRef.current || capturedBindingKeyRef.current)) {
-          bridge.send('voice.resumeHotkeys');
-          hotkeysSuspendedRef.current = false;
-        }
         if (capturedInputRef.current) return;
         capturedInputRef.current = null;
         markCapturedBinding(null);
@@ -175,23 +171,22 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
 
   useEffect(() => {
     if (!capturedInputRef.current || !recordingKey || capturedBindingKeyRef.current !== recordingKey) return;
-    const finishRecording = () => {
-      capturedInputRef.current = null;
-      markCapturedBinding(null);
-      setRecordingKey(null);
-    };
-
-    window.addEventListener('keyup', finishRecording, true);
-    window.addEventListener('mouseup', finishRecording, true);
     return () => {
-      window.removeEventListener('keyup', finishRecording, true);
-      window.removeEventListener('mouseup', finishRecording, true);
       if (hotkeysSuspendedRef.current && !capturedInputRef.current) {
         bridge.send('voice.resumeHotkeys');
         hotkeysSuspendedRef.current = false;
       }
     };
   }, [recordingKey, capturedBindingKey]);
+
+  useEffect(() => {
+    return () => {
+      if (hotkeysSuspendedRef.current) {
+        bridge.send('voice.resumeHotkeys');
+        hotkeysSuspendedRef.current = false;
+      }
+    };
+  }, []);
 
   return (
     <div className="shortcuts-settings-tab">

--- a/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.tsx
@@ -35,11 +35,17 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
   const [isPromptOpen, setIsPromptOpen] = useState(false);
   const [capturedBindingKey, setCapturedBindingKey] = useState<keyof ShortcutsSettings | null>(null);
   const capturedInputRef = useRef<string | null>(null);
+  const capturedBindingKeyRef = useRef<keyof ShortcutsSettings | null>(null);
   const hotkeysSuspendedRef = useRef(false);
 
   useEffect(() => {
     setLocalSettings(settings);
   }, [settings]);
+
+  const markCapturedBinding = (bindingId: keyof ShortcutsSettings | null) => {
+    capturedBindingKeyRef.current = bindingId;
+    setCapturedBindingKey(bindingId);
+  };
 
   const clearBinding = (bindingId: keyof ShortcutsSettings) => {
     setLocalSettings((prev) => ({ ...prev, [bindingId]: null }));
@@ -77,7 +83,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
       
       if (!confirmed) {
         capturedInputRef.current = null;
-        setCapturedBindingKey(null);
+        markCapturedBinding(null);
         setRecordingKey(null);
         return;
       }
@@ -96,7 +102,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
         return newSettings;
       });
       capturedInputRef.current = null;
-      setCapturedBindingKey(null);
+      markCapturedBinding(null);
       setRecordingKey(null);
       return;
     }
@@ -108,7 +114,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
       return newSettings;
     });
     capturedInputRef.current = key;
-    setCapturedBindingKey(recordingKey);
+    markCapturedBinding(recordingKey);
   }, [recordingKey, allBindings, onChange, onClearBinding]);
 
   useEffect(() => {
@@ -144,7 +150,7 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
       const finishRecording = () => {
         if (!capturedInputRef.current) return;
         capturedInputRef.current = null;
-        setCapturedBindingKey(null);
+        markCapturedBinding(null);
         setRecordingKey(null);
       };
       window.addEventListener('keydown', onKey, true);
@@ -156,15 +162,36 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
         window.removeEventListener('mousedown', onMouse, true);
         window.removeEventListener('keyup', finishRecording, true);
         window.removeEventListener('mouseup', finishRecording, true);
-        if (hotkeysSuspendedRef.current) {
+        if (hotkeysSuspendedRef.current && (!capturedInputRef.current || capturedBindingKeyRef.current)) {
           bridge.send('voice.resumeHotkeys');
           hotkeysSuspendedRef.current = false;
         }
+        if (capturedInputRef.current) return;
         capturedInputRef.current = null;
-        setCapturedBindingKey(null);
+        markCapturedBinding(null);
       };
     }
   }, [recordingKey, isPromptOpen, handleInput]);
+
+  useEffect(() => {
+    if (!capturedInputRef.current || !recordingKey || capturedBindingKeyRef.current !== recordingKey) return;
+    const finishRecording = () => {
+      capturedInputRef.current = null;
+      markCapturedBinding(null);
+      setRecordingKey(null);
+    };
+
+    window.addEventListener('keyup', finishRecording, true);
+    window.addEventListener('mouseup', finishRecording, true);
+    return () => {
+      window.removeEventListener('keyup', finishRecording, true);
+      window.removeEventListener('mouseup', finishRecording, true);
+      if (hotkeysSuspendedRef.current && !capturedInputRef.current) {
+        bridge.send('voice.resumeHotkeys');
+        hotkeysSuspendedRef.current = false;
+      }
+    };
+  }, [recordingKey, capturedBindingKey]);
 
   return (
     <div className="shortcuts-settings-tab">

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
@@ -124,6 +124,7 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
           initialDescription={editChannel.description}
           initialPosition={editChannel.position ?? 0}
           initialPassword=""
+          showPosition
           onClose={() => setEditChannel(null)}
           onSave={(name, description, position) => {
             bridge.send('voice.editChannel', {

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
@@ -127,7 +127,7 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
           showPosition
           onClose={() => setEditChannel(null)}
           onSave={(name, description, position) => {
-            bridge.send('voice.editChannel', {
+            bridge.send('admin.updateChannel', {
               channelId: editChannel.id,
               name,
               description,

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
@@ -6,6 +6,7 @@ import { ContextMenu } from '../../ContextMenu/ContextMenu';
 import type { ContextMenuItem } from '../../ContextMenu/ContextMenu';
 import { EditChannelDialog } from '../../EditChannelDialog/EditChannelDialog';
 import { AclEditorDialog } from '../../AclEditor/AclEditorDialog';
+import { SettingsHelp } from '../SettingsHelp';
 import { sortChannelsByMumbleOrder } from '../../../utils/channelOrdering';
 
 const REQUESTS = [{ id: 1, requestedBy: 'Mike', channelName: 'Officer Chat', status: 'Pending' }];
@@ -107,9 +108,10 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
 
       <div className="admin-action-row">
         <button type="button" className="btn btn-secondary btn-sm" disabled>Create Channel</button>
+        <SettingsHelp content="Right-click a channel for admin actions." label="More information about channel admin actions" />
       </div>
 
-      <p className="admin-help-text">Create Channel is not available yet. Right-click a channel for admin actions.</p>
+      <p className="admin-help-text">Create Channel is not available yet.</p>
       {contextMenu && menuItems.length > 0 && (
         <ContextMenu
           x={contextMenu.x}

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
@@ -65,7 +65,7 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
                 type="button"
                 className={`admin-channel-row ${channel.id === selectedChannelId ? 'selected' : ''}`}
                 role="row"
-                aria-label={channel.name}
+                aria-label={`${channel.name} Position ${channel.position ?? 0}`}
                 onClick={() => setSelectedChannelId(channel.id)}
                 onContextMenu={(e) => {
                   e.preventDefault();
@@ -73,7 +73,8 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
                   setContextMenu({ x: e.clientX, y: e.clientY, channelId: channel.id });
                 }}
               >
-                {channel.name}
+                <span className="admin-channel-row-name">{channel.name}</span>
+                <span className="admin-channel-position-pill">Position {channel.position ?? 0}</span>
               </button>
             ))
           ) : (

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminChannelsSection.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { prompt } from '../../../hooks/usePrompt';
+import bridge from '../../../bridge';
 import type { Channel } from '../../../types';
+import { ContextMenu } from '../../ContextMenu/ContextMenu';
+import type { ContextMenuItem } from '../../ContextMenu/ContextMenu';
+import { EditChannelDialog } from '../../EditChannelDialog/EditChannelDialog';
+import { AclEditorDialog } from '../../AclEditor/AclEditorDialog';
+import { sortChannelsByMumbleOrder } from '../../../utils/channelOrdering';
 
 const REQUESTS = [{ id: 1, requestedBy: 'Mike', channelName: 'Officer Chat', status: 'Pending' }];
 
@@ -9,30 +15,39 @@ interface AdminChannelsSectionProps {
 }
 
 export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProps) {
-  const [selectedChannelId, setSelectedChannelId] = useState<number | null>(channels[0]?.id ?? null);
-  const selectedChannel = channels.find(channel => channel.id === selectedChannelId) ?? null;
+  const orderedChannels = useMemo(() => sortChannelsByMumbleOrder(channels), [channels]);
+  const [selectedChannelId, setSelectedChannelId] = useState<number | null>(orderedChannels[0]?.id ?? null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; channelId: number } | null>(null);
+  const [editChannel, setEditChannel] = useState<Channel | null>(null);
+  const [permissionsChannel, setPermissionsChannel] = useState<Channel | null>(null);
+  const contextChannel = orderedChannels.find(channel => channel.id === contextMenu?.channelId) ?? null;
 
   useEffect(() => {
-    if (selectedChannelId != null && channels.some(channel => channel.id === selectedChannelId)) {
+    if (selectedChannelId != null && orderedChannels.some(channel => channel.id === selectedChannelId)) {
       return;
     }
 
-    setSelectedChannelId(channels[0]?.id ?? null);
-  }, [channels, selectedChannelId]);
+    setSelectedChannelId(orderedChannels[0]?.id ?? null);
+  }, [orderedChannels, selectedChannelId]);
 
-  const handleDeleteChannel = async () => {
-    if (!selectedChannel) return;
-
+  const handleDeleteChannel = async (channel: Channel) => {
     const result = await prompt({
       title: 'Delete Channel',
-      message: `Type "${selectedChannel.name}" to confirm deleting this channel.`,
-      placeholder: selectedChannel.name,
+      message: `Type "${channel.name}" to confirm deleting this channel.`,
+      placeholder: channel.name,
       confirmLabel: 'Delete',
       cancelLabel: 'Cancel',
     });
 
-    if (result !== selectedChannel.name) return;
+    if (result !== channel.name) return;
+    bridge.send('voice.removeChannel', { channelId: channel.id });
   };
+
+  const menuItems: ContextMenuItem[] = contextChannel ? [
+    { type: 'item', label: 'Edit Channel', onClick: () => setEditChannel(contextChannel) },
+    { type: 'item', label: 'Edit Permissions', onClick: () => setPermissionsChannel(contextChannel) },
+    { type: 'item', label: 'Delete Channel', onClick: () => void handleDeleteChannel(contextChannel) },
+  ] : [];
 
   return (
     <section className="settings-section admin-section">
@@ -43,8 +58,8 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
       <div className="admin-card">
         <h4 className="heading-label">Existing Channels</h4>
         <div className="admin-table-placeholder" role="table" aria-label="Existing Channels table">
-          {channels.length > 0 ? (
-            channels.map(channel => (
+          {orderedChannels.length > 0 ? (
+            orderedChannels.map(channel => (
               <button
                 key={channel.id}
                 type="button"
@@ -52,6 +67,11 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
                 role="row"
                 aria-label={channel.name}
                 onClick={() => setSelectedChannelId(channel.id)}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  setSelectedChannelId(channel.id);
+                  setContextMenu({ x: e.clientX, y: e.clientY, channelId: channel.id });
+                }}
               >
                 {channel.name}
               </button>
@@ -86,10 +106,46 @@ export function AdminChannelsSection({ channels = [] }: AdminChannelsSectionProp
 
       <div className="admin-action-row">
         <button type="button" className="btn btn-secondary btn-sm" disabled>Create Channel</button>
-        <button type="button" className="btn btn-danger btn-sm" onClick={handleDeleteChannel} disabled={!selectedChannel}>Delete Channel</button>
       </div>
 
-      <p className="admin-help-text">Create Channel is not available yet. Request actions and safe delete are available.</p>
+      <p className="admin-help-text">Create Channel is not available yet. Right-click a channel for admin actions.</p>
+      {contextMenu && menuItems.length > 0 && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={menuItems}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+      {editChannel && (
+        <EditChannelDialog
+          isOpen={true}
+          initialName={editChannel.name}
+          initialDescription={editChannel.description}
+          initialPosition={editChannel.position ?? 0}
+          initialPassword=""
+          onClose={() => setEditChannel(null)}
+          onSave={(name, description, position) => {
+            bridge.send('voice.editChannel', {
+              channelId: editChannel.id,
+              name,
+              description,
+              position,
+            });
+            setEditChannel(null);
+          }}
+        />
+      )}
+      {permissionsChannel && (
+        <AclEditorDialog
+          isOpen={true}
+          channelId={permissionsChannel.id}
+          channelName={permissionsChannel.name}
+          availableUsers={[]}
+          isNativePasswordProtected={permissionsChannel.isEnterRestricted ?? false}
+          onClose={() => setPermissionsChannel(null)}
+        />
+      )}
     </section>
   );
 }

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
@@ -74,8 +74,8 @@ describe('Admin workspace sections', () => {
     expect(screen.getByRole('heading', { name: 'Channels' })).toBeInTheDocument();
     expect(screen.getByText('Existing Channels')).toBeInTheDocument();
     expect(screen.getByText('Channel Requests')).toBeInTheDocument();
-    expect(screen.getByRole('row', { name: 'General' })).toBeInTheDocument();
-    expect(screen.getByRole('row', { name: 'Raid Planning' })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: 'General Position 2' })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: 'Raid Planning Position 1' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create Channel' })).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Delete Channel' })).not.toBeInTheDocument();
   });
@@ -91,7 +91,7 @@ describe('Admin workspace sections', () => {
     promptMock.mockResolvedValue('General');
     render(<AdminChannelsSection channels={liveChannels} />);
 
-    fireEvent.contextMenu(screen.getByRole('row', { name: /General/i }));
+    fireEvent.contextMenu(screen.getByRole('row', { name: /General Position 2/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Delete Channel' }));
 
     await waitFor(() => {
@@ -126,13 +126,27 @@ describe('Admin workspace sections', () => {
       { id: 9, name: 'Alpha', position: 1 },
     ]} />);
 
-    expect(screen.getAllByRole('row').map(row => row.getAttribute('aria-label'))).toEqual(['Alpha', 'Bravo', 'Zulu']);
+    expect(screen.getAllByRole('row').map(row => row.getAttribute('aria-label'))).toEqual(['Alpha Position 1', 'Bravo Position 1', 'Zulu Position 3']);
+  });
+
+  it('shows each admin channel position in row labels and visible pills', () => {
+    render(<AdminChannelsSection channels={[
+      { id: 7, name: 'Root' },
+      { id: 8, name: 'Raid', position: 12 },
+      { id: 9, name: 'No Position', position: undefined },
+    ]} />);
+
+    expect(screen.getByRole('row', { name: 'Root Position 0' })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: 'Raid Position 12' })).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: 'No Position Position 0' })).toBeInTheDocument();
+    expect(screen.getAllByText('Position 0')).toHaveLength(2);
+    expect(screen.getByText('Position 12')).toBeInTheDocument();
   });
 
   it('opens admin channel actions from a right-click context menu', () => {
     render(<AdminChannelsSection channels={liveChannels} />);
 
-    fireEvent.contextMenu(screen.getByRole('row', { name: 'General' }));
+    fireEvent.contextMenu(screen.getByRole('row', { name: 'General Position 2' }));
 
     expect(screen.getByTestId('admin-channel-menu')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Edit Channel' })).toBeInTheDocument();
@@ -144,7 +158,7 @@ describe('Admin workspace sections', () => {
   it('sends edited channel position through the admin edit action', () => {
     render(<AdminChannelsSection channels={[{ id: 7, name: 'General', position: 3 }]} />);
 
-    fireEvent.contextMenu(screen.getByRole('row', { name: 'General' }));
+    fireEvent.contextMenu(screen.getByRole('row', { name: 'General Position 3' }));
     fireEvent.click(screen.getByRole('button', { name: 'Edit Channel' }));
 
     expect(screen.getByText('position enabled')).toBeInTheDocument();

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
@@ -39,6 +39,12 @@ vi.mock('../../AclEditor/AclEditorDialog', () => ({
   AclEditorDialog: () => <div data-testid="admin-acl-editor" />,
 }));
 
+vi.mock('../SettingsHelp', () => ({
+  SettingsHelp: ({ content, label }: { content: string; label: string }) => (
+    <button type="button" aria-label={label} data-help-content={content}>?</button>
+  ),
+}));
+
 vi.mock('../../../bridge', () => ({
   default: {
     send: vi.fn(),
@@ -109,7 +115,11 @@ describe('Admin workspace sections', () => {
   it('keeps disabled admin actions paired with visible explanatory text', () => {
     render(<AdminChannelsSection channels={liveChannels} />);
     expect(screen.getByRole('button', { name: 'Create Channel' })).toBeDisabled();
-    expect(screen.getByText('Create Channel is not available yet. Right-click a channel for admin actions.')).toBeInTheDocument();
+    expect(screen.getByText('Create Channel is not available yet.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'More information about channel admin actions' })).toHaveAttribute(
+      'data-help-content',
+      'Right-click a channel for admin actions.',
+    );
   });
 
   it('shows an empty-state message when no live channels are available', () => {

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { AdminSectionPlaceholder } from './AdminSectionPlaceholder';
 import { AdminChannelsSection } from './AdminChannelsSection';
 import type { Channel } from '../../../types';
+import bridge from '../../../bridge';
 
 const { promptMock } = vi.hoisted(() => ({
   promptMock: vi.fn(),
@@ -12,9 +13,42 @@ vi.mock('../../../hooks/usePrompt', () => ({
   prompt: promptMock,
 }));
 
+vi.mock('../../ContextMenu/ContextMenu', () => ({
+  ContextMenu: ({ items }: { items: Array<{ label?: string; type: string; onClick?: () => void }> }) => (
+    <div data-testid="admin-channel-menu">
+      {items.map((item, index) =>
+        item.type === 'item' ? <button key={`${item.label}-${index}`} onClick={item.onClick}>{item.label}</button> : <hr key={`divider-${index}`} />
+      )}
+    </div>
+  ),
+}));
+
+vi.mock('../../EditChannelDialog/EditChannelDialog', () => ({
+  EditChannelDialog: (props: Record<string, unknown>) => (
+    <div data-testid="admin-edit-channel-dialog">
+      <span>{String(props.initialPosition)}</span>
+      <button onClick={() => (props.onSave as (name: string, description: string, position: number) => void)('General', 'Updated', 12)}>
+        Save Admin Edit Channel
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../../AclEditor/AclEditorDialog', () => ({
+  AclEditorDialog: () => <div data-testid="admin-acl-editor" />,
+}));
+
+vi.mock('../../../bridge', () => ({
+  default: {
+    send: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
 const liveChannels: Channel[] = [
-  { id: 7, name: 'General' },
-  { id: 9, name: 'Raid Planning', parent: 7 },
+  { id: 7, name: 'General', position: 2 },
+  { id: 9, name: 'Raid Planning', parent: 7, position: 1 },
 ];
 
 describe('Admin workspace sections', () => {
@@ -42,7 +76,7 @@ describe('Admin workspace sections', () => {
     expect(screen.getByRole('row', { name: 'General' })).toBeInTheDocument();
     expect(screen.getByRole('row', { name: 'Raid Planning' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create Channel' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Delete Channel' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete Channel' })).not.toBeInTheDocument();
   });
 
   it('renders inline approve and deny actions for each channel request row', () => {
@@ -56,7 +90,7 @@ describe('Admin workspace sections', () => {
     promptMock.mockResolvedValue('General');
     render(<AdminChannelsSection channels={liveChannels} />);
 
-    fireEvent.click(screen.getByRole('row', { name: /General/i }));
+    fireEvent.contextMenu(screen.getByRole('row', { name: /General/i }));
     fireEvent.click(screen.getByRole('button', { name: 'Delete Channel' }));
 
     await waitFor(() => {
@@ -74,13 +108,50 @@ describe('Admin workspace sections', () => {
   it('keeps disabled admin actions paired with visible explanatory text', () => {
     render(<AdminChannelsSection channels={liveChannels} />);
     expect(screen.getByRole('button', { name: 'Create Channel' })).toBeDisabled();
-    expect(screen.getByText('Create Channel is not available yet. Request actions and safe delete are available.')).toBeInTheDocument();
+    expect(screen.getByText('Create Channel is not available yet. Right-click a channel for admin actions.')).toBeInTheDocument();
   });
 
   it('shows an empty-state message when no live channels are available', () => {
     render(<AdminChannelsSection channels={[]} />);
 
     expect(screen.getByText('No channels are available yet.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Delete Channel' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Delete Channel' })).not.toBeInTheDocument();
+  });
+
+  it('sorts admin channels by the same Mumble order as the sidebar', () => {
+    render(<AdminChannelsSection channels={[
+      { id: 7, name: 'Zulu', position: 3 },
+      { id: 8, name: 'Bravo', position: 1 },
+      { id: 9, name: 'Alpha', position: 1 },
+    ]} />);
+
+    expect(screen.getAllByRole('row').map(row => row.getAttribute('aria-label'))).toEqual(['Alpha', 'Bravo', 'Zulu']);
+  });
+
+  it('opens admin channel actions from a right-click context menu', () => {
+    render(<AdminChannelsSection channels={liveChannels} />);
+
+    fireEvent.contextMenu(screen.getByRole('row', { name: 'General' }));
+
+    expect(screen.getByTestId('admin-channel-menu')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit Channel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit Permissions' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete Channel' })).toBeInTheDocument();
+    expect(within(screen.getByTestId('admin-channel-menu')).queryByRole('button', { name: 'Create Channel' })).not.toBeInTheDocument();
+  });
+
+  it('sends edited channel position through the admin edit action', () => {
+    render(<AdminChannelsSection channels={[{ id: 7, name: 'General', position: 3 }]} />);
+
+    fireEvent.contextMenu(screen.getByRole('row', { name: 'General' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Channel' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save Admin Edit Channel' }));
+
+    expect(vi.mocked(bridge.send)).toHaveBeenCalledWith('voice.editChannel', {
+      channelId: 7,
+      name: 'General',
+      description: 'Updated',
+      position: 12,
+    });
   });
 });

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
@@ -150,7 +150,7 @@ describe('Admin workspace sections', () => {
     expect(screen.getByText('position enabled')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Save Admin Edit Channel' }));
 
-    expect(vi.mocked(bridge.send)).toHaveBeenCalledWith('voice.editChannel', {
+    expect(vi.mocked(bridge.send)).toHaveBeenCalledWith('admin.updateChannel', {
       channelId: 7,
       name: 'General',
       description: 'Updated',

--- a/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/AdminWorkspaceSections.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../EditChannelDialog/EditChannelDialog', () => ({
   EditChannelDialog: (props: Record<string, unknown>) => (
     <div data-testid="admin-edit-channel-dialog">
       <span>{String(props.initialPosition)}</span>
+      <span>{props.showPosition ? 'position enabled' : 'position hidden'}</span>
       <button onClick={() => (props.onSave as (name: string, description: string, position: number) => void)('General', 'Updated', 12)}>
         Save Admin Edit Channel
       </button>
@@ -145,6 +146,8 @@ describe('Admin workspace sections', () => {
 
     fireEvent.contextMenu(screen.getByRole('row', { name: 'General' }));
     fireEvent.click(screen.getByRole('button', { name: 'Edit Channel' }));
+
+    expect(screen.getByText('position enabled')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Save Admin Edit Channel' }));
 
     expect(vi.mocked(bridge.send)).toHaveBeenCalledWith('voice.editChannel', {

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
@@ -111,6 +111,26 @@ describe('ChannelTree screen share behavior', () => {
     vi.clearAllMocks();
   });
 
+  it('sorts sibling channels by Mumble position, then name, then id', () => {
+    render(
+      <ChannelTree
+        channels={[
+          { id: 4, name: 'Zulu', position: 5 },
+          { id: 2, name: 'Bravo', position: 1 },
+          { id: 3, name: 'Alpha', position: 1 },
+          { id: 5, name: 'Alpha', position: 1 },
+        ]}
+        users={[]}
+        onJoinChannel={vi.fn()}
+      />
+    );
+
+    const labels = Array.from(document.querySelectorAll('.channel-name')).map(el => el.textContent);
+
+    expect(labels).toEqual(['Alpha', 'Alpha', 'Bravo', 'Zulu']);
+    expect(screen.getAllByText('Alpha')[0].closest('.channel-item')).toHaveAttribute('data-channel-id', '3');
+  });
+
   it('shows channel sharing indicators for every active share room', () => {
     render(
       <ChannelTree

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -13,6 +13,7 @@ import { AFK_THRESHOLD_SEC } from '../../hooks/useIdleActions';
 import type { ShareInfo } from '../../hooks/useScreenShare';
 import { EditChannelDialog } from '../EditChannelDialog/EditChannelDialog';
 import { Icon } from '../Icon/Icon';
+import { compareChannelsByMumbleOrder, sortChannelsByMumbleOrder } from '../../utils/channelOrdering';
 import { AclEditorDialog } from '../AclEditor/AclEditorDialog';
 import { getSavedChannelPassword } from '../../utils/channelPasswords';
 import './ChannelTree.css';
@@ -35,6 +36,7 @@ interface Channel {
   id: number;
   name: string;
   parent?: number;
+  position?: number;
   description?: string;
   isEnterRestricted?: boolean;
   canEnter?: boolean;
@@ -91,7 +93,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
   const [infoDialogUser, setInfoDialogUser] = useState<{ userId: string; userName: string; isSelf: boolean } | null>(null);
   const [draggedUser, setDraggedUser] = useState<number | null>(null);
   const [dropTargetChannel, setDropTargetChannel] = useState<number | null>(null);
-  const [editChannelDialog, setEditChannelDialog] = useState<{ id: number; name: string; description?: string; initialPassword: string } | null>(null);
+  const [editChannelDialog, setEditChannelDialog] = useState<{ id: number; name: string; description?: string; initialPassword: string; position: number } | null>(null);
   const [aclEditorChannel, setAclEditorChannel] = useState<{ id: number; name: string } | null>(null);
   const { hasPermission, Permission, requestPermissions } = usePermissions();
   const sharingChannelIds = useMemo(() => {
@@ -240,9 +242,10 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     });
 
     const sortChildren = (channels: ChannelWithUsers[]) => {
+      channels.sort(compareChannelsByMumbleOrder);
       channels.forEach(ch => {
         if (ch.children.length > 0) {
-          ch.children.sort((a, b) => a.id - b.id);
+          ch.children = sortChannelsByMumbleOrder(ch.children);
           sortChildren(ch.children);
         }
       });
@@ -280,7 +283,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     const isChannelActive = (channelId: number) => channelContextMenu?.channelId === channelId;
 
     return (
-      <div key={channel.id} className={`channel-item${pendingChannelAction !== null ? ' channel-item--pending' : ''}`} data-level={level}>
+      <div key={channel.id} className={`channel-item${pendingChannelAction !== null ? ' channel-item--pending' : ''}`} data-level={level} data-channel-id={channel.id}>
         <div 
           className={`channel-row ${isCurrentChannel ? 'current' : ''}${hasUnread ? ' channel-row--unread' : ''}${channel.users.length === 0 && !hasUnread ? ' channel-row--empty' : ''}${isFolder ? ' is-folder' : ''}${dropTargetChannel === channel.id ? ' channel-row--drop-target' : ''}${isChannelActive(channel.id) ? ' channel-row--context-active' : ''}`}
           style={{ paddingLeft: `calc(16px + ${level * 20}px)` }}
@@ -528,6 +531,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
             name: channelContextMenu.channelName,
             description: channel?.description || '',
             initialPassword: '',
+            position: channel?.position ?? 0,
           });
           bridge.send('acl.getChannel', { channelId: channelContextMenu.channelId });
           setChannelContextMenu(null);
@@ -764,8 +768,9 @@ onClick: () => {
           initialName={editChannelDialog.name}
           initialDescription={editChannelDialog.description}
           initialPassword={editChannelDialog.initialPassword}
+          initialPosition={editChannelDialog.position}
           onClose={() => setEditChannelDialog(null)}
-          onSave={async (name, description) => {
+          onSave={async (name, description, position) => {
             const channel = channels.find(c => c.id === editChannelDialog!.id);
             const oldName = channel?.name || '';
 
@@ -787,6 +792,7 @@ onClick: () => {
               channelId: editChannelDialog!.id,
               name,
               description,
+              position,
             });
             setEditChannelDialog(null);
           }}

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -770,7 +770,7 @@ onClick: () => {
           initialPassword={editChannelDialog.initialPassword}
           initialPosition={editChannelDialog.position}
           onClose={() => setEditChannelDialog(null)}
-          onSave={async (name, description, position) => {
+          onSave={async (name, description) => {
             const channel = channels.find(c => c.id === editChannelDialog!.id);
             const oldName = channel?.name || '';
 
@@ -792,7 +792,6 @@ onClick: () => {
               channelId: editChannelDialog!.id,
               name,
               description,
-              position,
             });
             setEditChannelDialog(null);
           }}

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
@@ -228,6 +228,48 @@ describe('Sidebar root user screen share behavior', () => {
     expect(dot.classList.contains('service-dot--connecting')).toBe(true);
   });
 
+  it('formats development server versions as Dev main short sha', () => {
+    useServiceStatusMock.mockReturnValue({
+      statuses: {
+        voice: { state: 'connected' },
+        chat: { state: 'connected' },
+        server: { state: 'connected', version: '0.0.0-alpha.0+8f4a2c91b7e0' },
+        livekit: { state: 'connected' },
+      } as ServiceStatusMap,
+      effectiveStatuses: {
+        voice: { state: 'connected' },
+        chat: { state: 'connected' },
+        server: { state: 'connected', version: '0.0.0-alpha.0+8f4a2c91b7e0' },
+        livekit: { state: 'connected' },
+      } as ServiceStatusMap,
+    });
+
+    renderSidebar();
+
+    expect(screen.getByLabelText('Brmble: Connected — Dev main 8f4a2c9')).toBeInTheDocument();
+  });
+
+  it('formats released server versions as clean SemVer', () => {
+    useServiceStatusMock.mockReturnValue({
+      statuses: {
+        voice: { state: 'connected' },
+        chat: { state: 'connected' },
+        server: { state: 'connected', version: '1.2.3' },
+        livekit: { state: 'connected' },
+      } as ServiceStatusMap,
+      effectiveStatuses: {
+        voice: { state: 'connected' },
+        chat: { state: 'connected' },
+        server: { state: 'connected', version: '1.2.3' },
+        livekit: { state: 'connected' },
+      } as ServiceStatusMap,
+    });
+
+    renderSidebar();
+
+    expect(screen.getByLabelText('Brmble: Connected — v1.2.3')).toBeInTheDocument();
+  });
+
   it('shows local sharing without watch controls or watch actions', () => {
     const onWatchScreenShare = vi.fn();
 

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
@@ -249,6 +249,27 @@ describe('Sidebar root user screen share behavior', () => {
     expect(screen.getByLabelText('Brmble: Connected — Dev main 8f4a2c9')).toBeInTheDocument();
   });
 
+  it('does not prefix already formatted local development server versions', () => {
+    useServiceStatusMock.mockReturnValue({
+      statuses: {
+        voice: { state: 'connected' },
+        chat: { state: 'connected' },
+        server: { state: 'connected', version: 'Dev main' },
+        livekit: { state: 'connected' },
+      } as ServiceStatusMap,
+      effectiveStatuses: {
+        voice: { state: 'connected' },
+        chat: { state: 'connected' },
+        server: { state: 'connected', version: 'Dev main' },
+        livekit: { state: 'connected' },
+      } as ServiceStatusMap,
+    });
+
+    renderSidebar();
+
+    expect(screen.getByLabelText('Brmble: Connected — Dev main')).toBeInTheDocument();
+  });
+
   it('formats released server versions as clean SemVer', () => {
     useServiceStatusMock.mockReturnValue({
       statuses: {

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -113,8 +113,16 @@ export function Sidebar({
     }
   };
 
-  const formatServerVersion = (v: string): string =>
-    v.startsWith('v') || v.startsWith('V') ? v : `v${v}`;
+  const formatServerVersion = (v: string): string => {
+    if (v.startsWith('Dev main ')) return v;
+
+    const metadataSha = v.match(/\+([0-9a-f]{7,40})$/i)?.[1];
+    if (metadataSha && /^0\.0\.0(?:[-+]|$)/i.test(v)) {
+      return `Dev main ${metadataSha.slice(0, 7)}`;
+    }
+
+    return v.startsWith('v') || v.startsWith('V') ? `v${v.slice(1)}` : `v${v}`;
+  };
 
   const dotTooltip = (svc: ServiceName): string => {
     const name = SERVICE_DISPLAY_NAMES[svc];

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar({
   };
 
   const formatServerVersion = (v: string): string => {
-    if (v.startsWith('Dev main ')) return v;
+    if (v === 'Dev main' || v.startsWith('Dev main ')) return v;
 
     const metadataSha = v.match(/\+([0-9a-f]{7,40})$/i)?.[1];
     if (metadataSha && /^0\.0\.0(?:[-+]|$)/i.test(v)) {

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -9,6 +9,7 @@ export interface Channel {
   id: number;
   name: string;
   parent?: number;
+  position?: number;
   type?: 'voice' | 'text';
   description?: string;
   isEnterRestricted?: boolean;

--- a/src/Brmble.Web/src/utils/channelOrdering.ts
+++ b/src/Brmble.Web/src/utils/channelOrdering.ts
@@ -1,0 +1,15 @@
+import type { Channel } from '../types';
+
+export function compareChannelsByMumbleOrder(a: Channel, b: Channel): number {
+  const positionDiff = (a.position ?? 0) - (b.position ?? 0);
+  if (positionDiff !== 0) return positionDiff;
+
+  const nameDiff = a.name.localeCompare(b.name);
+  if (nameDiff !== 0) return nameDiff;
+
+  return a.id - b.id;
+}
+
+export function sortChannelsByMumbleOrder<T extends Channel>(channels: T[]): T[] {
+  return [...channels].sort(compareChannelsByMumbleOrder);
+}

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -31,7 +31,7 @@ public class MumbleAdapterBridgeTests
     {
         var adapter = CreateAdapterWithBridge(out var bridge);
         var channels = GetChannelDictionary(adapter);
-        channels[4] = new Channel(adapter, 4, "Secret", 0) { IsEnterRestricted = true, CanEnter = false };
+        channels[4] = new Channel(adapter, 4, "Secret", 0) { IsEnterRestricted = true, CanEnter = false, Position = 9 };
 
         InvokePrivate(adapter, "SendVoiceConnected");
 
@@ -44,6 +44,7 @@ public class MumbleAdapterBridgeTests
         Assert.IsTrue(channel.GetProperty("isEnterRestricted").GetBoolean());
         Assert.IsFalse(channel.GetProperty("canEnter").GetBoolean());
         Assert.IsFalse(channel.GetProperty("hasPasswordRestriction").GetBoolean());
+        Assert.AreEqual(9, channel.GetProperty("position").GetInt32());
     }
 
     [TestMethod]
@@ -93,6 +94,26 @@ public class MumbleAdapterBridgeTests
         Assert.IsTrue(channel.GetProperty("isEnterRestricted").GetBoolean());
         Assert.IsTrue(channel.GetProperty("canEnter").GetBoolean());
         Assert.IsFalse(channel.GetProperty("hasPasswordRestriction").GetBoolean());
+    }
+
+    [TestMethod]
+    public void ChannelState_IncludesPositionInBridgePayload()
+    {
+        var adapter = CreateAdapterWithBridge(out var bridge);
+
+        adapter.ChannelState(new ChannelState
+        {
+            ChannelId = 4,
+            Name = "Secret",
+            Parent = 0,
+            Position = 12
+        });
+
+        var sent = NativeBridgeTestHarness.DrainMessages(bridge);
+        var channelJoined = sent.Single(m => m.Type == "voice.channelJoined");
+        using var doc = JsonDocument.Parse(channelJoined.DataJson);
+
+        Assert.AreEqual(12, doc.RootElement.GetProperty("position").GetInt32());
     }
 
     [TestMethod]

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -117,6 +117,31 @@ public class MumbleAdapterBridgeTests
     }
 
     [TestMethod]
+    public void CreateEditChannelState_IncludesRequestedPosition()
+    {
+        var adapter = CreateAdapterWithBridge(out _);
+        var channel = new Channel(adapter, 4, "Secret", 0) { Position = 2 };
+
+        var state = MumbleAdapter.CreateEditChannelState(4, channel, "Secret", "Updated", 12);
+
+        Assert.AreEqual(4u, state.ChannelId);
+        Assert.AreEqual("Secret", state.Name);
+        Assert.AreEqual("Updated", state.Description);
+        Assert.AreEqual(12, state.Position);
+    }
+
+    [TestMethod]
+    public void CreateEditChannelState_PreservesExistingPositionWhenMissing()
+    {
+        var adapter = CreateAdapterWithBridge(out _);
+        var channel = new Channel(adapter, 4, "Secret", 0) { Position = 2 };
+
+        var state = MumbleAdapter.CreateEditChannelState(4, channel, "Secret", "Updated", null);
+
+        Assert.AreEqual(2, state.Position);
+    }
+
+    [TestMethod]
     public void HandleWebSocketMessage_AclChangedManagedPasswordMarker_UpdatesChannelPayloadWithoutToken()
     {
         var adapter = CreateAdapterWithBridge(out var bridge);

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -120,14 +120,44 @@ public class MumbleAdapterBridgeTests
     public void CreateEditChannelState_IncludesRequestedPosition()
     {
         var adapter = CreateAdapterWithBridge(out _);
-        var channel = new Channel(adapter, 4, "Secret", 0) { Position = 2 };
+        var channel = new Channel(adapter, 4, "Secret", 7) { Position = 2 };
 
         var state = MumbleAdapter.CreateEditChannelState(4, channel, "Secret", "Updated", 12);
 
         Assert.AreEqual(4u, state.ChannelId);
+        Assert.AreEqual(7u, state.Parent);
+        Assert.IsTrue(state.ShouldSerializeParent());
         Assert.AreEqual("Secret", state.Name);
         Assert.AreEqual("Updated", state.Description);
         Assert.AreEqual(12, state.Position);
+    }
+
+    [TestMethod]
+    public void CreateEditChannelState_MarksZeroPositionForSerialization()
+    {
+        var adapter = CreateAdapterWithBridge(out _);
+        var channel = new Channel(adapter, 4, "Secret", 0) { Position = 2 };
+
+        var state = MumbleAdapter.CreateEditChannelState(4, channel, "Secret", "Updated", 0);
+
+        Assert.AreEqual(0, state.Position);
+        Assert.IsTrue(state.ShouldSerializePosition());
+    }
+
+    [TestMethod]
+    public void CreateEditChannelState_RoundTripsZeroPositionThroughProtobuf()
+    {
+        var adapter = CreateAdapterWithBridge(out _);
+        var channel = new Channel(adapter, 4, "Secret", 0) { Position = 2 };
+        var state = MumbleAdapter.CreateEditChannelState(4, channel, "Secret", "Updated", 0);
+
+        using var stream = new MemoryStream();
+        ProtoBuf.Serializer.Serialize(stream, state);
+        stream.Position = 0;
+
+        var roundTripped = ProtoBuf.Serializer.Deserialize<ChannelState>(stream);
+        Assert.IsTrue(roundTripped.ShouldSerializePosition());
+        Assert.AreEqual(0, roundTripped.Position);
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Mumble/MumbleAclServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleAclServiceTests.cs
@@ -51,6 +51,26 @@ public class MumbleAclServiceTests
     }
 
     [TestMethod]
+    public async Task UpdateChannelStateAsync_PreservesExistingStateAndWritesPosition()
+    {
+        var ice = new Mock<IMumbleAclIceClient>();
+        ice.Setup(i => i.GetChannelStateAsync(4))
+            .ReturnsAsync(new MumbleServer.Channel(4, "Old", 7, [2], "Old description", false, 3));
+        var service = new MumbleAclService(ice.Object, NullLogger<MumbleAclService>.Instance);
+
+        await service.UpdateChannelStateAsync(4, new ChannelUpdateRequest("New", "Updated", 12));
+
+        ice.Verify(i => i.SetChannelStateAsync(It.Is<MumbleServer.Channel>(channel =>
+            channel.id == 4
+            && channel.name == "New"
+            && channel.parent == 7
+            && channel.links.SequenceEqual(new[] { 2 })
+            && channel.description == "Updated"
+            && channel.temporary == false
+            && channel.position == 12)), Times.Once);
+    }
+
+    [TestMethod]
     public async Task HasWritePermissionAsync_DelegatesToMumblePermissionWrite()
     {
         var ice = new Mock<IMumbleAclIceClient>();

--- a/tests/Brmble.Server.Tests/ServerInfo/ServerVersionProviderTests.cs
+++ b/tests/Brmble.Server.Tests/ServerInfo/ServerVersionProviderTests.cs
@@ -23,4 +23,22 @@ public class ServerVersionProviderTests
         Assert.IsFalse(provider.Version.StartsWith("v", StringComparison.OrdinalIgnoreCase),
             $"Version should be SemVer without 'v' prefix, got '{provider.Version}'.");
     }
+
+    [TestMethod]
+    public void FormatVersion_ForRelease_ReturnsSemVer()
+    {
+        Assert.AreEqual("1.2.3", ServerVersionProvider.FormatVersion("1.2.3", null));
+    }
+
+    [TestMethod]
+    public void FormatVersion_ForReleaseWithSourceRevision_ReturnsSemVer()
+    {
+        Assert.AreEqual("1.2.3", ServerVersionProvider.FormatVersion("1.2.3+8f4a2c91b7e0", null));
+    }
+
+    [TestMethod]
+    public void FormatVersion_ForMainBuild_ReturnsDevMainShortSha()
+    {
+        Assert.AreEqual("Dev main 8f4a2c9", ServerVersionProvider.FormatVersion("0.0.0-alpha.0", "8f4a2c91b7e0"));
+    }
 }

--- a/tests/Brmble.Server.Tests/ServerInfo/ServerVersionProviderTests.cs
+++ b/tests/Brmble.Server.Tests/ServerInfo/ServerVersionProviderTests.cs
@@ -41,4 +41,10 @@ public class ServerVersionProviderTests
     {
         Assert.AreEqual("Dev main 8f4a2c9", ServerVersionProvider.FormatVersion("0.0.0-alpha.0", "8f4a2c91b7e0"));
     }
+
+    [TestMethod]
+    public void FormatVersion_ForMainBuildWithoutSha_ReturnsDevMain()
+    {
+        Assert.AreEqual("Dev main", ServerVersionProvider.FormatVersion("0.0.0-alpha.0", null));
+    }
 }


### PR DESCRIPTION
# Summary

## Issues Fixed
- **#525**: Dev server version now displays Dev main <short-sha> when SHA is available; releases show clean SemVer like 1.2.3.
- **#545**: Sidebar and admin channel lists sort by Mumble Position field; position editing only in Settings > Admin > Channels.
- **#548**: Shortcut recorder exits/updates display after valid input; duplicate-binding prompt flows work correctly.

## Changes
### Version Display (#525)
- ServerVersionProvider.cs maps no-SHA raw MinVer to Dev main; full SHA appended when available.
- Dockerfile infers Git SHA from included .git/ metadata when SOURCE_REVISION_ID is unset.
- Sidebar no longer prepends  to already formatted Dev main.

### Channel Ordering (#545)
- Added position?: number to frontend channel types and client channel payload.
- Sidebar and admin channel lists use channelOrdering.ts (Mumble position sort).
- Admin channel editing uses server privileged ICE API (PATCH /acl/channels/{channelId}/state), not client oice.editChannel.
- Server preserves existing channel parent/links/temporary state while updating name/description/position.

### Shortcut Recorder (#548)
- Captured key remains visible across parent rerenders before key release.
- Unmount while key held correctly resumes hotkeys.

### Admin Channel Position Feedback
- Admin channel rows display right-aligned Position N pills.
- Missing position defaults to Position 0.
- Failed position saves show a warning notification (persistent per UI guide).
- Notification lifecycle cleanup and repeated-event refresh handled.

### UI Guide Compliance
- Failed position save notification: info to warning (errors must not auto-dismiss).
- Replaced inline Right-click a channel... text with SettingsHelp component.
- Replaced native white number spinner with themed chevron-up/chevron-down icon stepper.
- Removed Password Access helper text from EditChannelDialog.

## Test Plan
- [x] 
pm test - 879 tests passed
- [x] 
pm run type-check - clean
- [x] 
pm run build - clean
- [x] dotnet test - all .NET suites passed (297 server tests)
- [x] Docker rebuild verified: /health returns Dev main <sha>
- [x] Regression tests for shortcut recorder, version display, position persistence, protobuf round-trip