### PR TITLE
Screenshare quality: simulcast/VP9, live settings apply, and sidebar stats tooltip

### DIFF
--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -472,6 +472,7 @@ Props:
 | `disabled` | `boolean` | `false` | Disables the trigger button |
 | `className` | `string` | `''` | Additional CSS classes on the wrapper |
 | `placeholder` | `string` | `undefined` | Shown when no option matches `value` |
+| `ariaLabel` | `string` | `undefined` | Accessible name for the trigger when there is no visible `<label>` |
 
 #### DOM Structure
 

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -506,6 +506,21 @@ Rules:
 
 ---
 
+### Screenshare Viewer Controls
+
+Reference: `src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.tsx`, `ScreenShareTile.css`
+
+Watched screen-share tiles expose viewer-side controls in the top-right `--controls` overlay, shown on hover for non-thumbnail tiles only. The overlay contains, left-to-right: a receive-quality `<Select>` (Auto / High / Medium / Low, defaulting to Auto) followed by the fullscreen button.
+
+Rules:
+1. **Reuse `<Select>`** for the quality dropdown — never a native select. Its portal dropdown escapes the tile's overflow, so it renders correctly inside the overlay.
+2. **Stop click propagation**: wrap the `<Select>` in `.screen-share-tile-quality-select-wrapper` with `onClick={(e) => e.stopPropagation()}` so opening the dropdown doesn't toggle tile focus.
+3. **Controls are viewer-only**: broadcaster encode settings (resolution, FPS, content type) live in the Screen Share settings tab, not on the tile.
+4. Quality maps to LiveKit `RemoteTrackPublication.setVideoQuality`; `Auto` pins to HIGH and lets adaptive stream pick the best simulcast layer. Only render the control when an `onViewerQualityChange` handler is supplied.
+5. All spacing/sizing uses tokens (`--space-*`, `--radius-*`) — no hardcoded values.
+
+---
+
 ## 5. Theme Compatibility
 
 ### Core Principle

