### PR TITLE
feat: LiveKit broadcaster controls - capture source + screen-share audio (B7/B8)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-livekit-broadcaster-capture-source.md
+++ b/docs/superpowers/plans/2026-06-05-livekit-broadcaster-capture-source.md
@@ -152,8 +152,8 @@ describe('ScreenShareSettingsTab', () => {
 
     render(<ScreenShareSettingsTab settings={settings} onChange={onChange} />);
 
-    await user.click(screen.getByRole('combobox', { name: 'Window (recommended for games)' }));
-    await user.click(screen.getByRole('option', { name: 'Screen' }));
+    await user.click(screen.getByRole('combobox', { name: 'Application Window' }));
+    await user.click(screen.getByRole('option', { name: 'Full Screen' }));
 
     expect(onChange).toHaveBeenCalledWith({
       ...settings,
@@ -179,14 +179,14 @@ In `ScreenShareSettingsTab.tsx`, add this option list after `VIEWER_MODE_OPTIONS
 
 ```ts
 const PREFERRED_CAPTURE_SOURCE_OPTIONS = [
-  { value: 'window', label: 'Window (recommended for games)' },
-  { value: 'screen', label: 'Screen' },
-  { value: 'browser', label: 'Browser/App' },
+  { value: 'window', label: 'Application Window' },
+  { value: 'screen', label: 'Full Screen' },
+  { value: 'browser', label: 'Browser Tab' },
   { value: 'auto', label: 'Auto' },
 ];
 ```
 
-Add this row between the System Audio row and Viewer Location row:
+Add this row at the top of the Screen Capture section, before Resolution:
 
 ```tsx
         <div className="settings-item">

--- a/docs/superpowers/plans/2026-06-05-livekit-broadcaster-capture-source.md
+++ b/docs/superpowers/plans/2026-06-05-livekit-broadcaster-capture-source.md
@@ -1,0 +1,419 @@
+# LiveKit Broadcaster Capture Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a themed Screen Share setting that defaults capture to Window and passes the corresponding LiveKit/browser display-surface hint when starting a share.
+
+**Architecture:** Extend the existing `ScreenShareSettings` model with a `preferredCaptureSource` enum-like string. Reuse the existing Settings tab `Select` and `SettingsHelp` patterns for UI, then map the setting inside `useScreenShare.startSharing` when building LiveKit capture options. No native picker, custom picker, game detection, or viewer behavior changes are included.
+
+**Tech Stack:** React 19, TypeScript, Vite, Vitest, Testing Library, LiveKit JS client.
+
+---
+
+## File Structure
+
+- Modify `src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx`: extend `ScreenShareSettings` and `DEFAULT_SCREEN_SHARE`.
+- Modify `src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx`: add the themed `Preferred Capture Source` select row and options.
+- Modify `src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx`: cover the new help button and select change behavior.
+- Modify `src/Brmble.Web/src/hooks/useScreenShare.ts`: map `preferredCaptureSource` to LiveKit `video.displaySurface` capture hints.
+- Modify `src/Brmble.Web/src/hooks/useScreenShare.test.ts`: cover default window hint, `auto` omission, and preservation of existing capture options.
+
+## Task 1: Extend Settings Model Defaults
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx:62-76`
+- Test: `src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx`
+
+- [ ] **Step 1: Write the failing settings-tab fixture update**
+
+Update the shared test fixture so TypeScript expects the new property everywhere that constructs `ScreenShareSettings`:
+
+```ts
+const settings: ScreenShareSettings = {
+  captureAudio: true,
+  resolution: '1080p',
+  fps: 30,
+  systemAudio: false,
+  viewerMode: 'in-app',
+  preferredCaptureSource: 'window',
+};
+```
+
+- [ ] **Step 2: Run type check to verify it fails before model change**
+
+Run from `src/Brmble.Web`:
+
+```powershell
+npm run type-check
+```
+
+Expected: FAIL with a TypeScript error that `preferredCaptureSource` does not exist in `ScreenShareSettings` or related call sites.
+
+- [ ] **Step 3: Add the model property and default**
+
+Change `ScreenShareSettings` and `DEFAULT_SCREEN_SHARE` to:
+
+```ts
+export interface ScreenShareSettings {
+  captureAudio: boolean;
+  resolution: '720p' | '1080p' | '1440p' | '4k';
+  fps: 15 | 30 | 60;
+  systemAudio: boolean;
+  viewerMode: 'in-app' | 'new-window';
+  preferredCaptureSource: 'auto' | 'window' | 'screen' | 'browser';
+}
+
+export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
+  captureAudio: false,
+  resolution: '1080p',
+  fps: 30,
+  systemAudio: false,
+  viewerMode: 'in-app',
+  preferredCaptureSource: 'window',
+};
+```
+
+- [ ] **Step 4: Run type check to verify it passes**
+
+Run from `src/Brmble.Web`:
+
+```powershell
+npm run type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add "src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx" "src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx"
+git commit -m "feat: add screen share capture source setting default"
+```
+
+## Task 2: Add Preferred Capture Source UI
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx:25-112`
+- Modify: `src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx:23-40`
+
+- [ ] **Step 1: Write failing tests for help and change behavior**
+
+Replace the test file with this content:
+
+```ts
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ScreenShareSettingsTab } from './ScreenShareSettingsTab';
+import type { ScreenShareSettings } from './SettingsModal';
+
+const settings: ScreenShareSettings = {
+  captureAudio: true,
+  resolution: '1080p',
+  fps: 30,
+  systemAudio: false,
+  viewerMode: 'in-app',
+  preferredCaptureSource: 'window',
+};
+
+describe('ScreenShareSettingsTab', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses shared settings help buttons and no inline note', () => {
+    render(<ScreenShareSettingsTab settings={settings} onChange={vi.fn()} />);
+
+    const captureAudioHelp = screen.getByRole('button', { name: 'More information about capture audio' });
+
+    expect(captureAudioHelp).toHaveClass('settings-info-btn');
+    expect(screen.getByRole('button', { name: 'More information about resolution' })).toHaveClass('settings-info-btn');
+    expect(screen.getByRole('button', { name: 'More information about frame rate' })).toHaveClass('settings-info-btn');
+    expect(screen.getByRole('button', { name: 'More information about system audio' })).toHaveClass('settings-info-btn');
+    expect(screen.getByRole('button', { name: 'More information about preferred capture source' })).toHaveClass('settings-info-btn');
+    expect(screen.getByRole('button', { name: 'More information about viewer location' })).toHaveClass('settings-info-btn');
+    expect(screen.queryByText('System audio is available on Windows and macOS. Audio capture requires browser support.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Choose Window for game sharing. Your system picker still asks which window to share.')).not.toBeInTheDocument();
+
+    fireEvent.focus(captureAudioHelp);
+    act(() => { vi.advanceTimersByTime(400); });
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('browser support');
+  });
+
+  it('updates preferred capture source through the themed select', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<ScreenShareSettingsTab settings={settings} onChange={onChange} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Window (recommended for games)' }));
+    await user.click(screen.getByRole('option', { name: 'Screen' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...settings,
+      preferredCaptureSource: 'screen',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run from `src/Brmble.Web`:
+
+```powershell
+npm run test -- src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
+```
+
+Expected: FAIL because the preferred capture source help button and select do not exist yet.
+
+- [ ] **Step 3: Add the UI option list and settings row**
+
+In `ScreenShareSettingsTab.tsx`, add this option list after `VIEWER_MODE_OPTIONS`:
+
+```ts
+const PREFERRED_CAPTURE_SOURCE_OPTIONS = [
+  { value: 'window', label: 'Window (recommended for games)' },
+  { value: 'screen', label: 'Screen' },
+  { value: 'browser', label: 'Browser/App' },
+  { value: 'auto', label: 'Auto' },
+];
+```
+
+Add this row between the System Audio row and Viewer Location row:
+
+```tsx
+        <div className="settings-item">
+          <div className="settings-label-group">
+            <span className="settings-label">Preferred Capture Source</span>
+            <SettingsHelp content="Choose Window for game sharing. Your system picker still asks which window to share." label="More information about preferred capture source" />
+          </div>
+          <Select
+            value={localSettings.preferredCaptureSource}
+            onChange={(value) => handleChange('preferredCaptureSource', value as ScreenShareSettings['preferredCaptureSource'])}
+            options={PREFERRED_CAPTURE_SOURCE_OPTIONS}
+          />
+        </div>
+```
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run from `src/Brmble.Web`:
+
+```powershell
+npm run test -- src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add "src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx" "src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx"
+git commit -m "feat: add screen share capture source selector"
+```
+
+## Task 3: Map Capture Source To LiveKit Options
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.ts:922-963`
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.test.ts:3225-3252`
+
+- [ ] **Step 1: Write failing hook tests for default window and auto behavior**
+
+Replace the final existing `passes correct capture options to setScreenShareEnabled` test with these two tests:
+
+```ts
+  it('passes default window capture source to setScreenShareEnabled', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const settings = {
+      captureAudio: true,
+      systemAudio: true,
+      resolution: '1080p' as const,
+      fps: 30 as const,
+      preferredCaptureSource: 'window' as const,
+    };
+
+    const { result } = renderHook(() => useScreenShare(undefined, settings));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.(liveKitToken('test-jwt'));
+      await promise;
+    });
+
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, expect.objectContaining({
+      audio: true,
+      systemAudio: 'include',
+      video: { displaySurface: 'window' },
+      resolution: { width: 1920, height: 1080, frameRate: 30 },
+      videoEncoding: { maxBitrate: 4_000_000, maxFramerate: 30 },
+    }));
+  });
+
+  it('omits display surface hint when preferred capture source is auto', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const settings = {
+      captureAudio: false,
+      systemAudio: false,
+      resolution: '720p' as const,
+      fps: 15 as const,
+      preferredCaptureSource: 'auto' as const,
+    };
+
+    const { result } = renderHook(() => useScreenShare(undefined, settings));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.(liveKitToken('test-jwt'));
+      await promise;
+    });
+
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, expect.not.objectContaining({
+      video: expect.anything(),
+    }));
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, expect.objectContaining({
+      resolution: { width: 1280, height: 720, frameRate: 15 },
+      videoEncoding: { maxBitrate: 2_000_000, maxFramerate: 15 },
+    }));
+  });
+```
+
+- [ ] **Step 2: Run the focused hook tests to verify they fail**
+
+Run from `src/Brmble.Web`:
+
+```powershell
+npm run test -- src/hooks/useScreenShare.test.ts
+```
+
+Expected: FAIL because `video.displaySurface` is not passed for the window case.
+
+- [ ] **Step 3: Add the mapping implementation**
+
+In `useScreenShare.ts`, after `captureOptions = {};` add:
+
+```ts
+        const displaySurfaceMap: Partial<Record<NonNullable<typeof screenShareSettings>['preferredCaptureSource'], 'window' | 'monitor' | 'browser'>> = {
+          window: 'window',
+          screen: 'monitor',
+          browser: 'browser',
+        };
+        const displaySurface = displaySurfaceMap[screenShareSettings.preferredCaptureSource];
+        if (displaySurface) {
+          captureOptions.video = { displaySurface };
+        }
+```
+
+The resulting block starts like this:
+
+```ts
+        captureOptions = {};
+
+        const displaySurfaceMap: Partial<Record<NonNullable<typeof screenShareSettings>['preferredCaptureSource'], 'window' | 'monitor' | 'browser'>> = {
+          window: 'window',
+          screen: 'monitor',
+          browser: 'browser',
+        };
+        const displaySurface = displaySurfaceMap[screenShareSettings.preferredCaptureSource];
+        if (displaySurface) {
+          captureOptions.video = { displaySurface };
+        }
+
+        if (screenShareSettings.captureAudio) {
+          captureOptions.audio = true;
+        }
+```
+
+- [ ] **Step 4: Run the focused hook tests to verify they pass**
+
+Run from `src/Brmble.Web`:
+
+```powershell
+npm run test -- src/hooks/useScreenShare.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add "src/Brmble.Web/src/hooks/useScreenShare.ts" "src/Brmble.Web/src/hooks/useScreenShare.test.ts"
+git commit -m "feat: pass preferred capture source to LiveKit"
+```
+
+## Task 4: Final Verification
+
+**Files:**
+- No code changes expected.
+
+- [ ] **Step 1: Run frontend tests**
+
+Run from `src/Brmble.Web`:
+
+```powershell
+npm run test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend type check**
+
+Run from `src/Brmble.Web`:
+
+```powershell
+npm run type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run frontend build**
+
+Run from `src/Brmble.Web`:
+
+```powershell
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Check git status**
+
+Run from repo root:
+
+```powershell
+git status --short --branch
+```
+
+Expected: branch is `feature/livekit-broadcaster-controls`; only unrelated pre-existing untracked files may remain.
+
+- [ ] **Step 5: Commit any verification-only fixes if needed**
+
+If a verification command reveals a real issue caused by this work, fix the smallest relevant code or test change, rerun the failing command, and commit with:
+
+```powershell
+git add "src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx" "src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx" "src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx" "src/Brmble.Web/src/hooks/useScreenShare.ts" "src/Brmble.Web/src/hooks/useScreenShare.test.ts"
+git commit -m "fix: stabilize screen share capture source setting"
+```
+
+If all verification commands pass and there are no uncommitted changes from this work, do not create an empty commit.
+
+## Self-Review
+
+- Spec coverage: Task 1 covers the data model/default. Task 2 covers UI guide-compliant settings UI and help text. Task 3 covers LiveKit display-surface mapping and unsupported/ignored hints by relying on existing error behavior. Task 4 covers verification. Deferred game-window suggestion remains documented in the spec/roadmap and is intentionally not implemented.
+- Placeholder scan: No placeholders, TODOs, or ambiguous implementation instructions remain.
+- Type consistency: The property name is consistently `preferredCaptureSource`; allowed values are consistently `'auto' | 'window' | 'screen' | 'browser'`; LiveKit display-surface outputs are consistently `'window' | 'monitor' | 'browser'`.

