### PR TITLE
feat: show Brmble and Mumble users in DM list

### DIFF
--- a/docs/superpowers/specs/pr-594-dm-directory-behavior-requirements.md
+++ b/docs/superpowers/specs/pr-594-dm-directory-behavior-requirements.md
@@ -1,0 +1,303 @@
+# PR #594: Direct Message Directory — Required Behavior
+
+## Purpose of this report
+
+This document describes the intended user experience and behavioral requirements for [Brmble PR #594](https://github.com/brmble/brmble/pull/594).
+
+The pull request is intended to expand the Direct Message sidebar so that users can discover people before a conversation exists. The current change is close to that goal, but it does not consistently distinguish between a person's registered Brmble identity and the client through which that person is currently connected.
+
+This report defines what the feature must do. It intentionally does not prescribe an implementation.
+
+## Core product rule
+
+Two separate facts determine Direct Message behavior:
+
+1. **Account identity determines persistent visibility.** A registered Brmble user has a persistent Matrix identity and should remain discoverable in the **Messages** section, even while offline and even when no previous DM conversation exists.
+2. **The currently connected client determines the live delivery route.** A user connected through the Brmble client can receive a Matrix DM. A user connected through a standard Mumble client must receive an original Mumble private message, even if that person also owns a registered Brmble account.
+
+The presence of a Matrix identity alone must not be treated as proof that the user's current client can receive Matrix messages.
+
+## Goals
+
+The completed feature must:
+
+- Make every registered Brmble user discoverable in the persistent **Messages** directory.
+- Make every eligible user currently connected through a standard Mumble client discoverable under **Mumble users**.
+- Select the delivery transport according to the recipient's currently connected client.
+- Preserve the existing behavior of Matrix DMs, including persistent rooms and history.
+- Preserve the existing behavior of Mumble private messages, including session-based delivery and ephemeral history.
+- Allow a registered Brmble user to appear in both sections when both entries represent valid but different messaging routes.
+- Prevent an online Brmble-client user from being unnecessarily duplicated under **Mumble users**.
+- Ensure that selecting a directory entry and sending the first message works even when no conversation with that entry existed previously.
+- Keep the two types of contacts visually and behaviorally understandable to the sender.
+
+## Non-goals
+
+This work is not intended to:
+
+- Merge Matrix and Mumble messages into one shared conversation.
+- Synchronize Mumble private-message history into Matrix.
+- Make Mumble private messages persistent across a local disconnect.
+- Change how Matrix rooms are created for first-time Brmble DMs.
+- Change the underlying Matrix or Mumble messaging protocols.
+- Assume that owning a Brmble account means the person is currently using the Brmble client.
+- Deduplicate two entries when doing so would hide a valid messaging route.
+
+## Terminology
+
+### Registered Brmble user
+
+A person who has a persistent Brmble/Matrix identity. This identity exists independently of whether the person is online and independently of which client they are currently using.
+
+### Brmble-client connection
+
+An active connection made through the Brmble client. This connection supports the Brmble Matrix DM experience.
+
+### Standard Mumble connection
+
+An active connection made through a non-Brmble Mumble client. This connection supports the original session-based Mumble private-message experience.
+
+A person using a standard Mumble client may still be a registered Brmble user. Registration and active-client capability are separate concepts.
+
+### Persistent Message entry
+
+An entry under **Messages** representing a registered Brmble/Matrix identity. Messages sent through this entry use Matrix and belong to the persistent DM conversation.
+
+### Mumble user entry
+
+An entry under **Mumble users** representing a currently reachable Mumble session. Messages sent through this entry use the original Mumble private-message route and remain ephemeral.
+
+## Authoritative behavior matrix
+
+| Recipient state | Show under Messages | Show under Mumble users | Transport from Messages | Transport from Mumble users |
+| --- | --- | --- | --- | --- |
+| Registered Brmble user, offline | Yes | No | Matrix | Not applicable |
+| Registered Brmble user, online through Brmble client | Yes | No | Matrix | Not applicable |
+| Registered Brmble user, online through standard Mumble client | Yes | Yes | Matrix | Mumble private message |
+| Unregistered user, online through standard Mumble client | No | Yes | Not applicable | Mumble private message |
+| Unregistered Mumble user, offline and with no active ephemeral conversation | No | No | Not applicable | Not applicable |
+| Current local user | No | No | Not applicable | Not applicable |
+
+## Why a registered user may correctly appear twice
+
+When a registered Brmble user is online through a standard Mumble client, two entries are intentional:
+
+- The **Messages** entry represents the person's persistent Brmble identity. Selecting it opens or creates the Matrix DM conversation.
+- The **Mumble users** entry represents the person's currently connected Mumble session. Selecting it starts or opens the ephemeral Mumble private-message conversation.
+
+These are not accidental duplicates. They are two different communication routes with different delivery characteristics and different history behavior.
+
+The UI should preserve that distinction instead of silently deciding that the persistent identity replaces the currently reachable Mumble session.
+
+## Client capability must control live routing
+
+The product must decide how to contact an online user based on the client the recipient is currently using:
+
+- If the recipient is connected through the Brmble client, the Brmble/Matrix route is available.
+- If the recipient is connected through a standard Mumble client, the original Mumble private-message route is the live route.
+
+A standard Mumble connection must continue to behave like a standard Mumble connection even when the username can be associated with a registered Brmble account or Matrix identity.
+
+This is important because a Matrix identity may be known for identification purposes while the recipient's current client is unable to display or receive the Matrix conversation in real time.
+
+## Expected behavior by section
+
+### Messages
+
+The **Messages** section must contain:
+
+- Existing Matrix DM conversations.
+- Registered Brmble users with whom no DM room exists yet.
+- Registered Brmble users who are offline.
+- Registered Brmble users who are currently online through either client type.
+
+Selecting a registered Brmble user must open the person's persistent Matrix conversation. If this is the first message, the Matrix DM room should continue to be created only when the message is sent.
+
+Existing previews, unread state, avatars, names, history, and room behavior should remain intact.
+
+### Mumble users
+
+The **Mumble users** section must contain eligible users who are currently connected through a standard Mumble client, including:
+
+- Users without a Brmble registration.
+- Registered Brmble users who happen to be using a standard Mumble client for the current connection.
+
+It must not contain:
+
+- The current local user.
+- A remote user whose active connection is through the Brmble client.
+- An automatically discovered offline user who has no remaining ephemeral conversation state under the existing Mumble DM behavior.
+
+The Mumble entry must retain the established visual and behavioral cues that it is ephemeral.
+
+## Selecting and messaging a first-time Mumble directory contact
+
+The central new interaction is messaging someone listed under **Mumble users** before any previous private conversation exists.
+
+The complete user flow must be:
+
+1. An eligible standard-Mumble user becomes visible under **Mumble users** while online.
+2. The sender selects that entry.
+3. The DM view clearly identifies the conversation as a Mumble direct message.
+4. The composer is enabled while the recipient has an active session.
+5. Sending the first message uses the recipient's current Mumble session.
+6. The sent message appears in the ephemeral conversation immediately.
+7. No Matrix room request is made for this interaction.
+8. The recipient receives the message through the standard Mumble private-message mechanism.
+
+Displaying the contact without making this flow work is not sufficient. Contact discovery and message delivery are one feature from the user's perspective.
+
+## Selecting the persistent entry for a registered standard-Mumble user
+
+If a registered user is currently connected through standard Mumble, the sender may still deliberately select that person's entry under **Messages**.
+
+That selection must continue to represent the persistent Matrix identity and must use Matrix. It must not silently switch to Mumble merely because the person is currently online through standard Mumble.
+
+The sender chooses the route by choosing the section and entry:
+
+- **Messages entry:** persistent Matrix conversation.
+- **Mumble users entry:** live, ephemeral Mumble conversation.
+
+## Presence and lifecycle expectations
+
+### When a standard-Mumble user connects
+
+- The user should appear under **Mumble users** once the connection is known and is eligible for private messaging.
+- If the person is also registered with Brmble, the existing **Messages** entry remains present.
+
+### When a standard-Mumble user disconnects
+
+- The disconnected session must no longer be treated as a valid send target.
+- The composer must not send to a stale session.
+- Any handling of an already-open ephemeral conversation should preserve the established Mumble DM lifecycle and offline behavior.
+- A directory-only Mumble entry with no retained conversation should no longer appear as an online user.
+
+### When a user reconnects through standard Mumble
+
+- The Mumble entry must use the new active session.
+- Messages must not be sent to the previous session.
+- Existing ephemeral state may resume only to the extent supported by the current product behavior.
+
+### When a user changes from standard Mumble to the Brmble client
+
+- The persistent **Messages** entry remains.
+- The user should no longer be offered as an active standard-Mumble entry once the old Mumble-client session is gone.
+- New communication through the Brmble-client presence should use Matrix.
+
+### When a user changes from the Brmble client to standard Mumble
+
+- The persistent **Messages** entry remains.
+- A separate **Mumble users** entry should appear for the active standard-Mumble session.
+- The Mumble entry must use the ephemeral Mumble route.
+
+### When the local user disconnects
+
+- Ephemeral Mumble conversation state should continue to follow the existing disconnect behavior and must not be presented as persistent history.
+- Persistent Matrix DM identity and room behavior should remain consistent with the existing product lifecycle.
+
+## Display-name and identity expectations
+
+- A persistent entry must be identified by the registered Brmble/Matrix identity.
+- A Mumble entry must represent the active Mumble user and session.
+- A current online display name may be shown where appropriate, but it must not change which transport the entry represents.
+- Two visible entries with the same display name are acceptable when one is the persistent Matrix route and the other is the active Mumble route.
+- The Mumble entry must remain visually distinguishable so the sender understands that its history and delivery behavior differ from the persistent entry.
+
+## Unread and conversation-state expectations
+
+- Existing Matrix unread tracking must remain unchanged.
+- Existing Mumble unread tracking must remain unchanged.
+- Reading one route must not incorrectly clear unread state belonging to the other route.
+- A Matrix conversation and a Mumble conversation for the same person are separate conversations.
+- A message preview from one route must not appear on the other route's entry.
+- Closing or losing an ephemeral Mumble conversation must not remove the person's persistent Brmble entry.
+
+## Search expectations
+
+- Search should match users in both sections.
+- A registered standard-Mumble user may produce two matching results because two valid routes exist.
+- Search results must retain the section and transport distinction.
+- Empty-state copy should refer to users where the directory is being searched, not only to existing conversations.
+
+## Failure conditions the PR must avoid
+
+The completed PR must not allow any of the following:
+
+- A certificate hash or other Mumble contact identifier being submitted as a Matrix user ID.
+- A first-time Mumble directory contact appearing selectable while messages are routed through Matrix.
+- A registered standard-Mumble user being removed from **Mumble users** merely because a Matrix identity is known.
+- A standard-Mumble session being treated as Brmble-capable based only on account registration or username mapping.
+- A message being sent to a stale Mumble session after disconnect or reconnect.
+- A standard-Mumble user being duplicated under **Mumble users** and also routed through Mumble from the **Messages** entry.
+- A Brmble-client user being unnecessarily duplicated as a standard-Mumble contact.
+- Matrix and Mumble histories being combined or confused.
+
+## Required acceptance scenarios
+
+The change should not be considered complete until all of the following behaviors have been verified.
+
+### Scenario 1: Offline registered user with no existing conversation
+
+- The user appears under **Messages**.
+- The user does not appear under **Mumble users**.
+- Selecting the entry opens an empty persistent DM view.
+- Sending the first message follows the Matrix room-creation flow.
+
+### Scenario 2: Online Brmble-client user
+
+- The user appears under **Messages**.
+- The user does not appear under **Mumble users**.
+- Sending from the entry uses Matrix.
+
+### Scenario 3: Online unregistered standard-Mumble user
+
+- The user appears under **Mumble users**.
+- The user does not appear under **Messages**.
+- Selecting the user and sending the first message uses the active Mumble session.
+- No Matrix operation is attempted.
+
+### Scenario 4: Registered user online through standard Mumble
+
+- The user appears under **Messages** as a persistent identity.
+- The user also appears under **Mumble users** as an active Mumble session.
+- Sending from **Messages** uses Matrix.
+- Sending from **Mumble users** uses the Mumble private-message route.
+- The two conversations retain separate histories and unread state.
+
+### Scenario 5: First-time Mumble directory message
+
+- The contact has no previous Mumble conversation state.
+- Selecting the automatically listed contact enables the correct Mumble conversation.
+- The first send succeeds through Mumble.
+- The sent message appears in the ephemeral history.
+- The operation does not attempt to create a Matrix room.
+
+### Scenario 6: Mumble recipient reconnects with a new session
+
+- The contact reflects the new active session.
+- A subsequent message reaches the new session.
+- No message is sent to the stale session.
+
+### Scenario 7: Recipient changes client type
+
+- Moving from standard Mumble to Brmble removes the active Mumble route when the old session ends while retaining the persistent entry.
+- Moving from Brmble to standard Mumble adds the active Mumble route while retaining the persistent entry.
+- Each entry continues to use the transport it represents.
+
+### Scenario 8: Local disconnect
+
+- Ephemeral Mumble history follows the existing clearing behavior.
+- The application does not present ephemeral Mumble history as persistent.
+- Persistent Matrix identity and room data continue to follow existing behavior.
+
+## Definition of done
+
+PR #594 is ready when:
+
+- The sidebar represents persistent identities and active Mumble sessions as separate concepts.
+- Active-client capability, rather than the mere presence of a Matrix identity, determines whether an online user belongs under **Mumble users**.
+- A registered user connected through standard Mumble can intentionally be contacted through either route by selecting the corresponding entry.
+- Every newly listed Mumble contact is fully usable on first selection and first send.
+- Existing Matrix and Mumble behavior remains intact outside the directory expansion.
+- The acceptance scenarios above are covered by behavioral verification, including transport assertions rather than only checking that contacts appear.
+

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -93,7 +93,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     })
     { Timeout = TimeSpan.FromSeconds(5) };
 
-    internal record SessionMappingEntry(string MatrixUserId, string MumbleName, string CompanionId, bool IsBrmbleClient = false);
+    internal record SessionMappingEntry(string MatrixUserId, string MumbleName, string CompanionId, bool IsBrmbleClient = false, string? CertHash = null);
 
     /// <summary>
     /// Parses a JSON object whose keys are session IDs and values contain
@@ -110,10 +110,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 var matrixId = prop.Value.TryGetProperty("matrixUserId", out var m) ? m.GetString() : null;
                 var name = prop.Value.TryGetProperty("mumbleName", out var n) ? n.GetString() : null;
                 var companionId = prop.Value.TryGetProperty("companionId", out var c) ? c.GetString() : "floppy";
+                var certHash = prop.Value.TryGetProperty("certHash", out var h) ? h.GetString() : null;
                 if (matrixId is not null && name is not null && companionId is not null)
                 {
                     var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b) && b.GetBoolean();
-                    result[sid] = new SessionMappingEntry(matrixId, name, companionId, isBrmble);
+                    result[sid] = new SessionMappingEntry(matrixId, name, companionId, isBrmble, certHash);
                 }
             }
         }
@@ -309,27 +310,30 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         _intentionalDisconnect = false;
         _rejected = false;
 
-        // Recreate audio manager if disposed by a previous Disconnect()
-        if (_audioManager == null)
-        {
-            _audioManager = new AudioManager(_hwnd);
-            WireAudioManagerBridgeEvents();
-        }
-
-        // InputRouter is app-lifetime; only the AudioManager-dependent
-        // subscription needs re-wiring when AudioManager was recreated.
-        // Reapply settings so the fresh AudioManager gets the user's
-        // transmission mode (otherwise it stays on its default Continuous
-        // mode and ServerSync's mic-start path leaves the mic running).
-        if (_inputRouter != null)
-        {
-            WireAudioManagerToInputRouter();
-            var settings = _appConfigService?.GetSettings();
-            if (settings != null) ApplySettings(settings);
-        }
-
+        // Everything below runs inside the try: an unexpected exception in
+        // setup (e.g. ApplySettings) must surface as voice.error instead of
+        // leaving the UI stuck on "Connecting" forever.
         try
         {
+            // Recreate audio manager if disposed by a previous Disconnect()
+            if (_audioManager == null)
+            {
+                _audioManager = new AudioManager(_hwnd);
+                WireAudioManagerBridgeEvents();
+            }
+
+            // InputRouter is app-lifetime; only the AudioManager-dependent
+            // subscription needs re-wiring when AudioManager was recreated.
+            // Reapply settings so the fresh AudioManager gets the user's
+            // transmission mode (otherwise it stays on its default Continuous
+            // mode and ServerSync's mic-start path leaves the mic running).
+            if (_inputRouter != null)
+            {
+                WireAudioManagerToInputRouter();
+                var settings = _appConfigService?.GetSettings();
+                if (settings != null) ApplySettings(settings);
+            }
+
             SendSystemMessage($"Connecting to {host}:{port}...", "connecting");
             _bridge?.NotifyUiThread();
 
@@ -2532,6 +2536,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                                 k.Value.MatrixUserId,
                                 k.Value.MumbleName,
                                 k.Value.CompanionId,
+                                k.Value.CertHash,
                                 k.Value.IsBrmbleClient
                             })
                         });