--- a/docs/superpowers/plans/2026-07-16-livekit-sidebar-stats-tooltip.md
+++ b/docs/superpowers/plans/2026-07-16-livekit-sidebar-stats-tooltip.md
@@ -1,0 +1,718 @@
+# LiveKit Sidebar Stats Tooltip — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Follow superpowers:test-driven-development rigidly: write the failing test, run it to confirm it fails for the right reason, write minimal code, confirm it passes, then commit.
+
+**Goal:** Enrich the sidebar's LiveKit (Screenshare) service-status dot hover tooltip with an at-a-glance health summary of active screenshare activity. When broadcasting, add a `Broadcasting: <resolution> <fps>fps` line. When watching, add a `Watching N share(s)` line followed by one `<name>: <W>×<H> (<quality>)` line per watched share. Uses only data the client already has — no `getStats()` plumbing, no change to the shared `Tooltip` component, no `UI_GUIDE.md` change.
+
+**Architecture:** A new small, pure string-builder (`buildLiveKitTooltip`) takes plain inputs (name, connection flags, quality, `isSharing`, preformatted `broadcastSummary`, `watchingShares`, `shareQualities`, `remoteVideoEls`) and returns the multi-line tooltip string (existing `\n` convention, same as the voice/server tooltips). `Sidebar.dotTooltip('livekit')` delegates to it. `App.tsx` threads five new optional props into `Sidebar` (four new + reusing the already-present `watchingShares`), and preformats `broadcastSummary` from `screenShareSettings`. Live per-share resolution is read from each remote `<video>` element's `videoWidth`/`videoHeight` at render time. No changes to `useScreenShare`, the `Tooltip` component, or `screenShareQuality.ts`.
+
+**Tech Stack:** React + TypeScript (Vite), Vitest + @testing-library/react (jsdom). Frontend only — no C# touched.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-livekit-sidebar-stats-tooltip-design.md` (approved, source of truth).
+
+---
+
+## File Structure
+
+| Path | Change |
+| --- | --- |
+| `src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts` | Create — pure `buildLiveKitTooltip` helper + `LiveKitTooltipInput` type |
+| `src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts` | Create — thorough unit tests for the helper |
+| `src/Brmble.Web/src/components/Sidebar/Sidebar.tsx` | Modify — add 4 new props, delegate `dotTooltip('livekit')` to helper |
+| `src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx` | Modify — keep/adjust existing tooltip test, add integration cases |
+| `src/Brmble.Web/src/App.tsx` | Modify — preformat `broadcastSummary`, pass 4 new props to `<Sidebar>` |
+
+---
+
+## Design Contract (locked)
+
+Given service name `name` (actual `SERVICE_DISPLAY_NAMES.livekit === 'Screenshare'`), the livekit tooltip (when no `error`) is built as:
+
+1. **Not in a room, connected** → `` `${name}: Available` `` (unchanged).
+2. **In a room, quality `reconnecting`** → `` `${name}: Reconnecting` `` (unchanged).
+3. **In a room** → first line is the existing aggregate:
+   - if `quality !== 'unknown'` → `` `${name}: Connected - ${quality}` ``
+   - else → `` `${name}: Connected` ``
+   Then append, in order:
+   - If `isSharing` and `broadcastSummary` is a non-empty string → line `` `Broadcasting: ${broadcastSummary}` ``.
+   - If `watchingShares.length > 0` → line `` `Watching ${n} share${n === 1 ? '' : 's'}` ``, then one line per share.
+4. **Per-share line** for a share `s` (key = `s.userId`):
+   - `label` = `s.userName` if non-empty (after trim), else `String(s.matrixUserId ?? s.userId)`.
+   - `q` = `shareQualities.get(s.userId)` (may be `undefined`).
+   - `el` = `remoteVideoEls.get(s.userId)`; `w = el?.videoWidth ?? 0`, `h = el?.videoHeight ?? 0`.
+   - `res` = (`w > 0 && h > 0`) ? `` `${w}×${h}` `` : `''` (U+00D7 MULTIPLICATION SIGN `×`).
+   - `qualSuffix` = (`q && q !== 'unknown'`) ? `` ` (${q})` `` : `''`.
+   - Compose: with res → `` `${label}: ${res}${qualSuffix}` ``; without res → `` `${label}${qualSuffix}` ``.
+5. **Fallthrough** (not connected / other services / has error) is handled by the existing `dotTooltip` code, NOT the helper. The helper is only invoked for the `svc === 'livekit' && !error` branch and returns `null` when it has nothing livekit-specific to say, so `dotTooltip` can fall through to its existing generic return.
+
+`broadcastSummary` (built in `App.tsx`) = `` `${screenShareSettings.resolution} ${screenShareSettings.fps}fps` `` when `isSharing`, else `undefined` (e.g. `1080p 30fps`).
+
+---
+
+## Task 1: Pure `buildLiveKitTooltip` helper
+
+**Files:**
+- Create: `src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts`
+- Create: `src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts`
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { buildLiveKitTooltip } from './livekitTooltip';
+import type { LiveKitTooltipInput } from './livekitTooltip';
+import type { ShareInfo } from '../../hooks/useScreenShare';
+import type { ScreenShareQuality } from '../../utils/screenShareQuality';
+
+const NAME = 'Screenshare';
+
+const makeShare = (overrides: Partial<ShareInfo> = {}): ShareInfo => ({
+  roomName: 'channel-0',
+  userName: 'Alice',
+  userId: 42,
+  matrixUserId: '@alice:example.com',
+  sessionId: 2,
+  ...overrides,
+});
+
+/** Minimal fake video element exposing only the dimensions the helper reads. */
+const fakeVideo = (videoWidth: number, videoHeight: number): HTMLVideoElement =>
+  ({ videoWidth, videoHeight } as HTMLVideoElement);
+
+const base = (overrides: Partial<LiveKitTooltipInput> = {}): LiveKitTooltipInput => ({
+  name: NAME,
+  connected: true,
+  isLiveKitRoomConnected: false,
+  screenShareQuality: 'unknown',
+  isSharing: false,
+  broadcastSummary: undefined,
+  watchingShares: [],
+  shareQualities: new Map<number, ScreenShareQuality>(),
+  remoteVideoEls: new Map<number, HTMLVideoElement>(),
+  ...overrides,
+});
+
+describe('buildLiveKitTooltip', () => {
+  it('returns Available when connected with no active room', () => {
+    expect(buildLiveKitTooltip(base())).toBe(`${NAME}: Available`);
+  });
+
+  it('returns Reconnecting when in a room and quality is reconnecting', () => {
+    expect(
+      buildLiveKitTooltip(base({ isLiveKitRoomConnected: true, screenShareQuality: 'reconnecting' })),
+    ).toBe(`${NAME}: Reconnecting`);
+  });
+
+  it('returns null when not connected (lets dotTooltip fall through)', () => {
+    expect(buildLiveKitTooltip(base({ connected: false }))).toBeNull();
+  });
+
+  it('shows the aggregate quality line when in a room', () => {
+    expect(
+      buildLiveKitTooltip(base({ isLiveKitRoomConnected: true, screenShareQuality: 'good' })),
+    ).toBe(`${NAME}: Connected - good`);
+  });
+
+  it('omits the quality suffix on the first line when quality is unknown but a share is active', () => {
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'unknown',
+          isSharing: true,
+          broadcastSummary: '1080p 30fps',
+        }),
+      ),
+    ).toBe(`${NAME}: Connected\nBroadcasting: 1080p 30fps`);
+  });
+
+  it('adds a Broadcasting line when sharing', () => {
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          isSharing: true,
+          broadcastSummary: '1440p 60fps',
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nBroadcasting: 1440p 60fps`);
+  });
+
+  it('does not add a Broadcasting line when sharing but summary is missing', () => {
+    expect(
+      buildLiveKitTooltip(
+        base({ isLiveKitRoomConnected: true, screenShareQuality: 'good', isSharing: true }),
+      ),
+    ).toBe(`${NAME}: Connected - good`);
+  });
+
+  it('adds a singular Watching line plus a per-share line with resolution and quality', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'good']]),
+          remoteVideoEls: new Map([[42, fakeVideo(1920, 1080)]]),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice: 1920×1080 (good)`);
+  });
+
+  it('pluralizes the Watching line for two shares', () => {
+    const a = makeShare({ userId: 42, userName: 'Alice' });
+    const b = makeShare({ userId: 7, userName: 'Bob' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'fair',
+          watchingShares: [a, b],
+          shareQualities: new Map([
+            [42, 'good'],
+            [7, 'poor'],
+          ]),
+          remoteVideoEls: new Map([
+            [42, fakeVideo(1920, 1080)],
+            [7, fakeVideo(1280, 720)],
+          ]),
+        }),
+      ),
+    ).toBe(
+      `${NAME}: Connected - fair\nWatching 2 shares\nAlice: 1920×1080 (good)\nBob: 1280×720 (poor)`,
+    );
+  });
+
+  it('shows Broadcasting and Watching together', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          isSharing: true,
+          broadcastSummary: '1080p 30fps',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'good']]),
+          remoteVideoEls: new Map([[42, fakeVideo(1920, 1080)]]),
+        }),
+      ),
+    ).toBe(
+      `${NAME}: Connected - good\nBroadcasting: 1080p 30fps\nWatching 1 share\nAlice: 1920×1080 (good)`,
+    );
+  });
+
+  it('omits the resolution when the video element has no dimensions', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'good']]),
+          remoteVideoEls: new Map([[42, fakeVideo(0, 0)]]),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice (good)`);
+  });
+
+  it('omits the resolution when there is no video element at all', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'fair']]),
+          remoteVideoEls: new Map(),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice (fair)`);
+  });
+
+  it('omits the quality suffix when the per-share quality is unknown', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'unknown']]),
+          remoteVideoEls: new Map([[42, fakeVideo(1920, 1080)]]),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice: 1920×1080`);
+  });
+
+  it('omits the quality suffix when the per-share quality is missing entirely', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map(),
+          remoteVideoEls: new Map([[42, fakeVideo(1920, 1080)]]),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice: 1920×1080`);
+  });
+
+  it('falls back to matrixUserId then userId when the userName is empty', () => {
+    const named = makeShare({ userId: 42, userName: '   ' });
+    const noMatrix = makeShare({ userId: 7, userName: '', matrixUserId: undefined });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [named, noMatrix],
+          shareQualities: new Map(),
+          remoteVideoEls: new Map(),
+        }),
+      ),
+    ).toBe(
+      `${NAME}: Connected - good\nWatching 2 shares\n@alice:example.com\n7`,
+    );
+  });
+});
+```
+
+Run and confirm failure (module does not exist yet):
+
+```
+cd src/Brmble.Web
+npx vitest run src/components/Sidebar/livekitTooltip.test.ts
+```
+
+- [ ] **Step 1.2: Implement the helper**
+
+Create `src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts`:
+
+```ts
+import type { ShareInfo } from '../../hooks/useScreenShare';
+import type { ScreenShareQuality } from '../../utils/screenShareQuality';
+
+export interface LiveKitTooltipInput {
+  /** Display name for the service (e.g. 'Screenshare'). */
+  name: string;
+  /** Whether the underlying livekit service status is 'connected'. */
+  connected: boolean;
+  /** True when a LiveKit room is active (sharing and/or watching). */
+  isLiveKitRoomConnected: boolean;
+  /** Aggregate room quality. */
+  screenShareQuality: ScreenShareQuality;
+  /** True when the local user is broadcasting a share. */
+  isSharing: boolean;
+  /** Preformatted broadcast summary, e.g. '1080p 30fps'. Undefined when not broadcasting. */
+  broadcastSummary?: string;
+  /** Shares the local user is currently watching. */
+  watchingShares: ShareInfo[];
+  /** Per-share quality keyed by ShareInfo.userId. */
+  shareQualities: Map<number, ScreenShareQuality>;
+  /** Live remote <video> elements keyed by ShareInfo.userId (for live dimensions). */
+  remoteVideoEls: Map<number, HTMLVideoElement>;
+}
+
+/**
+ * Builds the multi-line LiveKit/Screenshare status tooltip string.
+ *
+ * Pure: inputs -> string. Returns `null` when there is nothing livekit-specific
+ * to say (e.g. not connected), so the caller can fall through to its generic
+ * tooltip. Uses the existing `\n` multi-line convention shared with the voice
+ * and server tooltips.
+ */
+export function buildLiveKitTooltip(input: LiveKitTooltipInput): string | null {
+  const {
+    name,
+    connected,
+    isLiveKitRoomConnected,
+    screenShareQuality,
+    isSharing,
+    broadcastSummary,
+    watchingShares,
+    shareQualities,
+    remoteVideoEls,
+  } = input;
+
+  if (connected && !isLiveKitRoomConnected) {
+    return `${name}: Available`;
+  }
+
+  if (isLiveKitRoomConnected && screenShareQuality === 'reconnecting') {
+    return `${name}: Reconnecting`;
+  }
+
+  if (!(connected && isLiveKitRoomConnected)) {
+    return null;
+  }
+
+  const firstLine =
+    screenShareQuality !== 'unknown'
+      ? `${name}: Connected - ${screenShareQuality}`
+      : `${name}: Connected`;
+
+  const lines: string[] = [firstLine];
+
+  if (isSharing && broadcastSummary) {
+    lines.push(`Broadcasting: ${broadcastSummary}`);
+  }
+
+  if (watchingShares.length > 0) {
+    const n = watchingShares.length;
+    lines.push(`Watching ${n} share${n === 1 ? '' : 's'}`);
+    for (const share of watchingShares) {
+      lines.push(buildShareLine(share, shareQualities, remoteVideoEls));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function buildShareLine(
+  share: ShareInfo,
+  shareQualities: Map<number, ScreenShareQuality>,
+  remoteVideoEls: Map<number, HTMLVideoElement>,
+): string {
+  const trimmedName = share.userName?.trim() ?? '';
+  const label = trimmedName !== '' ? trimmedName : String(share.matrixUserId ?? share.userId);
+
+  const el = remoteVideoEls.get(share.userId);
+  const w = el?.videoWidth ?? 0;
+  const h = el?.videoHeight ?? 0;
+  const res = w > 0 && h > 0 ? `${w}\u00D7${h}` : '';
+
+  const q = shareQualities.get(share.userId);
+  const qualSuffix = q && q !== 'unknown' ? ` (${q})` : '';
+
+  return res !== '' ? `${label}: ${res}${qualSuffix}` : `${label}${qualSuffix}`;
+}
+```
+
+- [ ] **Step 1.3: Confirm the tests pass**
+
+```
+cd src/Brmble.Web
+npx vitest run src/components/Sidebar/livekitTooltip.test.ts
+```
+
+All cases green.
+
+- [ ] **Step 1.4: Commit**
+
+```
+git add src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts
+git commit -m "feat: add pure buildLiveKitTooltip screenshare stats string builder"
+```
+
+---
+
+## Task 2: Wire the helper into `Sidebar`
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Sidebar/Sidebar.tsx`
+- Modify: `src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx`
+
+- [ ] **Step 2.1: Update the existing tooltip test and add integration cases**
+
+The `Screenshare: Connected - poor` test at `Sidebar.test.tsx` (~line 217) must keep passing unchanged (backward compat). Add new integration cases after it that exercise the new props end-to-end through the rendered dot's `aria-label`.
+
+In `Sidebar.test.tsx`, add these tests immediately after the existing `it('shows active Screenshare quality in service status tooltip text', ...)` block (~line 224):
+
+```tsx
+  it('adds a Broadcasting line to the Screenshare tooltip when sharing', () => {
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'good',
+      isSharing: true,
+      broadcastSummary: '1080p 30fps',
+    });
+
+    expect(
+      screen.getByLabelText('Screenshare: Connected - good\nBroadcasting: 1080p 30fps'),
+    ).toBeInTheDocument();
+  });
+
+  it('adds a Watching line and a per-share resolution line to the Screenshare tooltip', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    const video = { videoWidth: 1920, videoHeight: 1080 } as HTMLVideoElement;
+
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'good',
+      watchingShares: [share],
+      shareQualities: new Map([[42, 'good']]),
+      remoteVideoEls: new Map([[42, video]]),
+    });
+
+    expect(
+      screen.getByLabelText('Screenshare: Connected - good\nWatching 1 share\nAlice: 1920×1080 (good)'),
+    ).toBeInTheDocument();
+  });
+
+  it('pluralizes the Watching line for two watched shares', () => {
+    const a = makeShare({ userId: 42, userName: 'Alice' });
+    const b = makeShare({ userId: 7, userName: 'Bob' });
+
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'fair',
+      watchingShares: [a, b],
+      shareQualities: new Map([
+        [42, 'good'],
+        [7, 'poor'],
+      ]),
+      remoteVideoEls: new Map([
+        [42, { videoWidth: 1920, videoHeight: 1080 } as HTMLVideoElement],
+        [7, { videoWidth: 1280, videoHeight: 720 } as HTMLVideoElement],
+      ]),
+    });
+
+    expect(
+      screen.getByLabelText(
+        'Screenshare: Connected - fair\nWatching 2 shares\nAlice: 1920×1080 (good)\nBob: 1280×720 (poor)',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the per-share resolution when the video element has no dimensions', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'good',
+      watchingShares: [share],
+      shareQualities: new Map([[42, 'good']]),
+      remoteVideoEls: new Map([[42, { videoWidth: 0, videoHeight: 0 } as HTMLVideoElement]]),
+    });
+
+    expect(
+      screen.getByLabelText('Screenshare: Connected - good\nWatching 1 share\nAlice (good)'),
+    ).toBeInTheDocument();
+  });
+```
+
+Run and confirm the four new cases fail (props not yet consumed) while the existing case still passes:
+
+```
+cd src/Brmble.Web
+npx vitest run src/components/Sidebar/Sidebar.test.tsx
+```
+
+- [ ] **Step 2.2: Add the new props to `SidebarProps` and destructuring**
+
+In `src/Brmble.Web/src/components/Sidebar/Sidebar.tsx`, extend the imports if needed — `ShareInfo` (line 13) and `ScreenShareQuality` (line 14) are already imported. Add the new import for the helper near the other local imports (after line 14):
+
+```tsx
+import { buildLiveKitTooltip } from './livekitTooltip';
+```
+
+Add the four new optional props to the `SidebarProps` interface. Replace lines 48-51:
+
+```tsx
+  activeShares?: ShareInfo[];
+  watchingShares?: ShareInfo[];
+  isLiveKitRoomConnected?: boolean;
+  screenShareQuality?: ScreenShareQuality;
+```
+
+with:
+
+```tsx
+  activeShares?: ShareInfo[];
+  watchingShares?: ShareInfo[];
+  isLiveKitRoomConnected?: boolean;
+  screenShareQuality?: ScreenShareQuality;
+  isSharing?: boolean;
+  broadcastSummary?: string;
+  shareQualities?: Map<number, ScreenShareQuality>;
+  remoteVideoEls?: Map<number, HTMLVideoElement>;
+```
+
+Add matching destructuring with safe defaults. Replace lines 79-82:
+
+```tsx
+  activeShares,
+  watchingShares,
+  isLiveKitRoomConnected = false,
+  screenShareQuality = 'unknown',
+```
+
+with:
+
+```tsx
+  activeShares,
+  watchingShares,
+  isLiveKitRoomConnected = false,
+  screenShareQuality = 'unknown',
+  isSharing = false,
+  broadcastSummary,
+  shareQualities,
+  remoteVideoEls,
+```
+
+- [ ] **Step 2.3: Delegate the livekit branch in `dotTooltip` to the helper**
+
+In `dotTooltip` (lines 129-162), replace the entire livekit block (lines 135-147):
+
+```tsx
+    if (svc === 'livekit' && !error) {
+      if (status.state === 'connected' && !isLiveKitRoomConnected) {
+        return `${name}: Available`;
+      }
+
+      if (isLiveKitRoomConnected && screenShareQuality === 'reconnecting') {
+        return `${name}: Reconnecting`;
+      }
+
+      if (status.state === 'connected' && isLiveKitRoomConnected && screenShareQuality !== 'unknown') {
+        return `${name}: Connected - ${screenShareQuality}`;
+      }
+    }
+```
+
+with:
+
+```tsx
+    if (svc === 'livekit' && !error) {
+      const livekitTooltip = buildLiveKitTooltip({
+        name,
+        connected: status.state === 'connected',
+        isLiveKitRoomConnected,
+        screenShareQuality,
+        isSharing,
+        broadcastSummary,
+        watchingShares: watchingShares ?? [],
+        shareQualities: shareQualities ?? new Map(),
+        remoteVideoEls: remoteVideoEls ?? new Map(),
+      });
+
+      if (livekitTooltip !== null) {
+        return livekitTooltip;
+      }
+    }
+```
+
+Note: this preserves the existing fall-through behavior — when the helper returns `null` (e.g. not connected, or connected+in-room+`unknown` quality with no active shares), `dotTooltip` continues to its generic `${name}: ${state}` return at the end, exactly matching the prior code path.
+
+- [ ] **Step 2.4: Confirm all Sidebar tests pass**
+
+```
+cd src/Brmble.Web
+npx vitest run src/components/Sidebar/Sidebar.test.tsx
+```
+
+Existing tooltip/backward-compat cases and the four new cases all green.
+
+- [ ] **Step 2.5: Commit**
+
+```
+git add src/Brmble.Web/src/components/Sidebar/Sidebar.tsx src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
+git commit -m "feat: render screenshare broadcast/watch stats in sidebar livekit tooltip"
+```
+
+---
+
+## Task 3: Thread the props from `App.tsx`
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+
+`useScreenShare` is already destructured at `App.tsx:3473` exposing `isSharing`, `watchingShares`, `remoteVideoEls`, `shareQualities`, `roomQuality`. `screenShareSettings` state is at `App.tsx:3334`. No new hooks/state needed.
+
+- [ ] **Step 3.1: Preformat `broadcastSummary` near the Sidebar render**
+
+Just before the `return`/JSX that renders `<Sidebar>` (the block starting at `App.tsx:4087`), the value is derived inline. Add the four new props to the `<Sidebar ... />` element. Locate the existing props (App.tsx:4108-4111):
+
+```tsx
+          activeShares={activeShares}
+          watchingShares={watchingShares}
+          isLiveKitRoomConnected={isSharing || watchingShares.length > 0}
+          screenShareQuality={roomQuality}
+```
+
+Replace with:
+
+```tsx
+          activeShares={activeShares}
+          watchingShares={watchingShares}
+          isLiveKitRoomConnected={isSharing || watchingShares.length > 0}
+          screenShareQuality={roomQuality}
+          isSharing={isSharing}
+          broadcastSummary={isSharing ? `${screenShareSettings.resolution} ${screenShareSettings.fps}fps` : undefined}
+          shareQualities={shareQualities}
+          remoteVideoEls={remoteVideoEls}
+```
+
+- [ ] **Step 3.2: Typecheck + build**
+
+```
+cd src/Brmble.Web
+npm run build
+```
+
+`tsc -b` clean, vite build succeeds. (`broadcastSummary` type is `string | undefined`, `shareQualities`/`remoteVideoEls` are the exact `Map` types Sidebar expects.)
+
+- [ ] **Step 3.3: Commit**
+
+```
+git add src/Brmble.Web/src/App.tsx
+git commit -m "feat: pass screenshare broadcast/watch stats to Sidebar tooltip"
+```
+
+---
+
+## Task 4: Full verification & self-review
+
+- [ ] **Step 4.1: Run the full frontend suite**
+
+```
+cd src/Brmble.Web
+npx vitest run
+```
+
+Expect the prior 935 tests plus the new livekitTooltip cases and four new Sidebar cases, all passing. No regressions.
+
+- [ ] **Step 4.2: Build + lint**
+
+```
+cd src/Brmble.Web
+npm run build
+npm run lint
+```
+
+Build clean. Lint must show **no new** problems beyond the known pre-existing baseline (16 problems: 15 errors, 1 warning in the `useScreenShare` files). New files (`livekitTooltip.ts`, `livekitTooltip.test.ts`) and the Sidebar/App edits must contribute zero lint issues.
+
+- [ ] **Step 4.3: Spec coverage self-review**
+
+Confirm against `docs/superpowers/specs/2026-07-16-livekit-sidebar-stats-tooltip-design.md`:
+- [ ] Available / Reconnecting lines unchanged.
+- [ ] Broadcasting line present with `<resolution> <fps>fps` when sharing.
+- [ ] `Watching N share(s)` line with correct singular/plural.
+- [ ] Per-share line `<name>: <W>×<H> (<quality>)`; resolution omitted when video has no dimensions; `(quality)` omitted when quality is `unknown`/missing; name falls back to matrixUserId then userId.
+- [ ] First line remains the existing aggregate `Connected - <quality>` (or `Connected` when `unknown`).
+- [ ] Only `Sidebar.tsx`, `App.tsx`, and the two new helper files changed. No changes to `useScreenShare`, `Tooltip`, `screenShareQuality.ts`, or `UI_GUIDE.md`.
+- [ ] No `getStats()` plumbing added.
+- [ ] Uses the shared `<Tooltip content>` (string, `\n`) mechanism — no native `title`.
+
+- [ ] **Step 4.4: Placeholder / hardcoded-value scan**
+
+- [ ] No TODO/placeholder left in the new code.
+- [ ] No hardcoded colors/spacing/fonts (this feature adds only string text, no CSS).
+
+---
+
+## Notes / Out of Scope
+
+- The `docker-local/docker-compose.yml` and `src/Brmble.Server/docker/livekit.yaml` UDP port changes remain uncommitted by design — NOT part of this feature's commits or any PR.
+- Accepted edge case (from spec): resolution may be stale by one render since `dotTooltip` is computed during render, not on hover. Acceptable for a glance.
+- Branch: `feature/screenshare-quality`. Do NOT push or open a PR without the user's explicit go-ahead (CLAUDE.md branch rules).

--- a/docs/superpowers/specs/2026-07-16-livekit-sidebar-stats-tooltip-design.md
+++ b/docs/superpowers/specs/2026-07-16-livekit-sidebar-stats-tooltip-design.md
@@ -1,0 +1,110 @@
+# LiveKit Sidebar Stats Tooltip — Design
+
+**Date:** 2026-07-16
+**Branch:** `feature/screenshare-quality`
+**Status:** Approved (pending written-spec review)
+
+## Goal
+
+Enrich the LiveKit connection dot's hover tooltip in the sidebar status
+indicator with an at-a-glance screenshare health readout, for both the
+broadcaster and viewers. This is a "quick glance" feature using data the client
+already has — no new WebRTC `getStats()` plumbing.
+
+## Non-Goals
+
+- No bitrate / packet-loss / jitter / framerate metrics (would require new
+  `getStats()` polling). Explicitly out of scope.
+- No change to the shared `Tooltip` component (stays string-only).
+- No new UI component, pattern, icon, or setting → no `UI_GUIDE.md` change.
+
+## Content & Format
+
+The LiveKit dot tooltip (`dotTooltip('livekit')` in `Sidebar.tsx`) becomes a
+multi-line string, using the existing `\n` convention already used by the voice
+and server tooltips. Content adapts to role:
+
+| State | Tooltip |
+|-------|---------|
+| Available (connected, no room) | `LiveKit: Available` (unchanged) |
+| Reconnecting | `LiveKit: Reconnecting` (unchanged) |
+| Broadcasting only | `LiveKit: Connected - <quality>`<br>`Broadcasting: 1080p 30fps` |
+| Watching only | `LiveKit: Connected - <quality>`<br>`Watching N share(s)`<br>`<name>: <W>×<H> (<quality>)` per share |
+| Broadcasting + watching | quality line + Broadcasting line + Watching lines |
+
+Example (watching two shares):
+
+```
+LiveKit: Connected - good
+Watching 2 shares
+alice: 1920×1080 (good)
+bob: 1280×720 (fair)
+```
+
+Rules:
+- The first line is the existing aggregate line
+  (`LiveKit: Connected - <screenShareQuality>`); unchanged behavior when
+  `screenShareQuality` is `unknown` (line omitted, falls back to existing logic).
+- "Watching N shares" uses singular/plural correctly (`1 share` / `2 shares`).
+- Per-share line: broadcaster display name, live resolution `W×H` read from the
+  share's `<video>` element (`videoWidth`/`videoHeight`), and the per-share
+  quality word from `shareQualities`.
+- If a share's video element has no dimensions yet (0×0 / not attached), omit the
+  resolution and show just `<name> (<quality>)`.
+- Per-share quality word maps from `ScreenShareQuality`: `good`/`fair`/`poor`/
+  `reconnecting`; `unknown` omits the `(...)` suffix.
+
+## Data Plumbing
+
+`dotTooltip` needs data the Sidebar does not currently receive. Thread new props
+from `App.tsx` → `Sidebar`, following the existing pattern (App already passes
+`screenShareQuality` and `isLiveKitRoomConnected`):
+
+| New Sidebar prop | Type | Source in App.tsx |
+|------------------|------|-------------------|
+| `isSharing` | `boolean` | `useScreenShare().isSharing` |
+| `broadcastSummary` | `string \| undefined` | preformatted `"1080p 30fps"` built in App from `screenShareSettings` when `isSharing`; `undefined` otherwise |
+| `watchingShares` | `ShareInfo[]` | `useScreenShare().watchingShares` |
+| `shareQualities` | `Map<number, ScreenShareQuality>` | `useScreenShare().shareQualities` |
+| `remoteVideoEls` | `Map<number, HTMLVideoElement>` | `useScreenShare().remoteVideoEls` |
+
+Notes:
+- The broadcaster's resolution/fps is passed **preformatted** as
+  `broadcastSummary` (decision: keep Sidebar dumb, avoid a settings dependency).
+  Format: `` `${resolution} ${fps}fps` `` e.g. `1080p 30fps`.
+- Live resolution is read from the `<video>` element at Sidebar render time.
+  `dotTooltip` is computed during render (not on hover), so values reflect the
+  last render. For a glance readout this is acceptable; the sidebar re-renders on
+  quality/state changes, refreshing the numbers.
+- All new props are optional with safe defaults so existing Sidebar tests /
+  usages that don't pass them keep working.
+
+## Components & Boundaries
+
+- `Sidebar.tsx` — the only component changing. `dotTooltip` gains a helper to
+  build the LiveKit multi-line string from the new props. Keep the helper small
+  and pure (inputs → string) so it is unit-testable.
+- `App.tsx` — passes the five new props; builds `broadcastSummary`.
+- No changes to `useScreenShare`, `Tooltip`, or `screenShareQuality.ts`
+  (reuse existing `ScreenShareQuality` type).
+
+## Testing
+
+- Update the existing tooltip test in `Sidebar.test.tsx:~217`.
+- New cases:
+  - Broadcasting only → includes `Broadcasting: 1080p 30fps`.
+  - Watching one share → `Watching 1 share` + `alice: 1920×1080 (good)`.
+  - Watching two shares → correct pluralization + two per-share lines.
+  - Broadcasting + watching → both sections present.
+  - Share with no video dimensions → resolution omitted, quality still shown.
+  - `unknown` per-share quality → no `(...)` suffix.
+  - Backward compatibility: Available / Reconnecting strings unchanged.
+
+## Risks / Edge Cases
+
+- Stale-by-one-render resolution: acceptable for a glance; documented above.
+- Long tooltips when watching up to 4 shares: 4 short lines, within tooltip
+  sizing already used by multi-line voice/server tooltips.
+- Name source: use the same display name already resolved for `watchingShares`
+  (`userName`); fall back to the numeric/matrix id if empty.
+```

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4109,6 +4109,10 @@ const handleConnect = (serverData: SavedServer) => {
           watchingShares={watchingShares}
           isLiveKitRoomConnected={isSharing || watchingShares.length > 0}
           screenShareQuality={roomQuality}
+          isSharing={isSharing}
+          broadcastSummary={isSharing ? `${screenShareSettings.resolution} ${screenShareSettings.fps}fps` : undefined}
+          shareQualities={shareQualities}
+          remoteVideoEls={remoteVideoEls}
           onWatchScreenShare={handleWatchScreenShare}
           onStopWatching={(userId) => disconnectViewer(userId)}
           onEditAvatar={connected ? () => setShowAvatarEditor(true) : undefined}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -3470,7 +3470,7 @@ const handleConnect = (serverData: SavedServer) => {
     setWatchedShareEndedNotifications(prev => [...prev, notification]);
   }, []);
 
-  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, roomQuality, shareQualities, disconnectViewer, connectAsViewer, isViewerConnectPending, handleScreenShareServiceUnavailable } = useScreenShare(() => {
+  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, roomQuality, shareQualities, viewerQualities, setViewerQuality, disconnectViewer, connectAsViewer, isViewerConnectPending, handleScreenShareServiceUnavailable } = useScreenShare(() => {
     setSharingChannelId(undefined);
     sharingChannelIdRef.current = undefined;
   }, screenShareSettings, handleLocalScreenShareEnded, handleWatchedShareEnded);
@@ -4150,11 +4150,13 @@ const handleConnect = (serverData: SavedServer) => {
                     watchingShares={watchingShares}
                     focusedShare={focusedShare}
                     remoteVideoEls={remoteVideoEls}
-                    roomQuality={roomQuality}
-                    shareQualities={shareQualities}
-                    onFocusShare={setFocusedShare}
-                    onCloseShare={(share) => disconnectViewer(share.userId)}
-                    screenShareViewerMode={screenShareSettings.viewerMode}
+                     roomQuality={roomQuality}
+                     shareQualities={shareQualities}
+                     viewerQualities={viewerQualities}
+                     onFocusShare={setFocusedShare}
+                     onCloseShare={(share) => disconnectViewer(share.userId)}
+                     onViewerQualityChange={setViewerQuality}
+                     screenShareViewerMode={screenShareSettings.viewerMode}
                     users={users}
                     disabled={!canSendActiveChannelChat}
                     topNotice={channelChatAccessNotice ?? brmbleServiceChatNotice}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -64,6 +64,7 @@ import { mapBrmbleServiceStatus } from './utils/brmbleServiceStatus';
 import { areMatrixCredentialsEqual } from './utils/matrixCredentials';
 import { getSavedChannelPassword } from './utils/channelPasswords';
 import { getOrderedChannels } from './utils/channelOrder';
+import { formatBroadcastSummary } from './utils/formatBroadcastSummary';
 import './App.css';
 
 export interface ScreenShareEndedNotification {
@@ -4110,7 +4111,7 @@ const handleConnect = (serverData: SavedServer) => {
           isLiveKitRoomConnected={isSharing || watchingShares.length > 0}
           screenShareQuality={roomQuality}
           isSharing={isSharing}
-          broadcastSummary={isSharing ? `${screenShareSettings.resolution} ${screenShareSettings.fps}fps` : undefined}
+          broadcastSummary={isSharing ? formatBroadcastSummary(screenShareSettings.resolution, screenShareSettings.fps) : undefined}
           shareQualities={shareQualities}
           remoteVideoEls={remoteVideoEls}
           onWatchScreenShare={handleWatchScreenShare}

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -7,7 +7,7 @@ import { groupMessages } from '../../utils/groupMessages';
 import { formatDateSeparator, formatFullDate } from '../../utils/formatDateSeparator';
 import type { ChatMessage, MentionableUser } from '../../types';
 import { ScreenShareGrid } from '../ScreenShareGrid';
-import type { ShareInfo } from '../../hooks/useScreenShare';
+import type { ShareInfo, ViewerQuality } from '../../hooks/useScreenShare';
 import type { ScreenShareQuality } from '../../utils/screenShareQuality';
 import { ContextMenu } from '../ContextMenu/ContextMenu';
 import type { ContextMenuItem } from '../ContextMenu/ContextMenu';
@@ -34,8 +34,10 @@ interface ChatPanelProps {
   remoteVideoEls?: Map<number, HTMLVideoElement>;
   roomQuality?: ScreenShareQuality;
   shareQualities?: Map<number, ScreenShareQuality>;
+  viewerQualities?: Map<number, ViewerQuality>;
   onFocusShare?: (share: ShareInfo | null) => void;
   onCloseShare?: (share: ShareInfo) => void;
+  onViewerQualityChange?: (userId: number, quality: ViewerQuality) => void;
   screenShareViewerMode?: 'in-app' | 'new-window';
   /** Connected users for avatar lookup by sender name */
   users?: { name: string; matrixUserId?: string; avatarUrl?: string }[];
@@ -57,7 +59,7 @@ const SPLIT_STORAGE_KEY = 'brmble-screenshare-split';
 const DEFAULT_SPLIT = 50;
 const REPLY_TARGET_HIGHLIGHT_MS = 1600;
 
-export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, focusedShare, remoteVideoEls, roomQuality, shareQualities, onFocusShare, onCloseShare, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard, currentUserMatrixId, onToggleReaction, typingIndicatorText, typingTargetId, onTypingStart, onTypingStop }: ChatPanelProps) {
+export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, focusedShare, remoteVideoEls, roomQuality, shareQualities, viewerQualities, onFocusShare, onCloseShare, onViewerQualityChange, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard, currentUserMatrixId, onToggleReaction, typingIndicatorText, typingTargetId, onTypingStart, onTypingStop }: ChatPanelProps) {
   // Build lookup maps from sender name and matrixUserId → avatar data for MessageBubble.
   // Name-based lookup works when Mumble name matches message sender.
   // MatrixUserId-based lookup handles cases where the user connected with a different
@@ -878,8 +880,10 @@ const [replyState, setReplyState] = useState<{
               videoElements={remoteVideoEls!}
               roomQuality={roomQuality}
               shareQualities={shareQualities}
+              viewerQualities={viewerQualities}
               onFocus={onFocusShare ?? (() => {})}
               onClose={onCloseShare!}
+              onViewerQualityChange={onViewerQualityChange}
             />
           </div>
           <div

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareGrid.tsx
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareGrid.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback } from 'react';
 import { ScreenShareTile } from './ScreenShareTile';
-import type { ShareInfo } from '../../hooks/useScreenShare';
+import type { ShareInfo, ViewerQuality } from '../../hooks/useScreenShare';
 import type { ScreenShareQuality } from '../../utils/screenShareQuality';
 import './ScreenShareGrid.css';
 
@@ -10,8 +10,10 @@ interface ScreenShareGridProps {
   videoElements: Map<number, HTMLVideoElement>;
   roomQuality?: ScreenShareQuality;
   shareQualities?: Map<number, ScreenShareQuality>;
+  viewerQualities?: Map<number, ViewerQuality>;
   onFocus: (share: ShareInfo | null) => void;
   onClose: (share: ShareInfo) => void;
+  onViewerQualityChange?: (userId: number, quality: ViewerQuality) => void;
 }
 
 function getLayout(count: number, hasFocus: boolean): string {
@@ -21,7 +23,7 @@ function getLayout(count: number, hasFocus: boolean): string {
   return `grid-${count}`;
 }
 
-export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, roomQuality = 'unknown', shareQualities, onFocus, onClose }: ScreenShareGridProps) {
+export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, roomQuality = 'unknown', shareQualities, viewerQualities, onFocus, onClose, onViewerQualityChange }: ScreenShareGridProps) {
   // Clear focus when only one stream remains (revert to single-stream view)
   useEffect(() => {
     if (watchingShares.length <= 1 && focusedShare) {
@@ -60,6 +62,11 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, r
     roomQuality === 'reconnecting' ? 'reconnecting' : shareQualities?.get(userId) ?? 'unknown'
   );
 
+  const viewerQualityFor = (userId: number): ViewerQuality => viewerQualities?.get(userId) ?? 'auto';
+  const handleViewerQualityChange = onViewerQualityChange
+    ? (userId: number) => (quality: ViewerQuality) => onViewerQualityChange(userId, quality)
+    : undefined;
+
   return (
     <div className="screen-share-grid" data-layout={layout}>
       {focusedShare && (
@@ -74,6 +81,8 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, r
                 isFocused={true}
                 isThumbnail={false}
                 quality={qualityForShare(focusedShare.userId)}
+                viewerQuality={viewerQualityFor(focusedShare.userId)}
+                onViewerQualityChange={handleViewerQualityChange?.(focusedShare.userId)}
                 onClick={() => handleTileClick(focusedShare)}
                 onClose={() => onClose(focusedShare)}
               />
@@ -114,6 +123,8 @@ export function ScreenShareGrid({ watchingShares, focusedShare, videoElements, r
                 isFocused={false}
                 isThumbnail={false}
                 quality={qualityForShare(share.userId)}
+                viewerQuality={viewerQualityFor(share.userId)}
+                onViewerQualityChange={handleViewerQualityChange?.(share.userId)}
                 onClick={() => handleTileClick(share)}
                 onClose={() => onClose(share)}
               />

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.css
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.css
@@ -90,8 +90,18 @@
   top: var(--space-xs);
   right: calc(var(--space-xs) + var(--space-lg) + var(--space-xs));
   display: flex;
+  align-items: center;
   gap: var(--space-xs);
   pointer-events: auto;
+}
+
+.screen-share-tile-quality-select-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.screen-share-tile-quality-select {
+  min-width: calc(var(--space-lg) * 3);
 }
 
 .screen-share-tile-control-btn {

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.tsx
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.tsx
@@ -135,6 +135,7 @@ export function ScreenShareTile({ videoEl, sharerName, isFocused, isThumbnail, q
             >
               <Select
                 className="screen-share-tile-quality-select"
+                ariaLabel="Receive quality"
                 value={viewerQuality}
                 onChange={(value) => onViewerQualityChange(value as ViewerQuality)}
                 options={VIEWER_QUALITY_OPTIONS}

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.tsx
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.tsx
@@ -1,8 +1,17 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
 import { Icon } from '../Icon/Icon';
 import { Tooltip } from '../Tooltip/Tooltip';
+import { Select } from '../Select';
 import type { ScreenShareQuality } from '../../utils/screenShareQuality';
+import type { ViewerQuality } from '../../hooks/useScreenShare';
 import './ScreenShareTile.css';
+
+const VIEWER_QUALITY_OPTIONS = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'high', label: 'High' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'low', label: 'Low' },
+];
 
 interface ScreenShareTileProps {
   videoEl: HTMLVideoElement;
@@ -10,11 +19,13 @@ interface ScreenShareTileProps {
   isFocused: boolean;
   isThumbnail: boolean;
   quality?: ScreenShareQuality;
+  viewerQuality?: ViewerQuality;
+  onViewerQualityChange?: (quality: ViewerQuality) => void;
   onClick: () => void;
   onClose: () => void;
 }
 
-export function ScreenShareTile({ videoEl, sharerName, isFocused, isThumbnail, quality = 'unknown', onClick, onClose }: ScreenShareTileProps) {
+export function ScreenShareTile({ videoEl, sharerName, isFocused, isThumbnail, quality = 'unknown', viewerQuality = 'auto', onViewerQualityChange, onClick, onClose }: ScreenShareTileProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showControls, setShowControls] = useState(false);
@@ -117,6 +128,19 @@ export function ScreenShareTile({ videoEl, sharerName, isFocused, isThumbnail, q
       </div>
       {!isThumbnail && (
         <div className="screen-share-tile-overlay screen-share-tile-overlay--controls">
+          {onViewerQualityChange && (
+            <div
+              className="screen-share-tile-quality-select-wrapper"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Select
+                className="screen-share-tile-quality-select"
+                value={viewerQuality}
+                onChange={(value) => onViewerQualityChange(value as ViewerQuality)}
+                options={VIEWER_QUALITY_OPTIONS}
+              />
+            </div>
+          )}
           <Tooltip content={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}>
             <button
               className="btn btn-ghost btn-icon screen-share-tile-control-btn"

--- a/src/Brmble.Web/src/components/Select/Select.tsx
+++ b/src/Brmble.Web/src/components/Select/Select.tsx
@@ -14,9 +14,10 @@ interface SelectProps {
   disabled?: boolean;
   className?: string;
   placeholder?: string;
+  ariaLabel?: string;
 }
 
-export function Select({ value, onChange, options, disabled, className, placeholder }: SelectProps) {
+export function Select({ value, onChange, options, disabled, className, placeholder, ariaLabel }: SelectProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [dropdownStyle, setDropdownStyle] = useState<CSSProperties>({});
@@ -176,6 +177,7 @@ export function Select({ value, onChange, options, disabled, className, placehol
         id={triggerId}
         type="button"
         role="combobox"
+        aria-label={ariaLabel}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-controls={listboxId}

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.test.tsx
@@ -11,6 +11,7 @@ const settings: ScreenShareSettings = {
   systemAudio: false,
   viewerMode: 'in-app',
   preferredCaptureSource: 'window',
+  contentType: 'motion',
 };
 
 beforeAll(() => {
@@ -95,6 +96,22 @@ describe('ScreenShareSettingsTab', () => {
     expect(onChange).toHaveBeenCalledWith({
       ...settings,
       preferredCaptureSource: 'screen',
+    });
+  });
+
+  it('updates content type through the themed select', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<ScreenShareSettingsTab settings={settings} onChange={onChange} />);
+
+    await user.click(screen.getByText('Motion (games & video)'));
+    await user.click(screen.getByRole('option', { name: 'Detail (text & code)' }));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...settings,
+      contentType: 'detail',
     });
   });
 });

--- a/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ScreenShareSettingsTab.tsx
@@ -34,6 +34,11 @@ const PREFERRED_CAPTURE_SOURCE_OPTIONS = [
   { value: 'auto', label: 'Auto' },
 ];
 
+const CONTENT_TYPE_OPTIONS = [
+  { value: 'motion', label: 'Motion (games & video)' },
+  { value: 'detail', label: 'Detail (text & code)' },
+];
+
 export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettingsTabProps) {
   const [localSettings, setLocalSettings] = useState<ScreenShareSettings>(settings);
 
@@ -89,6 +94,18 @@ export function ScreenShareSettingsTab({ settings, onChange }: ScreenShareSettin
             value={String(localSettings.fps)}
             onChange={(value) => handleChange('fps', Number(value) as ScreenShareSettings['fps'])}
             options={FPS_OPTIONS}
+          />
+        </div>
+
+        <div className="settings-item">
+          <div className="settings-label-group">
+            <span className="settings-label">Content Type</span>
+            <SettingsHelp content="Motion keeps video and games smooth by favouring frame rate under load. Detail keeps text and code sharp by favouring resolution." label="More information about content type" />
+          </div>
+          <Select
+            value={localSettings.contentType}
+            onChange={(value) => handleChange('contentType', value as ScreenShareSettings['contentType'])}
+            options={CONTENT_TYPE_OPTIONS}
           />
         </div>
 

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -68,6 +68,7 @@ export interface ScreenShareSettings {
   systemAudio: boolean;
   viewerMode: 'in-app' | 'new-window';
   preferredCaptureSource: 'auto' | 'window' | 'screen' | 'browser';
+  contentType: 'motion' | 'detail';
 }
 
 export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
@@ -77,6 +78,7 @@ export const DEFAULT_SCREEN_SHARE: ScreenShareSettings = {
   systemAudio: false,
   viewerMode: 'in-app',
   preferredCaptureSource: 'window',
+  contentType: 'motion',
 };
 
 interface AppSettings {

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { getDefaultNormalizer } from '@testing-library/dom';
 import { Sidebar } from './Sidebar';
 import type { ShareInfo } from '../../hooks/useScreenShare';
 import type { ServiceStatusMap } from '../../types';
@@ -106,6 +107,11 @@ vi.mock('../../bridge', () => ({
 }));
 
 const channels = [{ id: 0, name: 'Connected', parent: 0 }];
+
+// The livekit tooltip is multi-line (\n separated). getByLabelText collapses
+// whitespace by default, which would merge the lines, so preserve newlines when
+// matching these multi-line aria-labels.
+const multiline = { normalizer: getDefaultNormalizer({ collapseWhitespace: false }) };
 
 const makeShare = (overrides: Partial<ShareInfo> = {}): ShareInfo => ({
   roomName: 'channel-0',
@@ -221,6 +227,78 @@ describe('Sidebar root user screen share behavior', () => {
     });
 
     expect(screen.getByLabelText('Screenshare: Connected - poor')).toBeInTheDocument();
+  });
+
+  it('adds a Broadcasting line to the Screenshare tooltip when sharing', () => {
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'good',
+      isSharing: true,
+      broadcastSummary: '1080p 30fps',
+    });
+
+    expect(
+      screen.getByLabelText('Screenshare: Connected - good\nBroadcasting: 1080p 30fps', multiline),
+    ).toBeInTheDocument();
+  });
+
+  it('adds a Watching line and a per-share resolution line to the Screenshare tooltip', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    const video = { videoWidth: 1920, videoHeight: 1080 } as HTMLVideoElement;
+
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'good',
+      watchingShares: [share],
+      shareQualities: new Map([[42, 'good']]),
+      remoteVideoEls: new Map([[42, video]]),
+    });
+
+    expect(
+      screen.getByLabelText('Screenshare: Connected - good\nWatching 1 share\nAlice: 1920×1080 (good)', multiline),
+    ).toBeInTheDocument();
+  });
+
+  it('pluralizes the Watching line for two watched shares', () => {
+    const a = makeShare({ userId: 42, userName: 'Alice' });
+    const b = makeShare({ userId: 7, userName: 'Bob' });
+
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'fair',
+      watchingShares: [a, b],
+      shareQualities: new Map([
+        [42, 'good'],
+        [7, 'poor'],
+      ]),
+      remoteVideoEls: new Map([
+        [42, { videoWidth: 1920, videoHeight: 1080 } as HTMLVideoElement],
+        [7, { videoWidth: 1280, videoHeight: 720 } as HTMLVideoElement],
+      ]),
+    });
+
+    expect(
+      screen.getByLabelText(
+        'Screenshare: Connected - fair\nWatching 2 shares\nAlice: 1920×1080 (good)\nBob: 1280×720 (poor)',
+        multiline,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the per-share resolution when the video element has no dimensions', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+
+    renderSidebar({
+      isLiveKitRoomConnected: true,
+      screenShareQuality: 'good',
+      watchingShares: [share],
+      shareQualities: new Map([[42, 'good']]),
+      remoteVideoEls: new Map([[42, { videoWidth: 0, videoHeight: 0 } as HTMLVideoElement]]),
+    });
+
+    expect(
+      screen.getByLabelText('Screenshare: Connected - good\nWatching 1 share\nAlice (good)', multiline),
+    ).toBeInTheDocument();
   });
 
   it('shows reconnecting Screenshare state for transient LiveKit reconnects', () => {

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import { useServiceStatus } from '../../hooks/useServiceStatus';
 import { useResizable } from '../../hooks/useResizable';
 import type { ShareInfo } from '../../hooks/useScreenShare';
 import type { ScreenShareQuality } from '../../utils/screenShareQuality';
+import { buildLiveKitTooltip } from './livekitTooltip';
 import { useProfileFingerprint } from '../../contexts/ProfileContext';
 import { prompt } from '../../hooks/usePrompt';
 import bridge from '../../bridge';
@@ -49,6 +50,10 @@ interface SidebarProps {
   watchingShares?: ShareInfo[];
   isLiveKitRoomConnected?: boolean;
   screenShareQuality?: ScreenShareQuality;
+  isSharing?: boolean;
+  broadcastSummary?: string;
+  shareQualities?: Map<number, ScreenShareQuality>;
+  remoteVideoEls?: Map<number, HTMLVideoElement>;
   onEditAvatar?: () => void;
   onRequestChannel?: () => void;
 }
@@ -80,6 +85,10 @@ export function Sidebar({
   watchingShares,
   isLiveKitRoomConnected = false,
   screenShareQuality = 'unknown',
+  isSharing = false,
+  broadcastSummary,
+  shareQualities,
+  remoteVideoEls,
   onEditAvatar,
   onRequestChannel
 }: SidebarProps) {
@@ -133,16 +142,20 @@ export function Sidebar({
     const error = status.error;
 
     if (svc === 'livekit' && !error) {
-      if (status.state === 'connected' && !isLiveKitRoomConnected) {
-        return `${name}: Available`;
-      }
+      const livekitTooltip = buildLiveKitTooltip({
+        name,
+        connected: status.state === 'connected',
+        isLiveKitRoomConnected,
+        screenShareQuality,
+        isSharing,
+        broadcastSummary,
+        watchingShares: watchingShares ?? [],
+        shareQualities: shareQualities ?? new Map(),
+        remoteVideoEls: remoteVideoEls ?? new Map(),
+      });
 
-      if (isLiveKitRoomConnected && screenShareQuality === 'reconnecting') {
-        return `${name}: Reconnecting`;
-      }
-
-      if (status.state === 'connected' && isLiveKitRoomConnected && screenShareQuality !== 'unknown') {
-        return `${name}: Connected - ${screenShareQuality}`;
+      if (livekitTooltip !== null) {
+        return livekitTooltip;
       }
     }
 

--- a/src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts
+++ b/src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts
@@ -237,4 +237,34 @@ describe('buildLiveKitTooltip', () => {
       ),
     ).toBe(`Screenshare: Connected - good\nWatching 1 share\n7`);
   });
+
+  it('strips embedded newlines from the label to prevent tooltip line injection', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice\r\nBroadcasting: fake' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'good']]),
+          remoteVideoEls: new Map([[42, fakeVideo(1920, 1080)]]),
+        }),
+      ),
+    ).toBe(`Screenshare: Connected - good\nWatching 1 share\nAlice Broadcasting: fake: 1920×1080 (good)`);
+  });
+
+  it('falls back to userId when a name is only newlines/control characters', () => {
+    const share = makeShare({ userId: 7, userName: '\r\n\t', matrixUserId: '\n' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map(),
+          remoteVideoEls: new Map(),
+        }),
+      ),
+    ).toBe(`Screenshare: Connected - good\nWatching 1 share\n7`);
+  });
 });

--- a/src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts
+++ b/src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import { buildLiveKitTooltip } from './livekitTooltip';
+import type { LiveKitTooltipInput } from './livekitTooltip';
+import type { ShareInfo } from '../../hooks/useScreenShare';
+import type { ScreenShareQuality } from '../../utils/screenShareQuality';
+
+const NAME = 'Screenshare';
+
+const makeShare = (overrides: Partial<ShareInfo> = {}): ShareInfo => ({
+  roomName: 'channel-0',
+  userName: 'Alice',
+  userId: 42,
+  matrixUserId: '@alice:example.com',
+  sessionId: 2,
+  ...overrides,
+});
+
+/** Minimal fake video element exposing only the dimensions the helper reads. */
+const fakeVideo = (videoWidth: number, videoHeight: number): HTMLVideoElement =>
+  ({ videoWidth, videoHeight } as HTMLVideoElement);
+
+const base = (overrides: Partial<LiveKitTooltipInput> = {}): LiveKitTooltipInput => ({
+  name: NAME,
+  connected: true,
+  isLiveKitRoomConnected: false,
+  screenShareQuality: 'unknown',
+  isSharing: false,
+  broadcastSummary: undefined,
+  watchingShares: [],
+  shareQualities: new Map<number, ScreenShareQuality>(),
+  remoteVideoEls: new Map<number, HTMLVideoElement>(),
+  ...overrides,
+});
+
+describe('buildLiveKitTooltip', () => {
+  it('returns Available when connected with no active room', () => {
+    expect(buildLiveKitTooltip(base())).toBe(`${NAME}: Available`);
+  });
+
+  it('returns Reconnecting when in a room and quality is reconnecting', () => {
+    expect(
+      buildLiveKitTooltip(base({ isLiveKitRoomConnected: true, screenShareQuality: 'reconnecting' })),
+    ).toBe(`${NAME}: Reconnecting`);
+  });
+
+  it('returns null when not connected (lets dotTooltip fall through)', () => {
+    expect(buildLiveKitTooltip(base({ connected: false }))).toBeNull();
+  });
+
+  it('shows the aggregate quality line when in a room', () => {
+    expect(
+      buildLiveKitTooltip(base({ isLiveKitRoomConnected: true, screenShareQuality: 'good' })),
+    ).toBe(`${NAME}: Connected - good`);
+  });
+
+  it('omits the quality suffix on the first line when quality is unknown but a share is active', () => {
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'unknown',
+          isSharing: true,
+          broadcastSummary: '1080p 30fps',
+        }),
+      ),
+    ).toBe(`${NAME}: Connected\nBroadcasting: 1080p 30fps`);
+  });
+
+  it('adds a Broadcasting line when sharing', () => {
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          isSharing: true,
+          broadcastSummary: '1440p 60fps',
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nBroadcasting: 1440p 60fps`);
+  });
+
+  it('does not add a Broadcasting line when sharing but summary is missing', () => {
+    expect(
+      buildLiveKitTooltip(
+        base({ isLiveKitRoomConnected: true, screenShareQuality: 'good', isSharing: true }),
+      ),
+    ).toBe(`${NAME}: Connected - good`);
+  });
+
+  it('adds a singular Watching line plus a per-share line with resolution and quality', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'good']]),
+          remoteVideoEls: new Map([[42, fakeVideo(1920, 1080)]]),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice: 1920×1080 (good)`);
+  });
+
+  it('pluralizes the Watching line for two shares', () => {
+    const a = makeShare({ userId: 42, userName: 'Alice' });
+    const b = makeShare({ userId: 7, userName: 'Bob' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'fair',
+          watchingShares: [a, b],
+          shareQualities: new Map([
+            [42, 'good'],
+            [7, 'poor'],
+          ]),
+          remoteVideoEls: new Map([
+            [42, fakeVideo(1920, 1080)],
+            [7, fakeVideo(1280, 720)],
+          ]),
+        }),
+      ),
+    ).toBe(
+      `${NAME}: Connected - fair\nWatching 2 shares\nAlice: 1920×1080 (good)\nBob: 1280×720 (poor)`,
+    );
+  });
+
+  it('shows Broadcasting and Watching together', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          isSharing: true,
+          broadcastSummary: '1080p 30fps',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'good']]),
+          remoteVideoEls: new Map([[42, fakeVideo(1920, 1080)]]),
+        }),
+      ),
+    ).toBe(
+      `${NAME}: Connected - good\nBroadcasting: 1080p 30fps\nWatching 1 share\nAlice: 1920×1080 (good)`,
+    );
+  });
+
+  it('omits the resolution when the video element has no dimensions', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'good']]),
+          remoteVideoEls: new Map([[42, fakeVideo(0, 0)]]),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice (good)`);
+  });
+
+  it('omits the resolution when there is no video element at all', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'fair']]),
+          remoteVideoEls: new Map(),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice (fair)`);
+  });
+
+  it('omits the quality suffix when the per-share quality is unknown', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map([[42, 'unknown']]),
+          remoteVideoEls: new Map([[42, fakeVideo(1920, 1080)]]),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice: 1920×1080`);
+  });
+
+  it('omits the quality suffix when the per-share quality is missing entirely', () => {
+    const share = makeShare({ userId: 42, userName: 'Alice' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map(),
+          remoteVideoEls: new Map([[42, fakeVideo(1920, 1080)]]),
+        }),
+      ),
+    ).toBe(`${NAME}: Connected - good\nWatching 1 share\nAlice: 1920×1080`);
+  });
+
+  it('falls back to matrixUserId then userId when the userName is empty', () => {
+    const named = makeShare({ userId: 42, userName: '   ' });
+    const noMatrix = makeShare({ userId: 7, userName: '', matrixUserId: undefined });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [named, noMatrix],
+          shareQualities: new Map(),
+          remoteVideoEls: new Map(),
+        }),
+      ),
+    ).toBe(
+      `${NAME}: Connected - good\nWatching 2 shares\n@alice:example.com\n7`,
+    );
+  });
+});