--- a/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
@@ -46,6 +46,8 @@ See full spec: `2026-04-17-multi-share-foundation-design.md`
 > What the person sharing can do.
 
 7. Window picker (specific window, not just full screen)
+   - Active slice: preferred capture source setting defaults to Window and passes a LiveKit/browser capture hint while keeping the native picker user-controlled.
+   - Deferred follow-up: suggest the current game window when starting share, using native foreground-window detection and later overlay/in-game context. The picker cannot be preselected programmatically, so this should remain a suggestion rather than automatic selection.
 8. Application/system audio capture
 9. Region capture (share a rectangle)
 10. Share the Brmble window itself (quick-share)

--- a/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
+++ b/docs/superpowers/specs/2026-04-17-livekit-feature-roadmap.md
@@ -49,6 +49,7 @@ See full spec: `2026-04-17-multi-share-foundation-design.md`
    - Active slice: preferred capture source setting defaults to Window and passes a LiveKit/browser capture hint while keeping the native picker user-controlled.
    - Deferred follow-up: suggest the current game window when starting share, using native foreground-window detection and later overlay/in-game context. The picker cannot be preselected programmatically, so this should remain a suggestion rather than automatic selection.
 8. Application/system audio capture
+   - Active slice: screen-share audio defaults to enabled with system audio opt-in; viewers attach LiveKit screen-share audio tracks when present.
 9. Region capture (share a rectangle)
 10. Share the Brmble window itself (quick-share)
 11. Auto-stop on lock/sleep
@@ -66,6 +67,8 @@ See full spec: `2026-04-17-multi-share-foundation-design.md`
 18. Fit-to-window vs. original size toggle
 19. Low-bandwidth viewer mode (request lower quality via simulcast/dynacast)
 20. Viewer count overlay on the stream
+
+**Deferred:** Screen-share audio mute/volume controls for viewers -- basic playback is implemented, but per-share viewer audio controls are not yet designed.
 
 **Deferred:** Zoom & pan -- cut for now.
 

--- a/docs/superpowers/specs/2026-06-05-livekit-broadcaster-capture-source-design.md
+++ b/docs/superpowers/specs/2026-06-05-livekit-broadcaster-capture-source-design.md
@@ -38,9 +38,9 @@ Add one row to the existing Screen Share settings tab under Screen Capture:
 
 Options:
 
-- `Window (recommended for games)` maps to `displaySurface: 'window'`
-- `Screen` maps to `displaySurface: 'monitor'`
-- `Browser/App` maps to `displaySurface: 'browser'`
+- `Application Window` maps to `displaySurface: 'window'`
+- `Full Screen` maps to `displaySurface: 'monitor'`
+- `Browser Tab` maps to `displaySurface: 'browser'`
 - `Auto` omits the display-surface hint
 
 Default:

--- a/docs/superpowers/specs/2026-06-05-livekit-broadcaster-capture-source-design.md
+++ b/docs/superpowers/specs/2026-06-05-livekit-broadcaster-capture-source-design.md
@@ -1,0 +1,90 @@
+# LiveKit Broadcaster Capture Source Design
+
+Date: 2026-06-05
+Status: Approved for implementation planning
+Branch: `feature/livekit-broadcaster-controls`
+
+## Context
+
+The LiveKit roadmap includes B. Broadcaster Controls. This slice intentionally starts with a small, low-risk control: a preferred capture source hint for screen sharing. The main user need is game sharing, so Brmble should bias the native picker toward sharing a window while still letting the user choose the final target.
+
+Brmble already has screen share settings for audio capture, system audio, resolution, frame rate, and viewer location. The existing settings tab follows the UI guide by using themed `Select` controls and `SettingsHelp` tooltips. This design extends that pattern and does not introduce a custom picker.
+
+## Goals
+
+- Add a `Preferred Capture Source` setting for screen sharing.
+- Default the setting to `Window`, because most Brmble screen shares are expected to be game windows.
+- Pass the preference into LiveKit/browser screen-share capture options as a display-surface hint.
+- Keep the OS/WebView2 picker user-controlled; Brmble cannot programmatically preselect a game window.
+- Use the existing UI guide patterns for settings rows, themed selects, and help text.
+- Document current-game window suggestion as a later roadmap item, not part of this slice.
+
+## Non-Goals
+
+- Do not implement native foreground-game/window detection in this slice.
+- Do not build a custom window picker.
+- Do not theme the native OS/WebView2 capture picker; it is browser/OS-controlled.
+- Do not add quality presets, region capture, webcam overlay, or lock/sleep handling in this slice.
+- Do not change screen-share viewing behavior.
+
+## User Experience
+
+Add one row to the existing Screen Share settings tab under Screen Capture:
+
+- Label: `Preferred Capture Source`
+- Control: existing themed `Select`
+- Help: existing `SettingsHelp`
+- Help content: `Choose Window for game sharing. Your system picker still asks which window to share.`
+
+Options:
+
+- `Window (recommended for games)` maps to `displaySurface: 'window'`
+- `Screen` maps to `displaySurface: 'monitor'`
+- `Browser/App` maps to `displaySurface: 'browser'`
+- `Auto` omits the display-surface hint
+
+Default:
+
+- New installs default to `window`.
+- Existing settings are normalized by merging with `DEFAULT_SCREEN_SHARE`, so missing saved values also become `window`.
+
+## Data Model
+
+Extend `ScreenShareSettings` with:
+
+```ts
+preferredCaptureSource: 'auto' | 'window' | 'screen' | 'browser';
+```
+
+The persisted settings object remains stored under `brmble-settings`. No explicit migration is required because existing settings are already merged with `DEFAULT_SCREEN_SHARE` when loaded.
+
+## LiveKit Integration
+
+`useScreenShare.startSharing` currently builds capture options before calling `room.localParticipant.setScreenShareEnabled(true, options)`.
+
+Update that capture-options builder so:
+
+- `preferredCaptureSource === 'window'` sets `video: { displaySurface: 'window' }`
+- `preferredCaptureSource === 'screen'` sets `video: { displaySurface: 'monitor' }`
+- `preferredCaptureSource === 'browser'` sets `video: { displaySurface: 'browser' }`
+- `preferredCaptureSource === 'auto'` keeps `video: true`
+
+Resolution, frame rate, audio, system audio, and encoding behavior remain unchanged in this slice.
+
+## Error Handling
+
+Unsupported or ignored display-surface hints should not produce Brmble-specific errors. Browsers may ignore hints or still show all capture surfaces. Existing screen-share error handling remains responsible for permission denial, picker cancellation, publish failures, and ended tracks.
+
+## Testing
+
+Add or update frontend tests for:
+
+- `ScreenShareSettingsTab` renders the new help button using `SettingsHelp` and no inline help paragraph.
+- Changing `Preferred Capture Source` calls `onChange` with the new value.
+- `useScreenShare` passes `video.displaySurface = 'window'` by default.
+- `useScreenShare` omits the display-surface hint when the value is `auto`.
+- Existing capture audio/system audio/resolution/FPS options continue to pass through.
+
+## Deferred Follow-Up
+
+Later B/Overlay work should investigate suggesting the current game window when the user starts sharing. The likely implementation is native foreground-window/process detection, improved by overlay/in-game context once the overlay is active. This should remain a suggestion because web screen capture APIs do not allow Brmble to preselect a specific OS window in the native picker.