@@ -2543,11 +2548,12 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                     var addMatrixId = root.TryGetProperty("matrixUserId", out var matrixProp) ? matrixProp.GetString() : null;
                     var addName = root.TryGetProperty("mumbleName", out var nameProp) ? nameProp.GetString() : null;
                     var addCompanionId = root.TryGetProperty("companionId", out var companionProp) ? companionProp.GetString() : "floppy";
+                    var addCertHash = root.TryGetProperty("certHash", out var certProp) ? certProp.GetString() : null;
                     var addIsBrmble = root.TryGetProperty("isBrmbleClient", out var brmbleProp) && brmbleProp.GetBoolean();
                     if (addSid > 0 && addMatrixId is not null && addName is not null && addCompanionId is not null)
                     {
-                        _sessionMappings[addSid] = new SessionMappingEntry(addMatrixId, addName, addCompanionId, addIsBrmble);
-                        _bridge?.Send("voice.userMappingUpdated", new { sessionId = addSid, matrixUserId = addMatrixId, mumbleName = addName, companionId = addCompanionId, isBrmbleClient = addIsBrmble, action = "added" });
+                        _sessionMappings[addSid] = new SessionMappingEntry(addMatrixId, addName, addCompanionId, addIsBrmble, addCertHash);
+                        _bridge?.Send("voice.userMappingUpdated", new { sessionId = addSid, matrixUserId = addMatrixId, mumbleName = addName, companionId = addCompanionId, certHash = addCertHash, isBrmbleClient = addIsBrmble, action = "added" });
                         _bridge?.NotifyUiThread();
                     }
                     break;
@@ -3395,13 +3401,18 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             {
                 var baseUri = new Uri(_apiUrl, UriKind.Absolute);
                 var uri = new Uri(baseUri, "livekit/share-started");
+                LogToFile($"[LiveKit] share-started notification begin: room={roomName}, uri={uri}");
                 var result = await PostViaBcTls(cert, uri, System.Text.Json.JsonSerializer.Serialize(new { roomName }));
                 if (result.Success)
+                {
+                    LogToFile($"[LiveKit] share-started notification succeeded: room={roomName}");
                     SendBrmbleServiceStatus("screenshare", "connected");
+                }
                 else
+                {
                     SendBrmbleServiceStatus("screenshare", "disconnected", reason: "share-started-failed");
-                if (!result.Success)
                     LogToFile($"[LiveKit] share-started notification failed: {result.Error}");
+                }
             }
             catch (Exception ex)
             {
@@ -4021,7 +4032,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 deafened = u.Deaf || u.SelfDeaf,
                 self = u == LocalUser,
                 comment = u.Comment,
-                certHash = u.CertificateHash,
+                certHash = u.CertificateHash ?? (hasMap ? sm!.CertHash : null),
                 matrixUserId = hasMap ? sm!.MatrixUserId : _userMappings.GetValueOrDefault(u.Name),
                 companionId = hasMap ? sm!.CompanionId : null,
                 isBrmbleClient = hasMap && sm!.IsBrmbleClient
@@ -4145,7 +4156,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             deafened = user != null ? (user.Deaf || user.SelfDeaf) : (userState.Deaf || userState.SelfDeaf),
             self = isSelf,
             comment = user?.Comment,
-            certHash = user?.CertificateHash,
+            certHash = user?.CertificateHash ?? (hasJoinMapping ? joinMapping!.CertHash : null),
             matrixUserId = hasJoinMapping ? joinMapping!.MatrixUserId : _userMappings.GetValueOrDefault(joinedUserName),
             companionId = hasJoinMapping ? joinMapping!.CompanionId : null,
             isBrmbleClient = hasJoinMapping && joinMapping!.IsBrmbleClient

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -88,6 +88,7 @@ public static class AuthEndpoints
                 var companionId = await userRepository.GetCompanionId(result.UserId);
                 if (sessionMapping.TryAddMatrixUser(sid, result.MatrixUserId, resolvedName, result.UserId, companionId))
                 {
+                    sessionMapping.TryUpdateCertHash(sid, certHash);
                     // This user just authenticated via Brmble, so mark them as a Brmble client
                     // immediately. Authenticate() may have failed to update the mapping if
                     // TryAddMatrixUser hadn't been called yet (race with SessionMappingHandler).
@@ -99,6 +100,7 @@ public static class AuthEndpoints
                         matrixUserId = result.MatrixUserId,
                         mumbleName = resolvedName,
                         companionId,
+                        certHash,
                         isBrmbleClient = true
                     });
                 }
@@ -108,6 +110,7 @@ public static class AuthEndpoints
                     // Ensure Brmble status is up to date — Authenticate() sets _activeSessions
                     // but TryUpdateBrmbleStatus may not have been called if the mapping
                     // was created before auth completed.
+                    sessionMapping.TryUpdateCertHash(sid, certHash);
                     sessionMapping.TryUpdateBrmbleStatus(sid, true);
                 }
             }
@@ -173,6 +176,7 @@ public static class AuthEndpoints
                             matrixUserId = kvp.Value.MatrixUserId,
                             mumbleName = kvp.Value.MumbleName,
                             companionId = kvp.Value.CompanionId,
+                            certHash = kvp.Value.CertHash,
                             isBrmbleClient = kvp.Value.IsBrmbleClient
                         }),
                 registered = result.IsRegistered,

--- a/src/Brmble.Server/Auth/AuthService.cs
+++ b/src/Brmble.Server/Auth/AuthService.cs
@@ -25,6 +25,7 @@ public interface IActiveBrmbleSessions
     bool IsBrmbleClientByName(string mumbleName);
     void TrackMumbleName(string mumbleName, string? certHash = null, bool active = false);
     void UntrackMumbleName(string mumbleName);
+    void Deactivate(string certHash);
 }
 
 public class AuthService : IActiveBrmbleSessions

--- a/src/Brmble.Server/Events/BrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/BrmbleEventBus.cs
@@ -27,6 +27,8 @@ public class BrmbleEventBus : IBrmbleEventBus
 
     public void RemoveClient(WebSocket ws) => _clients.TryRemove(ws, out _);
 
+    public bool HasConnectedClient(long userId) => _clients.Values.Any(id => id == userId);
+
     public async Task BroadcastAsync(object message)
     {
         var json = JsonSerializer.Serialize(message, JsonOptions);

--- a/src/Brmble.Server/Events/IBrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/IBrmbleEventBus.cs
@@ -6,6 +6,7 @@ public interface IBrmbleEventBus
 {
     void AddClient(WebSocket ws, long userId);
     void RemoveClient(WebSocket ws);
+    bool HasConnectedClient(long userId);
     Task BroadcastAsync(object message);
     Task BroadcastToChannelAsync(int channelId, object message);
     Task<IReadOnlySet<long>> GetConnectedUserIdsAsync();

--- a/src/Brmble.Server/Events/ISessionMappingService.cs
+++ b/src/Brmble.Server/Events/ISessionMappingService.cs
@@ -1,6 +1,6 @@
 namespace Brmble.Server.Events;
 
-public record SessionMapping(string MatrixUserId, string MumbleName, long UserId, string CompanionId, bool IsBrmbleClient = false);
+public record SessionMapping(string MatrixUserId, string MumbleName, long UserId, string CompanionId, bool IsBrmbleClient = false, string? CertHash = null);
 
 public interface ISessionMappingService
 {
@@ -13,5 +13,6 @@ public interface ISessionMappingService
     bool TryGetMappingByUserId(long userId, out int sessionId, out SessionMapping? mapping);
     bool TryUpdateCompanionId(int sessionId, string companionId);
     bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient);
+    bool TryUpdateCertHash(int sessionId, string certHash);
     IReadOnlyDictionary<int, SessionMapping> GetSnapshot();
 }

--- a/src/Brmble.Server/Events/SessionMappingHandler.cs
+++ b/src/Brmble.Server/Events/SessionMappingHandler.cs
@@ -37,28 +37,24 @@ public class SessionMappingHandler : IMumbleEventHandler
         var isBrmbleClient = _activeSessions.IsBrmbleClient(user.CertHash);
 
         var mappingAdded = _sessionMapping.TryAddMatrixUser(user.SessionId, dbUser.MatrixUserId, user.Name, dbUser.Id, companionId);
-        var activatedExistingMapping = !mappingAdded && isBrmbleClient && _sessionMapping.TryUpdateBrmbleStatus(user.SessionId, true);
+        _sessionMapping.TryUpdateCertHash(user.SessionId, user.CertHash);
+        _sessionMapping.TryUpdateBrmbleStatus(user.SessionId, isBrmbleClient);
 
-        if (mappingAdded && isBrmbleClient)
-            _sessionMapping.TryUpdateBrmbleStatus(user.SessionId, true);
-
-        if (mappingAdded)
+        _logger.LogInformation(
+            "Mapped session {Session} ({Name}) to {MatrixUserId} via cert (brmbleClient={IsBrmble}, added={Added})",
+            user.SessionId, user.Name, dbUser.MatrixUserId, isBrmbleClient, mappingAdded);
+        await _eventBus.BroadcastAsync(new
         {
-            _logger.LogInformation(
-                "Mapped session {Session} ({Name}) to {MatrixUserId} via cert (brmbleClient={IsBrmble})",
-                user.SessionId, user.Name, dbUser.MatrixUserId, isBrmbleClient);
-            await _eventBus.BroadcastAsync(new
-            {
-                type = "userMappingAdded",
-                sessionId = user.SessionId,
-                matrixUserId = dbUser.MatrixUserId,
-                mumbleName = user.Name,
-                companionId,
-                isBrmbleClient
-            });
-        }
+            type = "userMappingAdded",
+            sessionId = user.SessionId,
+            matrixUserId = dbUser.MatrixUserId,
+            mumbleName = user.Name,
+            companionId,
+            certHash = user.CertHash,
+            isBrmbleClient
+        });
 
-        if (activatedExistingMapping)
+        if (!mappingAdded && isBrmbleClient)
         {
             await _eventBus.BroadcastAsync(new
             {

--- a/src/Brmble.Server/Events/SessionMappingService.cs
+++ b/src/Brmble.Server/Events/SessionMappingService.cs
@@ -100,6 +100,17 @@ public class SessionMappingService : ISessionMappingService
         return false;
     }
 
+    public bool TryUpdateCertHash(int sessionId, string certHash)
+    {
+        if (_sessionToMapping.TryGetValue(sessionId, out var existing))
+        {
+            _sessionToMapping[sessionId] = existing with { CertHash = certHash };
+            return true;
+        }
+
+        return false;
+    }
+
     public IReadOnlyDictionary<int, SessionMapping> GetSnapshot()
     {
         return new Dictionary<int, SessionMapping>(_sessionToMapping);

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -43,15 +43,8 @@ public static class BrmbleWebSocketHandler
         {
             activeSessions.TrackMumbleName(currentMapping!.MumbleName, hash, active: true);
             sessionMapping.TryUpdateBrmbleStatus(currentSessionId, true);
-            await eventBus.BroadcastAsync(new
-            {
-                type = "userMappingAdded",
-                sessionId = currentSessionId,
-                matrixUserId = currentMapping.MatrixUserId,
-                mumbleName = currentMapping.MumbleName,
-                certHash = currentMapping.CertHash,
-                isBrmbleClient = true
-            });
+            sessionMapping.TryUpdateCertHash(currentSessionId, hash);
+            await eventBus.BroadcastAsync(CreateUserMappingAddedPayload(currentSessionId, currentMapping, hash));
         }
 
         eventBus.AddClient(ws, user.Id);
@@ -95,4 +88,14 @@ public static class BrmbleWebSocketHandler
                 activeSessions.Deactivate(hash);
         }
     }
+
+    internal static object CreateUserMappingAddedPayload(int sessionId, SessionMapping mapping, string certHash) => new
+    {
+        type = "userMappingAdded",
+        sessionId,
+        matrixUserId = mapping.MatrixUserId,
+        mumbleName = mapping.MumbleName,
+        certHash,
+        isBrmbleClient = true
+    };
 }

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -49,6 +49,7 @@ public static class BrmbleWebSocketHandler
                 sessionId = currentSessionId,
                 matrixUserId = currentMapping.MatrixUserId,
                 mumbleName = currentMapping.MumbleName,
+                certHash = currentMapping.CertHash,
                 isBrmbleClient = true
             });
         }
@@ -66,6 +67,7 @@ public static class BrmbleWebSocketHandler
                         matrixUserId = kvp.Value.MatrixUserId,
                         mumbleName = kvp.Value.MumbleName,
                         companionId = kvp.Value.CompanionId,
+                        certHash = kvp.Value.CertHash,
                         isBrmbleClient = kvp.Value.IsBrmbleClient
                     });
             var snapshotJson = JsonSerializer.Serialize(new { type = "sessionMappingSnapshot", mappings = snapshot }, JsonOptions);
@@ -89,6 +91,8 @@ public static class BrmbleWebSocketHandler
         finally
         {
             eventBus.RemoveClient(ws);
+            if (!eventBus.HasConnectedClient(user.Id))
+                activeSessions.Deactivate(hash);
         }
     }
 }