--- a/src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts
+++ b/src/Brmble.Web/src/components/Sidebar/livekitTooltip.test.ts
@@ -222,4 +222,19 @@ describe('buildLiveKitTooltip', () => {
       `${NAME}: Connected - good\nWatching 2 shares\n@alice:example.com\n7`,
     );
   });
+
+  it('falls back past an empty matrixUserId to the numeric userId', () => {
+    const share = makeShare({ userId: 7, userName: '', matrixUserId: '   ' });
+    expect(
+      buildLiveKitTooltip(
+        base({
+          isLiveKitRoomConnected: true,
+          screenShareQuality: 'good',
+          watchingShares: [share],
+          shareQualities: new Map(),
+          remoteVideoEls: new Map(),
+        }),
+      ),
+    ).toBe(`Screenshare: Connected - good\nWatching 1 share\n7`);
+  });
 });

--- a/src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts
+++ b/src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts
@@ -1,0 +1,97 @@
+import type { ShareInfo } from '../../hooks/useScreenShare';
+import type { ScreenShareQuality } from '../../utils/screenShareQuality';
+
+export interface LiveKitTooltipInput {
+  /** Display name for the service (e.g. 'Screenshare'). */
+  name: string;
+  /** Whether the underlying livekit service status is 'connected'. */
+  connected: boolean;
+  /** True when a LiveKit room is active (sharing and/or watching). */
+  isLiveKitRoomConnected: boolean;
+  /** Aggregate room quality. */
+  screenShareQuality: ScreenShareQuality;
+  /** True when the local user is broadcasting a share. */
+  isSharing: boolean;
+  /** Preformatted broadcast summary, e.g. '1080p 30fps'. Undefined when not broadcasting. */
+  broadcastSummary?: string;
+  /** Shares the local user is currently watching. */
+  watchingShares: ShareInfo[];
+  /** Per-share quality keyed by ShareInfo.userId. */
+  shareQualities: Map<number, ScreenShareQuality>;
+  /** Live remote <video> elements keyed by ShareInfo.userId (for live dimensions). */
+  remoteVideoEls: Map<number, HTMLVideoElement>;
+}
+
+/**
+ * Builds the multi-line LiveKit/Screenshare status tooltip string.
+ *
+ * Pure: inputs -> string. Returns `null` when there is nothing livekit-specific
+ * to say (e.g. not connected), so the caller can fall through to its generic
+ * tooltip. Uses the existing `\n` multi-line convention shared with the voice
+ * and server tooltips.
+ */
+export function buildLiveKitTooltip(input: LiveKitTooltipInput): string | null {
+  const {
+    name,
+    connected,
+    isLiveKitRoomConnected,
+    screenShareQuality,
+    isSharing,
+    broadcastSummary,
+    watchingShares,
+    shareQualities,
+    remoteVideoEls,
+  } = input;
+
+  if (connected && !isLiveKitRoomConnected) {
+    return `${name}: Available`;
+  }
+
+  if (isLiveKitRoomConnected && screenShareQuality === 'reconnecting') {
+    return `${name}: Reconnecting`;
+  }
+
+  if (!(connected && isLiveKitRoomConnected)) {
+    return null;
+  }
+
+  const firstLine =
+    screenShareQuality !== 'unknown'
+      ? `${name}: Connected - ${screenShareQuality}`
+      : `${name}: Connected`;
+
+  const lines: string[] = [firstLine];
+
+  if (isSharing && broadcastSummary) {
+    lines.push(`Broadcasting: ${broadcastSummary}`);
+  }
+
+  if (watchingShares.length > 0) {
+    const n = watchingShares.length;
+    lines.push(`Watching ${n} share${n === 1 ? '' : 's'}`);
+    for (const share of watchingShares) {
+      lines.push(buildShareLine(share, shareQualities, remoteVideoEls));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function buildShareLine(
+  share: ShareInfo,
+  shareQualities: Map<number, ScreenShareQuality>,
+  remoteVideoEls: Map<number, HTMLVideoElement>,
+): string {
+  const trimmedName = share.userName?.trim() ?? '';
+  const label = trimmedName !== '' ? trimmedName : String(share.matrixUserId ?? share.userId);
+
+  const el = remoteVideoEls.get(share.userId);
+  const w = el?.videoWidth ?? 0;
+  const h = el?.videoHeight ?? 0;
+  const res = w > 0 && h > 0 ? `${w}\u00D7${h}` : '';
+
+  const q = shareQualities.get(share.userId);
+  const qualSuffix = q && q !== 'unknown' ? ` (${q})` : '';
+
+  return res !== '' ? `${label}: ${res}${qualSuffix}` : `${label}${qualSuffix}`;
+}

--- a/src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts
+++ b/src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts
@@ -83,7 +83,9 @@ function buildShareLine(
   remoteVideoEls: Map<number, HTMLVideoElement>,
 ): string {
   const trimmedName = share.userName?.trim() ?? '';
-  const label = trimmedName !== '' ? trimmedName : String(share.matrixUserId ?? share.userId);
+  const trimmedMatrixId = share.matrixUserId?.trim() ?? '';
+  const label =
+    trimmedName !== '' ? trimmedName : trimmedMatrixId !== '' ? trimmedMatrixId : String(share.userId);
 
   const el = remoteVideoEls.get(share.userId);
   const w = el?.videoWidth ?? 0;

--- a/src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts
+++ b/src/Brmble.Web/src/components/Sidebar/livekitTooltip.ts
@@ -77,13 +77,21 @@ export function buildLiveKitTooltip(input: LiveKitTooltipInput): string | null {
   return lines.join('\n');
 }
 
+// Remove control characters (including newlines) so a remote-supplied name
+// cannot inject or spoof additional tooltip lines, then collapse whitespace.
+function sanitizeLabel(value: string | undefined): string {
+  if (!value) return '';
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\u0000-\u001F\u007F]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
 function buildShareLine(
   share: ShareInfo,
   shareQualities: Map<number, ScreenShareQuality>,
   remoteVideoEls: Map<number, HTMLVideoElement>,
 ): string {
-  const trimmedName = share.userName?.trim() ?? '';
-  const trimmedMatrixId = share.matrixUserId?.trim() ?? '';
+  const trimmedName = sanitizeLabel(share.userName);
+  const trimmedMatrixId = sanitizeLabel(share.matrixUserId);
   const label =
     trimmedName !== '' ? trimmedName : trimmedMatrixId !== '' ? trimmedMatrixId : String(share.userId);
 

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useScreenShare } from './useScreenShare';
+import { useScreenShare, type ScreenShareSettings } from './useScreenShare';
 import bridge from '../bridge';
 
 const roomEventHandlers = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -9,7 +9,16 @@ let localSharePublicationEnabled = false;
 let mockRoomConstructionCount = 0;
 const mockRoomInstances: Array<{ connect: ReturnType<typeof vi.fn> }> = [];
 
+let senderEncodings: Array<{ maxBitrate?: number; maxFramerate?: number }> = [{}];
+const mockScreenShareMediaStreamTrack = { contentHint: '' };
+const mockScreenShareSender = {
+  getParameters: vi.fn(() => ({ encodings: senderEncodings, degradationPreference: undefined as string | undefined })),
+  setParameters: vi.fn().mockResolvedValue(undefined),
+};
+
 const mockLocalScreenShareTrack = {
+  mediaStreamTrack: mockScreenShareMediaStreamTrack,
+  sender: mockScreenShareSender,
   addEventListener: vi.fn((event: string, handler: () => void) => {
     const handlers = localTrackEventHandlers.get(event) ?? new Set<() => void>();
     handlers.add(handler);
@@ -151,6 +160,8 @@ describe('useScreenShare', () => {
     localSharePublicationEnabled = false;
     mockRoomConstructionCount = 0;
     mockRoomInstances.length = 0;
+    senderEncodings = [{}];
+    mockScreenShareMediaStreamTrack.contentHint = '';
   });
 
   afterEach(() => {
@@ -1627,6 +1638,64 @@ describe('useScreenShare', () => {
     expect(result.current.focusedShare).toBeNull();
     expect(result.current.remoteVideoEls.has(10)).toBe(false);
     expect(mockRoom.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('self-heals a pending watched share when the broadcaster republishes without a shareStopped event', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+    let watchedShareEnded = 0;
+    const screenShareTrack = {
+      kind: 'video',
+      source: 'screen_share',
+      attach: vi.fn(() => document.createElement('video')),
+      detach: vi.fn(),
+    };
+
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const { result } = renderHook(() => useScreenShare(undefined, undefined, undefined, () => { watchedShareEnded += 1; }));
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const p = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await p;
+    });
+
+    act(() => {
+      emitRoomEvent('trackSubscribed', screenShareTrack, {}, { identity: '@alice:test' });
+    });
+    expect(result.current.watchingShares).toHaveLength(1);
+
+    // Broadcaster restarts (re-capture): track unsubscribes then a new one subscribes,
+    // with NO livekit.screenShareStopped bridge event in between.
+    await act(async () => {
+      emitRoomEvent('trackUnsubscribed', screenShareTrack, {}, { identity: '@alice:test' });
+      await Promise.resolve();
+    });
+    expect(result.current.watchingShares).toEqual([]);
+
+    const republishedTrack = {
+      kind: 'video',
+      source: 'screen_share',
+      attach: vi.fn(() => document.createElement('video')),
+      detach: vi.fn(),
+    };
+    act(() => {
+      emitRoomEvent('trackSubscribed', republishedTrack, {}, { identity: '@alice:test' });
+    });
+
+    expect(result.current.watchingShares).toHaveLength(1);
+    expect(result.current.watchingShares[0].userId).toBe(10);
+    expect(result.current.remoteVideoEls.has(10)).toBe(true);
+    expect(republishedTrack.attach).toHaveBeenCalledTimes(1);
+    expect(watchedShareEnded).toBe(0);
   });
 
   it('attaches and detaches screen-share audio tracks for watched shares', async () => {
@@ -3488,5 +3557,123 @@ describe('useScreenShare', () => {
       expect.objectContaining({ contentHint: 'detail' }),
       expect.objectContaining({ degradationPreference: 'maintain-resolution' }),
     );
+  });
+
+  describe('applying settings to an active share', () => {
+    const baseSettings: ScreenShareSettings = {
+      captureAudio: false,
+      systemAudio: false,
+      resolution: '1080p',
+      fps: 30,
+      preferredCaptureSource: 'window',
+      contentType: 'motion',
+    };
+
+    const startActiveShare = async (settings: ScreenShareSettings) => {
+      let tokenHandler: ((data: unknown) => void) | null = null;
+      (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+        if (type === 'livekit.token') tokenHandler = handler;
+      });
+
+      const view = renderHook(
+        (props: ScreenShareSettings) => useScreenShare(undefined, props),
+        { initialProps: settings },
+      );
+
+      await act(async () => {
+        const promise = view.result.current.startSharing('channel-1');
+        tokenHandler?.(liveKitToken('test-jwt'));
+        await promise;
+      });
+      expect(view.result.current.isSharing).toBe(true);
+      (mockRoom.localParticipant.setScreenShareEnabled as ReturnType<typeof vi.fn>).mockClear();
+      (bridge.send as ReturnType<typeof vi.fn>).mockClear();
+      return view;
+    };
+
+    it('live-applies contentType and fps changes to the active track without re-capturing', async () => {
+      vi.useFakeTimers();
+      const view = await startActiveShare(baseSettings);
+
+      await act(async () => {
+        view.rerender({ ...baseSettings, contentType: 'detail', fps: 60 });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      // No re-capture: setScreenShareEnabled must not be toggled off/on again.
+      expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalled();
+      // Live-applied on the existing track.
+      expect(mockScreenShareMediaStreamTrack.contentHint).toBe('detail');
+      expect(mockScreenShareSender.setParameters).toHaveBeenCalled();
+      expect(senderEncodings[0].maxFramerate).toBe(60);
+      const params = (mockScreenShareSender.setParameters as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as { degradationPreference?: string };
+      expect(params.degradationPreference).toBe('maintain-resolution');
+      // No stop/start bridge chatter → viewers keep watching with no notification.
+      const sends = (bridge.send as ReturnType<typeof vi.fn>).mock.calls.map(([type]) => type);
+      expect(sends).not.toContain('livekit.shareStopped');
+      expect(sends).not.toContain('livekit.shareStarted');
+      expect(view.result.current.isSharing).toBe(true);
+    });
+
+    it('re-captures the active share on resolution change without emitting shareStopped/shareStarted', async () => {
+      vi.useFakeTimers();
+      const view = await startActiveShare(baseSettings);
+
+      await act(async () => {
+        view.rerender({ ...baseSettings, resolution: '4k' });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      // Re-capture: unpublish then republish with the new options.
+      expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(false);
+      expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ resolution: { width: 3840, height: 2160, frameRate: 30 } }),
+        expect.objectContaining({ videoEncoding: { maxBitrate: 18_000_000, maxFramerate: 30 } }),
+      );
+      // Silent to viewers: no bridge stop/start events (no "Share ended" notification).
+      const sends = (bridge.send as ReturnType<typeof vi.fn>).mock.calls.map(([type]) => type);
+      expect(sends).not.toContain('livekit.shareStopped');
+      expect(sends).not.toContain('livekit.shareStarted');
+      expect(view.result.current.isSharing).toBe(true);
+    });
+
+    it('re-captures on capture-source change', async () => {
+      vi.useFakeTimers();
+      const view = await startActiveShare(baseSettings);
+
+      await act(async () => {
+        view.rerender({ ...baseSettings, preferredCaptureSource: 'screen' });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(false);
+      expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ video: { displaySurface: 'monitor' } }),
+        expect.anything(),
+      );
+    });
+
+    it('does nothing when settings are unchanged', async () => {
+      vi.useFakeTimers();
+      const view = await startActiveShare(baseSettings);
+
+      await act(async () => {
+        view.rerender({ ...baseSettings });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalled();
+      expect(mockScreenShareSender.setParameters).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -112,6 +112,17 @@ vi.mock('livekit-client', () => ({
     Kind: { Audio: 'audio', Video: 'video' },
     Source: { ScreenShare: 'screen_share', ScreenShareAudio: 'screen_share_audio' },
   },
+  VideoQuality: { LOW: 0, MEDIUM: 1, HIGH: 2 },
+  VideoPreset: class MockVideoPreset {
+    width: number;
+    height: number;
+    constructor(width: number, height: number, maxBitrate: number, maxFramerate?: number) {
+      this.width = width;
+      this.height = height;
+      void maxBitrate;
+      void maxFramerate;
+    }
+  },
 }));
 
 vi.mock('../bridge', () => ({
@@ -220,7 +231,7 @@ describe('useScreenShare', () => {
       await sharePromise;
     });
 
-    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, undefined);
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, undefined, undefined);
     expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(false);
     expect(result.current.isSharing).toBe(false);
     expect((bridge.send as ReturnType<typeof vi.fn>).mock.calls.filter(([type]) => type === 'livekit.shareStarted')).toHaveLength(0);
@@ -1234,6 +1245,50 @@ describe('useScreenShare', () => {
     });
 
     expect(result.current.shareQualities.get(10)).toBe('fair');
+  });
+
+  it('applies a viewer quality override to the watched screen-share publication', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    let shareStartedHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+      if (type === 'livekit.screenShareStarted') shareStartedHandler = handler;
+    });
+
+    const setVideoQuality = vi.fn();
+    const screenSharePub = {
+      kind: 'video',
+      source: 'screen_share',
+      setVideoQuality,
+      track: { kind: 'video', source: 'screen_share', attach: vi.fn(() => document.createElement('video')) },
+    };
+    mockRoom.remoteParticipants.set('@alice:test', {
+      identity: '@alice:test',
+      connectionQuality: 'good',
+      trackPublications: new Map([['pub1', screenSharePub]]),
+    });
+
+    const { result } = renderHook(() => useScreenShare());
+
+    act(() => {
+      shareStartedHandler?.({ roomName: 'channel-1', userName: 'alice', userId: 10, matrixUserId: '@alice:test' });
+    });
+
+    await act(async () => {
+      const promise = result.current.connectAsViewer('channel-1', 10, '@alice:test');
+      tokenHandler?.(liveKitToken('jwt'));
+      await promise;
+    });
+
+    // connectAsViewer pins auto -> HIGH on attach
+    expect(setVideoQuality).toHaveBeenCalledWith(2);
+
+    act(() => {
+      result.current.setViewerQuality(10, 'low');
+    });
+
+    expect(result.current.viewerQualities.get(10)).toBe('low');
+    expect(setVideoQuality).toHaveBeenLastCalledWith(0);
   });
 
   it('ignores stale room-scoped activeShareResult after global discovery becomes current', () => {
@@ -3350,13 +3405,21 @@ describe('useScreenShare', () => {
       await promise;
     });
 
-    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, expect.objectContaining({
-      audio: true,
-      systemAudio: 'include',
-      video: { displaySurface: 'window' },
-      resolution: { width: 1920, height: 1080, frameRate: 30 },
-      videoEncoding: { maxBitrate: 4_000_000, maxFramerate: 30 },
-    }));
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        audio: true,
+        systemAudio: 'include',
+        video: { displaySurface: 'window' },
+        resolution: { width: 1920, height: 1080, frameRate: 30 },
+        contentHint: 'motion',
+      }),
+      expect.objectContaining({
+        videoEncoding: { maxBitrate: 6_000_000, maxFramerate: 30 },
+        simulcast: true,
+        degradationPreference: 'maintain-framerate',
+      }),
+    );
   });
 
   it('omits display surface hint when preferred capture source is auto', async () => {
@@ -3381,12 +3444,49 @@ describe('useScreenShare', () => {
       await promise;
     });
 
-    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, expect.not.objectContaining({
-      video: expect.anything(),
-    }));
-    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(true, expect.objectContaining({
-      resolution: { width: 1280, height: 720, frameRate: 15 },
-      videoEncoding: { maxBitrate: 2_000_000, maxFramerate: 15 },
-    }));
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
+      true,
+      expect.not.objectContaining({ video: expect.anything() }),
+      expect.anything(),
+    );
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        resolution: { width: 1280, height: 720, frameRate: 15 },
+      }),
+      expect.objectContaining({
+        videoEncoding: { maxBitrate: 3_000_000, maxFramerate: 15 },
+      }),
+    );
+  });
+
+  it('encodes detail content with maintain-resolution and a detail content hint', async () => {
+    let tokenHandler: ((data: unknown) => void) | null = null;
+    (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+      if (type === 'livekit.token') tokenHandler = handler;
+    });
+
+    const settings = {
+      captureAudio: false,
+      systemAudio: false,
+      resolution: '1080p' as const,
+      fps: 30 as const,
+      preferredCaptureSource: 'window' as const,
+      contentType: 'detail' as const,
+    };
+
+    const { result } = renderHook(() => useScreenShare(undefined, settings));
+
+    await act(async () => {
+      const promise = result.current.startSharing('channel-1');
+      tokenHandler?.(liveKitToken('test-jwt'));
+      await promise;
+    });
+
+    expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ contentHint: 'detail' }),
+      expect.objectContaining({ degradationPreference: 'maintain-resolution' }),
+    );
   });
 });

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -37,6 +37,104 @@ export interface ScreenShareSettings {
   contentType?: 'motion' | 'detail';
 }
 
