### PR TITLE
fix: screen share quality dropdown, content type persistence, and live resolution changes

### DIFF
--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -498,7 +498,7 @@ div.brmble-select-dropdown[role="listbox"]
 
 Rules:
 1. **Always use `<Select>` instead of native `<select>`** -- native selects don't respect theme tokens
-2. Dropdown renders via portal (`document.body`) to escape overflow containers -- follows the same pattern as ContextMenu and Tooltip
+2. Dropdown renders via portal (`document.body`, or the active `document.fullscreenElement` when one is present so it stays visible over a fullscreen screen-share tile) to escape overflow containers -- follows the same pattern as ContextMenu and Tooltip
 3. Position auto-flips above trigger if there isn't enough space below
 4. Clicking outside or pressing Escape dismisses the dropdown
 5. Full ARIA: `role="combobox"` on trigger, `role="listbox"` on dropdown, `role="option"` on items, `aria-expanded`, `aria-activedescendant`
@@ -515,7 +515,7 @@ Watched screen-share tiles expose viewer-side controls in the top-right `--contr
 
 Rules:
 1. **Reuse `<Select>`** for the quality dropdown — never a native select. Its portal dropdown escapes the tile's overflow, so it renders correctly inside the overlay.
-2. **Stop click propagation**: wrap the `<Select>` in `.screen-share-tile-quality-select-wrapper` with `onClick={(e) => e.stopPropagation()}` so opening the dropdown doesn't toggle tile focus.
+2. **Stop click propagation**: wrap the `<Select>` in `.screen-share-tile-quality-select-wrapper` with `onClick={(e) => e.stopPropagation()}` so opening the dropdown doesn't toggle tile focus. Wrap that wrapper in a `<Tooltip>` explaining the control (viewers otherwise can't tell it controls *received* quality).
 3. **Controls are viewer-only**: broadcaster encode settings (resolution, FPS, content type) live in the Screen Share settings tab, not on the tile.
 4. Quality maps to LiveKit `RemoteTrackPublication.setVideoQuality`; `Auto` pins to HIGH and lets adaptive stream pick the best simulcast layer. Only render the control when an `onViewerQualityChange` handler is supplied.
 5. All spacing/sizing uses tokens (`--space-*`, `--radius-*`) — no hardcoded values.

--- a/src/Brmble.Client/Services/AppConfig/AppSettings.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppSettings.cs
@@ -63,7 +63,8 @@ public record ScreenShareSettings(
     int Fps = 30,
     bool SystemAudio = false,
     string ViewerMode = "in-app",
-    string PreferredCaptureSource = "window"
+    string PreferredCaptureSource = "window",
+    string ContentType = "motion"
 );
 
 public record AppSettings(

--- a/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.tsx
+++ b/src/Brmble.Web/src/components/ScreenShareGrid/ScreenShareTile.tsx
@@ -129,18 +129,20 @@ export function ScreenShareTile({ videoEl, sharerName, isFocused, isThumbnail, q
       {!isThumbnail && (
         <div className="screen-share-tile-overlay screen-share-tile-overlay--controls">
           {onViewerQualityChange && (
-            <div
-              className="screen-share-tile-quality-select-wrapper"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Select
-                className="screen-share-tile-quality-select"
-                ariaLabel="Receive quality"
-                value={viewerQuality}
-                onChange={(value) => onViewerQualityChange(value as ViewerQuality)}
-                options={VIEWER_QUALITY_OPTIONS}
-              />
-            </div>
+            <Tooltip content="Quality of the video you receive. Lower it to save bandwidth; Auto adapts to your connection.">
+              <div
+                className="screen-share-tile-quality-select-wrapper"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Select
+                  className="screen-share-tile-quality-select"
+                  ariaLabel="Receive quality"
+                  value={viewerQuality}
+                  onChange={(value) => onViewerQualityChange(value as ViewerQuality)}
+                  options={VIEWER_QUALITY_OPTIONS}
+                />
+              </div>
+            </Tooltip>
           )}
           <Tooltip content={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}>
             <button

--- a/src/Brmble.Web/src/components/Select/Select.tsx
+++ b/src/Brmble.Web/src/components/Select/Select.tsx
@@ -224,11 +224,13 @@ export function Select({ value, onChange, options, disabled, className, placehol
             );
           })}
         </div>,
-        // Portal into the active fullscreen element when present; portaling to
-        // document.body would render the menu outside the fullscreen top layer,
-        // making it invisible/unclickable (e.g. the viewer quality dropdown on a
-        // maximized screen-share tile).
-        document.fullscreenElement ?? document.body
+        // Portal into the active fullscreen element only when it actually contains this
+        // Select; portaling to document.body would render the menu outside the fullscreen
+        // top layer (invisible/unclickable), while portaling into an unrelated fullscreen
+        // element would misplace it. Falls back to document.body otherwise.
+        (document.fullscreenElement?.contains(triggerRef.current)
+          ? document.fullscreenElement
+          : document.body)
       )}
     </div>
   );

--- a/src/Brmble.Web/src/components/Select/Select.tsx
+++ b/src/Brmble.Web/src/components/Select/Select.tsx
@@ -224,7 +224,11 @@ export function Select({ value, onChange, options, disabled, className, placehol
             );
           })}
         </div>,
-        document.body
+        // Portal into the active fullscreen element when present; portaling to
+        // document.body would render the menu outside the fullscreen top layer,
+        // making it invisible/unclickable (e.g. the viewer quality dropdown on a
+        // maximized screen-share tile).
+        document.fullscreenElement ?? document.body
       )}
     </div>
   );

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -10,7 +10,7 @@ let mockRoomConstructionCount = 0;
 const mockRoomInstances: Array<{ connect: ReturnType<typeof vi.fn> }> = [];
 
 let senderEncodings: Array<{ maxBitrate?: number; maxFramerate?: number }> = [{}];
-const mockScreenShareMediaStreamTrack = { contentHint: '' };
+const mockScreenShareMediaStreamTrack = { contentHint: '', applyConstraints: vi.fn().mockResolvedValue(undefined) };
 const mockScreenShareSender = {
   getParameters: vi.fn(() => ({ encodings: senderEncodings, degradationPreference: undefined as string | undefined })),
   setParameters: vi.fn().mockResolvedValue(undefined),
@@ -162,6 +162,7 @@ describe('useScreenShare', () => {
     mockRoomInstances.length = 0;
     senderEncodings = [{}];
     mockScreenShareMediaStreamTrack.contentHint = '';
+    mockScreenShareMediaStreamTrack.applyConstraints.mockClear();
   });
 
   afterEach(() => {
@@ -3617,8 +3618,9 @@ describe('useScreenShare', () => {
       expect(view.result.current.isSharing).toBe(true);
     });
 
-    it('re-captures the active share on resolution change without emitting shareStopped/shareStarted', async () => {
+    it('live-applies a resolution change to the active track without re-capturing or re-prompting the picker', async () => {
       vi.useFakeTimers();
+      senderEncodings = [{ maxBitrate: 6_000_000 }];
       const view = await startActiveShare(baseSettings);
 
       await act(async () => {
@@ -3628,13 +3630,18 @@ describe('useScreenShare', () => {
         await vi.advanceTimersByTimeAsync(1000);
       });
 
-      // Re-capture: unpublish then republish with the new options.
-      expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(false);
-      expect(mockRoom.localParticipant.setScreenShareEnabled).toHaveBeenCalledWith(
-        true,
-        expect.objectContaining({ resolution: { width: 3840, height: 2160, frameRate: 30 } }),
-        expect.objectContaining({ videoEncoding: { maxBitrate: 18_000_000, maxFramerate: 30 } }),
+      // No re-capture: setScreenShareEnabled must not be toggled off/on (no getDisplayMedia picker).
+      expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalled();
+      // Constrained the existing capture in place.
+      expect(mockScreenShareMediaStreamTrack.applyConstraints).toHaveBeenCalledWith(
+        expect.objectContaining({
+          width: { ideal: 3840 },
+          height: { ideal: 2160 },
+          frameRate: { ideal: 30 },
+        }),
       );
+      // Top-layer bitrate ceiling raised to the 4k target.
+      expect(senderEncodings[0].maxBitrate).toBe(18_000_000);
       // Silent to viewers: no bridge stop/start events (no "Share ended" notification).
       const sends = (bridge.send as ReturnType<typeof vi.fn>).mock.calls.map(([type]) => type);
       expect(sends).not.toContain('livekit.shareStopped');

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -123,16 +123,19 @@ const buildScreenShareOptions = (settings: ScreenShareSettings): {
   return { captureOptions, publishOptions };
 };
 
-/** Settings whose changes require a fresh getDisplayMedia capture (picker prompt). */
+/**
+ * Settings whose changes require a fresh getDisplayMedia capture (picker prompt).
+ * Resolution is deliberately NOT here — it is applied live via track.applyConstraints
+ * so viewers keep watching and the broadcaster is never re-prompted for a source.
+ */
 const screenShareNeedsRecapture = (prev: ScreenShareSettings, next: ScreenShareSettings): boolean =>
-  prev.resolution !== next.resolution ||
   prev.preferredCaptureSource !== next.preferredCaptureSource ||
   prev.captureAudio !== next.captureAudio ||
   prev.systemAudio !== next.systemAudio;
 
 /** Settings whose changes can be applied to the live track without re-capturing. */
 const screenShareNeedsLiveApply = (prev: ScreenShareSettings, next: ScreenShareSettings): boolean =>
-  prev.contentType !== next.contentType || prev.fps !== next.fps;
+  prev.contentType !== next.contentType || prev.fps !== next.fps || prev.resolution !== next.resolution;
 
 
 export type LocalShareStopReason = 'manual' | 'source-closed' | 'interrupted' | 'error' | 'blocked-capture' | 'moved-channel';
@@ -1260,15 +1263,35 @@ export function useScreenShare(
     }
     if (track.mediaStreamTrack) {
       try { track.mediaStreamTrack.contentHint = screenShareContentHint(settings); } catch { /* ignore */ }
+      // Resolution/fps change: constrain the existing capture in place. Bounded by the
+      // source's native resolution (can't upscale beyond what the display provides), but
+      // never re-prompts the picker and viewers keep watching the same track.
+      const res = SCREEN_SHARE_RESOLUTION_MAP[settings.resolution];
+      if (res) {
+        try {
+          void track.mediaStreamTrack.applyConstraints({
+            width: { ideal: res.width },
+            height: { ideal: res.height },
+            frameRate: { ideal: settings.fps },
+          });
+        } catch { /* ignore */ }
+      }
     }
     const sender = track.sender;
     if (sender && typeof sender.getParameters === 'function' && typeof sender.setParameters === 'function') {
       try {
         const params = sender.getParameters();
         params.degradationPreference = screenShareDegradationPreference(settings) as RTCDegradationPreference;
-        if (params.encodings?.length && settings.fps) {
+        const maxBitrate = SCREEN_SHARE_BITRATE_MAP[settings.resolution];
+        if (params.encodings?.length) {
           for (const enc of params.encodings) {
-            enc.maxFramerate = settings.fps;
+            if (settings.fps) {
+              enc.maxFramerate = settings.fps;
+            }
+            // Only raise the top layer's ceiling; leave the low simulcast layer as-is.
+            if (maxBitrate && enc.maxBitrate && enc.maxBitrate > 600_000) {
+              enc.maxBitrate = maxBitrate;
+            }
           }
         }
         void sender.setParameters(params);
@@ -1277,7 +1300,7 @@ export function useScreenShare(
     sendScreenShareDebugEvent('applySettings.liveApplied');
   }, []);
 
-  // Re-acquire the capture (resolution or capture-source changed) by toggling the local
+  // Re-acquire the capture (capture-source or audio changed) by toggling the local
   // screen share off then on with fresh options. Deliberately does NOT send the
   // livekit.shareStopped/shareStarted bridge events, so viewers get no "Share ended"
   // notification — their track briefly unsubscribes then self-heals on resubscribe.

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -1268,13 +1268,15 @@ export function useScreenShare(
       // never re-prompts the picker and viewers keep watching the same track.
       const res = SCREEN_SHARE_RESOLUTION_MAP[settings.resolution];
       if (res) {
-        try {
-          void track.mediaStreamTrack.applyConstraints({
+        // applyConstraints is async; attach .catch so a rejected constraint change
+        // never surfaces as an unhandled promise rejection.
+        void Promise.resolve(
+          track.mediaStreamTrack.applyConstraints({
             width: { ideal: res.width },
             height: { ideal: res.height },
             frameRate: { ideal: settings.fps },
-          });
-        } catch { /* ignore */ }
+          }),
+        ).catch(() => { /* best-effort; resolution steering must never break the share */ });
       }
     }
     const sender = track.sender;
@@ -1288,7 +1290,9 @@ export function useScreenShare(
             if (settings.fps) {
               enc.maxFramerate = settings.fps;
             }
-            // Only raise the top layer's ceiling; leave the low simulcast layer as-is.
+            // Match the top layer's bitrate ceiling to the target resolution (raising it
+            // for larger resolutions, lowering it for smaller ones). The low simulcast
+            // layer (<= 600 kbps) is left untouched.
             if (maxBitrate && enc.maxBitrate && enc.maxBitrate > 600_000) {
               enc.maxBitrate = maxBitrate;
             }

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -1286,16 +1286,21 @@ export function useScreenShare(
         params.degradationPreference = screenShareDegradationPreference(settings) as RTCDegradationPreference;
         const maxBitrate = SCREEN_SHARE_BITRATE_MAP[settings.resolution];
         if (params.encodings?.length) {
+          // Identify the top (highest-bitrate) layer so we only steer its ceiling,
+          // even if a mid simulcast layer is added later. The low layer is left as-is.
+          let topEnc: typeof params.encodings[number] | undefined;
           for (const enc of params.encodings) {
             if (settings.fps) {
               enc.maxFramerate = settings.fps;
             }
-            // Match the top layer's bitrate ceiling to the target resolution (raising it
-            // for larger resolutions, lowering it for smaller ones). The low simulcast
-            // layer (<= 600 kbps) is left untouched.
-            if (maxBitrate && enc.maxBitrate && enc.maxBitrate > 600_000) {
-              enc.maxBitrate = maxBitrate;
+            if (enc.maxBitrate && (!topEnc || (topEnc.maxBitrate ?? 0) < enc.maxBitrate)) {
+              topEnc = enc;
             }
+          }
+          // Match the top layer's bitrate ceiling to the target resolution (raising it
+          // for larger resolutions, lowering it for smaller ones).
+          if (maxBitrate && topEnc?.maxBitrate) {
+            topEnc.maxBitrate = maxBitrate;
           }
         }
         void sender.setParameters(params);


### PR DESCRIPTION
## Summary
Fixes three screen-share bugs found on this branch:

1. **Viewer quality dropdown broken when maximized/fullscreen** — `Select` portaled its menu to `document.body`, which sits outside the fullscreen top layer, making the dropdown invisible/unclickable on a maximized tile. It now portals into `document.fullscreenElement ?? document.body`. Also added a tooltip clarifying that the control adjusts the *received* video quality.
2. **Content Type reverted to Motion** — the C# `ScreenShareSettings` record had no `ContentType` field, so `settings.set` dropped it and the echoed `settings.updated` reset it to the default. Added `ContentType` so it round-trips.
3. **Changing resolution while broadcasting reopened the source picker** — resolution changes were treated as "needs recapture" (`getDisplayMedia` → OS picker). Resolution now applies live via `mediaStreamTrack.applyConstraints` plus a bitrate ceiling bump on the top simulcast layer, so viewers keep watching and the broadcaster is never re-prompted.

## Notes
- `applyConstraints` can only downscale/relax within the source's native capture resolution (browser limitation), but never re-prompts.
- Updated `docs/UI_GUIDE.md` for the tooltip and fullscreen-portal behavior.

## Testing
- Frontend: `useScreenShare.test.ts` — 109 passed (resolution test rewritten to assert live-apply)
- `tsc --noEmit` clean
- C# client build: 0 warnings, 0 errors
- Manually verified all three flows in the running client