--- a/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
+++ b/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
@@ -1,0 +1,173 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+import bridge from './bridge';
+import { ServiceStatusProvider } from './hooks/useServiceStatus';
+
+const mockValues = vi.hoisted(() => {
+  let dmChatPanelProps: Record<string, unknown> | undefined;
+  const matrixClient = {
+    lastMessages: new Map(),
+    activeMessages: [],
+    setActiveChannel: vi.fn(),
+    sendMessage: vi.fn(),
+    sendImageMessage: vi.fn(),
+    uploadContent: vi.fn(),
+    fetchHistory: vi.fn(),
+    sendReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    dmLastMessages: new Map(),
+    activeDmMessages: [],
+    setActiveDmContact: vi.fn(),
+    dmRoomMap: new Map<string, string>(),
+    dmUserDisplayNames: new Map(),
+    dmUserAvatarUrls: new Map(),
+    sendDMMessage: vi.fn(),
+    fetchDMHistory: vi.fn(),
+    fetchAvatarUrl: vi.fn().mockResolvedValue(undefined),
+    client: { marker: 'matrix-client', getRoom: vi.fn(() => undefined) },
+    activeTypingText: 'Val is typing',
+    startTyping: vi.fn(),
+    stopTyping: vi.fn(),
+  };
+  const dmStore = {
+    contacts: [],
+    selectedContact: null as { id: string; displayName: string; unreadCount: number; isEphemeral?: boolean; mumbleSessionId?: number | null } | null,
+    messages: [],
+    appMode: 'dm' as 'channels' | 'dm',
+    selectContact: vi.fn(),
+    sendMessage: vi.fn(),
+    startDM: vi.fn(),
+    clearSelection: vi.fn(),
+    toggleMode: vi.fn(),
+    closeDM: vi.fn(),
+    appModeRef: { current: 'dm' as 'channels' | 'dm' },
+    selectedContactIdRef: { current: null as string | null },
+    receiveMumbleDM: vi.fn(),
+    updateMumbleSession: vi.fn(),
+    clearMumbleContacts: vi.fn(),
+    startMumbleDM: vi.fn(),
+  };
+  const unreadTracker = {
+    roomUnreads: new Map(),
+    getRoomUnread: vi.fn(() => ({ notificationCount: 0, highlightCount: 0, fullyReadEventId: null })),
+    markRoomRead: vi.fn(),
+    getFullyReadEventId: vi.fn(() => null),
+    getMarkerTimestamp: vi.fn(() => null),
+    totalUnreadCount: 0,
+    totalDmUnreadCount: 0,
+  };
+  const idleActions = { autoLeftAt: null, preLeaveStartedAt: null, preLeaveCancelledAt: null, dismissNotification: vi.fn(), dismissPreLeaveCancelled: vi.fn() };
+  const screenShare = {
+    isSharing: false, startSharing: vi.fn(), stopSharing: vi.fn(), markLocalShareTeardownIntent: vi.fn(), error: null,
+    activeShare: null, activeShares: [], watchingShare: null, watchingShares: [], isViewerConnectPending: false,
+    focusedShare: null, setFocusedShare: vi.fn(), setDiscoveryTarget: vi.fn(), remoteVideoEl: null, remoteVideoEls: new Map(),
+    roomQuality: undefined, shareQualities: new Map(), addWatchingShare: vi.fn(), removeWatchingShare: vi.fn(),
+    disconnectViewer: vi.fn(), connectAsViewer: vi.fn(), handleScreenShareServiceUnavailable: vi.fn(),
+  };
+  const notificationQueue = { register: vi.fn(), unregister: vi.fn(), isVisible: vi.fn(() => false), visibleCount: 0, totalCount: 0 };
+
+  return {
+    matrixClient, dmStore, unreadTracker, idleActions, screenShare, notificationQueue,
+    get dmChatPanelProps() { return dmChatPanelProps; },
+    setDmChatPanelProps: (props: Record<string, unknown> | undefined) => { dmChatPanelProps = props; },
+  };
+});
+
+vi.mock('./bridge', () => {
+  const handlers = new Map<string, Set<(data: unknown) => void>>();
+  return { default: {
+    send: vi.fn(),
+    on: vi.fn((event: string, handler: (data: unknown) => void) => { if (!handlers.has(event)) handlers.set(event, new Set()); handlers.get(event)!.add(handler); }),
+    off: vi.fn((event: string, handler: (data: unknown) => void) => handlers.get(event)?.delete(handler)),
+    __emit: (event: string, data?: unknown) => handlers.get(event)?.forEach(handler => handler(data)),
+    __reset: () => handlers.clear(),
+  } };
+});
+
+vi.mock('./components/Header/Header', () => ({ Header: () => <header /> }));
+vi.mock('./components/Sidebar/Sidebar', () => ({ Sidebar: () => <aside /> }));
+vi.mock('./components/ChatPanel/ChatPanel', () => ({
+  ChatPanel: (props: Record<string, unknown>) => {
+    if (props.isDM) mockValues.setDmChatPanelProps(props);
+    return <section />;
+  },
+}));
+vi.mock('./components/ServerList/ServerList', () => ({ ServerList: () => <section /> }));
+vi.mock('./components/ConnectionState/ConnectionState', () => ({ ConnectionState: () => <section /> }));
+vi.mock('./components/DMContactList/DMContactList', () => ({ DMContactList: () => null }));
+vi.mock('./components/NeonD/NeonDGame', () => ({ NeonDGame: () => null }));
+vi.mock('./components/SettingsModal/SettingsModal', () => ({
+  DEFAULT_SCREEN_SHARE: { captureAudio: false, resolution: '1080p', fps: 30, systemAudio: false, viewerMode: 'in-app' },
+  SettingsModal: () => null,
+}));
+vi.mock('./hooks/useMatrixClient', () => ({ useMatrixClient: () => mockValues.matrixClient }));
+vi.mock('./hooks/useChatStore', () => ({ useChatStore: () => ({ messages: [], addMessage: vi.fn() }), addMessageToStore: vi.fn(), clearChatStorage: vi.fn(), purgeEphemeralMessages: vi.fn() }));
+vi.mock('./hooks/useDMStore', () => ({ useDMStore: () => mockValues.dmStore }));
+vi.mock('./hooks/useUnreadTracker', () => ({ resetMarkersCache: vi.fn(), useUnreadTracker: () => mockValues.unreadTracker }));
+vi.mock('./hooks/useBrmbleIdle', () => ({ useBrmbleIdle: () => 0 }));
+vi.mock('./hooks/useIdleStatus', () => ({ useIdleStatus: () => ({ voiceIdle: {}, systemIdle: 0, isLocked: false }) }));
+vi.mock('./hooks/useIdleActions', () => ({ AFK_THRESHOLD_SEC: 600, useIdleActions: () => mockValues.idleActions }));
+vi.mock('./hooks/useServerHealth', () => ({ useServerHealth: () => undefined }));
+vi.mock('./hooks/useCompanionOverlayPublisher', () => ({ useCompanionOverlayPublisher: () => undefined }));
+vi.mock('./hooks/useLeaveVoiceCooldown', () => ({ useLeaveVoiceCooldown: () => ({ isOnCooldown: false, trigger: vi.fn() }) }));
+vi.mock('./hooks/useNotificationQueue', () => ({ useNotificationQueue: () => mockValues.notificationQueue }));
+vi.mock('./hooks/useScreenShare', () => ({ useScreenShare: () => mockValues.screenShare }));
+
+function renderConnectedApp() {
+  render(<ServiceStatusProvider><App /></ServiceStatusProvider>);
+  act(() => {
+    (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('server.credentials', {
+      matrix: { homeserverUrl: 'https://example.com', accessToken: 'token', userId: '@me:example.com', roomMap: {} },
+    });
+    (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('voice.connected', { username: 'Me', channelId: 0, users: [] });
+  });
+}
+
+describe('DM route Matrix isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    (bridge as unknown as { __reset: () => void }).__reset();
+    mockValues.setDmChatPanelProps(undefined);
+    mockValues.matrixClient.dmRoomMap.clear();
+    mockValues.dmStore.appMode = 'dm';
+    mockValues.dmStore.appModeRef.current = 'dm';
+  });
+
+  it('omits Matrix state from an online Mumble DM route', () => {
+    mockValues.dmStore.selectedContact = { id: 'cert-val', displayName: 'Vanilla Val', unreadCount: 0, isEphemeral: true, mumbleSessionId: 42 };
+    renderConnectedApp();
+
+    expect(mockValues.matrixClient.setActiveDmContact).toHaveBeenLastCalledWith(null);
+    expect(mockValues.dmChatPanelProps).toEqual(expect.objectContaining({
+      channelId: 'dm-cert-val', channelName: 'Vanilla Val', matrixClient: null, matrixRoomId: null, readMarkerTs: null,
+      disabled: false, topNotice: 'This is a Mumble direct message. Chat history will be lost when you disconnect.',
+      typingIndicatorText: undefined, typingTargetId: undefined, onTypingStart: undefined, onTypingStop: undefined,
+      onToggleReaction: undefined, currentUserMatrixId: undefined,
+    }));
+  });
+
+  it('keeps an offline Mumble DM route separate from Matrix state', () => {
+    mockValues.dmStore.selectedContact = { id: 'cert-val', displayName: 'Vanilla Val', unreadCount: 0, isEphemeral: true, mumbleSessionId: null };
+    renderConnectedApp();
+
+    expect(mockValues.dmChatPanelProps).toEqual(expect.objectContaining({
+      channelId: 'dm-cert-val', matrixClient: null, matrixRoomId: null, disabled: true, typingTargetId: undefined,
+    }));
+  });
+
+  it('preserves Matrix props for a Matrix DM route', () => {
+    mockValues.dmStore.selectedContact = { id: '@val:example.com', displayName: 'Vanilla Val', unreadCount: 0 };
+    mockValues.matrixClient.dmRoomMap.set('@val:example.com', '!val:example.com');
+    renderConnectedApp();
+
+    expect(mockValues.matrixClient.setActiveDmContact).toHaveBeenLastCalledWith('@val:example.com');
+    expect(mockValues.dmChatPanelProps).toEqual(expect.objectContaining({
+      channelId: 'dm-@val:example.com', channelName: 'Vanilla Val', matrixClient: mockValues.matrixClient.client,
+      matrixRoomId: '!val:example.com', topNotice: undefined, typingTargetId: '@val:example.com',
+      onTypingStart: mockValues.matrixClient.startTyping, onTypingStop: mockValues.matrixClient.stopTyping,
+      onToggleReaction: expect.any(Function), currentUserMatrixId: '@me:example.com',
+    }));
+  });
+});

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4248,7 +4248,7 @@ const handleConnect = (serverData: SavedServer) => {
         <DMContactList
           contacts={dmContactsWithUnreads}
           selectedUserId={dmStore.selectedContact?.id ?? null}
-          onSelectContact={(id: string, _name: string) => dmStore.selectContact(id)}
+          onSelectContact={(id: string) => dmStore.selectContact(id)}
           onCloseConversation={dmStore.closeDM}
           visible={dmStore.appMode === 'dm'}
         />

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4245,7 +4245,6 @@ const handleConnect = (serverData: SavedServer) => {
           selectedUserId={dmStore.selectedContact?.id ?? null}
           onSelectContact={(id: string, _name: string) => dmStore.selectContact(id)}
           onCloseConversation={dmStore.closeDM}
-           onlineUserIds={users.filter(u => !u.self && u.matrixUserId).map(u => u.matrixUserId!)}
           visible={dmStore.appMode === 'dm'}
         />
       </div>

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -2513,7 +2513,7 @@ function App() {
     };
 
     const onUserMappingUpdated = (data: unknown) => {
-      const d = data as { sessionId: number; matrixUserId?: string; companionId?: CompanionId; isBrmbleClient?: boolean; action: string } | undefined;
+      const d = data as { sessionId: number; matrixUserId?: string; companionId?: CompanionId; certHash?: string; isBrmbleClient?: boolean; action: string } | undefined;
       if (d?.sessionId !== undefined) {
         setUsers(prev => prev.map(u =>
           u.session === d.sessionId
@@ -2521,6 +2521,7 @@ function App() {
               ...u,
               matrixUserId: d.action === 'added' ? d.matrixUserId : undefined,
               companionId: d.action === 'added' ? d.companionId : u.companionId,
+              certHash: d.action === 'added' ? (d.certHash ?? u.certHash) : u.certHash,
               isBrmbleClient: d.action === 'added' ? d.isBrmbleClient : undefined,
             }
             : u
@@ -2533,16 +2534,16 @@ function App() {
     };
 
     const onSessionMappingSnapshot = (data: unknown) => {
-      const d = data as { mappings: Record<string, { matrixUserId: string; mumbleName: string; companionId?: CompanionId; isBrmbleClient?: boolean }> } | undefined;
+      const d = data as { mappings: Record<string, { matrixUserId: string; mumbleName: string; companionId?: CompanionId; certHash?: string; isBrmbleClient?: boolean }> } | undefined;
       if (d?.mappings && typeof d.mappings === 'object') {
         setUsers(prev => {
-          const mappingMap = new Map<number, { matrixUserId: string; companionId?: CompanionId; isBrmbleClient?: boolean }>();
+          const mappingMap = new Map<number, { matrixUserId: string; companionId?: CompanionId; certHash?: string; isBrmbleClient?: boolean }>();
           for (const [sid, entry] of Object.entries(d.mappings)) {
-            mappingMap.set(Number(sid), { matrixUserId: entry.matrixUserId, companionId: entry.companionId, isBrmbleClient: entry.isBrmbleClient });
+            mappingMap.set(Number(sid), { matrixUserId: entry.matrixUserId, companionId: entry.companionId, certHash: entry.certHash, isBrmbleClient: entry.isBrmbleClient });
           }
           return prev.map(u => {
             const m = mappingMap.get(u.session);
-            return m ? { ...u, matrixUserId: m.matrixUserId, companionId: m.companionId ?? u.companionId, isBrmbleClient: m.isBrmbleClient } : u;
+            return m ? { ...u, matrixUserId: m.matrixUserId, companionId: m.companionId ?? u.companionId, certHash: m.certHash ?? u.certHash, isBrmbleClient: m.isBrmbleClient } : u;
           });
         });
         // Fetch avatars for users that gained a matrixUserId

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -64,6 +64,7 @@ import { mapBrmbleServiceStatus } from './utils/brmbleServiceStatus';
 import { areMatrixCredentialsEqual } from './utils/matrixCredentials';
 import { getSavedChannelPassword } from './utils/channelPasswords';
 import { getOrderedChannels } from './utils/channelOrder';
+import { formatBroadcastSummary } from './utils/formatBroadcastSummary';
 import './App.css';
 
 export interface ScreenShareEndedNotification {
@@ -629,6 +630,11 @@ interface User {
   isBrmbleClient?: boolean;
 }
 
+interface BrmbleDMUser {
+  matrixUserId: string;
+  displayName: string;
+}
+
 interface ChannelChatAccessState {
   canRead: boolean;
   canSend: boolean;
@@ -824,6 +830,12 @@ interface ServerRemovalNotification extends ScreenShareEndedNotification {
 function App() {
   // --- Notification queue (max 3 visible, priority-based) ---
   const notifQueue = useNotificationQueue();
+  // Stable ref to the notification queue so effects that must only run on
+  // specific triggers (e.g. channel change) can call queue methods without
+  // depending on the queue object's identity, which churns on every
+  // register/unregister and would otherwise re-run those effects unexpectedly.
+  const notifQueueRef = useRef(notifQueue);
+  notifQueueRef.current = notifQueue;
 
   // --- Brmblegotchi settings state ---
   const [brmblegotchiEnabled, setBrmblegotchiEnabledState] = useState<boolean>(() => {
@@ -1005,6 +1017,7 @@ function App() {
   const [hasPendingInvite] = useState(false);
 
   const [matrixCredentials, setMatrixCredentials] = useState<MatrixCredentials | null>(null);
+  const [brmbleDMUsers, setBrmbleDMUsers] = useState<BrmbleDMUser[]>([]);
   const matrixOverlayCallbacks = useMemo(() => ({
     onChannelMessage: (channelId: string, message: ChatMessage) => {
       const settings = overlaySettingsRef.current;
@@ -1188,6 +1201,7 @@ function App() {
     matrixDmUserAvatarUrls: matrixClient.dmUserAvatarUrls,
     sendMatrixDM: matrixClient.sendDMMessage,
     fetchDMHistory: matrixClient.fetchDMHistory,
+    brmbleUsers: brmbleDMUsers,
     users,
     username,
     sendMumbleDM: (targetSession: number, text: string) => {
@@ -1303,6 +1317,7 @@ function App() {
   const disconnectViewerRef = useRef<(() => Promise<void>) | null>(null);
   const handleScreenShareServiceUnavailableRef = useRef<(() => Promise<void>) | null>(null);
   const requestActiveShareDiscoveryRef = useRef<((channelId: string | undefined) => void) | null>(null);
+  const previousScreenShareServiceConnectedRef = useRef(false);
   const pendingCompanionRef = useRef<{ requestId: number; next: CompanionId; previous: CompanionId } | null>(null);
   const companionRequestIdRef = useRef(0);
 
@@ -1610,8 +1625,17 @@ function App() {
       if ((status.service === 'session' || status.service === 'screenshare') && mapped.update.state !== 'connected') {
         void handleScreenShareServiceUnavailableRef.current?.();
       }
-      if (status.service === 'screenshare' && status.state === 'connected') {
-        requestActiveShareDiscoveryRef.current?.(currentChannelIdRef.current);
+      if (status.service === 'screenshare') {
+        const nowConnected = status.state === 'connected';
+        const wasConnected = previousScreenShareServiceConnectedRef.current;
+        previousScreenShareServiceConnectedRef.current = nowConnected;
+        // Only run discovery when the screenshare service *transitions* into
+        // connected. Discovery success itself emits a "connected" status, so
+        // re-triggering on every "connected" message caused an infinite
+        // discovery loop that exhausted the server rate limit (HTTP 429).
+        if (nowConnected && !wasConnected) {
+          requestActiveShareDiscoveryRef.current?.(currentChannelIdRef.current);
+        }
       }
     };
 
@@ -1747,6 +1771,7 @@ function App() {
       setSpeakingUsers(new Map());
       hasMatrixCredentialsForSessionRef.current = false;
       setMatrixCredentials(null);
+      setBrmbleDMUsers([]);
       setCurrentUserAvatarUrl(undefined);
       fetchedAvatarIdsRef.current.clear();
       disconnectViewerRef.current?.();
@@ -1764,9 +1789,14 @@ function App() {
 
     const onServerCredentials = (data: unknown) => {
       setConnectionError(null);
-      const wrapped = data as { matrix?: MatrixCredentials } | undefined;
+      const wrapped = data as { matrix?: MatrixCredentials; userMappings?: Record<string, string> } | undefined;
       const d = wrapped?.matrix;
       if (d?.homeserverUrl && d.accessToken && d.userId && d.roomMap) {
+        const directoryUsers = Object.entries(wrapped?.userMappings ?? {})
+          .map(([displayName, matrixUserId]) => ({ displayName, matrixUserId }))
+          .filter(user => user.matrixUserId !== d.userId)
+          .sort((left, right) => left.displayName.localeCompare(right.displayName));
+        setBrmbleDMUsers(directoryUsers);
         if (!hasMatrixCredentialsForSessionRef.current) {
           clearChatStorage();
           hasMatrixCredentialsForSessionRef.current = true;
@@ -3132,6 +3162,7 @@ const handleConnect = (serverData: SavedServer) => {
         setSpeakingUsers(new Map());
         hasMatrixCredentialsForSessionRef.current = false;
         setMatrixCredentials(null);
+        setBrmbleDMUsers([]);
         setSharingChannelId(undefined);
       },
     });
@@ -3331,12 +3362,20 @@ const handleConnect = (serverData: SavedServer) => {
     const applyScreenShareSettings = (value: unknown) => {
       if (!value || typeof value !== 'object') return;
 
+      const payload = value as Record<string, unknown>;
+      const settingsPayload =
+        payload.settings && typeof payload.settings === 'object'
+          ? payload.settings as Record<string, unknown>
+          : null;
+
       const candidate =
-        'screenShare' in value &&
-        value.screenShare &&
-        typeof value.screenShare === 'object'
-          ? value.screenShare
-          : value;
+        settingsPayload
+          ? settingsPayload.screenShare
+          : payload.screenShare && typeof payload.screenShare === 'object'
+            ? payload.screenShare
+            : payload;
+
+      if (!candidate || typeof candidate !== 'object') return;
 
       setScreenShareSettings((current) => ({
         ...current,
@@ -3373,11 +3412,13 @@ const handleConnect = (serverData: SavedServer) => {
 
     const handleStorage = () => loadSettings();
     window.addEventListener('storage', handleStorage);
+    window.addEventListener('brmble-settings-updated', handleStorage);
 
     return () => {
       bridgeApi.off?.('settings.current', handleBridgeSettings);
       bridgeApi.off?.('settings.updated', handleBridgeSettings);
       window.removeEventListener('storage', handleStorage);
+      window.removeEventListener('brmble-settings-updated', handleStorage);
     };
   }, []);
 
@@ -3454,7 +3495,7 @@ const handleConnect = (serverData: SavedServer) => {
     setWatchedShareEndedNotifications(prev => [...prev, notification]);
   }, []);
 
-  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, roomQuality, shareQualities, disconnectViewer, connectAsViewer, isViewerConnectPending, handleScreenShareServiceUnavailable } = useScreenShare(() => {
+  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, roomQuality, shareQualities, viewerQualities, setViewerQuality, disconnectViewer, connectAsViewer, isViewerConnectPending, handleScreenShareServiceUnavailable } = useScreenShare(() => {
     setSharingChannelId(undefined);
     sharingChannelIdRef.current = undefined;
   }, screenShareSettings, handleLocalScreenShareEnded, handleWatchedShareEnded);
@@ -3760,11 +3801,19 @@ const handleConnect = (serverData: SavedServer) => {
       const d = data as { roomName: string; userName: string; userId?: number; matrixUserId?: string; sessionId?: number };
       const selfUser = usersRef.current.find(u => u.self);
       const voiceChannelId = selfUser?.channelId;
-      // Only show notification for other users' shares in our channel
+      // Only show notification for other users' shares in our channel.
+      // Prefer the session id to identify self; when the server payload omits
+      // it, fall back to matching the Matrix identity so the broadcaster does
+      // not get a notification for their own share (the event is broadcast to
+      // everyone in the room, including the sharer).
+      const selfMatrixUserId = selfUser?.matrixUserId ?? matrixCredentialsRef.current?.userId;
+      const isSelfShare = (d.sessionId != null && selfUser?.session != null)
+        ? d.sessionId === selfUser.session
+        : (selfMatrixUserId != null && d.matrixUserId != null && d.matrixUserId === selfMatrixUserId);
       if (
         voiceChannelId != null &&
         d.roomName === `channel-${voiceChannelId}` &&
-        d.sessionId !== selfUser?.session &&
+        !isSelfShare &&
         shouldShowOptionalNotification(optionalNotificationSettingsRef.current, 'notificationRemoteScreenShare')
       ) {
         setScreenShareNotification({ userName: d.userName, roomName: d.roomName, userId: d.userId, matrixUserId: d.matrixUserId });
@@ -3805,13 +3854,19 @@ const handleConnect = (serverData: SavedServer) => {
 
   requestActiveShareDiscoveryRef.current = requestActiveShareDiscovery;
 
-  // Check for active screen shares when switching channels
+  // Check for active screen shares when switching channels.
+  // Depends ONLY on currentChannelId: the other collaborators (disconnectViewer,
+  // notifQueue, requestActiveShareDiscovery) are accessed via refs so their
+  // identity churn — notably notifQueue changing on every register/unregister —
+  // does not re-run this effect and wipe a freshly shown screen-share
+  // notification.
   useEffect(() => {
-    disconnectViewer();
+    disconnectViewerRef.current?.();
     setScreenShareNotification(null);
-    notifQueue.unregister('screen-share');
-    requestActiveShareDiscovery(currentChannelId);
-  }, [currentChannelId, disconnectViewer, notifQueue, requestActiveShareDiscovery]);
+    notifQueueRef.current.unregister('screen-share');
+    requestActiveShareDiscoveryRef.current?.(currentChannelId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentChannelId]);
 
   useEffect(() => {
     const previousConnectionStatus = previousConnectionStatusRef.current;
@@ -4079,6 +4134,10 @@ const handleConnect = (serverData: SavedServer) => {
           watchingShares={watchingShares}
           isLiveKitRoomConnected={isSharing || watchingShares.length > 0}
           screenShareQuality={roomQuality}
+          isSharing={isSharing}
+          broadcastSummary={isSharing ? formatBroadcastSummary(screenShareSettings.resolution, screenShareSettings.fps) : undefined}
+          shareQualities={shareQualities}
+          remoteVideoEls={remoteVideoEls}
           onWatchScreenShare={handleWatchScreenShare}
           onStopWatching={(userId) => disconnectViewer(userId)}
           onEditAvatar={connected ? () => setShowAvatarEditor(true) : undefined}
@@ -4120,11 +4179,13 @@ const handleConnect = (serverData: SavedServer) => {
                     watchingShares={watchingShares}
                     focusedShare={focusedShare}
                     remoteVideoEls={remoteVideoEls}
-                    roomQuality={roomQuality}
-                    shareQualities={shareQualities}
-                    onFocusShare={setFocusedShare}
-                    onCloseShare={(share) => disconnectViewer(share.userId)}
-                    screenShareViewerMode={screenShareSettings.viewerMode}
+                     roomQuality={roomQuality}
+                     shareQualities={shareQualities}
+                     viewerQualities={viewerQualities}
+                     onFocusShare={setFocusedShare}
+                     onCloseShare={(share) => disconnectViewer(share.userId)}
+                     onViewerQualityChange={setViewerQuality}
+                     screenShareViewerMode={screenShareSettings.viewerMode}
                     users={users}
                     disabled={!canSendActiveChannelChat}
                     topNotice={channelChatAccessNotice ?? brmbleServiceChatNotice}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1209,32 +1209,37 @@ function App() {
     },
   });
 
+  const selectedDmIsMumble = dmStore.selectedContact?.isEphemeral === true;
+  const activeDmMatrixContactId = dmStore.appMode === 'dm' && !selectedDmIsMumble
+    ? (dmStore.selectedContact?.id ?? null)
+    : null;
+
   useLayoutEffect(() => {
     matrixClient.setActiveChannel(dmStore.appMode === 'dm' ? null : permittedActiveMatrixChannelId);
   }, [dmStore.appMode, matrixClient.setActiveChannel, permittedActiveMatrixChannelId]);
 
   useLayoutEffect(() => {
-    matrixClient.setActiveDmContact(dmStore.appMode === 'dm' ? (dmStore.selectedContact?.id ?? null) : null);
-  }, [dmStore.appMode, dmStore.selectedContact?.id, matrixClient.setActiveDmContact]);
+    matrixClient.setActiveDmContact(activeDmMatrixContactId);
+  }, [activeDmMatrixContactId, matrixClient.setActiveDmContact]);
 
   // Determine active Matrix room ID (depends on dmStore.selectedContact)
   const activeMatrixRoomId = useMemo(() => {
-    if (dmStore.selectedContact && matrixClient?.dmRoomMap) {
-      const roomId = matrixClient.dmRoomMap.get(dmStore.selectedContact.id);
-      if (roomId) return roomId;
+    if (dmStore.appMode === 'dm') {
+      return activeDmMatrixContactId && matrixClient?.dmRoomMap
+        ? matrixClient.dmRoomMap.get(activeDmMatrixContactId) ?? null
+        : null;
     }
+
     if (permittedActiveMatrixChannelId && matrixCredentials?.roomMap?.[permittedActiveMatrixChannelId]) {
       return matrixCredentials.roomMap[permittedActiveMatrixChannelId];
     }
     return null;
-  }, [dmStore.selectedContact, matrixClient?.dmRoomMap, matrixCredentials?.roomMap, permittedActiveMatrixChannelId]);
+  }, [dmStore.appMode, activeDmMatrixContactId, matrixClient?.dmRoomMap, matrixCredentials?.roomMap, permittedActiveMatrixChannelId]);
 
   const dmMatrixRoomId = useMemo(() => {
-    if (dmStore.selectedContact && matrixClient?.dmRoomMap) {
-      return matrixClient.dmRoomMap.get(dmStore.selectedContact.id) ?? null;
-    }
-    return null;
-  }, [dmStore.selectedContact, matrixClient?.dmRoomMap]);
+    if (!activeDmMatrixContactId || !matrixClient?.dmRoomMap) return null;
+    return matrixClient.dmRoomMap.get(activeDmMatrixContactId) ?? null;
+  }, [activeDmMatrixContactId, matrixClient?.dmRoomMap]);
 
   const unreadTracker = useUnreadTracker(
     matrixClient?.client ?? null,
@@ -4209,20 +4214,20 @@ const handleConnect = (serverData: SavedServer) => {
                     currentUsername={username}
                     onSendMessage={dmStore.sendMessage}
                     isDM={true}
-                    matrixClient={matrixClient.client}
-                    matrixRoomId={dmMatrixRoomId}
-                    readMarkerTs={dmDividerTs}
+                    matrixClient={selectedDmIsMumble ? null : matrixClient.client}
+                    matrixRoomId={selectedDmIsMumble ? null : dmMatrixRoomId}
+                    readMarkerTs={selectedDmIsMumble ? null : dmDividerTs}
                     users={users}
                     disabled={dmStore.selectedContact?.isEphemeral === true && dmStore.selectedContact?.mumbleSessionId == null}
-                    topNotice={dmStore.selectedContact?.isEphemeral ? 'This is a Mumble direct message. Chat history will be lost when you disconnect.' : undefined}
+                    topNotice={selectedDmIsMumble ? 'This is a Mumble direct message. Chat history will be lost when you disconnect.' : undefined}
                     onMessageContextMenu={handleChatMessageContextMenu}
-                     onCopyToClipboard={handleCopyToClipboard}
-                     currentUserMatrixId={matrixCredentials?.userId}
-                     onToggleReaction={handleToggleDmReaction}
-                     typingIndicatorText={dmStore.appMode === 'dm' ? matrixClient.activeTypingText : undefined}
-                     typingTargetId={dmStore.selectedContact?.id}
-                     onTypingStart={matrixClient.startTyping}
-                     onTypingStop={matrixClient.stopTyping}
+                    onCopyToClipboard={handleCopyToClipboard}
+                    currentUserMatrixId={selectedDmIsMumble ? undefined : matrixCredentials?.userId}
+                    onToggleReaction={selectedDmIsMumble ? undefined : handleToggleDmReaction}
+                    typingIndicatorText={!selectedDmIsMumble && dmStore.appMode === 'dm' ? matrixClient.activeTypingText : undefined}
+                    typingTargetId={!selectedDmIsMumble ? (activeDmMatrixContactId ?? undefined) : undefined}
+                    onTypingStart={!selectedDmIsMumble ? matrixClient.startTyping : undefined}
+                    onTypingStop={!selectedDmIsMumble ? matrixClient.stopTyping : undefined}
                   />
                   </ErrorBoundary>
                 </div>

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.css
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.css
@@ -64,6 +64,29 @@
   font-style: italic;
 }
 
+.dm-contact-empty-section {
+  padding: var(--space-sm);
+  text-align: left;
+}
+
+.dm-contact-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.dm-contact-section + .dm-contact-section {
+  margin-top: var(--space-md);
+}
+
+.dm-contact-section-title {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  padding: var(--space-xs) var(--space-sm) var(--space-2xs);
+  text-transform: uppercase;
+}
+
 .dm-contact-entry {
   display: flex;
   align-items: center;

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import bridge from '../../bridge';
+import { DMContactList } from './DMContactList';
+import type { DMContact } from '../../hooks/useDMStore';
+
+vi.mock('../../bridge', () => ({
+  default: {
+    send: vi.fn(),
+  },
+}));
+
+vi.mock('../Avatar/Avatar', () => ({
+  default: ({ isMumbleOnly }: { isMumbleOnly?: boolean }) => (
+    <span data-testid={isMumbleOnly ? 'mumble-avatar' : 'matrix-avatar'} />
+  ),
+}));
+
+const matrixContact: DMContact = {
+  id: '@val:example.com',
+  displayName: 'Vanilla Val',
+  unreadCount: 2,
+  lastMessage: 'persistent preview',
+  lastMessageTime: 1000,
+  onlineSessionId: 33,
+};
+
+const offlineMatrixContact: DMContact = {
+  id: '@offline:example.com',
+  displayName: 'Offline Olive',
+  unreadCount: 0,
+};
+
+const mumbleContact: DMContact = {
+  id: 'cert-val',
+  displayName: 'Vanilla Val',
+  unreadCount: 1,
+  lastMessage: 'ephemeral preview',
+  lastMessageTime: 2000,
+  isEphemeral: true,
+  mumbleCertHash: 'cert-val',
+  mumbleSessionId: 44,
+};
+
+function renderList(contacts: DMContact[] = [matrixContact, mumbleContact]) {
+  const onSelectContact = vi.fn();
+  const onCloseConversation = vi.fn();
+
+  render(
+    <DMContactList
+      contacts={contacts}
+      selectedUserId={null}
+      onSelectContact={onSelectContact}
+      onCloseConversation={onCloseConversation}
+      visible={true}
+    />,
+  );
+
+  return { onSelectContact, onCloseConversation };
+}
+
+describe('DMContactList directory behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a registered standard-Mumble user as two visually distinct route entries', () => {
+    renderList();
+
+    expect(screen.getByRole('heading', { name: 'Messages' })).toBeInTheDocument();
+    expect(screen.getByText('Mumble users')).toBeInTheDocument();
+    expect(screen.getAllByText('Vanilla Val')).toHaveLength(2);
+    expect(screen.getByText('persistent preview')).toBeInTheDocument();
+    expect(screen.getByText('ephemeral preview')).toBeInTheDocument();
+    expect(screen.getByText('mumble')).toBeInTheDocument();
+    expect(screen.getByTestId('matrix-avatar')).toBeInTheDocument();
+    expect(screen.getByTestId('mumble-avatar')).toBeInTheDocument();
+  });
+
+  it('keeps search results in their route sections when both routes match', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.type(screen.getByPlaceholderText('Search users...'), 'val');
+
+    expect(screen.getAllByText('Vanilla Val')).toHaveLength(2);
+    expect(screen.getByText('Mumble users')).toBeInTheDocument();
+  });
+
+  it('uses user-focused empty copy while searching the directory', async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.type(screen.getByPlaceholderText('Search users...'), 'nobody');
+
+    expect(screen.getByText('No matching users')).toBeInTheDocument();
+    expect(screen.queryByText('No conversations yet')).not.toBeInTheDocument();
+  });
+
+  it('selects the exact route ID that was clicked', async () => {
+    const user = userEvent.setup();
+    const { onSelectContact } = renderList();
+
+    const buttons = screen.getAllByRole('button', { name: /Vanilla Val/ });
+
+    await user.click(buttons[0]);
+    await user.click(buttons[1]);
+
+    expect(onSelectContact).toHaveBeenNthCalledWith(1, '@val:example.com', 'Vanilla Val');
+    expect(onSelectContact).toHaveBeenNthCalledWith(2, 'cert-val', 'Vanilla Val');
+  });
+
+  it('opens user info for a Mumble route with the active Mumble session and selects the certificate route from the real dialog', async () => {
+    const user = userEvent.setup();
+    const { onSelectContact } = renderList();
+
+    const mumbleButton = screen.getAllByRole('button', { name: /Vanilla Val/ })[1];
+    fireEvent.contextMenu(mumbleButton);
+    await user.click(screen.getByRole('button', { name: 'User Information' }));
+
+    expect(bridge.send).toHaveBeenCalledWith('voice.setVolume', { session: 44, volume: 100 });
+    expect(bridge.send).toHaveBeenCalledWith('voice.setLocalMute', { session: 44, muted: false });
+
+    await user.click(screen.getByRole('button', { name: /Send Direct Message/ }));
+
+    expect(onSelectContact).toHaveBeenCalledWith('cert-val', 'Vanilla Val');
+  });
+
+  it('opens user info for an online Matrix route with the real Mumble session and selects the Matrix route from the real dialog', async () => {
+    const user = userEvent.setup();
+    const { onSelectContact } = renderList([matrixContact]);
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /Vanilla Val/ }));
+    await user.click(screen.getByRole('button', { name: 'User Information' }));
+
+    expect(bridge.send).toHaveBeenCalledWith('voice.setVolume', { session: 33, volume: 100 });
+    expect(bridge.send).toHaveBeenCalledWith('voice.setLocalMute', { session: 33, muted: false });
+
+    await user.click(screen.getByRole('button', { name: /Send Direct Message/ }));
+
+    expect(onSelectContact).toHaveBeenCalledWith('@val:example.com', 'Vanilla Val');
+  });
+
+  it('disables user info for an offline Matrix directory contact', () => {
+    renderList([offlineMatrixContact]);
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /Offline Olive/ }));
+
+    expect(screen.getByRole('button', { name: 'User Information' })).toBeDisabled();
+  });
+
+  it('disables user info for an offline Mumble route', () => {
+    renderList([{ ...mumbleContact, mumbleSessionId: null }]);
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: /Vanilla Val/ }));
+
+    expect(screen.getByRole('button', { name: 'User Information' })).toBeDisabled();
+  });
+});

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
@@ -47,7 +47,7 @@ function renderList(contacts: DMContact[] = [matrixContact, mumbleContact]) {
   const onSelectContact = vi.fn();
   const onCloseConversation = vi.fn();
 
-  render(
+  const view = render(
     <DMContactList
       contacts={contacts}
       selectedUserId={null}
@@ -57,7 +57,7 @@ function renderList(contacts: DMContact[] = [matrixContact, mumbleContact]) {
     />,
   );
 
-  return { onSelectContact, onCloseConversation };
+  return { ...view, onSelectContact, onCloseConversation };
 }
 
 describe('DMContactList directory behavior', () => {
@@ -128,6 +128,31 @@ describe('DMContactList directory behavior', () => {
     await user.click(screen.getByRole('button', { name: /Send Direct Message/ }));
 
     expect(onSelectContact).toHaveBeenCalledWith('cert-val', 'Vanilla Val');
+  });
+
+  it('updates an open Mumble user info dialog to the current active session after reconnect', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('volume_55', '80');
+    const { rerender } = renderList();
+
+    const mumbleButton = screen.getAllByRole('button', { name: /Vanilla Val/ })[1];
+    fireEvent.contextMenu(mumbleButton);
+    await user.click(screen.getByRole('button', { name: 'User Information' }));
+
+    expect(bridge.send).toHaveBeenCalledWith('voice.setVolume', { session: 44, volume: 100 });
+
+    rerender(
+      <DMContactList
+        contacts={[matrixContact, { ...mumbleContact, mumbleSessionId: 55 }]}
+        selectedUserId={null}
+        onSelectContact={vi.fn()}
+        onCloseConversation={vi.fn()}
+        visible={true}
+      />,
+    );
+
+    expect(bridge.send).toHaveBeenCalledWith('voice.setVolume', { session: 55, volume: 80 });
+    expect(bridge.send).toHaveBeenCalledWith('voice.setLocalMute', { session: 55, muted: false });
   });
 
   it('opens user info for an online Matrix route with the real Mumble session and selects the Matrix route from the real dialog', async () => {

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
@@ -63,6 +63,9 @@ function renderList(contacts: DMContact[] = [matrixContact, mumbleContact]) {
 describe('DMContactList directory behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('volume_44', '100');
+    localStorage.setItem('volume_33', '100');
   });
 
   it('renders a registered standard-Mumble user as two visually distinct route entries', () => {

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
@@ -24,6 +24,8 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
   const filtered = contacts.filter(c =>
     c.displayName.toLowerCase().includes(searchQuery.toLowerCase())
   );
+  const messageContacts = filtered.filter(c => !c.isEphemeral);
+  const mumbleContacts = filtered.filter(c => c.isEphemeral);
 
   const formatTime = (ts?: number) => {
     if (!ts) return '';
@@ -48,7 +50,7 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
         <Icon name="search" size={14} />
         <input
           type="text"
-          placeholder="Search conversations..."
+          placeholder="Search users..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="dm-contact-search-input"
@@ -58,43 +60,44 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
       <div className="dm-contact-entries">
         {filtered.length === 0 && (
           <p className="dm-contact-empty">
-            {searchQuery ? 'No matching conversations' : 'No conversations yet'}
+            {searchQuery ? 'No matching users' : 'No conversations yet'}
           </p>
         )}
-        {filtered.map(contact => (
-          <button
-            key={contact.id}
-            className={`dm-contact-entry ${selectedUserId === contact.id ? 'active' : ''} ${contact.isEphemeral && contact.mumbleSessionId == null ? 'offline' : ''}`}
-            onClick={() => onSelectContact(contact.id, contact.displayName)}
-            onContextMenu={(e) => {
-              e.preventDefault();
-              setContextMenu({ x: e.clientX, y: e.clientY, id: contact.id, displayName: contact.displayName, isEphemeral: contact.isEphemeral });
-            }}
-          >
-            <Avatar user={{ name: contact.displayName, matrixUserId: contact.isEphemeral ? undefined : contact.id, avatarUrl: contact.avatarUrl }} size={28} isMumbleOnly={contact.isEphemeral} />
-            <div className="dm-contact-info">
-              <div className="dm-contact-name-row">
-                <Tooltip content="">
-                <span className="dm-contact-name">
-                  {contact.displayName}
-                </span>
-                </Tooltip>
-                {contact.isEphemeral && (
-                  <span className="dm-contact-ephemeral-tag">mumble</span>
-                )}
-                {contact.lastMessageTime && (
-                  <span className="dm-contact-time">{formatTime(contact.lastMessageTime)}</span>
-                )}
-              </div>
-              {contact.lastMessage && (
-                <span className="dm-contact-preview">{contact.lastMessage}</span>
-              )}
-            </div>
-            {contact.unreadCount > 0 && (
-              <span className="dm-contact-unread">{contact.unreadCount}</span>
+
+        {messageContacts.length > 0 && (
+          <div className="dm-contact-section">
+            {messageContacts.map(contact => (
+              <ContactEntry
+                key={contact.id}
+                contact={contact}
+                selected={selectedUserId === contact.id}
+                formatTime={formatTime}
+                onSelectContact={onSelectContact}
+                onOpenContextMenu={setContextMenu}
+              />
+            ))}
+          </div>
+        )}
+
+        {(mumbleContacts.length > 0 || (!searchQuery && messageContacts.length > 0)) && (
+          <div className="dm-contact-section">
+            <div className="dm-contact-section-title">Mumble users</div>
+            {mumbleContacts.length === 0 ? (
+              <p className="dm-contact-empty dm-contact-empty-section">No Mumble users online</p>
+            ) : (
+              mumbleContacts.map(contact => (
+                <ContactEntry
+                  key={contact.id}
+                  contact={contact}
+                  selected={selectedUserId === contact.id}
+                  formatTime={formatTime}
+                  onSelectContact={onSelectContact}
+                  onOpenContextMenu={setContextMenu}
+                />
+              ))
             )}
-          </button>
-        ))}
+          </div>
+        )}
       </div>
 
       {contextMenu && (
@@ -150,5 +153,49 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
         );
       })()}
     </div>
+  );
+}
+
+interface ContactEntryProps {
+  contact: DMContact;
+  selected: boolean;
+  formatTime: (ts?: number) => string;
+  onSelectContact: (id: string, displayName: string) => void;
+  onOpenContextMenu: (menu: { x: number; y: number; id: string; displayName: string; isEphemeral?: boolean }) => void;
+}
+
+function ContactEntry({ contact, selected, formatTime, onSelectContact, onOpenContextMenu }: ContactEntryProps) {
+  return (
+    <button
+      className={`dm-contact-entry ${selected ? 'active' : ''} ${contact.isEphemeral && contact.mumbleSessionId == null ? 'offline' : ''}`}
+      onClick={() => onSelectContact(contact.id, contact.displayName)}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onOpenContextMenu({ x: e.clientX, y: e.clientY, id: contact.id, displayName: contact.displayName, isEphemeral: contact.isEphemeral });
+      }}
+    >
+      <Avatar user={{ name: contact.displayName, matrixUserId: contact.isEphemeral ? undefined : contact.id, avatarUrl: contact.avatarUrl }} size={28} isMumbleOnly={contact.isEphemeral} />
+      <div className="dm-contact-info">
+        <div className="dm-contact-name-row">
+          <Tooltip content="">
+          <span className="dm-contact-name">
+            {contact.displayName}
+          </span>
+          </Tooltip>
+          {contact.isEphemeral && (
+            <span className="dm-contact-ephemeral-tag">mumble</span>
+          )}
+          {contact.lastMessageTime && (
+            <span className="dm-contact-time">{formatTime(contact.lastMessageTime)}</span>
+          )}
+        </div>
+        {contact.lastMessage && (
+          <span className="dm-contact-preview">{contact.lastMessage}</span>
+        )}
+      </div>
+      {contact.unreadCount > 0 && (
+        <span className="dm-contact-unread">{contact.unreadCount}</span>
+      )}
+    </button>
   );
 }

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
@@ -162,17 +162,20 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
 
       {infoDialogUser && (() => {
         const contact = contacts.find(c => c.id === infoDialogUser.id);
+        const isEphemeral = contact?.isEphemeral ?? infoDialogUser.isEphemeral;
+        const activeSession = isEphemeral
+          ? contact?.mumbleSessionId
+          : contact?.onlineSessionId;
+        if (activeSession == null) return null;
         return (
         <UserInfoDialog
           isOpen={true}
           onClose={() => setInfoDialogUser(null)}
-          userName={infoDialogUser.displayName}
-          session={infoDialogUser.isEphemeral
-            ? (infoDialogUser.mumbleSessionId ?? 0)
-            : (infoDialogUser.onlineSessionId ?? 0)}
+          userName={contact?.displayName ?? infoDialogUser.displayName}
+          session={activeSession}
           isSelf={false}
           comment={undefined}
-          matrixUserId={infoDialogUser.isEphemeral ? undefined : contact?.id}
+          matrixUserId={isEphemeral ? undefined : contact?.id}
           avatarUrl={contact?.avatarUrl}
           onStartDM={(_userId, userName) => onSelectContact(infoDialogUser.id, userName)}
         />

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
@@ -12,14 +12,27 @@ interface DMContactListProps {
   selectedUserId: string | null;
   onSelectContact: (id: string, displayName: string) => void;
   onCloseConversation: (id: string) => void;
-  onlineUserIds: string[];
   visible: boolean;
 }
 
-export function DMContactList({ contacts, selectedUserId, onSelectContact, onCloseConversation, onlineUserIds, visible }: DMContactListProps) {
+export function DMContactList({ contacts, selectedUserId, onSelectContact, onCloseConversation, visible }: DMContactListProps) {
   const [searchQuery, setSearchQuery] = useState('');
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; id: string; displayName: string; isEphemeral?: boolean } | null>(null);
-  const [infoDialogUser, setInfoDialogUser] = useState<{ id: string; displayName: string } | null>(null);
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    id: string;
+    displayName: string;
+    isEphemeral?: boolean;
+    mumbleSessionId?: number | null;
+    onlineSessionId?: number;
+  } | null>(null);
+  const [infoDialogUser, setInfoDialogUser] = useState<{
+    id: string;
+    displayName: string;
+    isEphemeral?: boolean;
+    mumbleSessionId?: number | null;
+    onlineSessionId?: number;
+  } | null>(null);
 
   const filtered = contacts.filter(c =>
     c.displayName.toLowerCase().includes(searchQuery.toLowerCase())
@@ -119,8 +132,19 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
               icon: (
                 <Icon name="info-filled" size={14} />
               ),
-              disabled: !onlineUserIds.includes(contextMenu.id),
-              onClick: () => { setInfoDialogUser({ id: contextMenu.id, displayName: contextMenu.displayName }); setContextMenu(null); },
+              disabled: contextMenu.isEphemeral
+                ? contextMenu.mumbleSessionId == null
+                : contextMenu.onlineSessionId == null,
+              onClick: () => {
+                setInfoDialogUser({
+                  id: contextMenu.id,
+                  displayName: contextMenu.displayName,
+                  isEphemeral: contextMenu.isEphemeral,
+                  mumbleSessionId: contextMenu.mumbleSessionId,
+                  onlineSessionId: contextMenu.onlineSessionId,
+                });
+                setContextMenu(null);
+              },
             },
             // Only Mumble (ephemeral) contacts can be closed — Brmble DMs are persistent
             ...(contextMenu.isEphemeral ? [{
@@ -143,12 +167,14 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
           isOpen={true}
           onClose={() => setInfoDialogUser(null)}
           userName={infoDialogUser.displayName}
-          session={0}
+          session={infoDialogUser.isEphemeral
+            ? (infoDialogUser.mumbleSessionId ?? 0)
+            : (infoDialogUser.onlineSessionId ?? 0)}
           isSelf={false}
           comment={undefined}
-          matrixUserId={contact?.id}
+          matrixUserId={infoDialogUser.isEphemeral ? undefined : contact?.id}
           avatarUrl={contact?.avatarUrl}
-          onStartDM={(userId, userName) => onSelectContact(userId, userName)}
+          onStartDM={(_userId, userName) => onSelectContact(infoDialogUser.id, userName)}
         />
         );
       })()}
@@ -161,7 +187,15 @@ interface ContactEntryProps {
   selected: boolean;
   formatTime: (ts?: number) => string;
   onSelectContact: (id: string, displayName: string) => void;
-  onOpenContextMenu: (menu: { x: number; y: number; id: string; displayName: string; isEphemeral?: boolean }) => void;
+  onOpenContextMenu: (menu: {
+    x: number;
+    y: number;
+    id: string;
+    displayName: string;
+    isEphemeral?: boolean;
+    mumbleSessionId?: number | null;
+    onlineSessionId?: number;
+  }) => void;
 }
 
 function ContactEntry({ contact, selected, formatTime, onSelectContact, onOpenContextMenu }: ContactEntryProps) {
@@ -171,7 +205,15 @@ function ContactEntry({ contact, selected, formatTime, onSelectContact, onOpenCo
       onClick={() => onSelectContact(contact.id, contact.displayName)}
       onContextMenu={(e) => {
         e.preventDefault();
-        onOpenContextMenu({ x: e.clientX, y: e.clientY, id: contact.id, displayName: contact.displayName, isEphemeral: contact.isEphemeral });
+        onOpenContextMenu({
+          x: e.clientX,
+          y: e.clientY,
+          id: contact.id,
+          displayName: contact.displayName,
+          isEphemeral: contact.isEphemeral,
+          mumbleSessionId: contact.mumbleSessionId,
+          onlineSessionId: contact.onlineSessionId,
+        });
       }}
     >
       <Avatar user={{ name: contact.displayName, matrixUserId: contact.isEphemeral ? undefined : contact.id, avatarUrl: contact.avatarUrl }} size={28} isMumbleOnly={contact.isEphemeral} />

--- a/src/Brmble.Web/src/hooks/useDMStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.test.ts
@@ -342,6 +342,24 @@ describe('useDMStore contact directory merge', () => {
     expect(result.current.contacts.some(contact => contact.isEphemeral === true)).toBe(false);
   });
 
+  it('does not list a Brmble-client user under Mumble users before Matrix mapping arrives', () => {
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        users: [
+          { name: 'me', session: 1, self: true },
+          {
+            name: 'Mapping Soon',
+            session: 2,
+            certHash: 'cert-soon',
+            isBrmbleClient: true,
+          },
+        ] as DMStoreOptions['users'],
+      }))
+    );
+
+    expect(result.current.contacts.find(contact => contact.id === 'cert-soon')).toBeUndefined();
+  });
+
   it('keeps existing Mumble history but disables the route when the active user switches to the Brmble client', () => {
     const sendMumbleDM = vi.fn();
     const standardUsers = [
@@ -468,14 +486,15 @@ describe('useDMStore contact directory merge', () => {
 
   it('sends later Mumble messages to the newest active session after reconnect', () => {
     const sendMumbleDM = vi.fn();
-    const { result } = renderHook(() =>
-      useDMStore(makeOptions({
-        sendMumbleDM,
-        users: [
-          { name: 'me', session: 1, self: true },
-          { name: 'Mumble Mike', session: 2, certHash: 'cert-mike' },
-        ] as DMStoreOptions['users'],
-      }))
+    const { result, rerender } = renderHook(
+      ({ session }) => useDMStore(makeOptions({
+          sendMumbleDM,
+          users: [
+            { name: 'me', session: 1, self: true },
+            { name: 'Mumble Mike', session, certHash: 'cert-mike' },
+          ] as DMStoreOptions['users'],
+        })),
+      { initialProps: { session: 2 } },
     );
 
     act(() => result.current.selectContact('cert-mike'));
@@ -483,8 +502,7 @@ describe('useDMStore contact directory merge', () => {
 
     expect(sendMumbleDM).toHaveBeenLastCalledWith(2, 'first session');
 
-    act(() => result.current.updateMumbleSession('cert-mike', null));
-    act(() => result.current.updateMumbleSession('cert-mike', 42, 'Mumble Mike'));
+    rerender({ session: 42 });
     act(() => result.current.selectContact('cert-mike'));
     act(() => result.current.sendMessage('new session'));
 

--- a/src/Brmble.Web/src/hooks/useDMStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.test.ts
@@ -121,6 +121,69 @@ describe('useDMStore contact directory merge', () => {
     ]);
   });
 
+  it('sends to a first-time displayed Mumble-only contact over Mumble', () => {
+    const sendMatrixDM = vi.fn().mockResolvedValue(undefined);
+    const sendMumbleDM = vi.fn();
+    const fetchDMHistory = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        fetchDMHistory,
+        sendMatrixDM,
+        sendMumbleDM,
+        users: [
+          { name: 'me', session: 1, self: true },
+          { name: 'Mumble Mike', session: 2, certHash: 'cert-mike' },
+        ] as DMStoreOptions['users'],
+      }))
+    );
+
+    act(() => result.current.selectContact('cert-mike'));
+    act(() => result.current.sendMessage('hello'));
+
+    expect(sendMumbleDM).toHaveBeenCalledTimes(1);
+    expect(sendMumbleDM).toHaveBeenCalledWith(2, 'hello');
+    expect(sendMatrixDM).not.toHaveBeenCalled();
+    expect(fetchDMHistory).not.toHaveBeenCalled();
+  });
+
+  it('treats registered vanilla Mumble users as Mumble contacts', () => {
+    const sendMatrixDM = vi.fn().mockResolvedValue(undefined);
+    const sendMumbleDM = vi.fn();
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        sendMatrixDM,
+        sendMumbleDM,
+        users: [
+          { name: 'me', session: 1, self: true },
+          {
+            name: 'Vanilla Val',
+            session: 2,
+            certHash: 'cert-val',
+            matrixUserId: '@val:example.com',
+            isBrmbleClient: false,
+          },
+        ] as DMStoreOptions['users'],
+      }))
+    );
+
+    expect(result.current.contacts).toEqual([
+      expect.objectContaining({
+        id: 'cert-val',
+        displayName: 'Vanilla Val',
+        isEphemeral: true,
+        mumbleCertHash: 'cert-val',
+        mumbleSessionId: 2,
+      }),
+    ]);
+
+    act(() => result.current.selectContact('cert-val'));
+    act(() => result.current.sendMessage('hello'));
+
+    expect(sendMumbleDM).toHaveBeenCalledTimes(1);
+    expect(sendMumbleDM).toHaveBeenCalledWith(2, 'hello');
+    expect(sendMatrixDM).not.toHaveBeenCalled();
+  });
+
   it('keeps Brmble users in the Matrix contact section when they are online', () => {
     const { result } = renderHook(() =>
       useDMStore(makeOptions({

--- a/src/Brmble.Web/src/hooks/useDMStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.test.ts
@@ -204,4 +204,292 @@ describe('useDMStore contact directory merge', () => {
     }));
     expect(result.current.contacts[0].isEphemeral).not.toBe(true);
   });
+
+  it('shows a registered standard-Mumble user in both route sections and keeps transports separate', () => {
+    const sendMatrixDM = vi.fn().mockResolvedValue(undefined);
+    const sendMumbleDM = vi.fn();
+    const fetchDMHistory = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        fetchDMHistory,
+        sendMatrixDM,
+        sendMumbleDM,
+        brmbleUsers: [
+          { matrixUserId: '@val:example.com', displayName: 'Val Persistent' },
+        ],
+        users: [
+          { name: 'me', session: 1, self: true, matrixUserId: '@me:example.com', isBrmbleClient: true },
+          {
+            name: 'Vanilla Val',
+            session: 2,
+            certHash: 'cert-val',
+            matrixUserId: '@val:example.com',
+            isBrmbleClient: false,
+          },
+        ] as DMStoreOptions['users'],
+      }))
+    );
+
+    expect(result.current.contacts).toEqual([
+      expect.objectContaining({
+        id: '@val:example.com',
+        displayName: 'Vanilla Val',
+        isEphemeral: undefined,
+        onlineSessionId: 2,
+      }),
+      expect.objectContaining({
+        id: 'cert-val',
+        displayName: 'Vanilla Val',
+        isEphemeral: true,
+        mumbleCertHash: 'cert-val',
+        mumbleSessionId: 2,
+      }),
+    ]);
+
+    act(() => result.current.selectContact('@val:example.com'));
+    act(() => result.current.sendMessage('persistent hello'));
+
+    expect(sendMatrixDM).toHaveBeenCalledTimes(1);
+    expect(sendMatrixDM).toHaveBeenCalledWith('@val:example.com', 'persistent hello');
+    expect(fetchDMHistory).toHaveBeenCalledWith('@val:example.com');
+    expect(sendMumbleDM).not.toHaveBeenCalled();
+
+    act(() => result.current.selectContact('cert-val'));
+    act(() => result.current.sendMessage('live hello'));
+
+    expect(sendMumbleDM).toHaveBeenCalledTimes(1);
+    expect(sendMumbleDM).toHaveBeenCalledWith(2, 'live hello');
+    expect(sendMatrixDM).toHaveBeenCalledTimes(1);
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({
+        channelId: 'cert-val',
+        sender: 'me',
+        content: 'live hello',
+      }),
+    ]);
+  });
+
+  it('returns empty Mumble history immediately after selecting a first-time Mumble route', () => {
+    const sendMatrixDM = vi.fn().mockResolvedValue(undefined);
+    const sendMumbleDM = vi.fn();
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        sendMatrixDM,
+        sendMumbleDM,
+        activeDmMessages: [
+          {
+            id: '$matrix-1',
+            channelId: '@val:example.com',
+            sender: 'Vanilla Val',
+            content: 'matrix history',
+            timestamp: new Date('2026-07-18T10:00:00Z'),
+          },
+        ],
+        brmbleUsers: [
+          { matrixUserId: '@val:example.com', displayName: 'Vanilla Val' },
+        ],
+        users: [
+          { name: 'me', session: 1, self: true },
+          {
+            name: 'Vanilla Val',
+            session: 22,
+            certHash: 'cert-val',
+            matrixUserId: '@val:example.com',
+            isBrmbleClient: false,
+          },
+        ] as DMStoreOptions['users'],
+      }))
+    );
+
+    act(() => result.current.selectContact('@val:example.com'));
+    expect(result.current.messages.map(message => message.content)).toEqual(['matrix history']);
+
+    act(() => result.current.selectContact('cert-val'));
+    expect(result.current.selectedContact).toEqual(expect.objectContaining({ id: 'cert-val', isEphemeral: true }));
+    expect(result.current.messages).toEqual([]);
+
+    act(() => result.current.sendMessage('mumble only'));
+
+    expect(result.current.messages.map(message => message.content)).toEqual(['mumble only']);
+    expect(sendMumbleDM).toHaveBeenCalledWith(22, 'mumble only');
+    expect(sendMatrixDM).not.toHaveBeenCalled();
+  });
+
+  it('does not list an online Brmble-client user under Mumble users even when a certHash is present', () => {
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        brmbleUsers: [
+          { matrixUserId: '@alice:example.com', displayName: 'Alice' },
+        ],
+        users: [
+          { name: 'me', session: 1, self: true },
+          {
+            name: 'Alice',
+            session: 2,
+            certHash: 'cert-alice',
+            matrixUserId: '@alice:example.com',
+            isBrmbleClient: true,
+          },
+        ] as DMStoreOptions['users'],
+      }))
+    );
+
+    expect(result.current.contacts).toEqual([
+      expect.objectContaining({
+        id: '@alice:example.com',
+        displayName: 'Alice',
+      }),
+    ]);
+    expect(result.current.contacts.some(contact => contact.isEphemeral === true)).toBe(false);
+  });
+
+  it('keeps existing Mumble history but disables the route when the active user switches to the Brmble client', () => {
+    const sendMumbleDM = vi.fn();
+    const standardUsers = [
+      { name: 'me', session: 1, self: true },
+      {
+        name: 'Switching Sam',
+        session: 2,
+        certHash: 'cert-sam',
+        matrixUserId: '@sam:example.com',
+        isBrmbleClient: false,
+      },
+    ] as DMStoreOptions['users'];
+    const brmbleUsers = [
+      { name: 'me', session: 1, self: true },
+      {
+        name: 'Switching Sam',
+        session: 2,
+        certHash: 'cert-sam',
+        matrixUserId: '@sam:example.com',
+        isBrmbleClient: true,
+      },
+    ] as DMStoreOptions['users'];
+
+    const { result, rerender } = renderHook(
+      ({ users }) => useDMStore(makeOptions({ sendMumbleDM, users })),
+      { initialProps: { users: standardUsers } },
+    );
+
+    act(() => result.current.startMumbleDM('cert-sam', 2, 'Switching Sam'));
+    act(() => result.current.sendMessage('before switch'));
+
+    rerender({ users: brmbleUsers });
+
+    const mumbleRoute = result.current.contacts.find(contact => contact.id === 'cert-sam');
+    expect(mumbleRoute).toEqual(expect.objectContaining({
+      isEphemeral: true,
+      mumbleSessionId: null,
+      lastMessage: 'before switch',
+    }));
+
+    act(() => result.current.selectContact('cert-sam'));
+    act(() => result.current.sendMessage('after switch'));
+
+    expect(sendMumbleDM).toHaveBeenCalledTimes(1);
+    expect(result.current.messages.map(message => message.content)).toEqual(['before switch']);
+  });
+
+  it('removes an unused stored Mumble route when the active user switches to the Brmble client', () => {
+    const standardUsers = [
+      { name: 'me', session: 1, self: true },
+      {
+        name: 'Switching Sam',
+        session: 2,
+        certHash: 'cert-sam',
+        matrixUserId: '@sam:example.com',
+        isBrmbleClient: false,
+      },
+    ] as DMStoreOptions['users'];
+    const brmbleUsers = [
+      { name: 'me', session: 1, self: true },
+      {
+        name: 'Switching Sam',
+        session: 2,
+        certHash: 'cert-sam',
+        matrixUserId: '@sam:example.com',
+        isBrmbleClient: true,
+      },
+    ] as DMStoreOptions['users'];
+
+    const { result, rerender } = renderHook(
+      ({ users }) => useDMStore(makeOptions({ users })),
+      { initialProps: { users: standardUsers } },
+    );
+
+    act(() => result.current.startMumbleDM('cert-sam', 2, 'Switching Sam'));
+    rerender({ users: brmbleUsers });
+
+    expect(result.current.contacts.find(contact => contact.id === 'cert-sam')).toBeUndefined();
+  });
+
+  it('excludes the current local user from every Matrix and Mumble contact source', () => {
+    const matrixDmRoomMap = new Map([
+      ['@me:example.com', '!self:example.com'],
+      ['@bob:example.com', '!bob:example.com'],
+    ]);
+
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        matrixDmRoomMap,
+        brmbleUsers: [
+          { matrixUserId: '@me:example.com', displayName: 'me' },
+          { matrixUserId: '@carol:example.com', displayName: 'Carol' },
+        ],
+        users: [
+          {
+            name: 'me',
+            session: 1,
+            self: true,
+            certHash: 'cert-me',
+            matrixUserId: '@me:example.com',
+            isBrmbleClient: true,
+          },
+          {
+            name: 'Bob',
+            session: 2,
+            certHash: 'cert-bob',
+            matrixUserId: '@bob:example.com',
+            isBrmbleClient: true,
+          },
+        ] as DMStoreOptions['users'],
+        username: 'me',
+      }))
+    );
+
+    act(() => result.current.startDM('@me:example.com', 'me'));
+    act(() => result.current.startMumbleDM('cert-me', 1, 'me'));
+
+    expect(result.current.contacts.map(contact => contact.id)).toEqual([
+      '@bob:example.com',
+      '@carol:example.com',
+    ]);
+    expect(result.current.selectedContact).toBeNull();
+  });
+
+  it('sends later Mumble messages to the newest active session after reconnect', () => {
+    const sendMumbleDM = vi.fn();
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        sendMumbleDM,
+        users: [
+          { name: 'me', session: 1, self: true },
+          { name: 'Mumble Mike', session: 2, certHash: 'cert-mike' },
+        ] as DMStoreOptions['users'],
+      }))
+    );
+
+    act(() => result.current.selectContact('cert-mike'));
+    act(() => result.current.sendMessage('first session'));
+
+    expect(sendMumbleDM).toHaveBeenLastCalledWith(2, 'first session');
+
+    act(() => result.current.updateMumbleSession('cert-mike', null));
+    act(() => result.current.updateMumbleSession('cert-mike', 42, 'Mumble Mike'));
+    act(() => result.current.selectContact('cert-mike'));
+    act(() => result.current.sendMessage('new session'));
+
+    expect(sendMumbleDM).toHaveBeenLastCalledWith(42, 'new session');
+    expect(sendMumbleDM).not.toHaveBeenCalledWith(2, 'new session');
+  });
 });

--- a/src/Brmble.Web/src/hooks/useDMStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.test.ts
@@ -509,4 +509,42 @@ describe('useDMStore contact directory merge', () => {
     expect(sendMumbleDM).toHaveBeenLastCalledWith(42, 'new session');
     expect(sendMumbleDM).not.toHaveBeenCalledWith(2, 'new session');
   });
+
+  it('keeps a selected first-time Mumble contact on the Mumble route after disconnect', () => {
+    const sendMumbleDM = vi.fn();
+    const sendMatrixDM = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderHook(
+      ({ users }) => useDMStore(makeOptions({
+        sendMumbleDM,
+        sendMatrixDM,
+        users,
+      })),
+      {
+        initialProps: {
+          users: [
+            { name: 'me', session: 1, self: true },
+            { name: 'Mumble Mike', session: 2, certHash: 'cert-mike' },
+          ] as DMStoreOptions['users'],
+        },
+      },
+    );
+
+    act(() => result.current.selectContact('cert-mike'));
+
+    rerender({
+      users: [
+        { name: 'me', session: 1, self: true },
+      ] as DMStoreOptions['users'],
+    });
+
+    act(() => result.current.sendMessage('after disconnect'));
+
+    expect(sendMumbleDM).not.toHaveBeenCalled();
+    expect(sendMatrixDM).not.toHaveBeenCalledWith('cert-mike', 'after disconnect');
+    expect(result.current.selectedContact).toEqual(expect.objectContaining({
+      id: 'cert-mike',
+      isEphemeral: true,
+      mumbleSessionId: null,
+    }));
+  });
 });

