### PR TITLE
fix: fresh install breaks after first connect (null settings sections)

### DIFF
--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -360,7 +360,17 @@ static class Program
         }
         catch (Exception ex)
         {
+            // A failure here leaves the window blank (Navigate never runs) and
+            // Debug.WriteLine is invisible in a WinExe — persist to the same
+            // file the unhandled-exception hooks in Main use.
             Debug.WriteLine($"[ERROR] InitWebView2Async: {ex}");
+            try
+            {
+                File.AppendAllText(
+                    Path.Combine(Path.GetTempPath(), "brmble-tls.log"),
+                    $"[{DateTime.Now:HH:mm:ss.fff}] InitWebView2Async FAILED (window will stay blank): {ex}\n\n");
+            }
+            catch { /* logging is best-effort */ }
         }
     }
 

--- a/src/Brmble.Client/Services/AppConfig/AppSettings.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppSettings.cs
@@ -67,10 +67,10 @@ public record ScreenShareSettings(
 );
 
 public record AppSettings(
-    AudioSettings Audio,
-    ShortcutsSettings Shortcuts,
-    MessagesSettings Messages,
-    OverlaySettings Overlay,
+    AudioSettings? Audio = null,
+    ShortcutsSettings? Shortcuts = null,
+    MessagesSettings? Messages = null,
+    OverlaySettings? Overlay = null,
     NoiseSuppressionSettings? NoiseSuppression = null,
     bool AutoConnectEnabled = false,
     string? AutoConnectServerId = null,
@@ -80,6 +80,13 @@ public record AppSettings(
     ScreenShareSettings? ScreenShare = null
 )
 {
+    // JSON from the frontend (settings.set) or an older config.json may omit
+    // entire sections or carry explicit nulls; never expose a null section.
+    public AudioSettings Audio { get; init; } = Audio ?? new AudioSettings();
+    public ShortcutsSettings Shortcuts { get; init; } = Shortcuts ?? new ShortcutsSettings();
+    public MessagesSettings Messages { get; init; } = Messages ?? new MessagesSettings();
+    public OverlaySettings Overlay { get; init; } = Overlay ?? new OverlaySettings();
+
     public NoiseSuppressionSettings NoiseSuppression { get; init; } = NoiseSuppression ?? new NoiseSuppressionSettings();
     public AppearanceSettings Appearance { get; init; } = Appearance ?? new AppearanceSettings();
     public ScreenShareSettings ScreenShare { get; init; } = ScreenShare ?? new ScreenShareSettings();

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -309,27 +309,30 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         _intentionalDisconnect = false;
         _rejected = false;
 
-        // Recreate audio manager if disposed by a previous Disconnect()
-        if (_audioManager == null)
-        {
-            _audioManager = new AudioManager(_hwnd);
-            WireAudioManagerBridgeEvents();
-        }
-
-        // InputRouter is app-lifetime; only the AudioManager-dependent
-        // subscription needs re-wiring when AudioManager was recreated.
-        // Reapply settings so the fresh AudioManager gets the user's
-        // transmission mode (otherwise it stays on its default Continuous
-        // mode and ServerSync's mic-start path leaves the mic running).
-        if (_inputRouter != null)
-        {
-            WireAudioManagerToInputRouter();
-            var settings = _appConfigService?.GetSettings();
-            if (settings != null) ApplySettings(settings);
-        }
-
+        // Everything below runs inside the try: an unexpected exception in
+        // setup (e.g. ApplySettings) must surface as voice.error instead of
+        // leaving the UI stuck on "Connecting" forever.
         try
         {
+            // Recreate audio manager if disposed by a previous Disconnect()
+            if (_audioManager == null)
+            {
+                _audioManager = new AudioManager(_hwnd);
+                WireAudioManagerBridgeEvents();
+            }
+
+            // InputRouter is app-lifetime; only the AudioManager-dependent
+            // subscription needs re-wiring when AudioManager was recreated.
+            // Reapply settings so the fresh AudioManager gets the user's
+            // transmission mode (otherwise it stays on its default Continuous
+            // mode and ServerSync's mic-start path leaves the mic running).
+            if (_inputRouter != null)
+            {
+                WireAudioManagerToInputRouter();
+                var settings = _appConfigService?.GetSettings();
+                if (settings != null) ApplySettings(settings);
+            }
+
             SendSystemMessage($"Connecting to {host}:{port}...", "connecting");
             _bridge?.NotifyUiThread();
 

--- a/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AppConfigServiceTests.cs
@@ -166,6 +166,51 @@ public class AppConfigServiceTests
     }
 
     [TestMethod]
+    public void LoadsConfigWithNullSettingsSections_FallsBackToDefaults()
+    {
+        // A fresh install's OnboardingWizard sends settings.set without
+        // shortcuts/messages/overlay, which used to be persisted as null
+        // and crash MumbleAdapter.ApplySettings on the next launch.
+        var configPath = Path.Combine(_tempDir, "config.json");
+        File.WriteAllText(configPath, """
+            {
+              "servers": [],
+              "settings": {
+                "audio": null,
+                "shortcuts": null,
+                "messages": null,
+                "overlay": null,
+                "appearance": { "theme": "classic" }
+              }
+            }
+            """);
+
+        var svc = new AppConfigService(_tempDir, null);
+        var settings = svc.GetSettings();
+
+        Assert.IsNotNull(settings.Audio);
+        Assert.IsNotNull(settings.Shortcuts);
+        Assert.IsNotNull(settings.Messages);
+        Assert.IsNotNull(settings.Overlay);
+    }
+
+    [TestMethod]
+    public void DeserializesPartialSettingsPayload_FallsBackToDefaults()
+    {
+        // Mirrors the settings.set bridge handler: the frontend may send a
+        // settings object that omits entire sections.
+        var settings = JsonSerializer.Deserialize<AppSettings>(
+            """{ "appearance": { "theme": "classic" }, "reconnectEnabled": true }""",
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        Assert.IsNotNull(settings);
+        Assert.IsNotNull(settings.Audio);
+        Assert.IsNotNull(settings.Shortcuts);
+        Assert.IsNotNull(settings.Messages);
+        Assert.IsNotNull(settings.Overlay);
+    }
+
+    [TestMethod]
     public void SavesAndReloads_Servers()
     {
         var svc = new AppConfigService(_tempDir, null);


### PR DESCRIPTION
## Problem

On a fresh install, the first connect attempt hangs on "Connecting" forever. After restarting the app, the window stays permanently blank (the WebView never loads the UI). Reproducible on any machine by wiping app state and reinstalling 0.4.

## Root cause

The OnboardingWizard (fresh installs only) sends `settings.set` with a settings object that omits the `shortcuts`, `messages`, and `overlay` sections. The bridge handler deserializes that payload straight into `AppSettings`, so those sections become `null` and are persisted as `null` in `config.json`.

`MumbleAdapter.ApplySettings` then dereferences `settings.Shortcuts.ToggleMuteKey` and throws a `NullReferenceException`:

- **During the first connect**: `Connect()` re-applies settings just before establishing the connection. The NRE aborted the attempt before any `voice.error` was emitted, leaving the UI stuck on "Connecting".
- **On every subsequent launch**: `ApplySettings` runs inside `InitWebView2Async`, whose catch only did `Debug.WriteLine` (invisible in a WinExe). The exception was swallowed, `Navigate()` never ran, and the window stayed blank.

Upgraded installs were unaffected because they never run the wizard and their config already has the sections populated. The code path is identical back to at least v0.3.1, so this is a fresh-install bug rather than a 0.4 regression.

## Fix

- `AppSettings`: guard `Audio`/`Shortcuts`/`Messages`/`Overlay` with the same null-coalescing init pattern already used for `NoiseSuppression`/`Appearance`/`ScreenShare`. Partial payloads and already-broken config files heal on load.
- `MumbleAdapter.Connect`: move AudioManager recreation and the settings re-apply inside the try block, so unexpected setup exceptions surface as `voice.error` + disconnect instead of a silent hang.
- `InitWebView2Async`: persist failures to `%TEMP%/brmble-tls.log` (the file the unhandled-exception hooks in `Main` already use), since a failure there leaves the window blank with no trace.

## Tests

- New: config.json with explicit `null` sections loads with defaults (mirrors the broken config from the field).
- New: partial `settings.set`-shaped payload deserializes with defaults.
- All 249 client tests pass.
- Verified end-to-end: a dev build launched against a real broken config (with `"shortcuts": null`) now loads the UI normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)