### PR TITLE
fix: wizard theme selector reflects the actually applied theme

### DIFF
--- a/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -127,13 +127,17 @@ interface WizardSettings {
 
 const SETTINGS_STORAGE_KEY = 'brmble-settings';
 
-function loadInitialSettings(): WizardSettings {
+export function loadInitialSettings(): WizardSettings {
+  // The applied theme lives on <html data-theme> (set by applyTheme, from
+  // either localStorage at boot or the native config via settings.current).
+  // Prefer it over localStorage, which can be stale or missing (#476).
+  const appliedTheme = document.documentElement.getAttribute('data-theme');
   try {
     const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
     if (stored) {
       const parsed = JSON.parse(stored);
       return {
-        theme: parsed.appearance?.theme ?? 'classic',
+        theme: appliedTheme ?? parsed.appearance?.theme ?? 'classic',
         brmblegotchiEnabled: parsed.brmblegotchi?.enabled ?? true,
         inputDevice: parsed.audio?.inputDevice ?? 'default',
         outputDevice: parsed.audio?.outputDevice ?? 'default',
@@ -147,7 +151,7 @@ function loadInitialSettings(): WizardSettings {
     }
   } catch { /* ignore */ }
   return {
-    theme: 'classic',
+    theme: appliedTheme ?? 'classic',
     brmblegotchiEnabled: true,
     inputDevice: 'default',
     outputDevice: 'default',

--- a/src/Brmble.Web/src/components/OnboardingWizard/loadInitialSettings.test.ts
+++ b/src/Brmble.Web/src/components/OnboardingWizard/loadInitialSettings.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadInitialSettings } from './OnboardingWizard';
+
+describe('loadInitialSettings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('prefers the applied data-theme over stale localStorage (#476)', () => {
+    document.documentElement.setAttribute('data-theme', 'midnight');
+    localStorage.setItem('brmble-settings', JSON.stringify({ appearance: { theme: 'classic' } }));
+
+    expect(loadInitialSettings().theme).toBe('midnight');
+  });
+
+  it('uses the applied data-theme when localStorage is empty', () => {
+    document.documentElement.setAttribute('data-theme', 'retro-terminal');
+
+    expect(loadInitialSettings().theme).toBe('retro-terminal');
+  });
+
+  it('falls back to localStorage theme when no data-theme is applied', () => {
+    localStorage.setItem('brmble-settings', JSON.stringify({ appearance: { theme: 'blue-lagoon' } }));
+
+    expect(loadInitialSettings().theme).toBe('blue-lagoon');
+  });
+
+  it('defaults to classic when nothing is stored or applied', () => {
+    expect(loadInitialSettings().theme).toBe('classic');
+  });
+});


### PR DESCRIPTION
## Problem

When onboarding runs on a machine that already has settings (e.g. after a reinstall with localStorage intact), the Interface step's theme dropdown showed Brmble Classic instead of the theme that is actually active.

## Root cause

`loadInitialSettings()` only read `appearance.theme` from localStorage, which can be stale or missing, while the actually applied theme is driven by `applyTheme()` — from localStorage at boot (`main.tsx`) or from the native config via the `settings.current` bridge event.

## Fix

`loadInitialSettings()` now prefers the `data-theme` attribute on `<html>` — maintained by `applyTheme()` regardless of source — and falls back to localStorage, then `classic`.

Fixes #476.

## Notes

- A pre-existing race (the wizard samples the theme once at mount and can write a stale value back on later saves) is tracked separately in #579; this PR narrows that window but intentionally does not restructure the wizard's save flow.

## Verification

- 4 new unit tests for `loadInitialSettings`
- All 965 frontend tests pass
- Reviewed with a 4-pass review (plan adherence / architecture / bugs / security): no in-scope findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)