### PR TITLE
chore: upgrade WebView2 SDK to 1.0.4078.44

### DIFF
--- a/src/Brmble.Client/Brmble.Client.csproj
+++ b/src/Brmble.Client/Brmble.Client.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
     <!-- Pin patched SQLitePCLRaw to resolve GHSA-2m69-gcr7-jv3q (transitive via Microsoft.Data.Sqlite) -->
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3800.47" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Bump `Microsoft.Web.WebView2` from `1.0.3800.47` to the latest stable `1.0.4078.44` in `src/Brmble.Client/Brmble.Client.csproj`.
- Isolated, low-risk SDK-only change that unblocks upcoming native screen-share picker work (gains the modern `ScreenCaptureStarting` event surface).

## Why
The SDK is the compile-time API; the browser engine is the evergreen runtime already on user machines. This keeps us on a supported SDK and prepares for replacing the native screen-share picker/HUD with a Brmble-themed picker via native capture.

## Verification
- `dotnet restore` — succeeds (version resolves on NuGet)
- `dotnet build` (client) — clean, 0 warnings / 0 errors; existing WebView2 code (cert handler, permission handler, CompanionOverlayHost) compiles unchanged
- `dotnet test` (Brmble.Client.Tests) — 249 passed, 0 failed
- Manual smoke test: app launches + WebView renders, self-signed cert accepted / server connect works, screen share works (native picker + start), companion overlay shows

## Notes
Pure version bump, no code changes. No API-breaking members were touched.