+/** Debounce window before applying edited settings to an already-active share. */
+const APPLY_SETTINGS_DEBOUNCE_MS = 400;
+
+const SCREEN_SHARE_RESOLUTION_MAP: Record<string, { width: number; height: number }> = {
+  '720p': { width: 1280, height: 720 },
+  '1080p': { width: 1920, height: 1080 },
+  '1440p': { width: 2560, height: 1440 },
+  '4k': { width: 3840, height: 2160 },
+};
+
+// Motion/video/game content needs substantially more bitrate than static desktops to
+// avoid the blocky degradation weak-bandwidth viewers were seeing. Raised across the board.
+const SCREEN_SHARE_BITRATE_MAP: Record<string, number> = {
+  '720p': 3_000_000,
+  '1080p': 6_000_000,
+  '1440p': 10_000_000,
+  '4k': 18_000_000,
+};
+
+const screenShareDegradationPreference = (settings: ScreenShareSettings): 'maintain-resolution' | 'maintain-framerate' =>
+  settings.contentType === 'detail' ? 'maintain-resolution' : 'maintain-framerate';
+
+const screenShareContentHint = (settings: ScreenShareSettings): 'detail' | 'motion' =>
+  settings.contentType === 'detail' ? 'detail' : 'motion';
+
+/**
+ * Build the getDisplayMedia capture options (2nd arg) and publish options (3rd arg)
+ * for setScreenShareEnabled from user settings. Shared by initial share start and by
+ * the re-capture path when resolution/capture-source settings change mid-share.
+ */
+const buildScreenShareOptions = (settings: ScreenShareSettings): {
+  captureOptions: Record<string, unknown> | undefined;
+  publishOptions: Record<string, unknown>;
+} => {
+  let captureOptions: Record<string, unknown> | undefined = {};
+
+  const displaySurfaceMap: Partial<Record<ScreenShareSettings['preferredCaptureSource'], 'window' | 'monitor' | 'browser'>> = {
+    window: 'window',
+    screen: 'monitor',
+    browser: 'browser',
+  };
+  const displaySurface = displaySurfaceMap[settings.preferredCaptureSource];
+  if (displaySurface) {
+    captureOptions.video = { displaySurface };
+  }
+
+  if (settings.captureAudio) {
+    captureOptions.audio = true;
+  }
+
+  if (settings.captureAudio && settings.systemAudio) {
+    captureOptions.systemAudio = 'include';
+  }
+
+  // Steer the encoder: motion content keeps framerate smooth (drop resolution under
+  // pressure); detail content preserves sharpness (drop framerate under pressure).
+  captureOptions.contentHint = screenShareContentHint(settings);
+
+  // publishOptions (3rd arg) — NOT capture options. videoEncoding/codec/simulcast belong here.
+  const publishOptions: Record<string, unknown> = {
+    degradationPreference: screenShareDegradationPreference(settings),
+    // Two-layer simulcast (high + one low) so weak-bandwidth viewers subscribe to the low
+    // layer cleanly instead of receiving a single high-res stream degraded by packet loss.
+    simulcast: true,
+    screenShareSimulcastLayers: [new VideoPreset(640, 360, 500_000, settings.fps ?? 15)],
+  };
+
+  if (settings.resolution || settings.fps) {
+    const res = SCREEN_SHARE_RESOLUTION_MAP[settings.resolution];
+    captureOptions.resolution = {
+      ...res,
+      frameRate: settings.fps,
+    };
+    publishOptions.videoEncoding = {
+      maxBitrate: SCREEN_SHARE_BITRATE_MAP[settings.resolution],
+      maxFramerate: settings.fps,
+    };
+  }
+
+  if (Object.keys(captureOptions).length === 0) {
+    captureOptions = undefined;
+  }
+
+  return { captureOptions, publishOptions };
+};
+
+/** Settings whose changes require a fresh getDisplayMedia capture (picker prompt). */
+const screenShareNeedsRecapture = (prev: ScreenShareSettings, next: ScreenShareSettings): boolean =>
+  prev.resolution !== next.resolution ||
+  prev.preferredCaptureSource !== next.preferredCaptureSource ||
+  prev.captureAudio !== next.captureAudio ||
+  prev.systemAudio !== next.systemAudio;
+
+/** Settings whose changes can be applied to the live track without re-capturing. */
+const screenShareNeedsLiveApply = (prev: ScreenShareSettings, next: ScreenShareSettings): boolean =>
+  prev.contentType !== next.contentType || prev.fps !== next.fps;
+
+
 export type LocalShareStopReason = 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel';
 export type WatchedShareEndReason = 'ended' | 'unexpected';
 export type WatchedShareEndedCallback = (share: ShareInfo, reason: WatchedShareEndReason) => void;
