### PR TITLE
fix: multi-client Debug testing + screenshare icon on connect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ The MSBuild target `CopyWebDist` copies `src/Brmble.Web/dist/` to the output `we
 
 - Brmble.Client is a raw Win32 + WebView2 app (no WPF/WinForms). There is no SynchronizationContext, so any non-WebView2 `await` in `InitWebView2Async` will break thread affinity and cause `Navigate()` to silently fail. Keep all non-WebView2 async work outside that method (e.g. synchronous calls in `Main`).
 
-- **Single instance:** `Main` holds a named mutex (`Local\Brmble.SingleInstance`). A second launch focuses the running window (`FindWindow` on class `BrmbleWindow`) and exits. To run a second copy anyway — e.g. a dev build next to an installed one — pass `--allow-multiple` (`dotnet run --project src/Brmble.Client -- --allow-multiple`) or set env `BRMBLE_ALLOW_MULTIPLE=1`.
+- **Single instance:** `Main` holds a named mutex (`Local\Brmble.SingleInstance`). A second launch focuses the running window (`FindWindow` on class `BrmbleWindow`) and exits. **Debug builds always allow multiple instances** (`#if DEBUG` in `Program.cs`), so a plain `dotnet run --project src/Brmble.Client` can run several clients side by side for local multi-client testing. Release/production builds enforce single-instance. To run a second copy of a Release/installed build — e.g. a dev build next to an installed one — pass `--allow-multiple` (`dotnet run -c Release --project src/Brmble.Client -- --allow-multiple`) or set env `BRMBLE_ALLOW_MULTIPLE=1`.
 
 ## Bridge Architecture
 

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -108,10 +108,15 @@ static class Program
             // Single instance: a second launch focuses the running window and
             // exits. Pass --allow-multiple (or set BRMBLE_ALLOW_MULTIPLE=1) to
             // bypass — handy for running a dev build alongside an installed copy.
+            // Debug builds (dotnet run) always allow multiple so local multi-client
+            // testing is friction-free; Release/production stays single-instance.
             // Mutex is a static field held for the process lifetime; the OS
             // releases it on exit.
             bool allowMultiple = args.Contains("--allow-multiple")
                 || Environment.GetEnvironmentVariable("BRMBLE_ALLOW_MULTIPLE") == "1";
