### PR TITLE
fix: compile out bridge logging in Release; make UpdateService IDisposable

### DIFF
--- a/src/Brmble.Client/Bridge/NativeBridge.cs
+++ b/src/Brmble.Client/Bridge/NativeBridge.cs
@@ -219,9 +219,9 @@ public sealed class NativeBridge
 #if DEBUG
     private static readonly object _logLock = new();
 #endif
-    // Conditional: calls (including argument interpolation) are compiled out
-    // of Release builds entirely — no per-message string allocation or disk
-    // I/O in production (#400).
+    // Conditional: call sites (including argument interpolation) are compiled out
+    // whenever the caller is built without the DEBUG symbol defined — no per-message
+    // string allocation or disk I/O in production by default (#400).
     [Conditional("DEBUG")]
     private static void LogBridge(string message)
     {

--- a/src/Brmble.Client/Bridge/NativeBridge.cs
+++ b/src/Brmble.Client/Bridge/NativeBridge.cs
@@ -219,6 +219,10 @@ public sealed class NativeBridge
 #if DEBUG
     private static readonly object _logLock = new();
 #endif
+    // Conditional: calls (including argument interpolation) are compiled out
+    // of Release builds entirely — no per-message string allocation or disk
+    // I/O in production (#400).
+    [Conditional("DEBUG")]
     private static void LogBridge(string message)
     {
         try

--- a/src/Brmble.Client/Services/Update/UpdateService.cs
+++ b/src/Brmble.Client/Services/Update/UpdateService.cs
@@ -9,7 +9,7 @@ namespace Brmble.Client.Services.Update;
 /// Checks for application updates via GitHub Releases using Velopack.
 /// Communicates update availability and progress to the frontend via NativeBridge.
 /// </summary>
-public class UpdateService : IService
+public class UpdateService : IService, IDisposable
 {
     private const string RepoUrl = "https://github.com/brmble/brmble";
     private static readonly TimeSpan CheckInterval = TimeSpan.FromHours(4);


### PR DESCRIPTION
Two small client maintenance fixes.

## #400 — NativeBridge.LogBridge production overhead

`LogBridge` is now `[Conditional("DEBUG")]`: in Release builds the compiler removes every call site including the interpolated message argument, so production does no per-message string allocation, `Debug.WriteLine`, or disk I/O. Debug builds keep the `bridge.log` file logging for diagnosis (valuable in a WinExe with no console).

Fixes #400.

## #401 — UpdateService missing IDisposable

`UpdateService` now declares `IService, IDisposable` — the `Dispose()` method already existed, so `using` statements and DI auto-disposal now work as expected.

Fixes #401.

## Verification

- Release and Debug builds pass
- All 249 client tests pass
- Reviewed with a 4-pass review (plan adherence / architecture / bugs / security): no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)