@@ -234,6 +332,9 @@ export function useScreenShare(
   const isRoomReconnectingRef = useRef(false);
   const isSharingRef = useRef(false);
   const isStartingShareRef = useRef(false);
+  // Snapshot of the settings currently applied to the active share, so an edit can be
+  // diffed to decide between a silent live-apply and a re-capture.
+  const appliedShareSettingsRef = useRef<ScreenShareSettings | null>(null);
   const focusedShareRef = useRef<ShareInfo | null>(null);
   const discoveryTargetRef = useRef<DiscoveryTarget>(null);
   const shareEventVersionRef = useRef(0);
@@ -678,6 +779,7 @@ export function useScreenShare(
 
     isSharingRef.current = false;
     setIsSharing(false);
+    appliedShareSettingsRef.current = null;
     recomputeRoomQuality();
 
     if (wasSharing && roomName) {
@@ -783,10 +885,27 @@ export function useScreenShare(
       }
 
       const watching = watchingSharesRef.current;
-      const matchedShare = watching.find(s => {
+      let matchedShare = watching.find(s => {
         const identity = s.matrixUserId ?? String(s.userId);
         return identity === participant.identity;
       });
+      // Self-heal: a broadcaster restarting their share (e.g. applying new
+      // resolution/capture-source settings) briefly unpublishes and republishes
+      // the track WITHOUT sending a livekit.screenShareStopped bridge event. That
+      // leaves the viewer's share parked in pendingUnsubscribedWatchedSharesRef.
+      // When the new track subscribes, restore the share so the tile keeps playing
+      // instead of staying blank — no "Share ended" notification is involved.
+      if (!matchedShare) {
+        for (const pending of pendingUnsubscribedWatchedSharesRef.current.values()) {
+          const identity = pending.matrixUserId ?? String(pending.userId);
+          if (identity === participant.identity) {
+            matchedShare = pending;
+            pendingUnsubscribedWatchedSharesRef.current.delete(watchedShareKey(pending.roomName, pending.userId));
+            addWatchingShare(pending);
+            break;
+          }
+        }
+      }
       if (!matchedShare) return;
       if (
         track.kind === Track.Kind.Video &&
@@ -916,7 +1035,7 @@ export function useScreenShare(
         void stopLocalShare(teardownIntent ?? 'interrupted', room);
       }
     });
-  }, [attachRemoteAudio, applyViewerQuality, clearTokenLease, clearWatchingState, detachRemoteAudio, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, recomputeRoomQuality, removeWatchingShare, resetQualityState, stopLocalShare, updateShareQuality]);
+  }, [addWatchingShare, attachRemoteAudio, applyViewerQuality, clearTokenLease, clearWatchingState, detachRemoteAudio, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, recomputeRoomQuality, removeWatchingShare, resetQualityState, stopLocalShare, updateShareQuality]);
 
   // Ensure we have a connected room for the given channel.
   // Returns the existing room if already connected to this channel, otherwise connects.
