### PR TITLE
fix: pin SQLitePCLRaw to 2.1.12 to resolve GHSA-2m69-gcr7-jv3q

### DIFF
--- a/src/Brmble.Client/Brmble.Client.csproj
+++ b/src/Brmble.Client/Brmble.Client.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+    <!-- Pin patched SQLitePCLRaw to resolve GHSA-2m69-gcr7-jv3q (transitive via Microsoft.Data.Sqlite) -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3800.47" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Velopack" Version="0.0.1298" />

--- a/src/Brmble.Server/Brmble.Server.csproj
+++ b/src/Brmble.Server/Brmble.Server.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Livekit.Server.Sdk.Dotnet" Version="1.2.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.3" />
+    <!-- Pin patched SQLitePCLRaw to resolve GHSA-2m69-gcr7-jv3q (transitive via Microsoft.Data.Sqlite) -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
     <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="all" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
     <PackageReference Include="ZeroC.Ice" Version="3.8.0" />


### PR DESCRIPTION
## Summary
Resolves NU1903 high-severity vulnerability warning (GHSA-2m69-gcr7-jv3q) surfaced when running the client.

## Cause
Microsoft.Data.Sqlite 10.0.5 transitively pulls in SQLitePCLRaw.lib.e_sqlite3 2.1.11, which ships the vulnerable native SQLite binary.

## Fix
Added a direct pin to SQLitePCLRaw.bundle_e_sqlite3 2.1.12 in `Brmble.Client.csproj`. This promotes the package to a direct reference, so NuGet unifies the entire SQLitePCLRaw family (including the leaf `lib.e_sqlite3`) to the patched 2.1.12. Stays within the same 2.1.x line for ABI compatibility with `Microsoft.Data.Sqlite` 10.0.5.

## Verification
- `dotnet list ... --include-transitive` now shows `SQLitePCLRaw.lib.e_sqlite3 2.1.12`
- NU1903 warning no longer appears on restore

## Note
This manual pin can be removed once `Microsoft.Data.Sqlite` is upgraded to a version that references a patched SQLitePCLRaw natively (comment added in csproj to flag this).