### PR TITLE
feat: prevent running the client twice (single instance)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ The MSBuild target `CopyWebDist` copies `src/Brmble.Web/dist/` to the output `we
 
 - Brmble.Client is a raw Win32 + WebView2 app (no WPF/WinForms). There is no SynchronizationContext, so any non-WebView2 `await` in `InitWebView2Async` will break thread affinity and cause `Navigate()` to silently fail. Keep all non-WebView2 async work outside that method (e.g. synchronous calls in `Main`).
 
+- **Single instance:** `Main` holds a named mutex (`Local\Brmble.SingleInstance`). A second launch focuses the running window (`FindWindow` on class `BrmbleWindow`) and exits. To run a second copy anyway — e.g. a dev build next to an installed one — pass `--allow-multiple` (`dotnet run --project src/Brmble.Client -- --allow-multiple`) or set env `BRMBLE_ALLOW_MULTIPLE=1`.
+
 ## Bridge Architecture
 
 The client uses a modular C# ↔ JavaScript bridge:

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -31,6 +31,7 @@ static class Program
     private static CompanionOverlayRelay? _overlayRelay;
     private static CompanionOverlayHost? _overlayHost;
     private static IntPtr _hwnd;
+    private static System.Threading.Mutex? _instanceMutex;
     private static volatile bool _muted;
     private static volatile bool _deafened;
     private static volatile string? _closeAction; // null = ask, "minimize", "quit"
@@ -68,7 +69,7 @@ static class Program
     }
 
     [STAThread]
-    static void Main()
+    static void Main(string[] args)
     {
         // Unhandled-exception trap for diagnosis. WinExe has no console; without
         // this hook a crashing background thread leaves no trace beyond exit
@@ -98,7 +99,34 @@ static class Program
 
         try
         {
+            // Must run before anything else: on install/update/uninstall,
+            // Velopack relaunches this exe with --veloapp-* args that Run()
+            // handles and then exits. Placing the single-instance check ahead of
+            // it would hijack those hook invocations.
             VelopackApp.Build().Run();
+
+            // Single instance: a second launch focuses the running window and
+            // exits. Pass --allow-multiple (or set BRMBLE_ALLOW_MULTIPLE=1) to
+            // bypass — handy for running a dev build alongside an installed copy.
+            // Mutex is a static field held for the process lifetime; the OS
+            // releases it on exit.
+            bool allowMultiple = args.Contains("--allow-multiple")
+                || Environment.GetEnvironmentVariable("BRMBLE_ALLOW_MULTIPLE") == "1";
+            if (!allowMultiple)
+            {
+                _instanceMutex = new System.Threading.Mutex(true, @"Local\Brmble.SingleInstance", out bool isNew);
+                if (!isNew)
+                {
+                    var existing = Win32Window.FindWindow("BrmbleWindow", null);
+                    if (existing != IntPtr.Zero)
+                    {
+                        Win32Window.ShowWindow(existing, Win32Window.SW_RESTORE);
+                        Win32Window.SetForegroundWindow(existing);
+                    }
+                    return;
+                }
+            }
+
             DevLog.Init();
 
             Win32Window.SetAppUserModelId(AppIdentity.AppUserModelId);

--- a/src/Brmble.Client/Win32Window.cs
+++ b/src/Brmble.Client/Win32Window.cs
@@ -238,6 +238,9 @@ internal static class Win32Window
     [DllImport("user32.dll")]
     public static extern bool SetForegroundWindow(IntPtr hwnd);
 
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern IntPtr FindWindow(string? lpClassName, string? lpWindowName);
+
     [DllImport("user32.dll")]
     public static extern bool ReleaseCapture();
 


### PR DESCRIPTION
## Summary

The client could be launched multiple times, each copy fighting over the same window, tray icon and voice connection. This adds a single-instance guard: a second launch now focuses the already-running window and exits.

- `Main` holds a named mutex (`Local\Brmble.SingleInstance`). If it already exists, `FindWindow` on the `BrmbleWindow` class restores + foregrounds the running instance, then the second process returns.
- The check is placed **after** `VelopackApp.Build().Run()`. Velopack relaunches the exe with `--veloapp-*` args during install/update/uninstall; putting the guard ahead of `Run()` would hijack those hook invocations.
- The mutex is a static field, so it stays rooted for the process lifetime; the OS releases it on exit.

## Dev escape hatch

To run a second copy anyway — e.g. a dev build next to an installed one:

```bash
dotnet run --project src/Brmble.Client -- --allow-multiple
# or
BRMBLE_ALLOW_MULTIPLE=1
```

Documented in `CLAUDE.md` under Architecture Notes.

## Notes

`FindWindow` also finds hidden windows, so the close-to-tray case works: `SW_RESTORE` both shows and activates a window hidden via `SW_HIDE`.

Deliberately not handled (inherent to mutex-based single instance, benign):
- A second launch during the first instance's startup/shutdown window exits silently without focusing anything.
- A tray-hidden window that was maximized returns as "normal" — identical to the existing tray double-click path, so no regression.

## Test plan

- [x] `dotnet build` — 0 errors
- [ ] Launch the client, launch it again → second launch focuses the first window and exits
- [ ] Minimize to tray, launch again → window returns from the tray
- [ ] `dotnet run --project src/Brmble.Client -- --allow-multiple` alongside a running instance → both run

🤖 Generated with [Claude Code](https://claude.com/claude-code)