@@ -1065,71 +1184,7 @@ export function useScreenShare(
       let captureOptions: Record<string, unknown> | undefined;
       let publishOptions: Record<string, unknown> | undefined;
       if (screenShareSettings) {
-        const resolutionMap: Record<string, { width: number; height: number }> = {
-          '720p': { width: 1280, height: 720 },
-          '1080p': { width: 1920, height: 1080 },
-          '1440p': { width: 2560, height: 1440 },
-          '4k': { width: 3840, height: 2160 },
-        };
-
-        // Motion/video/game content needs substantially more bitrate than static desktops to
-        // avoid the blocky degradation weak-bandwidth viewers were seeing. Raised across the board.
-        const bitrateMap: Record<string, number> = {
-          '720p': 3_000_000,
-          '1080p': 6_000_000,
-          '1440p': 10_000_000,
-          '4k': 18_000_000,
-        };
-
-        captureOptions = {};
-
-        const displaySurfaceMap: Partial<Record<ScreenShareSettings['preferredCaptureSource'], 'window' | 'monitor' | 'browser'>> = {
-          window: 'window',
-          screen: 'monitor',
-          browser: 'browser',
-        };
-        const displaySurface = displaySurfaceMap[screenShareSettings.preferredCaptureSource];
-        if (displaySurface) {
-          captureOptions.video = { displaySurface };
-        }
-
-        if (screenShareSettings.captureAudio) {
-          captureOptions.audio = true;
-        }
-
-        if (screenShareSettings.captureAudio && screenShareSettings.systemAudio) {
-          captureOptions.systemAudio = 'include';
-        }
-
-        // Steer the encoder: motion content keeps framerate smooth (drop resolution under
-        // pressure); detail content preserves sharpness (drop framerate under pressure).
-        const isDetail = screenShareSettings.contentType === 'detail';
-        captureOptions.contentHint = isDetail ? 'detail' : 'motion';
-
-        // publishOptions (3rd arg) — NOT capture options. videoEncoding/codec/simulcast belong here.
-        publishOptions = {
-          degradationPreference: isDetail ? 'maintain-resolution' : 'maintain-framerate',
-          // Two-layer simulcast (high + one low) so weak-bandwidth viewers subscribe to the low
-          // layer cleanly instead of receiving a single high-res stream degraded by packet loss.
-          simulcast: true,
-          screenShareSimulcastLayers: [new VideoPreset(640, 360, 500_000, screenShareSettings.fps ?? 15)],
-        };
-
-        if (screenShareSettings.resolution || screenShareSettings.fps) {
-          const res = resolutionMap[screenShareSettings.resolution];
-          captureOptions.resolution = {
-            ...res,
-            frameRate: screenShareSettings.fps,
-          };
-          publishOptions.videoEncoding = {
-            maxBitrate: bitrateMap[screenShareSettings.resolution],
-            maxFramerate: screenShareSettings.fps,
-          };
-        }
-
-        if (Object.keys(captureOptions).length === 0) {
-          captureOptions = undefined;
-        }
+        ({ captureOptions, publishOptions } = buildScreenShareOptions(screenShareSettings));
       }
 
       sendScreenShareDebugEvent('startSharing.setScreenShareEnabled.begin');
@@ -1145,6 +1200,7 @@ export function useScreenShare(
 
       isSharingRef.current = true;
       setIsSharing(true);
+      appliedShareSettingsRef.current = screenShareSettings ?? null;
       recomputeRoomQuality();
       bindLocalShareEndListener(room);
 
@@ -1190,6 +1246,88 @@ export function useScreenShare(
     }
     await stopLocalShare('manual');
   }, [invalidateRoomLifecycle, stopLocalShare]);