--- a/src/Brmble.Client/Services/AppConfig/AppSettings.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppSettings.cs
@@ -57,6 +57,15 @@ public record AppearanceSettings(
     string Theme = "classic"
 );
 
+public record ScreenShareSettings(
+    bool CaptureAudio = false,
+    string Resolution = "1080p",
+    int Fps = 30,
+    bool SystemAudio = false,
+    string ViewerMode = "in-app",
+    string PreferredCaptureSource = "window"
+);
+
 public record AppSettings(
     AudioSettings Audio,
     ShortcutsSettings Shortcuts,
@@ -67,11 +76,13 @@ public record AppSettings(
     string? AutoConnectServerId = null,
     bool ReconnectEnabled = true,
     bool RememberLastChannel = true,
-    AppearanceSettings? Appearance = null
+    AppearanceSettings? Appearance = null,
+    ScreenShareSettings? ScreenShare = null
 )
 {
     public NoiseSuppressionSettings NoiseSuppression { get; init; } = NoiseSuppression ?? new NoiseSuppressionSettings();
     public AppearanceSettings Appearance { get; init; } = Appearance ?? new AppearanceSettings();
+    public ScreenShareSettings ScreenShare { get; init; } = ScreenShare ?? new ScreenShareSettings();
 
     public static AppSettings Default => new(
         new AudioSettings(),

--- a/src/Brmble.Client/Services/AppConfig/AppSettings.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppSettings.cs
@@ -58,7 +58,7 @@ public record AppearanceSettings(
 );
 
 public record ScreenShareSettings(
-    bool CaptureAudio = false,
+    bool CaptureAudio = true,
     string Resolution = "1080p",
     int Fps = 30,
     bool SystemAudio = false,

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -3376,13 +3376,18 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             {
                 var baseUri = new Uri(_apiUrl, UriKind.Absolute);
                 var uri = new Uri(baseUri, "livekit/share-started");
+                LogToFile($"[LiveKit] share-started notification begin: room={roomName}, uri={uri}");
                 var result = await PostViaBcTls(cert, uri, System.Text.Json.JsonSerializer.Serialize(new { roomName }));
                 if (result.Success)
+                {
+                    LogToFile($"[LiveKit] share-started notification succeeded: room={roomName}");
                     SendBrmbleServiceStatus("screenshare", "connected");
+                }
                 else
+                {
                     SendBrmbleServiceStatus("screenshare", "disconnected", reason: "share-started-failed");
-                if (!result.Success)
                     LogToFile($"[LiveKit] share-started notification failed: {result.Error}");
+                }
             }
             catch (Exception ex)
             {

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -1258,6 +1258,35 @@ describe('active share discovery', () => {
     expect(screen.getByText('Alice started sharing their screen')).toBeInTheDocument();
   });
 
+  it('does not notify for the broadcaster\'s own share when session id is missing but identity matches self', () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'screen-share');
+
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [{ id: 1, name: 'General' }],
+        users: [
+          { name: 'TestUser', self: true, channelId: 1, matrixUserId: '@self:example.com' },
+        ],
+      });
+    });
+
+    act(() => {
+      bridge.emit('livekit.screenShareStarted', {
+        roomName: 'channel-1',
+        userName: 'TestUser',
+        userId: 7,
+        matrixUserId: '@self:example.com',
+      });
+    });
+
+    expect(notifQueue.register).not.toHaveBeenCalledWith('screen-share', 'info');
+    expect(screen.queryByText('TestUser started sharing their screen')).not.toBeInTheDocument();
+  });
+
   it('clears visible optional screen share notification when global disable is enabled', () => {
     vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'screen-share');
 

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -1228,6 +1228,36 @@ describe('active share discovery', () => {
     expect(screen.queryByText('Alice started sharing their screen')).not.toBeInTheDocument();
   });
 
+  it('registers remote screen share notification when session ids are missing', async () => {
+    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'screen-share');
+
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [{ id: 1, name: 'General' }],
+        users: [
+          { name: 'TestUser', self: true, channelId: 1 },
+          { name: 'Alice', channelId: 1, matrixUserId: '@alice:example.com' },
+        ],
+      });
+    });
+
+    act(() => {
+      bridge.emit('livekit.screenShareStarted', {
+        roomName: 'channel-1',
+        userName: 'Alice',
+        userId: 42,
+        matrixUserId: '@alice:example.com',
+      });
+    });
+
+    expect(notifQueue.register).toHaveBeenCalledWith('screen-share', 'info');
+    expect(screen.getByText('Alice started sharing their screen')).toBeInTheDocument();
+  });
+
   it('clears visible optional screen share notification when global disable is enabled', () => {
     vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'screen-share');
 

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -702,6 +702,44 @@ describe('active share discovery', () => {
     expect(screenShareState.startSharing).toHaveBeenCalledWith('channel-1');
   });
 
+  it('uses same-document screen share settings updates before starting share', async () => {
+    const view = render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [{ id: 1, name: 'General' }],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+      bridge.emit('brmble.serviceStatus', { service: 'screenshare', state: 'connected' });
+    });
+
+    localStorage.setItem('brmble-settings', JSON.stringify({
+      screenShare: {
+        captureAudio: false,
+        resolution: '1080p',
+        fps: 30,
+        systemAudio: false,
+        viewerMode: 'in-app',
+        preferredCaptureSource: 'auto',
+      },
+    }));
+    act(() => {
+      window.dispatchEvent(new Event('brmble-settings-updated'));
+    });
+
+    await act(async () => {
+      view.getByTestId('header-toggle-screen-share').click();
+      await Promise.resolve();
+    });
+
+    expect(getScreenShareSettingsArg()).toEqual(expect.objectContaining({
+      preferredCaptureSource: 'auto',
+    }));
+    expect(screenShareState.startSharing).toHaveBeenCalledWith('channel-1');
+  });
+
   it('does not start local sharing while Brmble-dependent screenshare status is idle', async () => {
     serviceStatus.statuses.server = { state: 'connecting' };
     serviceStatus.statuses.livekit = { state: 'connected' };

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -26,6 +26,9 @@ const {
   getLocalShareEndedHandler,
   clearLocalShareEndedHandler,
   captureLocalShareEndedHandler,
+  getScreenShareSettingsArg,
+  clearScreenShareSettingsArg,
+  captureScreenShareSettingsArg,
 } = vi.hoisted(() => {
   const handlers = new Map<string, Set<BridgeHandler>>();
   const disconnect = vi.fn();
@@ -73,6 +76,7 @@ const {
   };
   let idleActionsArgs: { onBeforeAutoLeave?: () => void | Promise<void> } | null = null;
   let localShareEndedHandler: ((reason: 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel') => void) | null = null;
+  let latestScreenShareSettings: unknown = null;
   let latestSidebarProps: { channels?: Array<{ id: number; canEnter?: boolean; hasPasswordRestriction?: boolean; position?: number; description?: string }> } = {};
   const mockBridge = {
     send: vi.fn(),
@@ -129,6 +133,13 @@ const {
     captureLocalShareEndedHandler: (handler?: (reason: 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel') => void) => {
       localShareEndedHandler = handler ?? null;
     },
+    getScreenShareSettingsArg: () => latestScreenShareSettings,
+    clearScreenShareSettingsArg: () => {
+      latestScreenShareSettings = null;
+    },
+    captureScreenShareSettingsArg: (settings: unknown) => {
+      latestScreenShareSettings = settings;
+    },
     notifQueue: {
       register: vi.fn(),
       unregister: vi.fn(),
@@ -157,6 +168,7 @@ vi.mock('./hooks/useMatrixClient', () => ({
 
 vi.mock('./hooks/useScreenShare', () => ({
   useScreenShare: (_onDisconnected?: () => void, _settings?: unknown, onLocalShareEnded?: (reason: 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel') => void) => {
+    captureScreenShareSettingsArg(_settings);
     captureLocalShareEndedHandler(onLocalShareEnded);
     return {
     isSharing: screenShareState.isSharing,
@@ -537,6 +549,7 @@ describe('active share discovery', () => {
     idleActionsState.preLeaveCancelledAt = null;
     clearIdleActionsArgs();
     clearLocalShareEndedHandler();
+    clearScreenShareSettingsArg();
     sidebarProps.current = {};
     vi.mocked(notifQueue.isVisible).mockReturnValue(false);
     vi.mocked(bridge.send).mockImplementation((type: string, payload?: unknown) => {
@@ -651,6 +664,42 @@ describe('active share discovery', () => {
     expect(screenShareState.startSharing).toHaveBeenCalledWith('channel-1');
     expect(bridge.send).toHaveBeenCalledWith('livekit.debug.toggleScreenShare.notSharing.inVoice.channel-1.canStart', {});
     expect(serviceStatus.updateStatus).toHaveBeenCalledWith('livekit', { state: 'connecting', error: undefined });
+  });
+
+  it('keeps screen share settings from native settings bridge wrappers before starting share', async () => {
+    const view = render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('settings.current', {
+        settings: {
+          screenShare: {
+            captureAudio: false,
+            resolution: '1080p',
+            fps: 30,
+            systemAudio: false,
+            viewerMode: 'in-app',
+            preferredCaptureSource: 'auto',
+          },
+        },
+      });
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [{ id: 1, name: 'General' }],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+      bridge.emit('brmble.serviceStatus', { service: 'screenshare', state: 'connected' });
+    });
+
+    await act(async () => {
+      view.getByTestId('header-toggle-screen-share').click();
+      await Promise.resolve();
+    });
+
+    expect(getScreenShareSettingsArg()).toEqual(expect.objectContaining({
+      preferredCaptureSource: 'auto',
+    }));
+    expect(screenShareState.startSharing).toHaveBeenCalledWith('channel-1');
   });
 
   it('does not start local sharing while Brmble-dependent screenshare status is idle', async () => {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -3776,23 +3776,19 @@ const handleConnect = (serverData: SavedServer) => {
       const d = data as { roomName: string; userName: string; userId?: number; matrixUserId?: string; sessionId?: number };
       const selfUser = usersRef.current.find(u => u.self);
       const voiceChannelId = selfUser?.channelId;
-      try {
-        bridge.send('livekit.debug.screenShareStarted.received', {
-          roomName: d.roomName,
-          userId: d.userId,
-          sessionId: d.sessionId,
-          selfSession: selfUser?.session,
-          voiceChannelId,
-          notificationsEnabled: shouldShowOptionalNotification(optionalNotificationSettingsRef.current, 'notificationRemoteScreenShare'),
-        });
-      } catch {
-        // Diagnostics must never affect notification handling.
-      }
-      // Only show notification for other users' shares in our channel
+      // Only show notification for other users' shares in our channel.
+      // Prefer the session id to identify self; when the server payload omits
+      // it, fall back to matching the Matrix identity so the broadcaster does
+      // not get a notification for their own share (the event is broadcast to
+      // everyone in the room, including the sharer).
+      const selfMatrixUserId = selfUser?.matrixUserId ?? matrixCredentialsRef.current?.userId;
+      const isSelfShare = (d.sessionId != null && selfUser?.session != null)
+        ? d.sessionId === selfUser.session
+        : (selfMatrixUserId != null && d.matrixUserId != null && d.matrixUserId === selfMatrixUserId);
       if (
         voiceChannelId != null &&
         d.roomName === `channel-${voiceChannelId}` &&
-        (d.sessionId == null || selfUser?.session == null || d.sessionId !== selfUser.session) &&
+        !isSelfShare &&
         shouldShowOptionalNotification(optionalNotificationSettingsRef.current, 'notificationRemoteScreenShare')
       ) {
         setScreenShareNotification({ userName: d.userName, roomName: d.roomName, userId: d.userId, matrixUserId: d.matrixUserId });

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -3378,11 +3378,13 @@ const handleConnect = (serverData: SavedServer) => {
 
     const handleStorage = () => loadSettings();
     window.addEventListener('storage', handleStorage);
+    window.addEventListener('brmble-settings-updated', handleStorage);
 
     return () => {
       bridgeApi.off?.('settings.current', handleBridgeSettings);
       bridgeApi.off?.('settings.updated', handleBridgeSettings);
       window.removeEventListener('storage', handleStorage);
+      window.removeEventListener('brmble-settings-updated', handleStorage);
     };
   }, []);
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -3328,12 +3328,20 @@ const handleConnect = (serverData: SavedServer) => {
     const applyScreenShareSettings = (value: unknown) => {
       if (!value || typeof value !== 'object') return;
 
+      const payload = value as Record<string, unknown>;
+      const settingsPayload =
+        payload.settings && typeof payload.settings === 'object'
+          ? payload.settings as Record<string, unknown>
+          : null;
+
       const candidate =
-        'screenShare' in value &&
-        value.screenShare &&
-        typeof value.screenShare === 'object'
-          ? value.screenShare
-          : value;
+        settingsPayload
+          ? settingsPayload.screenShare
+          : payload.screenShare && typeof payload.screenShare === 'object'
+            ? payload.screenShare
+            : payload;
+
+      if (!candidate || typeof candidate !== 'object') return;
 
       setScreenShareSettings((current) => ({
         ...current,

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -3771,7 +3771,7 @@ const handleConnect = (serverData: SavedServer) => {
       if (
         voiceChannelId != null &&
         d.roomName === `channel-${voiceChannelId}` &&
-        d.sessionId !== selfUser?.session &&
+        (d.sessionId == null || selfUser?.session == null || d.sessionId !== selfUser.session) &&
         shouldShowOptionalNotification(optionalNotificationSettingsRef.current, 'notificationRemoteScreenShare')
       ) {
         setScreenShareNotification({ userName: d.userName, roomName: d.roomName, userId: d.userId, matrixUserId: d.matrixUserId });

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -823,6 +823,12 @@ interface ServerRemovalNotification extends ScreenShareEndedNotification {
 function App() {
   // --- Notification queue (max 3 visible, priority-based) ---
   const notifQueue = useNotificationQueue();
+  // Stable ref to the notification queue so effects that must only run on
+  // specific triggers (e.g. channel change) can call queue methods without
+  // depending on the queue object's identity, which churns on every
+  // register/unregister and would otherwise re-run those effects unexpectedly.
+  const notifQueueRef = useRef(notifQueue);
+  notifQueueRef.current = notifQueue;
 
   // --- Brmblegotchi settings state ---
   const [brmblegotchiEnabled, setBrmblegotchiEnabledState] = useState<boolean>(() => {
@@ -3824,13 +3830,19 @@ const handleConnect = (serverData: SavedServer) => {
 
   requestActiveShareDiscoveryRef.current = requestActiveShareDiscovery;
 
-  // Check for active screen shares when switching channels
+  // Check for active screen shares when switching channels.
+  // Depends ONLY on currentChannelId: the other collaborators (disconnectViewer,
+  // notifQueue, requestActiveShareDiscovery) are accessed via refs so their
+  // identity churn — notably notifQueue changing on every register/unregister —
+  // does not re-run this effect and wipe a freshly shown screen-share
+  // notification.
   useEffect(() => {
-    disconnectViewer();
+    disconnectViewerRef.current?.();
     setScreenShareNotification(null);
-    notifQueue.unregister('screen-share');
-    requestActiveShareDiscovery(currentChannelId);
-  }, [currentChannelId, disconnectViewer, notifQueue, requestActiveShareDiscovery]);
+    notifQueueRef.current.unregister('screen-share');
+    requestActiveShareDiscoveryRef.current?.(currentChannelId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentChannelId]);
 
   useEffect(() => {
     const previousConnectionStatus = previousConnectionStatusRef.current;

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -3767,6 +3767,18 @@ const handleConnect = (serverData: SavedServer) => {
       const d = data as { roomName: string; userName: string; userId?: number; matrixUserId?: string; sessionId?: number };
       const selfUser = usersRef.current.find(u => u.self);
       const voiceChannelId = selfUser?.channelId;
+      try {
+        bridge.send('livekit.debug.screenShareStarted.received', {
+          roomName: d.roomName,
+          userId: d.userId,
+          sessionId: d.sessionId,
+          selfSession: selfUser?.session,
+          voiceChannelId,
+          notificationsEnabled: shouldShowOptionalNotification(optionalNotificationSettingsRef.current, 'notificationRemoteScreenShare'),
+        });
+      } catch {
+        // Diagnostics must never affect notification handling.
+      }
       // Only show notification for other users' shares in our channel
       if (
         voiceChannelId != null &&

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
@@ -39,11 +39,12 @@ describe('ScreenShareSettingsTab', () => {
     expect(screen.getByRole('button', { name: 'More information about viewer location' })).toHaveClass('settings-info-btn');
     expect(screen.queryByText('System audio is available on Windows and macOS. Audio capture requires browser support.')).not.toBeInTheDocument();
     expect(screen.queryByText('Choose Window for game sharing. Your system picker still asks which window to share.')).not.toBeInTheDocument();
-    expect(screen.queryByText('Share audio from the selected screen, window, or browser tab when supported. Voice chat uses Brmble separately.')).not.toBeInTheDocument();
+    expect(screen.queryByText(/capturing a single application window's audio is not supported/)).not.toBeInTheDocument();
 
     fireEvent.focus(captureAudioHelp);
     act(() => { vi.advanceTimersByTime(400); });
 
+    expect(screen.getByRole('tooltip')).toHaveTextContent('single application window');
     expect(screen.getByRole('tooltip')).toHaveTextContent('Voice chat uses Brmble separately');
   });
 

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
@@ -9,6 +9,7 @@ const settings: ScreenShareSettings = {
   fps: 30,
   systemAudio: false,
   viewerMode: 'in-app',
+  preferredCaptureSource: 'window',
 };
 
 describe('ScreenShareSettingsTab', () => {

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ScreenShareSettingsTab } from './ScreenShareSettingsTab';
 import type { ScreenShareSettings } from './SettingsModal';
 
@@ -11,6 +12,10 @@ const settings: ScreenShareSettings = {
   viewerMode: 'in-app',
   preferredCaptureSource: 'window',
 };
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
 
 describe('ScreenShareSettingsTab', () => {
   beforeEach(() => {
@@ -30,12 +35,30 @@ describe('ScreenShareSettingsTab', () => {
     expect(screen.getByRole('button', { name: 'More information about resolution' })).toHaveClass('settings-info-btn');
     expect(screen.getByRole('button', { name: 'More information about frame rate' })).toHaveClass('settings-info-btn');
     expect(screen.getByRole('button', { name: 'More information about system audio' })).toHaveClass('settings-info-btn');
+    expect(screen.getByRole('button', { name: 'More information about preferred capture source' })).toHaveClass('settings-info-btn');
     expect(screen.getByRole('button', { name: 'More information about viewer location' })).toHaveClass('settings-info-btn');
     expect(screen.queryByText('System audio is available on Windows and macOS. Audio capture requires browser support.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Choose Window for game sharing. Your system picker still asks which window to share.')).not.toBeInTheDocument();
 
     fireEvent.focus(captureAudioHelp);
     act(() => { vi.advanceTimersByTime(400); });
 
     expect(screen.getByRole('tooltip')).toHaveTextContent('browser support');
+  });
+
+  it('updates preferred capture source through the themed select', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<ScreenShareSettingsTab settings={settings} onChange={onChange} />);
+
+    await user.click(screen.getByText('Window (recommended for games)'));
+    await user.click(screen.getByRole('option', { name: 'Screen' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...settings,
+      preferredCaptureSource: 'screen',
+    });
   });
 });

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
@@ -39,11 +39,46 @@ describe('ScreenShareSettingsTab', () => {
     expect(screen.getByRole('button', { name: 'More information about viewer location' })).toHaveClass('settings-info-btn');
     expect(screen.queryByText('System audio is available on Windows and macOS. Audio capture requires browser support.')).not.toBeInTheDocument();
     expect(screen.queryByText('Choose Window for game sharing. Your system picker still asks which window to share.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Share audio from the selected screen, window, or browser tab when supported. Voice chat uses Brmble separately.')).not.toBeInTheDocument();
 
     fireEvent.focus(captureAudioHelp);
     act(() => { vi.advanceTimersByTime(400); });
 
-    expect(screen.getByRole('tooltip')).toHaveTextContent('browser support');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Voice chat uses Brmble separately');
+  });
+
+  it('turns system audio off and disables it when capture audio is turned off', () => {
+    const onChange = vi.fn();
+
+    render(<ScreenShareSettingsTab settings={{ ...settings, systemAudio: true }} onChange={onChange} />);
+
+    const toggles = screen.getAllByRole('checkbox');
+    const captureAudioToggle = toggles[0];
+    const systemAudioToggle = toggles[1];
+
+    fireEvent.click(captureAudioToggle);
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...settings,
+      captureAudio: false,
+      systemAudio: false,
+    });
+    expect(systemAudioToggle).toBeDisabled();
+  });
+
+  it('orders capture source, quality, audio, then viewer location settings', () => {
+    render(<ScreenShareSettingsTab settings={settings} onChange={vi.fn()} />);
+
+    const labels = screen.getAllByText(/^(Preferred Capture Source|Resolution|Frame Rate|Capture Audio|System Audio|Viewer Location)$/).map((label) => label.textContent);
+
+    expect(labels).toEqual([
+      'Preferred Capture Source',
+      'Resolution',
+      'Frame Rate',
+      'Capture Audio',
+      'System Audio',
+      'Viewer Location',
+    ]);
   });
 
   it('updates preferred capture source through the themed select', async () => {
@@ -53,8 +88,8 @@ describe('ScreenShareSettingsTab', () => {
 
     render(<ScreenShareSettingsTab settings={settings} onChange={onChange} />);
 
-    await user.click(screen.getByText('Window (recommended for games)'));
-    await user.click(screen.getByRole('option', { name: 'Screen' }));
+    await user.click(screen.getByText('Application Window'));
+    await user.click(screen.getByRole('option', { name: 'Full Screen' }));
 
     expect(onChange).toHaveBeenCalledWith({
       ...settings,

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -28,9 +28,9 @@ const VIEWER_MODE_OPTIONS = [
 ];
 
 const PREFERRED_CAPTURE_SOURCE_OPTIONS = [
-  { value: 'window', label: 'Window (recommended for games)' },
-  { value: 'screen', label: 'Screen' },
-  { value: 'browser', label: 'Browser/App' },
+  { value: 'window', label: 'Application Window' },
+  { value: 'screen', label: 'Full Screen' },
+  { value: 'browser', label: 'Browser Tab' },
   { value: 'auto', label: 'Auto' },
 ];
 
@@ -42,7 +42,11 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
   }, [settings]);
 
   const handleChange = <K extends keyof ScreenShareSettings>(key: K, value: ScreenShareSettings[K]) => {
-    const newSettings = { ...localSettings, [key]: value };
+    const newSettings = {
+      ...localSettings,
+      [key]: value,
+      ...(key === 'captureAudio' && value === false ? { systemAudio: false } : {}),
+    };
     setLocalSettings(newSettings);
     onChange(newSettings);
   };
@@ -52,19 +56,16 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
       <div className="settings-section">
         <h3 className="heading-section settings-section-title">Screen Capture</h3>
         
-        <div className="settings-item settings-toggle">
+        <div className="settings-item">
           <div className="settings-label-group">
-            <span className="settings-label">Capture Audio</span>
-            <SettingsHelp content="Capture microphone audio along with screen share when browser support is available." label="More information about capture audio" />
+            <span className="settings-label">Preferred Capture Source</span>
+            <SettingsHelp content="Choose Window for game sharing. Your system picker still asks which window to share." label="More information about preferred capture source" />
           </div>
-          <label className="brmble-toggle">
-            <input
-              type="checkbox"
-              checked={localSettings.captureAudio}
-              onChange={(e) => handleChange('captureAudio', e.target.checked)}
-            />
-            <span className="brmble-toggle-slider"></span>
-          </label>
+          <Select
+            value={localSettings.preferredCaptureSource}
+            onChange={(value) => handleChange('preferredCaptureSource', value as ScreenShareSettings['preferredCaptureSource'])}
+            options={PREFERRED_CAPTURE_SOURCE_OPTIONS}
+          />
         </div>
 
         <div className="settings-item">
@@ -93,29 +94,33 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
 
         <div className="settings-item settings-toggle">
           <div className="settings-label-group">
-            <span className="settings-label">System Audio</span>
-            <SettingsHelp content="Capture system audio when supported. System audio is available on Windows and macOS, and requires browser support." label="More information about system audio" />
+            <span className="settings-label">Capture Audio</span>
+            <SettingsHelp content="Share audio from the selected screen, window, or browser tab when supported. Voice chat uses Brmble separately." label="More information about capture audio" />
           </div>
           <label className="brmble-toggle">
             <input
               type="checkbox"
-              checked={localSettings.systemAudio}
-              onChange={(e) => handleChange('systemAudio', e.target.checked)}
+              checked={localSettings.captureAudio}
+              onChange={(e) => handleChange('captureAudio', e.target.checked)}
             />
             <span className="brmble-toggle-slider"></span>
           </label>
         </div>
 
-        <div className="settings-item">
+        <div className="settings-item settings-toggle">
           <div className="settings-label-group">
-            <span className="settings-label">Preferred Capture Source</span>
-            <SettingsHelp content="Choose Window for game sharing. Your system picker still asks which window to share." label="More information about preferred capture source" />
+            <span className="settings-label">System Audio</span>
+            <SettingsHelp content="Request system audio when supported. Only available when capture audio is enabled." label="More information about system audio" />
           </div>
-          <Select
-            value={localSettings.preferredCaptureSource}
-            onChange={(value) => handleChange('preferredCaptureSource', value as ScreenShareSettings['preferredCaptureSource'])}
-            options={PREFERRED_CAPTURE_SOURCE_OPTIONS}
-          />
+          <label className="brmble-toggle">
+            <input
+              type="checkbox"
+              checked={localSettings.captureAudio && localSettings.systemAudio}
+              disabled={!localSettings.captureAudio}
+              onChange={(e) => handleChange('systemAudio', e.target.checked)}
+            />
+            <span className="brmble-toggle-slider"></span>
+          </label>
         </div>
 
         <div className="settings-item">

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -95,7 +95,7 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         <div className="settings-item settings-toggle">
           <div className="settings-label-group">
             <span className="settings-label">Capture Audio</span>
-            <SettingsHelp content="Share audio from the selected screen, window, or browser tab when supported. Voice chat uses Brmble separately." label="More information about capture audio" />
+            <SettingsHelp content="Shares audio together with your screen. Works when sharing a whole screen or a browser tab; capturing a single application window's audio is not supported by the system. You must also enable audio in the screen picker. Voice chat uses Brmble separately." label="More information about capture audio" />
           </div>
           <label className="brmble-toggle">
             <input
@@ -110,7 +110,7 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
         <div className="settings-item settings-toggle">
           <div className="settings-label-group">
             <span className="settings-label">System Audio</span>
-            <SettingsHelp content="Request system audio when supported. Only available when capture audio is enabled." label="More information about system audio" />
+            <SettingsHelp content="Shares your computer's system audio when sharing a whole screen. Only available when capture audio is enabled and offered by the screen picker." label="More information about system audio" />
           </div>
           <label className="brmble-toggle">
             <input

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -27,6 +27,13 @@ const VIEWER_MODE_OPTIONS = [
   { value: 'new-window', label: 'Full window' },
 ];
 
+const PREFERRED_CAPTURE_SOURCE_OPTIONS = [
+  { value: 'window', label: 'Window (recommended for games)' },
+  { value: 'screen', label: 'Screen' },
+  { value: 'browser', label: 'Browser/App' },
+  { value: 'auto', label: 'Auto' },
+];
+
 export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettingsTabProps) {
   const [localSettings, setLocalSettings] = useState<ScreenShareSettings>(settings);
 
@@ -97,6 +104,18 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
             />
             <span className="brmble-toggle-slider"></span>
           </label>
+        </div>
+
+        <div className="settings-item">
+          <div className="settings-label-group">
+            <span className="settings-label">Preferred Capture Source</span>
+            <SettingsHelp content="Choose Window for game sharing. Your system picker still asks which window to share." label="More information about preferred capture source" />
+          </div>
+          <Select
+            value={localSettings.preferredCaptureSource}
+            onChange={(value) => handleChange('preferredCaptureSource', value as ScreenShareSettings['preferredCaptureSource'])}
+            options={PREFERRED_CAPTURE_SOURCE_OPTIONS}
+          />
         </div>
 
         <div className="settings-item">

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.test.tsx
@@ -43,6 +43,15 @@ describe('SettingsModal tabs', () => {
     expect(screen.queryByRole('button', { name: 'Messages' })).not.toBeInTheDocument();
   });
 
+  it('defaults screen share capture audio on and system audio off', async () => {
+    render(<SettingsModal isOpen={true} onClose={vi.fn()} initialTab="screenShare" />);
+
+    const toggles = await screen.findAllByRole('checkbox');
+
+    expect(toggles[0]).toBeChecked();
+    expect(toggles[1]).not.toBeChecked();
+  });
+
   it('registers native shortcut changes for every shortcut action', async () => {
     render(<SettingsModal isOpen onClose={vi.fn()} initialTab="shortcuts" />);
 

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { SettingsModal } from './SettingsModal';
 
@@ -76,5 +76,48 @@ describe('SettingsModal tabs', () => {
     );
 
     expect(screen.getByTestId('admin-users-prop')).toHaveTextContent('Alice');
+  });
+
+  it('normalizes legacy screen share settings from native settings', async () => {
+    render(<SettingsModal isOpen onClose={vi.fn()} initialTab="screenShare" />);
+
+    await waitFor(() => {
+      expect(bridgeMock.on).toHaveBeenCalledWith('settings.current', expect.any(Function));
+    });
+
+    const currentSettingsHandler = bridgeMock.on.mock.calls.find(
+      ([event]) => event === 'settings.current',
+    )?.[1] as ((data: unknown) => void) | undefined;
+
+    const legacyScreenShareSettings = {
+      captureAudio: true,
+      resolution: '1080p',
+      fps: 30,
+      systemAudio: false,
+      viewerMode: 'in-app',
+    } as unknown;
+
+    act(() => {
+      currentSettingsHandler?.({ settings: { screenShare: legacyScreenShareSettings } });
+    });
+
+    const captureAudioToggle = screen.getAllByRole('checkbox')[0];
+    await waitFor(() => {
+      expect(captureAudioToggle).toBeChecked();
+    });
+
+    bridgeMock.send.mockClear();
+    fireEvent.click(captureAudioToggle);
+
+    await waitFor(() => {
+      expect(bridgeMock.send).toHaveBeenCalledWith('settings.set', {
+        settings: expect.objectContaining({
+          screenShare: expect.objectContaining({
+            captureAudio: false,
+            preferredCaptureSource: 'window',
+          }),
+        }),
+      });
+    });
   });
 });

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.test.tsx
@@ -133,6 +133,51 @@ describe('SettingsModal tabs', () => {
     });
   });
 
+  it('normalizes stored system audio off when capture audio is off on load', async () => {
+    render(<SettingsModal isOpen onClose={vi.fn()} initialTab="screenShare" />);
+
+    await waitFor(() => {
+      expect(bridgeMock.on).toHaveBeenCalledWith('settings.current', expect.any(Function));
+    });
+
+    const currentSettingsHandler = bridgeMock.on.mock.calls.find(
+      ([event]) => event === 'settings.current',
+    )?.[1] as ((data: unknown) => void) | undefined;
+
+    // Legacy/divergent combo: capture audio off but system audio still true.
+    const divergentScreenShareSettings = {
+      captureAudio: false,
+      systemAudio: true,
+      resolution: '1080p',
+      fps: 30,
+      viewerMode: 'in-app',
+      preferredCaptureSource: 'window',
+    } as unknown;
+
+    act(() => {
+      currentSettingsHandler?.({ settings: { screenShare: divergentScreenShareSettings } });
+    });
+
+    const [captureAudioToggle, systemAudioToggle] = await screen.findAllByRole('checkbox');
+    expect(captureAudioToggle).not.toBeChecked();
+    expect(systemAudioToggle).not.toBeChecked();
+
+    bridgeMock.send.mockClear();
+    // Re-enabling capture audio must NOT resurrect system audio.
+    fireEvent.click(captureAudioToggle);
+
+    await waitFor(() => {
+      expect(bridgeMock.send).toHaveBeenCalledWith('settings.set', {
+        settings: expect.objectContaining({
+          screenShare: expect.objectContaining({
+            captureAudio: true,
+            systemAudio: false,
+          }),
+        }),
+      });
+    });
+  });
+
   it('shows channel request history in the profile tab', () => {
     render(<SettingsModal isOpen onClose={vi.fn()} />);
 

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -199,10 +199,17 @@ export function SettingsModal(props: SettingsModalProps) {
             audio: { ...DEFAULT_SETTINGS.audio, ...(d.settings!.audio ?? {}) },
             overlay: normalizeOverlaySettings(d.settings!.overlay ?? {}),
             brmblegotchi: d.settings!.brmblegotchi ?? prev.brmblegotchi ?? DEFAULT_BRMBLEGOTCHI,
-            screenShare: {
-              ...DEFAULT_SCREEN_SHARE,
-              ...((d.settings!.screenShare ?? prev.screenShare) ?? {}),
-            },
+            screenShare: (() => {
+              const merged = {
+                ...DEFAULT_SCREEN_SHARE,
+                ...((d.settings!.screenShare ?? prev.screenShare) ?? {}),
+              };
+              // System audio is only meaningful when capture audio is on.
+              // Normalize on load so a legacy/divergent stored combo
+              // (captureAudio: false, systemAudio: true) cannot silently
+              // resurrect system audio when capture audio is re-enabled.
+              return { ...merged, systemAudio: merged.captureAudio && merged.systemAudio };
+            })(),
             noiseSuppression: normalizedNs,
           };
           if (d.settings!.appearance?.theme) {

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -69,7 +69,7 @@ export interface ScreenShareSettings {
 }
 
 export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
-  captureAudio: false,
+  captureAudio: true,
   resolution: '1080p',
   fps: 30,
   systemAudio: false,

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -65,6 +65,7 @@ export interface ScreenShareSettings {
   fps: 15 | 30 | 60;
   systemAudio: boolean;
   viewerMode: 'in-app' | 'new-window';
+  preferredCaptureSource: 'auto' | 'window' | 'screen' | 'browser';
 }
 
 export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
@@ -73,6 +74,7 @@ export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
   fps: 30,
   systemAudio: false,
   viewerMode: 'in-app',
+  preferredCaptureSource: 'window',
 };
 
 interface AppSettings {

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -394,6 +394,7 @@ export function SettingsModal(props: SettingsModalProps) {
     setSettings(newSettings);
     bridge.send('settings.set', { settings: newSettings });
     localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(newSettings));
+    window.dispatchEvent(new Event('brmble-settings-updated'));
   };
 
   const handleConnectionChange = (connection: ConnectionSettings) => {

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -43,7 +43,7 @@ interface SettingsModalProps {
   };
   onUploadAvatar?: (blob: Blob, contentType: string) => void;
   onRemoveAvatar?: () => void;
-  initialTab?: 'profile' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection' | 'admin';
+  initialTab?: 'profile' | 'audio' | 'shortcuts' | 'messages' | 'appearance' | 'connection' | 'screenShare' | 'admin';
   brmblegotchiEnabled?: boolean;
   setBrmblegotchiEnabled?: (enabled: boolean) => void;
   onLiveCompanionChange?: (nextCompanion: CompanionSelection, previousCompanion: CompanionSelection) => void;
@@ -197,7 +197,10 @@ export function SettingsModal(props: SettingsModalProps) {
             audio: { ...DEFAULT_SETTINGS.audio, ...(d.settings!.audio ?? {}) },
             overlay: normalizeOverlaySettings(d.settings!.overlay ?? {}),
             brmblegotchi: d.settings!.brmblegotchi ?? prev.brmblegotchi ?? DEFAULT_BRMBLEGOTCHI,
-            screenShare: d.settings!.screenShare ?? prev.screenShare ?? DEFAULT_SCREEN_SHARE,
+            screenShare: {
+              ...DEFAULT_SCREEN_SHARE,
+              ...((d.settings!.screenShare ?? prev.screenShare) ?? {}),
+            },
             noiseSuppression: normalizedNs,
           };
           if (d.settings!.appearance?.theme) {

--- a/src/Brmble.Web/src/hooks/useNotificationQueue.test.ts
+++ b/src/Brmble.Web/src/hooks/useNotificationQueue.test.ts
@@ -1,0 +1,54 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useNotificationQueue } from './useNotificationQueue';
+
+/**
+ * Regression coverage for the screen-share notification vanishing bug.
+ *
+ * The App had an effect that cleared the remote screen-share notification on
+ * channel switch, but it also depended on the `notifQueue` object returned by
+ * this hook. Because the hook returns a NEW object identity whenever an entry
+ * is registered/unregistered, registering the screen-share notification itself
+ * changed `notifQueue`, re-ran that effect, and immediately cleared the
+ * notification it had just shown.
+ *
+ * This test pins the root-cause property: registering a notification MUST
+ * change the hook's returned object identity (documenting the churn), which is
+ * exactly why effects must not depend on that identity for channel-change
+ * logic. The App-level fix depends only on `currentChannelId`.
+ */
+describe('useNotificationQueue identity', () => {
+  it('returns a new object identity when an entry is registered', () => {
+    const { result } = renderHook(() => useNotificationQueue());
+
+    const before = result.current;
+
+    act(() => {
+      result.current.register('screen-share', 'info');
+    });
+
+    const after = result.current;
+
+    // The identity churn is real: this is why the channel-switch effect must
+    // not depend on the queue object.
+    expect(after).not.toBe(before);
+    expect(after.isVisible('screen-share')).toBe(true);
+  });
+
+  it('returns a new object identity when an entry is unregistered', () => {
+    const { result } = renderHook(() => useNotificationQueue());
+
+    act(() => {
+      result.current.register('screen-share', 'info');
+    });
+    const before = result.current;
+
+    act(() => {
+      result.current.unregister('screen-share');
+    });
+    const after = result.current;
+
+    expect(after).not.toBe(before);
+    expect(after.isVisible('screen-share')).toBe(false);
+  });
+});

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -42,6 +42,7 @@ const emitLocalTrackEvent = (event: string) => {
 
 // Mock livekit-client
 const mockRoom = {
+  startAudio: vi.fn().mockResolvedValue(undefined),
   connect: vi.fn().mockImplementation(async () => { mockRoom.state = 'connected'; }),
   disconnect: vi.fn().mockResolvedValue(undefined),
   name: 'channel-1',
@@ -75,6 +76,7 @@ const mockRoom = {
 vi.mock('livekit-client', () => ({
   Room: class MockRoom {
     connect = vi.fn((...args: unknown[]) => mockRoom.connect(...args));
+    startAudio = vi.fn((...args: unknown[]) => mockRoom.startAudio(...args));
     disconnect = vi.fn((...args: unknown[]) => mockRoom.disconnect(...args));
     name = mockRoom.name;
     get state() { return mockRoom.state; }
@@ -131,6 +133,7 @@ describe('useScreenShare', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRoom.state = undefined;
+    mockRoom.startAudio.mockResolvedValue(undefined);
     mockRoom.remoteParticipants.clear();
     roomEventHandlers.clear();
     localTrackEventHandlers.clear();
@@ -1648,6 +1651,30 @@ describe('useScreenShare', () => {
 
     expect(screenShareAudioTrack.attach).toHaveBeenCalledTimes(1);
     expect(document.body.contains(audioEl)).toBe(true);
+  });
+
+  it('starts LiveKit audio playback when watching a share', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const p = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await p;
+    });
+
+    expect(mockRoom.startAudio).toHaveBeenCalled();
   });
 
   it('reports track unsubscribe before share stop once as ended', async () => {

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -1615,6 +1615,41 @@ describe('useScreenShare', () => {
     expect(result.current.watchingShares).toHaveLength(1);
   });
 
+  it('uses the publication source when attaching screen-share audio tracks', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+    const audioEl = document.createElement('audio');
+    const screenShareAudioTrack = {
+      kind: 'audio',
+      attach: vi.fn(() => audioEl),
+      detach: vi.fn(),
+    };
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const p = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await p;
+    });
+
+    act(() => {
+      emitRoomEvent('trackSubscribed', screenShareAudioTrack, { source: 'screen_share_audio' }, { identity: '@alice:test' });
+    });
+
+    expect(screenShareAudioTrack.attach).toHaveBeenCalledTimes(1);
+    expect(document.body.contains(audioEl)).toBe(true);
+  });
+
   it('reports track unsubscribe before share stop once as ended', async () => {
     let tokenHandler: ((data: unknown) => void) | null = null;
     let shareStartedHandler: ((data: unknown) => void) | null = null;

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -3222,7 +3222,7 @@ describe('useScreenShare', () => {
     expect(onLocalShareEnded).toHaveBeenNthCalledWith(2, 'error');
   });
 
-  it('passes correct capture options to setScreenShareEnabled', async () => {
+  it('passes default window capture source to setScreenShareEnabled', async () => {
     let tokenHandler: ((data: unknown) => void) | null = null;
     (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
       if (type === 'livekit.token') tokenHandler = handler;
@@ -3233,6 +3233,7 @@ describe('useScreenShare', () => {
       systemAudio: true,
       resolution: '1080p' as const,
       fps: 30 as const,
+      preferredCaptureSource: 'window' as const,
     };
 
     const { result } = renderHook(() => useScreenShare(undefined, settings));
@@ -3246,8 +3247,40 @@ describe('useScreenShare', () => {
     expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, expect.objectContaining({
       audio: true,
       systemAudio: 'include',
+      video: { displaySurface: 'window' },
       resolution: { width: 1920, height: 1080, frameRate: 30 },
       videoEncoding: { maxBitrate: 4_000_000, maxFramerate: 30 },
+    }));
+  });
+
+  it('omits display surface hint when preferred capture source is auto', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const settings = {
+      captureAudio: false,
+      systemAudio: false,
+      resolution: '720p' as const,
+      fps: 15 as const,
+      preferredCaptureSource: 'auto' as const,
+    };
+
+    const { result } = renderHook(() => useScreenShare(undefined, settings));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.(liveKitToken('test-jwt'));
+      await promise;
+    });
+
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, expect.not.objectContaining({
+      video: expect.anything(),
+    }));
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, expect.objectContaining({
+      resolution: { width: 1280, height: 720, frameRate: 15 },
+      videoEncoding: { maxBitrate: 2_000_000, maxFramerate: 15 },
     }));
   });
 });

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -107,8 +107,8 @@ vi.mock('livekit-client', () => ({
     Unknown: 'unknown',
   },
   Track: {
-    Kind: { Video: 'video' },
-    Source: { ScreenShare: 'screen_share' },
+    Kind: { Audio: 'audio', Video: 'video' },
+    Source: { ScreenShare: 'screen_share', ScreenShareAudio: 'screen_share_audio' },
   },
 }));
 
@@ -1569,6 +1569,50 @@ describe('useScreenShare', () => {
     expect(result.current.focusedShare).toBeNull();
     expect(result.current.remoteVideoEls.has(10)).toBe(false);
     expect(mockRoom.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('attaches and detaches screen-share audio tracks for watched shares', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+    const audioEl = document.createElement('audio');
+    const screenShareAudioTrack = {
+      kind: 'audio',
+      source: 'screen_share_audio',
+      attach: vi.fn(() => audioEl),
+      detach: vi.fn(),
+    };
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const p = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await p;
+    });
+
+    act(() => {
+      emitRoomEvent('trackSubscribed', screenShareAudioTrack, {}, { identity: '@alice:test' });
+    });
+
+    expect(screenShareAudioTrack.attach).toHaveBeenCalledTimes(1);
+    expect(document.body.contains(audioEl)).toBe(true);
+
+    act(() => {
+      emitRoomEvent('trackUnsubscribed', screenShareAudioTrack, {}, { identity: '@alice:test' });
+    });
+
+    expect(screenShareAudioTrack.detach).toHaveBeenCalledTimes(1);
+    expect(document.body.contains(audioEl)).toBe(false);
+    expect(result.current.watchingShares).toHaveLength(1);
   });
 
   it('reports track unsubscribe before share stop once as ended', async () => {

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -329,6 +329,9 @@ export function useScreenShare(
     el.dataset.screenShareAudio = String(userId);
     document.body.appendChild(el);
     remoteAudioElsRef.current.set(userId, el);
+    void roomRef.current?.startAudio?.().catch((err: unknown) => {
+      console.warn('[LiveKit] screen-share audio playback could not start', err);
+    });
   }, [detachRemoteAudio]);
 
   const clearTokenRefreshTimer = useCallback(() => {
@@ -1124,6 +1127,9 @@ export function useScreenShare(
 
       // Add to watching list (handles max 4 enforcement via addWatchingShare)
       addWatchingShare(newShare);
+      void room.startAudio?.().catch((err: unknown) => {
+        console.warn('[LiveKit] viewer audio playback could not start', err);
+      });
 
       // Subscribe to the target's screen share track
       const participant = room.remoteParticipants.get(participantIdentity);

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -23,6 +23,7 @@ export interface ScreenShareSettings {
   resolution: '720p' | '1080p' | '1440p' | '4k';
   fps: 15 | 30 | 60;
   systemAudio: boolean;
+  preferredCaptureSource: 'auto' | 'window' | 'screen' | 'browser';
 }
 
 export type LocalShareStopReason = 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel';
@@ -936,6 +937,16 @@ export function useScreenShare(
         };
 
         captureOptions = {};
+
+        const displaySurfaceMap: Partial<Record<ScreenShareSettings['preferredCaptureSource'], 'window' | 'monitor' | 'browser'>> = {
+          window: 'window',
+          screen: 'monitor',
+          browser: 'browser',
+        };
+        const displaySurface = displaySurfaceMap[screenShareSettings.preferredCaptureSource];
+        if (displaySurface) {
+          captureOptions.video = { displaySurface };
+        }
 
         if (screenShareSettings.captureAudio) {
           captureOptions.audio = true;

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -688,7 +688,7 @@ export function useScreenShare(
   }, [clearLocalShareEndListener, stopLocalShare]);
 
   const bindRoomEvents = useCallback((room: Room) => {
-    room.on(RoomEvent.TrackSubscribed, (track, _pub, participant) => {
+    room.on(RoomEvent.TrackSubscribed, (track, pub, participant) => {
       if (roomRef.current !== room) {
         return;
       }
@@ -708,13 +708,13 @@ export function useScreenShare(
       }
       if (
         track.kind === Track.Kind.Audio &&
-        track.source === Track.Source.ScreenShareAudio
+        (track.source === Track.Source.ScreenShareAudio || pub.source === Track.Source.ScreenShareAudio)
       ) {
         attachRemoteAudio(matchedShare.userId, track as { attach: () => HTMLElement });
       }
     });
 
-    room.on(RoomEvent.TrackUnsubscribed, (track, _pub, participant) => {
+    room.on(RoomEvent.TrackUnsubscribed, (track, pub, participant) => {
       if (roomRef.current !== room) {
         return;
       }
@@ -735,7 +735,7 @@ export function useScreenShare(
       }
       if (
         track.kind === Track.Kind.Audio &&
-        track.source === Track.Source.ScreenShareAudio
+        (track.source === Track.Source.ScreenShareAudio || pub.source === Track.Source.ScreenShareAudio)
       ) {
         track.detach();
         detachRemoteAudio(matchedShare.userId);

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -182,6 +182,7 @@ export function useScreenShare(
   const [isViewerConnectPending, setIsViewerConnectPending] = useState(false);
   const [focusedShare, _setFocusedShare] = useState<ShareInfo | null>(null);
   const [remoteVideoEls, setRemoteVideoEls] = useState<Map<number, HTMLVideoElement>>(new Map());
+  const remoteAudioElsRef = useRef<Map<number, HTMLAudioElement>>(new Map());
   const [roomQuality, setRoomQuality] = useState<ScreenShareQuality>('unknown');
   const [shareQualities, setShareQualities] = useState<Map<number, ScreenShareQuality>>(new Map());
 
@@ -313,6 +314,23 @@ export function useScreenShare(
     recomputeRoomQuality();
   }, [recomputeRoomQuality]);
 
+  const detachRemoteAudio = useCallback((userId: number) => {
+    const audioEl = remoteAudioElsRef.current.get(userId);
+    if (!audioEl) return;
+
+    audioEl.remove();
+    remoteAudioElsRef.current.delete(userId);
+  }, []);
+
+  const attachRemoteAudio = useCallback((userId: number, track: { attach: () => HTMLElement }) => {
+    detachRemoteAudio(userId);
+    const el = track.attach() as HTMLAudioElement;
+    el.autoplay = true;
+    el.dataset.screenShareAudio = String(userId);
+    document.body.appendChild(el);
+    remoteAudioElsRef.current.set(userId, el);
+  }, [detachRemoteAudio]);
+
   const clearTokenRefreshTimer = useCallback(() => {
     if (tokenRefreshTimerRef.current) {
       clearTimeout(tokenRefreshTimerRef.current);
@@ -366,6 +384,7 @@ export function useScreenShare(
     if (evictedUserId != null) {
       const evicted = evictedUserId;
       setFocusedShare(p => p?.userId === evicted ? null : p);
+      detachRemoteAudio(evicted);
       removeShareQuality(evicted);
       setRemoteVideoEls(p => {
         const m = new Map(p);
@@ -375,7 +394,7 @@ export function useScreenShare(
     }
 
     recomputeRoomQuality();
-  }, [recomputeRoomQuality, removeShareQuality, setFocusedShare]);
+  }, [detachRemoteAudio, recomputeRoomQuality, removeShareQuality, setFocusedShare]);
 
   const removeWatchingShare = useCallback((userId: number, options?: { clearPending?: boolean }) => {
     const removedShares = watchingSharesRef.current.filter(s => s.userId === userId);
@@ -388,6 +407,7 @@ export function useScreenShare(
     watchingSharesRef.current = next;
     setWatchingShares(next);
     setFocusedShare(prev => prev?.userId === userId ? null : prev);
+    detachRemoteAudio(userId);
     setRemoteVideoEls(prev => {
       const next = new Map(prev);
       next.delete(userId);
@@ -395,16 +415,19 @@ export function useScreenShare(
     });
     removeShareQuality(userId);
     return next;
-  }, [removeShareQuality, setFocusedShare]);
+  }, [detachRemoteAudio, removeShareQuality, setFocusedShare]);
 
   const clearWatchingState = useCallback(() => {
     setRemoteVideoEls(new Map());
+    for (const userId of remoteAudioElsRef.current.keys()) {
+      detachRemoteAudio(userId);
+    }
     updateWatchingShares([]);
     setFocusedShare(null);
     shareQualitiesRef.current = new Map();
     setShareQualities(new Map());
     recomputeRoomQuality();
-  }, [recomputeRoomQuality, setFocusedShare, updateWatchingShares]);
+  }, [detachRemoteAudio, recomputeRoomQuality, setFocusedShare, updateWatchingShares]);
 
   const endWatchedShare = useCallback((share: ShareInfo, reason: WatchedShareEndReason) => {
     const key = watchedShareKey(share.roomName, share.userId);
@@ -683,6 +706,12 @@ export function useScreenShare(
         const el = track.attach() as HTMLVideoElement;
         setRemoteVideoEls(prev => new Map(prev).set(matchedShare.userId, el));
       }
+      if (
+        track.kind === Track.Kind.Audio &&
+        track.source === Track.Source.ScreenShareAudio
+      ) {
+        attachRemoteAudio(matchedShare.userId, track as { attach: () => HTMLElement });
+      }
     });
 
     room.on(RoomEvent.TrackUnsubscribed, (track, _pub, participant) => {
@@ -703,6 +732,13 @@ export function useScreenShare(
         track.detach();
         pendingUnsubscribedWatchedSharesRef.current.set(watchedShareKey(matchedShare.roomName, matchedShare.userId), matchedShare);
         removeWatchingShare(matchedShare.userId, { clearPending: false });
+      }
+      if (
+        track.kind === Track.Kind.Audio &&
+        track.source === Track.Source.ScreenShareAudio
+      ) {
+        track.detach();
+        detachRemoteAudio(matchedShare.userId);
       }
     });
 
@@ -789,7 +825,7 @@ export function useScreenShare(
         void stopLocalShare(teardownIntent ?? 'interrupted', room);
       }
     });
-  }, [clearTokenLease, clearWatchingState, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, recomputeRoomQuality, removeWatchingShare, resetQualityState, stopLocalShare, updateShareQuality]);
+  }, [attachRemoteAudio, clearTokenLease, clearWatchingState, detachRemoteAudio, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, recomputeRoomQuality, removeWatchingShare, resetQualityState, stopLocalShare, updateShareQuality]);
 
   // Ensure we have a connected room for the given channel.
   // Returns the existing room if already connected to this channel, otherwise connects.
@@ -1049,6 +1085,9 @@ export function useScreenShare(
             if (pub.track && pub.track.kind === Track.Kind.Video && pub.source === Track.Source.ScreenShare) {
               pub.track.detach();
             }
+            if (pub.track && pub.track.kind === Track.Kind.Audio && pub.source === Track.Source.ScreenShareAudio) {
+              pub.track.detach();
+            }
           });
         }
       }
@@ -1095,6 +1134,9 @@ export function useScreenShare(
             const el = pub.track.attach() as HTMLVideoElement;
             setRemoteVideoEls(prev => new Map(prev).set(targetUserId, el));
           }
+          if (pub.track && pub.track.kind === Track.Kind.Audio && pub.source === Track.Source.ScreenShareAudio) {
+            attachRemoteAudio(targetUserId, pub.track as unknown as { attach: () => HTMLElement });
+          }
         });
       }
       // If track not yet available, TrackSubscribed event will pick it up
@@ -1110,7 +1152,7 @@ export function useScreenShare(
       unregisterPendingViewerAttempt(pendingAttempt);
       endViewerConnectAttempt();
     }
-  }, [activeShares, ensureRoom, addWatchingShare, removeWatchingShare, maybeDisconnectRoom, beginViewerConnectAttempt, endViewerConnectAttempt, registerPendingViewerAttempt, unregisterPendingViewerAttempt, updateShareQuality]);
+  }, [activeShares, ensureRoom, addWatchingShare, removeWatchingShare, maybeDisconnectRoom, beginViewerConnectAttempt, endViewerConnectAttempt, registerPendingViewerAttempt, unregisterPendingViewerAttempt, updateShareQuality, attachRemoteAudio]);
 
   const disconnectViewer = useCallback(async (userId?: number) => {
     const room = roomRef.current;
@@ -1125,6 +1167,9 @@ export function useScreenShare(
         if (participant) {
           participant.trackPublications.forEach((pub: RemoteTrackPublication) => {
             if (pub.track && pub.track.kind === Track.Kind.Video && pub.source === Track.Source.ScreenShare) {
+              pub.track.detach();
+            }
+            if (pub.track && pub.track.kind === Track.Kind.Audio && pub.source === Track.Source.ScreenShareAudio) {
               pub.track.detach();
             }
           });
@@ -1195,6 +1240,9 @@ export function useScreenShare(
           if (participant) {
             participant.trackPublications.forEach((pub: RemoteTrackPublication) => {
               if (pub.track && pub.track.kind === Track.Kind.Video && pub.source === Track.Source.ScreenShare) {
+                pub.track.detach();
+              }
+              if (pub.track && pub.track.kind === Track.Kind.Audio && pub.source === Track.Source.ScreenShareAudio) {
                 pub.track.detach();
               }
             });

--- a/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
@@ -91,6 +91,35 @@ public class AppConfigServiceTests
     }
 
     [TestMethod]
+    public void SavesAndReloads_ScreenShareSettings()
+    {
+        var svc = new AppConfigService(_tempDir, null);
+        var updated = AppSettings.Default with
+        {
+            ScreenShare = AppSettings.Default.ScreenShare with
+            {
+                CaptureAudio = true,
+                Resolution = "1440p",
+                Fps = 60,
+                SystemAudio = true,
+                ViewerMode = "new-window",
+                PreferredCaptureSource = "auto"
+            }
+        };
+
+        svc.SetSettings(updated);
+        var svc2 = new AppConfigService(_tempDir, null);
+        var screenShare = svc2.GetSettings().ScreenShare;
+
+        Assert.IsTrue(screenShare.CaptureAudio);
+        Assert.AreEqual("1440p", screenShare.Resolution);
+        Assert.AreEqual(60, screenShare.Fps);
+        Assert.IsTrue(screenShare.SystemAudio);
+        Assert.AreEqual("new-window", screenShare.ViewerMode);
+        Assert.AreEqual("auto", screenShare.PreferredCaptureSource);
+    }
+
+    [TestMethod]
     public void LoadsLegacyNotificationsEnabledFalse_AsOptionalNotificationsDisabled()
     {
         var legacyJson = """


### PR DESCRIPTION
## Summary

Implements the two active slices of Roadmap **section B (Broadcaster Controls)** for LiveKit screen sharing, plus a notification bug fix uncovered during testing.

## B7 — Preferred capture source (window picker)
- New Screen Share setting: **Application Window / Full Screen / Browser Tab / Auto** (defaults to **Window**).
- Maps the choice to a `displaySurface` hint passed to LiveKit/`getDisplayMedia`; the OS picker remains user-controlled (browsers cannot preselect a source programmatically).
- Legacy settings normalization, native persistence (`AppSettings.cs`), same-session settings sync, and bridge payload handling.

## B8 — Application / system audio capture
- Screen-share audio **defaults on**, with **System Audio** as an opt-in (only enabled when Capture Audio is on).
- Viewers attach and play LiveKit `ScreenShareAudio` tracks.
- Native persistence of the audio toggles.
- **Help text corrected to match platform reality:** Chromium/WebView2 can capture whole-screen and browser-tab audio, but **not** a single application window's audio; audio must also be enabled in the OS screen picker.

## Bug fix — screen-share notification vanishing
The channel-switch effect that clears the remote screen-share notification depended on the `notifQueue` object. `useNotificationQueue` returns a new object identity on every register/unregister, so registering the screen-share notification itself re-ran the effect and immediately cleared the notification it had just shown (it flashed for under a render). The effect now depends only on `currentChannelId`, reaching collaborators via refs. Added a regression test pinning the queue's identity-churn behaviour.

Note: this was a **pre-existing latent bug from `main`**, only exposed by this branch's two-client screen-share testing.

## Docs
- Capture-source design + implementation plan.
- Roadmap (`2026-04-17-livekit-feature-roadmap.md`) updated for the B7/B8 active slices.

## Deferred / follow-up
- **Native per-application (game) audio capture** — not possible via the browser path; researched and tracked in #571 (WASAPI process loopback → native LiveKit audio track).
- **Game-window auto-suggest** on share start — deferred per roadmap (picker cannot be preselected programmatically).

## Verification
- Web test suite green (settings, screen-share, notification-queue suites re-verified after each change).
- Native tests: 247 pass.
- `npm run type-check`, `npm run build`, and both client builds clean.
- Manually verified end-to-end with two local clients (main + worktree): capture-source hint, screen-share audio (whole-screen/system), and the fixed start notification.