--- a/src/Brmble.Web/src/hooks/useDMStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.test.ts
@@ -234,7 +234,6 @@ describe('useDMStore contact directory merge', () => {
       expect.objectContaining({
         id: '@val:example.com',
         displayName: 'Vanilla Val',
-        isEphemeral: undefined,
         onlineSessionId: 2,
       }),
       expect.objectContaining({

--- a/src/Brmble.Web/src/hooks/useDMStore.test.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.test.ts
@@ -81,3 +81,64 @@ describe('useDMStore pendingMessages on Matrix send failure', () => {
     expect(pending).toHaveLength(0);
   });
 });
+
+describe('useDMStore contact directory merge', () => {
+  it('includes all known Brmble users even when no DM room exists', () => {
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        brmbleUsers: [
+          { matrixUserId: '@alice:example.com', displayName: 'Alice' },
+          { matrixUserId: '@bob:example.com', displayName: 'Bob' },
+        ],
+      }))
+    );
+
+    expect(result.current.contacts).toEqual([
+      expect.objectContaining({ id: '@alice:example.com', displayName: 'Alice' }),
+      expect.objectContaining({ id: '@bob:example.com', displayName: 'Bob' }),
+    ]);
+    expect(result.current.contacts.every(contact => contact.isEphemeral !== true)).toBe(true);
+  });
+
+  it('includes online Mumble-only users as ephemeral contacts', () => {
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        users: [
+          { name: 'me', session: 1, self: true },
+          { name: 'Mumble Mike', session: 2, certHash: 'cert-mike' },
+        ] as DMStoreOptions['users'],
+      }))
+    );
+
+    expect(result.current.contacts).toEqual([
+      expect.objectContaining({
+        id: 'cert-mike',
+        displayName: 'Mumble Mike',
+        isEphemeral: true,
+        mumbleCertHash: 'cert-mike',
+        mumbleSessionId: 2,
+      }),
+    ]);
+  });
+
+  it('keeps Brmble users in the Matrix contact section when they are online', () => {
+    const { result } = renderHook(() =>
+      useDMStore(makeOptions({
+        brmbleUsers: [
+          { matrixUserId: '@alice:example.com', displayName: 'Alice Offline Name' },
+        ],
+        users: [
+          { name: 'me', session: 1, self: true },
+          { name: 'Alice Online Name', session: 2, certHash: 'cert-alice', matrixUserId: '@alice:example.com', isBrmbleClient: true },
+        ] as DMStoreOptions['users'],
+      }))
+    );
+
+    expect(result.current.contacts).toHaveLength(1);
+    expect(result.current.contacts[0]).toEqual(expect.objectContaining({
+      id: '@alice:example.com',
+      displayName: 'Alice Online Name',
+    }));
+    expect(result.current.contacts[0].isEphemeral).not.toBe(true);
+  });
+});

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -209,7 +209,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     for (const user of users) {
       if (user.self || !user.certHash || selfCertHashes.has(user.certHash)) continue;
       liveUsersByCertHash.set(user.certHash, user);
-      if (user.isBrmbleClient === true && user.matrixUserId) continue;
+      if (user.isBrmbleClient === true) continue;
 
       ephemeral.set(user.certHash, {
         id: user.certHash,
@@ -232,7 +232,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
       const hasRetainedConversation = Boolean(lastMsg);
 
-      if (onlineUser?.isBrmbleClient === true && onlineUser.matrixUserId) {
+      if (onlineUser?.isBrmbleClient === true) {
         if (!hasRetainedConversation) continue;
         ephemeral.set(certHash, {
           ...mc,
@@ -351,7 +351,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
     const derivedContact = contacts.find(c => c.id === selectedContactId && c.isEphemeral);
     const storedContact = mumbleContacts.get(selectedContactId);
-    const contact = derivedContact?.mumbleSessionId === null ? derivedContact : storedContact ?? derivedContact;
+    const contact = derivedContact ?? storedContact;
     if (contact?.isEphemeral) {
       // Mumble DM path
       if (contact.mumbleSessionId == null) return; // offline, can't send

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -20,6 +20,12 @@ export interface DMContact {
   mumbleSessionId?: number | null;  // null = offline
 }
 
+export interface BrmbleDMUser {
+  matrixUserId: string;
+  displayName: string;
+  avatarUrl?: string;
+}
+
 export interface DMStoreOptions {
   matrixDmLastMessages: Map<string, MessagePreview> | undefined;
   activeDmMessages: ChatMessage[] | undefined;
@@ -29,6 +35,7 @@ export interface DMStoreOptions {
   sendMatrixDM: ((targetMatrixUserId: string, text: string) => Promise<void>) | undefined;
   fetchDMHistory: ((targetMatrixUserId: string) => Promise<void>) | undefined;
   sendMumbleDM?: (targetSession: number, text: string) => void;
+  brmbleUsers?: BrmbleDMUser[];
   users: User[];
   username: string;
 }
@@ -72,6 +79,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     sendMatrixDM,
     fetchDMHistory,
     sendMumbleDM,
+    brmbleUsers = [],
     users,
     username,
   } = options;
@@ -141,27 +149,76 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       }
     }
 
+    // Merge all known Brmble users, including offline users and users without
+    // an existing DM room. Selecting one keeps using the Matrix DM path.
+    for (const directoryUser of brmbleUsers) {
+      if (seen.has(directoryUser.matrixUserId)) continue;
+      const user = users.find(u => u.matrixUserId === directoryUser.matrixUserId);
+      seen.add(directoryUser.matrixUserId);
+      result.push({
+        id: directoryUser.matrixUserId,
+        displayName: user?.name ?? directoryUser.displayName,
+        avatarUrl: user?.avatarUrl ?? directoryUser.avatarUrl ?? matrixDmUserAvatarUrls?.get(directoryUser.matrixUserId),
+        unreadCount: 0,
+      });
+    }
+
+    // Merge online Brmble users that are visible in Mumble but were not present
+    // in the directory snapshot for any reason.
+    for (const user of users) {
+      if (user.self || !user.matrixUserId || seen.has(user.matrixUserId)) continue;
+      seen.add(user.matrixUserId);
+      result.push({
+        id: user.matrixUserId,
+        displayName: user.name,
+        avatarUrl: user.avatarUrl,
+        unreadCount: 0,
+      });
+    }
+
     // Merge pending Matrix contacts (first-time DMs before room is created)
     for (const [id, pc] of pendingMatrixContacts) {
       if (!seen.has(id)) {
+        seen.add(id);
         result.push(pc);
       }
     }
 
-    // Merge Mumble contacts
+    // Merge online Mumble-only users and any existing ephemeral Mumble contacts.
+    const ephemeral = new Map<string, DMContact>();
+    for (const user of users) {
+      if (user.self || !user.certHash || user.matrixUserId) continue;
+      ephemeral.set(user.certHash, {
+        id: user.certHash,
+        displayName: user.name,
+        avatarUrl: user.avatarUrl,
+        unreadCount: 0,
+        isEphemeral: true,
+        mumbleCertHash: user.certHash,
+        mumbleSessionId: user.session,
+      });
+    }
+
     for (const [, mc] of mumbleContacts) {
+      const onlineContact = mc.mumbleCertHash ? ephemeral.get(mc.mumbleCertHash) : undefined;
       const msgs = mumbleMessages.get(mc.mumbleCertHash!);
       const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
-      result.push({
+      ephemeral.set(mc.mumbleCertHash!, {
         ...mc,
+        displayName: onlineContact?.displayName ?? mc.displayName,
+        avatarUrl: onlineContact?.avatarUrl ?? mc.avatarUrl,
+        mumbleSessionId: onlineContact?.mumbleSessionId ?? mc.mumbleSessionId,
         lastMessage: lastMsg?.content,
         lastMessageTime: lastMsg?.timestamp.getTime(),
       });
     }
 
-    result.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
+    const matrixContacts = result.sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0));
+    const mumbleOnlyContacts = [...ephemeral.values()]
+      .sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0) || a.displayName.localeCompare(b.displayName));
+    result.splice(0, result.length, ...matrixContacts, ...mumbleOnlyContacts);
     return result;
-  }, [matrixDmRoomMap, matrixDmLastMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, users, pendingMatrixContacts, mumbleContacts, mumbleMessages]);
+  }, [matrixDmRoomMap, matrixDmLastMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, brmbleUsers, users, pendingMatrixContacts, mumbleContacts, mumbleMessages]);
 
   // ---- Selected contact ----------------------------------------------------
 

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -20,6 +20,7 @@ export interface DMContact {
   isEphemeral?: boolean;
   mumbleCertHash?: string;
   mumbleSessionId?: number | null;  // null = offline or no active standard-Mumble route
+  persistedFromDirectory?: boolean;
 }
 
 export interface BrmbleDMUser {
@@ -231,6 +232,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       const msgs = mumbleMessages.get(certHash);
       const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
       const hasRetainedConversation = Boolean(lastMsg);
+      const isSelectedRoute = selectedContactId === certHash;
 
       if (onlineUser?.isBrmbleClient === true) {
         if (!hasRetainedConversation) continue;
@@ -245,13 +247,13 @@ export function useDMStore(options: DMStoreOptions): DMStore {
         continue;
       }
 
-      if (!onlineContact && !hasRetainedConversation) continue;
+      if (!onlineContact && !hasRetainedConversation && !isSelectedRoute) continue;
 
       ephemeral.set(certHash, {
         ...mc,
         displayName: onlineContact?.displayName ?? mc.displayName,
         avatarUrl: onlineContact?.avatarUrl ?? mc.avatarUrl,
-        mumbleSessionId: onlineContact?.mumbleSessionId ?? mc.mumbleSessionId,
+        mumbleSessionId: onlineContact?.mumbleSessionId ?? (mc.persistedFromDirectory ? null : mc.mumbleSessionId),
         lastMessage: lastMsg?.content,
         lastMessageTime: lastMsg?.timestamp.getTime(),
       });
@@ -262,7 +264,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       .sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0) || a.displayName.localeCompare(b.displayName));
     result.splice(0, result.length, ...matrixContacts, ...mumbleOnlyContacts);
     return result;