+
+  // Apply encoder-only changes (content type, framerate, degradation preference) to the
+  // already-published track. No getDisplayMedia re-prompt, no flicker, and viewers keep
+  // watching the same track uninterrupted.
+  const applyLiveScreenShareSettings = useCallback((settings: ScreenShareSettings) => {
+    const room = roomRef.current;
+    const pub = room?.localParticipant.getTrackPublication?.(Track.Source.ScreenShare);
+    const track = pub?.track as { mediaStreamTrack?: MediaStreamTrack; sender?: RTCRtpSender } | undefined;
+    if (!track) {
+      return;
+    }
+    if (track.mediaStreamTrack) {
+      try { track.mediaStreamTrack.contentHint = screenShareContentHint(settings); } catch { /* ignore */ }
+    }
+    const sender = track.sender;
+    if (sender && typeof sender.getParameters === 'function' && typeof sender.setParameters === 'function') {
+      try {
+        const params = sender.getParameters();
+        params.degradationPreference = screenShareDegradationPreference(settings) as RTCDegradationPreference;
+        if (params.encodings?.length && settings.fps) {
+          for (const enc of params.encodings) {
+            enc.maxFramerate = settings.fps;
+          }
+        }
+        void sender.setParameters(params);
+      } catch { /* ignore */ }
+    }
+    sendScreenShareDebugEvent('applySettings.liveApplied');
+  }, []);
+
+  // Re-acquire the capture (resolution or capture-source changed) by toggling the local
+  // screen share off then on with fresh options. Deliberately does NOT send the
+  // livekit.shareStopped/shareStarted bridge events, so viewers get no "Share ended"
+  // notification — their track briefly unsubscribes then self-heals on resubscribe.
+  const recaptureActiveScreenShare = useCallback(async (settings: ScreenShareSettings) => {
+    const room = roomRef.current;
+    if (!room || !isSharingRef.current) {
+      return;
+    }
+    const { captureOptions, publishOptions } = buildScreenShareOptions(settings);
+    sendScreenShareDebugEvent('applySettings.recapture.begin');
+    try {
+      await room.localParticipant.setScreenShareEnabled(false);
+      if (!isSharingRef.current || roomRef.current !== room) {
+        return;
+      }
+      await room.localParticipant.setScreenShareEnabled(true, captureOptions, publishOptions);
+      bindLocalShareEndListener(room);
+      sendScreenShareDebugEvent('applySettings.recapture.done');
+    } catch (err) {
+      sendScreenShareDebugEvent('applySettings.recapture.error');
+      setError(getErrorLikeDetails(err)?.message || 'Screen share failed');
+    }
+  }, [bindLocalShareEndListener]);
+
+  const applyScreenShareSettingsToActiveShare = useCallback(async (
+    prev: ScreenShareSettings,
+    next: ScreenShareSettings,
+  ) => {
+    appliedShareSettingsRef.current = next;
+    if (screenShareNeedsRecapture(prev, next)) {
+      await recaptureActiveScreenShare(next);
+    } else if (screenShareNeedsLiveApply(prev, next)) {
+      applyLiveScreenShareSettings(next);
+    }
+  }, [applyLiveScreenShareSettings, recaptureActiveScreenShare]);
+
+  // Auto-apply edited screenshare settings to a running share (debounced so slider drags
+  // don't thrash). Live-applies encoder changes; re-captures only for resolution/source.
+  useEffect(() => {
+    if (!isSharing || !screenShareSettings) {
+      return;
+    }
+    const prev = appliedShareSettingsRef.current;
+    if (!prev || (!screenShareNeedsRecapture(prev, screenShareSettings) && !screenShareNeedsLiveApply(prev, screenShareSettings))) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      void applyScreenShareSettingsToActiveShare(prev, screenShareSettings);
+    }, APPLY_SETTINGS_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [isSharing, screenShareSettings, applyScreenShareSettingsToActiveShare]);
 
   // --- Viewer logic ---
 

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -206,6 +206,7 @@ const logScreenShareDiag = (
   el: HTMLVideoElement | null,
   pub?: { videoQuality?: unknown; dimensions?: { width: number; height: number } },
 ) => {
+  if (!import.meta.env.DEV) return;
   try {
     const dims = pub?.dimensions;
     console.info('[LiveKit][screenshare-diag]', where, {

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -1,7 +1,16 @@
 import { useCallback, useRef, useState, useEffect, type SetStateAction } from 'react';
-import { Room, RoomEvent, Track, RemoteTrackPublication } from 'livekit-client';
+import { Room, RoomEvent, Track, RemoteTrackPublication, VideoPreset, VideoQuality } from 'livekit-client';
 import bridge from '../bridge';
 import { type ScreenShareQuality, mapLiveKitQuality, worstQuality } from '../utils/screenShareQuality';
+
+/** Viewer-selected receive quality for a watched screen share. 'auto' defers to adaptive stream. */
+export type ViewerQuality = 'auto' | 'high' | 'medium' | 'low';
+
+const VIEWER_QUALITY_TO_LIVEKIT: Record<Exclude<ViewerQuality, 'auto'>, VideoQuality> = {
+  high: VideoQuality.HIGH,
+  medium: VideoQuality.MEDIUM,
+  low: VideoQuality.LOW,
+};
 
 export interface ShareInfo {
   roomName: string;
@@ -24,6 +33,8 @@ export interface ScreenShareSettings {
   fps: 15 | 30 | 60;
   systemAudio: boolean;
   preferredCaptureSource: 'auto' | 'window' | 'screen' | 'browser';
+  /** Optimize encoding for smooth motion (games/video) or sharp detail (text/code). */
+  contentType?: 'motion' | 'detail';
 }
 
 export type LocalShareStopReason = 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel';
@@ -83,6 +94,31 @@ const sendScreenShareDebugEvent = (eventName: string) => {
     bridge.send(`livekit.debug.${eventName}`, {});
   } catch {
     // Diagnostics must never affect the share lifecycle.
+  }
+};
+
+/**
+ * Phase 0 instrumentation: log the actual received layer/resolution/quality per viewer so we
+ * can confirm whether pixelation is per-viewer (bandwidth/layer) or per-broadcaster (encode).
+ * Cheap console diagnostics only — never affects the share lifecycle.
+ */
+const logScreenShareDiag = (
+  where: string,
+  userId: number,
+  el: HTMLVideoElement | null,
+  pub?: { videoQuality?: unknown; dimensions?: { width: number; height: number } },
+) => {
+  try {
+    const dims = pub?.dimensions;
+    console.info('[LiveKit][screenshare-diag]', where, {
+      userId,
+      elementSize: el ? `${el.clientWidth}x${el.clientHeight}` : 'n/a',
+      videoResolution: el ? `${el.videoWidth}x${el.videoHeight}` : 'n/a',
+      publishedDimensions: dims ? `${dims.width}x${dims.height}` : 'n/a',
+      videoQuality: pub?.videoQuality,
+    });
+  } catch {
+    // Diagnostics must never throw.
   }
 };
 
@@ -185,12 +221,14 @@ export function useScreenShare(
   const remoteAudioElsRef = useRef<Map<number, HTMLAudioElement>>(new Map());
   const [roomQuality, setRoomQuality] = useState<ScreenShareQuality>('unknown');
   const [shareQualities, setShareQualities] = useState<Map<number, ScreenShareQuality>>(new Map());
+  const [viewerQualities, setViewerQualities] = useState<Map<number, ViewerQuality>>(new Map());
 
   // Single room connection per channel — used for both publishing and subscribing
   const roomRef = useRef<Room | null>(null);
   const watchingSharesRef = useRef<ShareInfo[]>([]);
   const activeSharesRef = useRef<ShareInfo[]>([]);
   const shareQualitiesRef = useRef<Map<number, ScreenShareQuality>>(new Map());
+  const viewerQualitiesRef = useRef<Map<number, ViewerQuality>>(new Map());
   const shareQualitiesBeforeReconnectRef = useRef<Map<number, ScreenShareQuality> | null>(null);
   const localQualityRef = useRef<ScreenShareQuality>('unknown');
   const isRoomReconnectingRef = useRef(false);
@@ -294,6 +332,8 @@ export function useScreenShare(
     localQualityRef.current = 'unknown';
     shareQualitiesRef.current = new Map();
     setShareQualities(new Map());
+    viewerQualitiesRef.current = new Map();
+    setViewerQualities(new Map());
     setRoomQuality('unknown');
   }, []);
 
@@ -313,6 +353,49 @@ export function useScreenShare(
     setShareQualities(next);
     recomputeRoomQuality();
   }, [recomputeRoomQuality]);
+
+  // Apply the viewer-selected receive quality to a participant's screen-share video track.
+  // 'auto' pins to HIGH so, with a 2-layer simulcast publish, adaptive stream is free to
+  // pick the best layer up to full quality; explicit levels force a fixed layer.
+  const applyViewerQuality = useCallback((participant: { trackPublications: Map<string, RemoteTrackPublication> }, userId: number) => {
+    const pref = viewerQualitiesRef.current.get(userId) ?? 'auto';
+    const target = pref === 'auto' ? VideoQuality.HIGH : VIEWER_QUALITY_TO_LIVEKIT[pref];
+    participant.trackPublications?.forEach((pub) => {
+      if (pub.kind === Track.Kind.Video && pub.source === Track.Source.ScreenShare) {
+        try {
+          pub.setVideoQuality?.(target);
+        } catch {
+          // Quality selection is best-effort; never break playback.
+        }
+      }
+    });
+  }, []);
+
+  const removeViewerQuality = useCallback((userId: number) => {
+    if (!viewerQualitiesRef.current.has(userId)) {
+      return;
+    }
+    const next = new Map(viewerQualitiesRef.current);
+    next.delete(userId);
+    viewerQualitiesRef.current = next;
+    setViewerQualities(next);
+  }, []);
+
+  const setViewerQuality = useCallback((userId: number, quality: ViewerQuality) => {
+    viewerQualitiesRef.current = new Map(viewerQualitiesRef.current).set(userId, quality);
+    setViewerQualities(viewerQualitiesRef.current);
+
+    const room = roomRef.current;
+    const share = watchingSharesRef.current.find(s => s.userId === userId);
+    if (!room || !share) {
+      return;
+    }
+    const identity = share.matrixUserId ?? String(userId);
+    const participant = room.remoteParticipants.get(identity);
+    if (participant) {
+      applyViewerQuality(participant, userId);
+    }
+  }, [applyViewerQuality]);
 
   const detachRemoteAudio = useCallback((userId: number) => {
     const audioEl = remoteAudioElsRef.current.get(userId);
@@ -417,8 +500,9 @@ export function useScreenShare(
       return next;
     });
     removeShareQuality(userId);
+    removeViewerQuality(userId);
     return next;
-  }, [detachRemoteAudio, removeShareQuality, setFocusedShare]);
+  }, [detachRemoteAudio, removeShareQuality, removeViewerQuality, setFocusedShare]);
 
   const clearWatchingState = useCallback(() => {
     setRemoteVideoEls(new Map());
@@ -429,6 +513,8 @@ export function useScreenShare(
     setFocusedShare(null);
     shareQualitiesRef.current = new Map();
     setShareQualities(new Map());
+    viewerQualitiesRef.current = new Map();
+    setViewerQualities(new Map());
     recomputeRoomQuality();
   }, [detachRemoteAudio, recomputeRoomQuality, setFocusedShare, updateWatchingShares]);
 
@@ -708,6 +794,8 @@ export function useScreenShare(
       ) {
         const el = track.attach() as HTMLVideoElement;
         setRemoteVideoEls(prev => new Map(prev).set(matchedShare.userId, el));
+        applyViewerQuality(participant, matchedShare.userId);
+        logScreenShareDiag('trackSubscribed', matchedShare.userId, el, pub);
       }
       if (
         track.kind === Track.Kind.Audio &&
@@ -828,7 +916,7 @@ export function useScreenShare(
         void stopLocalShare(teardownIntent ?? 'interrupted', room);
       }
     });