+#if DEBUG
+            allowMultiple = true;
+#endif
             if (!allowMultiple)
             {
                 _instanceMutex = new System.Threading.Mutex(true, @"Local\Brmble.SingleInstance", out bool isNew);

--- a/src/Brmble.Server/Program.cs
+++ b/src/Brmble.Server/Program.cs
@@ -47,21 +47,36 @@ builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
 
-    options.AddFixedWindowLimiter("livekit-token", limiterOptions =>
-    {
-        limiterOptions.PermitLimit = 10;
-        limiterOptions.Window = TimeSpan.FromMinutes(1);
-        limiterOptions.QueueLimit = 0;
-        limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-    });
+    // Per-client partition key so one client's requests can't starve others.
+    // These endpoints require a client certificate; fall back to remote IP.
+    static string LiveKitPartitionKey(HttpContext ctx) =>
+        ctx.Connection.ClientCertificate?.Thumbprint
+        ?? ctx.Connection.RemoteIpAddress?.ToString()
+        ?? "unknown";
 
-    options.AddFixedWindowLimiter("livekit-active-share", limiterOptions =>
-    {
-        limiterOptions.PermitLimit = 30;
-        limiterOptions.Window = TimeSpan.FromMinutes(1);
-        limiterOptions.QueueLimit = 0;
-        limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-    });
+    options.AddPolicy("livekit-token", httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(LiveKitPartitionKey(httpContext), _ =>
+            new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            }));
+
+    // Active-share discovery fires on connect and on every channel switch, so
+    // this must be generous per client. A global limiter here caused 429s that
+    // silently broke the "who is sharing" icon for everyone once the shared
+    // budget was exhausted.
+    options.AddPolicy("livekit-active-share", httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(LiveKitPartitionKey(httpContext), _ =>
+            new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 60,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            }));
 
     options.AddFixedWindowLimiter("channel-request-create", limiterOptions =>
     {

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -816,6 +816,46 @@ describe('active share discovery', () => {
     expect(bridge.send).toHaveBeenCalledWith('livekit.checkActiveShare', expect.objectContaining({ roomName: 'channel-1' }));
   });
 
+  it('does not re-trigger active share discovery on repeated connected statuses without a disconnect', async () => {
+    render(React.createElement(App));
+
+    act(() => {
+      bridge.emit('voice.connected', {
+        username: 'TestUser',
+        channelId: 1,
+        channels: [{ id: 1, name: 'General' }],
+        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(bridge.send).toHaveBeenCalledWith('livekit.checkActiveShare', expect.objectContaining({ roomName: 'channel-1' }));
+    });
+
+    // Establish the 'connected' baseline. The first connected status may
+    // legitimately trigger discovery once (transition into connected).
+    act(() => {
+      bridge.emit('brmble.serviceStatus', { service: 'screenshare', state: 'connected' });
+    });
+
+    vi.mocked(bridge.send).mockClear();
+
+    // The client emits a 'connected' screenshare status on every successful
+    // active-share discovery. Repeated 'connected' statuses (no intervening
+    // disconnect) must NOT re-trigger discovery, otherwise the loop that
+    // exhausted the server rate limit (HTTP 429) reappears.
+    act(() => {
+      bridge.emit('brmble.serviceStatus', { service: 'screenshare', state: 'connected' });
+      bridge.emit('brmble.serviceStatus', { service: 'screenshare', state: 'connected' });
+      bridge.emit('brmble.serviceStatus', { service: 'screenshare', state: 'connected' });
+    });
+
+    const checkActiveShareCalls = vi.mocked(bridge.send).mock.calls.filter(
+      ([type]) => type === 'livekit.checkActiveShare',
+    );
+    expect(checkActiveShareCalls).toHaveLength(0);
+  });
+
   it('does not tear down LiveKit lifecycle when active share discovery fails', () => {
     render(React.createElement(App));
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1310,6 +1310,7 @@ function App() {
   const disconnectViewerRef = useRef<(() => Promise<void>) | null>(null);
   const handleScreenShareServiceUnavailableRef = useRef<(() => Promise<void>) | null>(null);
   const requestActiveShareDiscoveryRef = useRef<((channelId: string | undefined) => void) | null>(null);
+  const previousScreenShareServiceConnectedRef = useRef(false);
   const pendingCompanionRef = useRef<{ requestId: number; next: CompanionId; previous: CompanionId } | null>(null);
   const companionRequestIdRef = useRef(0);
 
@@ -1617,8 +1618,17 @@ function App() {
       if ((status.service === 'session' || status.service === 'screenshare') && mapped.update.state !== 'connected') {
         void handleScreenShareServiceUnavailableRef.current?.();
       }
-      if (status.service === 'screenshare' && status.state === 'connected') {
-        requestActiveShareDiscoveryRef.current?.(currentChannelIdRef.current);
+      if (status.service === 'screenshare') {
+        const nowConnected = status.state === 'connected';
+        const wasConnected = previousScreenShareServiceConnectedRef.current;
+        previousScreenShareServiceConnectedRef.current = nowConnected;
+        // Only run discovery when the screenshare service *transitions* into
+        // connected. Discovery success itself emits a "connected" status, so
+        // re-triggering on every "connected" message caused an infinite
+        // discovery loop that exhausted the server rate limit (HTTP 429).
+        if (nowConnected && !wasConnected) {
+          requestActiveShareDiscoveryRef.current?.(currentChannelIdRef.current);
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- Fix the screenshare icon not appearing for a client that connects while someone is already sharing.
- Enable running multiple client instances in Debug builds for local multi-client testing.

## Screenshare fix (root cause)
The client's `livekit.checkActiveShare` handler emits a `screenshare 'connected'` service status on **every** successful active-share discovery. `App.tsx` re-triggered discovery on every such status, creating an infinite discovery loop that exhausted the server rate limit (HTTP 429). A connecting client whose discovery hit 429 never learned about in-progress shares, so the icon never rendered.

- `App.tsx`: only re-trigger discovery on a **transition** into `connected` (tracked via `previousScreenShareServiceConnectedRef`), breaking the loop.
- `Brmble.Server/Program.cs`: partition the `livekit-token` and `livekit-active-share` rate limiters **per client** (cert thumbprint / remote IP) and raise active-share to 60/min as defense-in-depth.

## Multi-client DX
- `Brmble.Client/Program.cs`: `#if DEBUG` bypass of the single-instance mutex so `dotnet run` can launch several clients side by side. Release/production still enforce single-instance.
- Documented in `CLAUDE.md`.

## Testing
- Rebuilt local docker server; sharer already sharing, second client connects -> icon now appears, discovery fires ~once, no 429.
- `npm run build` and `dotnet build` both clean.