-  }, [matrixDmRoomMap, matrixDmLastMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, brmbleUsers, users, pendingMatrixContacts, mumbleContacts, mumbleMessages, selfMatrixUserIds, selfCertHashes]);
+  }, [matrixDmRoomMap, matrixDmLastMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, brmbleUsers, users, pendingMatrixContacts, mumbleContacts, mumbleMessages, selfMatrixUserIds, selfCertHashes, selectedContactId]);
 
   // ---- Selected contact ----------------------------------------------------
 
@@ -291,14 +293,19 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   const selectContact = useCallback((id: string) => {
     setSelectedContactId(id);
     setAppMode('dm');
-    const isMumbleContact = mumbleContacts.has(id) || contacts.some(c => c.id === id && c.isEphemeral);
+    const ephemeralContact = contacts.find(c => c.id === id && c.isEphemeral);
+    const isMumbleContact = mumbleContacts.has(id) || ephemeralContact !== undefined;
 
-    // Clear Mumble unread if applicable
     setMumbleContacts(prev => {
       const contact = prev.get(id);
       if (contact && contact.unreadCount > 0) {
         const next = new Map(prev);
         next.set(id, { ...contact, unreadCount: 0 });
+        return next;
+      }
+      if (!contact && ephemeralContact) {
+        const next = new Map(prev);
+        next.set(id, { ...ephemeralContact, unreadCount: 0, persistedFromDirectory: true });
         return next;
       }
       return prev;

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -14,10 +14,12 @@ export interface DMContact {
   lastMessage?: string;
   lastMessageTime?: number;
   unreadCount: number;
+  /** Active Mumble session for an online Matrix contact, used only by user-info controls. */
+  onlineSessionId?: number;
   // Mumble DM fields (only set for ephemeral Mumble contacts)
   isEphemeral?: boolean;
   mumbleCertHash?: string;
-  mumbleSessionId?: number | null;  // null = offline
+  mumbleSessionId?: number | null;  // null = offline or no active standard-Mumble route
 }
 
 export interface BrmbleDMUser {
@@ -121,6 +123,14 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     }
   }, [users.length]);
 
+  const selfMatrixUserIds = useMemo(() => {
+    return new Set(users.filter(user => user.self && user.matrixUserId).map(user => user.matrixUserId!));
+  }, [users]);
+
+  const selfCertHashes = useMemo(() => {
+    return new Set(users.filter(user => user.self && user.certHash).map(user => user.certHash!));
+  }, [users]);
+
   // ---- Matrix contacts derived from matrixDmRoomMap ------------------------
 
   const contacts: DMContact[] = useMemo(() => {
@@ -129,6 +139,8 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
     if (matrixDmRoomMap) {
       for (const [matrixUserId] of matrixDmRoomMap) {
+        if (selfMatrixUserIds.has(matrixUserId)) continue;
+
         seen.add(matrixUserId);
         const user = users.find(u => u.matrixUserId === matrixUserId);
         const lastPreview = matrixDmLastMessages?.get(matrixUserId);
@@ -144,7 +156,8 @@ export function useDMStore(options: DMStoreOptions): DMStore {
           avatarUrl: user?.avatarUrl ?? matrixDmUserAvatarUrls?.get(matrixUserId),
           lastMessage: lastPreview?.content,
           lastMessageTime: lastPreview?.ts,
-          unreadCount: 0, // Matrix unread is tracked globally via matrixDmUnreadCount
+          unreadCount: 0,
+          onlineSessionId: user?.session,
         });
       }
     }
@@ -152,7 +165,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     // Merge all known Brmble users, including offline users and users without
     // an existing DM room. Selecting one keeps using the Matrix DM path.
     for (const directoryUser of brmbleUsers) {
-      if (seen.has(directoryUser.matrixUserId)) continue;
+      if (seen.has(directoryUser.matrixUserId) || selfMatrixUserIds.has(directoryUser.matrixUserId)) continue;
       const user = users.find(u => u.matrixUserId === directoryUser.matrixUserId);
       seen.add(directoryUser.matrixUserId);
       result.push({
@@ -160,6 +173,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
         displayName: user?.name ?? directoryUser.displayName,
         avatarUrl: user?.avatarUrl ?? directoryUser.avatarUrl ?? matrixDmUserAvatarUrls?.get(directoryUser.matrixUserId),
         unreadCount: 0,
+        onlineSessionId: user?.session,
       });
     }
 
@@ -173,22 +187,30 @@ export function useDMStore(options: DMStoreOptions): DMStore {
         displayName: user.name,
         avatarUrl: user.avatarUrl,
         unreadCount: 0,
+        onlineSessionId: user.session,
       });
     }
 
     // Merge pending Matrix contacts (first-time DMs before room is created)
     for (const [id, pc] of pendingMatrixContacts) {
-      if (!seen.has(id)) {
+      if (!seen.has(id) && !selfMatrixUserIds.has(id)) {
         seen.add(id);
-        result.push(pc);
+        const user = users.find(u => u.matrixUserId === id);
+        result.push({ ...pc, onlineSessionId: user?.session });
       }
     }
 
-    // Merge online Mumble users that are not reachable through Brmble/Matrix,
-    // plus any existing ephemeral Mumble contacts.
+    // Merge online standard-Mumble users that have a stable certificate hash,
+    // plus retained ephemeral conversations. Cert-less users are intentionally
+    // excluded from this pass; see the plan scope note.
     const ephemeral = new Map<string, DMContact>();
+    const liveUsersByCertHash = new Map<string, User>();
+
     for (const user of users) {
-      if (user.self || !user.certHash || (user.isBrmbleClient && user.matrixUserId)) continue;
+      if (user.self || !user.certHash || selfCertHashes.has(user.certHash)) continue;
+      liveUsersByCertHash.set(user.certHash, user);
+      if (user.isBrmbleClient === true && user.matrixUserId) continue;
+
       ephemeral.set(user.certHash, {
         id: user.certHash,
         displayName: user.name,
@@ -201,10 +223,31 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     }
 
     for (const [, mc] of mumbleContacts) {
-      const onlineContact = mc.mumbleCertHash ? ephemeral.get(mc.mumbleCertHash) : undefined;
-      const msgs = mumbleMessages.get(mc.mumbleCertHash!);
+      const certHash = mc.mumbleCertHash;
+      if (!certHash || selfCertHashes.has(certHash)) continue;
+
+      const onlineUser = liveUsersByCertHash.get(certHash);
+      const onlineContact = ephemeral.get(certHash);
+      const msgs = mumbleMessages.get(certHash);
       const lastMsg = msgs && msgs.length > 0 ? msgs[msgs.length - 1] : undefined;
-      ephemeral.set(mc.mumbleCertHash!, {
+      const hasRetainedConversation = Boolean(lastMsg);
+
+      if (onlineUser?.isBrmbleClient === true && onlineUser.matrixUserId) {
+        if (!hasRetainedConversation) continue;
+        ephemeral.set(certHash, {
+          ...mc,
+          displayName: onlineUser.name,
+          avatarUrl: onlineUser.avatarUrl ?? mc.avatarUrl,
+          mumbleSessionId: null,
+          lastMessage: lastMsg?.content,
+          lastMessageTime: lastMsg?.timestamp.getTime(),
+        });
+        continue;
+      }
+
+      if (!onlineContact && !hasRetainedConversation) continue;
+
+      ephemeral.set(certHash, {
         ...mc,
         displayName: onlineContact?.displayName ?? mc.displayName,
         avatarUrl: onlineContact?.avatarUrl ?? mc.avatarUrl,
@@ -219,7 +262,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       .sort((a, b) => (b.lastMessageTime ?? 0) - (a.lastMessageTime ?? 0) || a.displayName.localeCompare(b.displayName));
     result.splice(0, result.length, ...matrixContacts, ...mumbleOnlyContacts);
     return result;
-  }, [matrixDmRoomMap, matrixDmLastMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, brmbleUsers, users, pendingMatrixContacts, mumbleContacts, mumbleMessages]);
+  }, [matrixDmRoomMap, matrixDmLastMessages, matrixDmUserDisplayNames, matrixDmUserAvatarUrls, brmbleUsers, users, pendingMatrixContacts, mumbleContacts, mumbleMessages, selfMatrixUserIds, selfCertHashes]);
 
   // ---- Selected contact ----------------------------------------------------
 
@@ -232,14 +275,16 @@ export function useDMStore(options: DMStoreOptions): DMStore {
 
   const messages: ChatMessage[] = useMemo(() => {
     if (!selectedContactId) return [];
-    // Check if this is a Mumble contact
-    const mumbleMsgs = mumbleMessages.get(selectedContactId);
-    if (mumbleMsgs) return mumbleMsgs;
-    // Otherwise Matrix messages
+
+    const contact = selectedContact ?? contacts.find(c => c.id === selectedContactId);
+    if (contact?.isEphemeral) {
+      return mumbleMessages.get(selectedContactId) ?? [];
+    }
+
     const matrixMsgs = activeDmMessages ?? [];
     const pending = pendingMessages.get(selectedContactId) ?? [];
     return [...matrixMsgs, ...pending];
-  }, [selectedContactId, activeDmMessages, pendingMessages, mumbleMessages]);
+  }, [selectedContactId, selectedContact, contacts, activeDmMessages, pendingMessages, mumbleMessages]);
 
   // ---- Actions -------------------------------------------------------------
 
@@ -265,6 +310,11 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   }, [fetchDMHistory, mumbleContacts, contacts]);
 
   const startDM = useCallback((matrixUserId: string, displayName: string, avatarUrl?: string) => {
+    if (selfMatrixUserIds.has(matrixUserId)) {
+      setSelectedContactId(null);
+      return;
+    }
+
     // Add a pending contact if no DM room exists yet (first-time DM)
     if (!matrixDmRoomMap?.has(matrixUserId)) {
       setPendingMatrixContacts(prev => {
@@ -286,7 +336,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     if (fetchDMHistory) {
       fetchDMHistory(matrixUserId).catch(console.warn);
     }
-  }, [fetchDMHistory, matrixDmRoomMap]);
+  }, [fetchDMHistory, matrixDmRoomMap, selfMatrixUserIds]);
 
   const clearSelection = useCallback(() => {
     setSelectedContactId(null);
@@ -299,10 +349,34 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   const sendMessage = useCallback((content: string) => {
     if (!selectedContactId) return;
 
-    const contact = mumbleContacts.get(selectedContactId) ?? contacts.find(c => c.id === selectedContactId && c.isEphemeral);
+    const derivedContact = contacts.find(c => c.id === selectedContactId && c.isEphemeral);
+    const storedContact = mumbleContacts.get(selectedContactId);
+    const contact = derivedContact?.mumbleSessionId === null ? derivedContact : storedContact ?? derivedContact;
     if (contact?.isEphemeral) {
       // Mumble DM path
       if (contact.mumbleSessionId == null) return; // offline, can't send
+      setMumbleContacts(prev => {
+        const existing = prev.get(contact.id);
+        const nextContact: DMContact = {
+          ...contact,
+          unreadCount: existing?.unreadCount ?? contact.unreadCount,
+          mumbleSessionId: contact.mumbleSessionId,
+        };
+
+        if (
+          existing &&
+          existing.displayName === nextContact.displayName &&
+          existing.avatarUrl === nextContact.avatarUrl &&
+          existing.mumbleSessionId === nextContact.mumbleSessionId &&
+          existing.unreadCount === nextContact.unreadCount
+        ) {
+          return prev;
+        }
+
+        const next = new Map(prev);
+        next.set(contact.id, nextContact);
+        return next;
+      });
       const msg: ChatMessage = {
         id: `mumble-${Date.now()}-${Math.random()}`,
         channelId: selectedContactId,
@@ -452,6 +526,11 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   }, []);
 
   const startMumbleDM = useCallback((certHash: string, sessionId: number, displayName: string) => {
+    if (selfCertHashes.has(certHash)) {
+      setSelectedContactId(null);
+      return;
+    }
+
     setMumbleContacts(prev => {
       const next = new Map(prev);
       if (!next.has(certHash)) {
@@ -468,7 +547,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     });
     setSelectedContactId(certHash);
     setAppMode('dm');
-  }, []);
+  }, [selfCertHashes]);
 
   // ---- Return --------------------------------------------------------------
 

--- a/src/Brmble.Web/src/hooks/useDMStore.ts
+++ b/src/Brmble.Web/src/hooks/useDMStore.ts
@@ -166,7 +166,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
     // Merge online Brmble users that are visible in Mumble but were not present
     // in the directory snapshot for any reason.
     for (const user of users) {
-      if (user.self || !user.matrixUserId || seen.has(user.matrixUserId)) continue;
+      if (user.self || !user.isBrmbleClient || !user.matrixUserId || seen.has(user.matrixUserId)) continue;
       seen.add(user.matrixUserId);
       result.push({
         id: user.matrixUserId,
@@ -184,10 +184,11 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       }
     }
 
-    // Merge online Mumble-only users and any existing ephemeral Mumble contacts.
+    // Merge online Mumble users that are not reachable through Brmble/Matrix,
+    // plus any existing ephemeral Mumble contacts.
     const ephemeral = new Map<string, DMContact>();
     for (const user of users) {
-      if (user.self || !user.certHash || user.matrixUserId) continue;
+      if (user.self || !user.certHash || (user.isBrmbleClient && user.matrixUserId)) continue;
       ephemeral.set(user.certHash, {
         id: user.certHash,
         displayName: user.name,
@@ -245,6 +246,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   const selectContact = useCallback((id: string) => {
     setSelectedContactId(id);
     setAppMode('dm');
+    const isMumbleContact = mumbleContacts.has(id) || contacts.some(c => c.id === id && c.isEphemeral);
 
     // Clear Mumble unread if applicable
     setMumbleContacts(prev => {
@@ -257,10 +259,10 @@ export function useDMStore(options: DMStoreOptions): DMStore {
       return prev;
     });
 
-    if (fetchDMHistory) {
+    if (!isMumbleContact && fetchDMHistory) {
       fetchDMHistory(id).catch(console.warn);
     }
-  }, [fetchDMHistory]);
+  }, [fetchDMHistory, mumbleContacts, contacts]);
 
   const startDM = useCallback((matrixUserId: string, displayName: string, avatarUrl?: string) => {
     // Add a pending contact if no DM room exists yet (first-time DM)
@@ -297,7 +299,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
   const sendMessage = useCallback((content: string) => {
     if (!selectedContactId) return;
 
-    const contact = mumbleContacts.get(selectedContactId);
+    const contact = mumbleContacts.get(selectedContactId) ?? contacts.find(c => c.id === selectedContactId && c.isEphemeral);
     if (contact?.isEphemeral) {
       // Mumble DM path
       if (contact.mumbleSessionId == null) return; // offline, can't send
@@ -359,7 +361,7 @@ export function useDMStore(options: DMStoreOptions): DMStore {
           });
         });
     }
-  }, [selectedContactId, username, sendMatrixDM, mumbleContacts, sendMumbleDM]);
+  }, [selectedContactId, username, sendMatrixDM, mumbleContacts, contacts, sendMumbleDM]);
 
   const closeDM = useCallback((id: string) => {
     // Deselect if this contact is currently active

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -288,6 +288,26 @@ internal sealed class TestTlsHttpServer : IAsyncDisposable
 public class MumbleAdapterParseTests
 {
     [TestMethod]
+    public void ParseSessionMappings_PreservesCertHash()
+    {
+        using var doc = JsonDocument.Parse("""
+        {
+            "42": {
+                "matrixUserId": "@mjg:example.com",
+                "mumbleName": "MJG",
+                "companionId": "bee",
+                "isBrmbleClient": false,
+                "certHash": "cert-mjg"
+            }
+        }
+        """);
+
+        var mappings = MumbleAdapter.ParseSessionMappings(doc.RootElement);
+
+        Assert.AreEqual("cert-mjg", mappings[42].CertHash);
+    }
+
+    [TestMethod]
     public void ServerSync_JoinsReconnectTargetAfterAuthenticateTokensApply()
     {
         var bridge = NativeBridgeTestHarness.Create();

--- a/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
+++ b/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
@@ -102,6 +102,23 @@ public class BrmbleEventBusTests
     }
 
     [TestMethod]
+    public void HasConnectedClient_TracksRemainingClientsForUser()
+    {
+        var ws1 = CreateMockWebSocket(WebSocketState.Open);
+        var ws2 = CreateMockWebSocket(WebSocketState.Open);
+        _bus.AddClient(ws1.Object, 1L);
+        _bus.AddClient(ws2.Object, 1L);
+
+        _bus.RemoveClient(ws1.Object);
+
+        Assert.IsTrue(_bus.HasConnectedClient(1L));
+
+        _bus.RemoveClient(ws2.Object);
+
+        Assert.IsFalse(_bus.HasConnectedClient(1L));
+    }
+
+    [TestMethod]
     public async Task BroadcastToChannelAsync_SendsOnlyToUsersInChannel()
     {
         // Set up channel membership: channel 5 has sessions 10 and 20

--- a/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
@@ -108,15 +108,22 @@ public class SessionMappingHandlerTests
     }
 
     [TestMethod]
-    public async Task OnUserConnected_AlreadyMapped_DoesNotBroadcast()
+    public async Task OnUserConnected_AlreadyMapped_BroadcastsRouteUpsert()
     {
         var user = await _repo.Insert("abc123", "Alice");
         _mapping.Setup(m => m.TryAddMatrixUser(1, user.MatrixUserId, "Alice", user.Id, "floppy")).Returns(false);
+        _mapping.Setup(m => m.TryUpdateBrmbleStatus(1, false)).Returns(true);
+        _mapping.Setup(m => m.TryUpdateCertHash(1, "abc123")).Returns(true);
 
         await _handler.OnUserConnected(new MumbleUser("Alice", "abc123", 1));
 
         _mapping.Verify(m => m.TryAddMatrixUser(1, user.MatrixUserId, "Alice", user.Id, "floppy"), Times.Once);
-        _bus.Verify(b => b.BroadcastAsync(It.IsAny<object>()), Times.Never);
+        _mapping.Verify(m => m.TryUpdateBrmbleStatus(1, false), Times.Once);
+        _bus.Verify(b => b.BroadcastAsync(It.Is<object>(message =>
+            message.GetType().GetProperty("type")!.GetValue(message)!.Equals("userMappingAdded") &&
+            message.GetType().GetProperty("sessionId")!.GetValue(message)!.Equals(1) &&
+            message.GetType().GetProperty("certHash")!.GetValue(message)!.Equals("abc123") &&
+            message.GetType().GetProperty("isBrmbleClient")!.GetValue(message)!.Equals(false))), Times.Once);
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Events/SessionMappingServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingServiceTests.cs
@@ -143,4 +143,15 @@ public class SessionMappingServiceTests
         Assert.IsTrue(updated);
         Assert.AreEqual("floppy", _svc.GetSnapshot()[42].CompanionId);
     }
+
+    [TestMethod]
+    public void TryUpdateCertHash_UpdatesExistingMapping()
+    {
+        _svc.TryAddMatrixUser(42, "@alice:test", "Alice", 100L, "bee");
+
+        var updated = _svc.TryUpdateCertHash(42, "cert-alice");
+
+        Assert.IsTrue(updated);
+        Assert.AreEqual("cert-alice", _svc.GetSnapshot()[42].CertHash);
+    }
 }

--- a/tests/Brmble.Server.Tests/Integration/AuthTokenTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/AuthTokenTests.cs
@@ -127,6 +127,31 @@ public class AuthTokenTests : IDisposable
     }
 
     [TestMethod]
+    public async Task PostAuthToken_SessionMappings_IncludeCertHash()
+    {
+        using var factory = new BrmbleServerFactory();
+        using var client = factory.CreateClient();
+
+        var sessionMapping = factory.Services.GetRequiredService<ISessionMappingService>();
+        sessionMapping.SetNameForSession("OtherUser", 42);
+        sessionMapping.TryAddMatrixUser(42, "@other:localhost", "OtherUser", 999, "retro");
+        sessionMapping.TryUpdateCertHash(42, "cert-other");
+
+        var response = await client.PostAsync("/auth/token", null);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var certHash = doc.RootElement
+            .GetProperty("sessionMappings")
+            .GetProperty("42")
+            .GetProperty("certHash")
+            .GetString();
+
+        Assert.AreEqual("cert-other", certHash);
+    }
+
+    [TestMethod]
     public async Task PostAuthToken_SelfSession_IsBrmbleClient_True()
     {
         // Verify that the authenticating user's own session gets isBrmbleClient = true

--- a/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
+++ b/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
@@ -56,6 +56,8 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
             .Returns((int sessionId, bool isBrmbleClient) => defaultSessionMapping.TryUpdateBrmbleStatus(sessionId, isBrmbleClient));
         SessionMappingMock.Setup(s => s.TryUpdateCompanionId(It.IsAny<int>(), It.IsAny<string>()))
             .Returns((int sessionId, string companionId) => defaultSessionMapping.TryUpdateCompanionId(sessionId, companionId));
+        SessionMappingMock.Setup(s => s.TryUpdateCertHash(It.IsAny<int>(), It.IsAny<string>()))
+            .Returns((int sessionId, string certHash) => defaultSessionMapping.TryUpdateCertHash(sessionId, certHash));
         SessionMappingMock.Setup(s => s.TryGetSessionId(It.IsAny<string>(), out It.Ref<int>.IsAny))
             .Returns((string mumbleName, out int sessionId) => defaultSessionMapping.TryGetSessionId(mumbleName, out sessionId));
         SessionMappingMock.Setup(s => s.TryGetSessionByUserId(It.IsAny<long>(), out It.Ref<int>.IsAny))

--- a/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
@@ -1,0 +1,25 @@
+using Brmble.Server.Events;
+using Brmble.Server.WebSockets;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.WebSockets;
+
+[TestClass]
+public class BrmbleWebSocketHandlerTests
+{
+    [TestMethod]
+    public void CreateUserMappingAddedPayload_UsesAuthoritativeCertHash()
+    {
+        var mapping = new SessionMapping(
+            MatrixUserId: "@alice:test.local",
+            MumbleName: "Alice",
+            UserId: 42,
+            CompanionId: "floppy",
+            CertHash: null,
+            IsBrmbleClient: false);
+
+        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash");
+
+        Assert.AreEqual("fresh-hash", payload.GetType().GetProperty("certHash")!.GetValue(payload));
+    }
+}


### PR DESCRIPTION
```markdown
## Summary

Adds a full DM user directory to the Direct Message panel.

Brmble users now appear in the Messages list even when they are offline or have never had an existing DM conversation with the current user. Online Mumble-only users are shown separately under a new “Mumble users” section, keeping the difference between persistent Brmble DMs and online-only Mumble DMs clear.

## What Changed

- Merged all known Brmble users from the auth `userMappings` payload into the DM contact list.
- Preserved existing Matrix DM behavior:
  - Existing conversations still show previews and unread state.
  - First-time Brmble DMs still create the Matrix DM room only when a message is sent.
- Added online Mumble-only users to the DM list as ephemeral contacts.
- Split the DM sidebar into:
  - **Messages**: Brmble users and Brmble DM conversations.
  - **Mumble users**: online Mumble-only users.
- Updated search copy from “conversations” to “users”.
- Added regression tests for:
  - Offline Brmble users with no existing DM room.
  - Online Mumble-only users.
  - Online Brmble users not being duplicated into the Mumble section.

## Behavior Notes

- Brmble users appear in **Messages** whether online or offline.
- Mumble-only users appear only while online.
- Brmble users who are also online do not appear under **Mumble users**.
- Existing chat send paths are unchanged:
  - Brmble users use Matrix DMs.
  - Mumble-only users use existing ephemeral Mumble private messages.

## Testing

- `npm.cmd run test -- src/hooks/useDMStore.test.ts`
- `npm.cmd run build`
```