-  }, [attachRemoteAudio, clearTokenLease, clearWatchingState, detachRemoteAudio, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, recomputeRoomQuality, removeWatchingShare, resetQualityState, stopLocalShare, updateShareQuality]);
+  }, [attachRemoteAudio, applyViewerQuality, clearTokenLease, clearWatchingState, detachRemoteAudio, invalidateRoomLifecycle, notifyUnexpectedWatchedShareEnds, recomputeRoomQuality, removeWatchingShare, resetQualityState, stopLocalShare, updateShareQuality]);
 
   // Ensure we have a connected room for the given channel.
   // Returns the existing room if already connected to this channel, otherwise connects.
@@ -873,7 +961,22 @@ export function useScreenShare(
         throw createSupersededRoomRequestError();
       }
 
-      const room = new Room();
+      const room = new Room({
+        // Let subscribers request only the layers they can render, and pause tracks
+        // for off-screen/hidden tiles — the core fix for per-viewer pixelation.
+        adaptiveStream: true,
+        // Stop publishing simulcast layers no viewer is consuming, saving upstream bandwidth.
+        dynacast: true,
+        publishDefaults: {
+          // Motion-heavy screen content (games/video) benefits most from VP9's efficiency;
+          // VP8 backup keeps older/limited WebView2 receivers working without forcing an upgrade.
+          videoCodec: 'vp9',
+          backupCodec: { codec: 'vp8' },
+          // Prefer dropping resolution over framerate for smooth motion; per-share overrides
+          // are applied in startSharing based on the broadcaster's contentType toggle.
+          degradationPreference: 'maintain-framerate',
+        },
+      });
       bindRoomEvents(room);
 
       roomRef.current = room;
@@ -960,6 +1063,7 @@ export function useScreenShare(
       sendScreenShareDebugEvent('startSharing.ensureRoom.done');
 
       let captureOptions: Record<string, unknown> | undefined;
+      let publishOptions: Record<string, unknown> | undefined;
       if (screenShareSettings) {
         const resolutionMap: Record<string, { width: number; height: number }> = {
           '720p': { width: 1280, height: 720 },
@@ -968,11 +1072,13 @@ export function useScreenShare(
           '4k': { width: 3840, height: 2160 },
         };
 
+        // Motion/video/game content needs substantially more bitrate than static desktops to
+        // avoid the blocky degradation weak-bandwidth viewers were seeing. Raised across the board.
         const bitrateMap: Record<string, number> = {
-          '720p': 2_000_000,
-          '1080p': 4_000_000,
-          '1440p': 8_000_000,
-          '4k': 15_000_000,
+          '720p': 3_000_000,
+          '1080p': 6_000_000,
+          '1440p': 10_000_000,
+          '4k': 18_000_000,
         };
 
         captureOptions = {};
@@ -995,13 +1101,27 @@ export function useScreenShare(
           captureOptions.systemAudio = 'include';
         }
 
+        // Steer the encoder: motion content keeps framerate smooth (drop resolution under
+        // pressure); detail content preserves sharpness (drop framerate under pressure).
+        const isDetail = screenShareSettings.contentType === 'detail';
+        captureOptions.contentHint = isDetail ? 'detail' : 'motion';
+
+        // publishOptions (3rd arg) — NOT capture options. videoEncoding/codec/simulcast belong here.
+        publishOptions = {
+          degradationPreference: isDetail ? 'maintain-resolution' : 'maintain-framerate',
+          // Two-layer simulcast (high + one low) so weak-bandwidth viewers subscribe to the low
+          // layer cleanly instead of receiving a single high-res stream degraded by packet loss.
+          simulcast: true,
+          screenShareSimulcastLayers: [new VideoPreset(640, 360, 500_000, screenShareSettings.fps ?? 15)],
+        };
+
         if (screenShareSettings.resolution || screenShareSettings.fps) {
           const res = resolutionMap[screenShareSettings.resolution];
           captureOptions.resolution = {
             ...res,
             frameRate: screenShareSettings.fps,
           };
-          captureOptions.videoEncoding = {
+          publishOptions.videoEncoding = {
             maxBitrate: bitrateMap[screenShareSettings.resolution],
             maxFramerate: screenShareSettings.fps,
           };
@@ -1013,7 +1133,7 @@ export function useScreenShare(
       }
 
       sendScreenShareDebugEvent('startSharing.setScreenShareEnabled.begin');
-      await room.localParticipant.setScreenShareEnabled(true, captureOptions);
+      await room.localParticipant.setScreenShareEnabled(true, captureOptions, publishOptions);
       sendScreenShareDebugEvent('startSharing.setScreenShareEnabled.done');
 
       if (shareStartCancelGenerationRef.current !== shareStartCancelGeneration || roomRef.current !== room) {
@@ -1139,6 +1259,8 @@ export function useScreenShare(
           if (pub.track && pub.track.kind === Track.Kind.Video && pub.source === Track.Source.ScreenShare) {
             const el = pub.track.attach() as HTMLVideoElement;
             setRemoteVideoEls(prev => new Map(prev).set(targetUserId, el));
+            applyViewerQuality(participant, targetUserId);
+            logScreenShareDiag('connectAsViewer', targetUserId, el, pub);
           }
           if (pub.track && pub.track.kind === Track.Kind.Audio && pub.source === Track.Source.ScreenShareAudio) {
             attachRemoteAudio(targetUserId, pub.track as unknown as { attach: () => HTMLElement });
@@ -1158,7 +1280,7 @@ export function useScreenShare(
       unregisterPendingViewerAttempt(pendingAttempt);
       endViewerConnectAttempt();
     }
-  }, [activeShares, ensureRoom, addWatchingShare, removeWatchingShare, maybeDisconnectRoom, beginViewerConnectAttempt, endViewerConnectAttempt, registerPendingViewerAttempt, unregisterPendingViewerAttempt, updateShareQuality, attachRemoteAudio]);
+  }, [activeShares, ensureRoom, addWatchingShare, removeWatchingShare, maybeDisconnectRoom, beginViewerConnectAttempt, endViewerConnectAttempt, registerPendingViewerAttempt, unregisterPendingViewerAttempt, updateShareQuality, attachRemoteAudio, applyViewerQuality]);
 
   const disconnectViewer = useCallback(async (userId?: number) => {
     const room = roomRef.current;
@@ -1399,6 +1521,8 @@ export function useScreenShare(
     remoteVideoEls,    // new
     roomQuality,
     shareQualities,
+    viewerQualities,      // new: per-viewer receive-quality overrides
+    setViewerQuality,     // new
     addWatchingShare,      // new
     removeWatchingShare,   // new
     disconnectViewer,

--- a/src/Brmble.Web/src/utils/formatBroadcastSummary.test.ts
+++ b/src/Brmble.Web/src/utils/formatBroadcastSummary.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { formatBroadcastSummary } from './formatBroadcastSummary';
+
+describe('formatBroadcastSummary', () => {
+  it('formats a standard resolution with fps', () => {
+    expect(formatBroadcastSummary('1080p', 30)).toBe('1080p 30fps');
+  });
+
+  it('formats 720p and 1440p unchanged', () => {
+    expect(formatBroadcastSummary('720p', 15)).toBe('720p 15fps');
+    expect(formatBroadcastSummary('1440p', 60)).toBe('1440p 60fps');
+  });
+
+  it('uppercases the 4k label to 4K for display consistency', () => {
+    expect(formatBroadcastSummary('4k', 30)).toBe('4K 30fps');
+  });
+
+  it('falls back to the raw resolution string when unmapped', () => {
+    expect(formatBroadcastSummary('8k', 30)).toBe('8k 30fps');
+  });
+});

--- a/src/Brmble.Web/src/utils/formatBroadcastSummary.ts
+++ b/src/Brmble.Web/src/utils/formatBroadcastSummary.ts
@@ -1,0 +1,19 @@
+/**
+ * Maps stored screen-share resolution values to their display labels.
+ * Only `4k` needs special casing (`4K`); the `<n>p` values display as-is.
+ */
+const RESOLUTION_LABELS: Record<string, string> = {
+  '720p': '720p',
+  '1080p': '1080p',
+  '1440p': '1440p',
+  '4k': '4K',
+};
+
+/**
+ * Formats a broadcast summary string for the sidebar tooltip, e.g. `1080p 30fps`.
+ * Unmapped resolutions fall back to their raw string.
+ */
+export function formatBroadcastSummary(resolution: string, fps: number): string {
+  const label = RESOLUTION_LABELS[resolution] ?? resolution;
+  return `${label} ${fps}fps`;
+}


### PR DESCRIPTION
## Summary

This branch improves LiveKit screenshare quality and observability across three layers:

- **Quality foundation** – simulcast + VP9, viewer-side quality controls, and per-share quality tracking.
- **Live settings apply** – changing screenshare settings mid-broadcast now applies to the active share (live encoder tweaks where possible, re-capture only when resolution/source changes), with viewer self-heal on republish and no spurious start/stop notifications.
- **Sidebar stats tooltip** – the LiveKit status dot's hover tooltip now shows an at-a-glance summary: a Broadcasting: <res> <fps>fps line when sharing, and Watching N share(s) plus a per-share <name>: <W>×<H> (<quality>) line when watching. Uses only data the client already has (no `getStats()`), reuses the shared `<Tooltip>`, and preserves existing Available/Reconnecting/`Connected - <quality>` behavior.

## Design & plan

- Spec: `docs/superpowers/specs/2026-07-16-livekit-sidebar-stats-tooltip-design.md`
- Plan: `docs/superpowers/plans/2026-07-16-livekit-sidebar-stats-tooltip.md`

## Implementation notes

- New pure helper `buildLiveKitTooltip` (inputs → string) makes the multi-line tooltip logic exhaustively unit-testable; `Sidebar` is a thin adapter and `App.tsx` threads the data.
- Per-share resolution is read live from the remote `<video>` element's `videoWidth`/`videoHeight`; per-share quality word comes from `shareQualities`.
- New `formatBroadcastSummary` util displays `4k` as `4K` for label consistency.

## Testing

- Frontend suite: **959 tests pass** (added 16 helper + 4 Sidebar + 4 broadcast-summary + Option A tests).
- `npm run build` clean (tsc + vite). No new lint issues introduced by these changes.

## Notes

- Local-only Docker UDP port tweaks (`docker-local/docker-compose.yml`, `src/Brmble.Server/docker/livekit.yaml`) are intentionally **excluded** from this branch.