### PR TITLE
fix: stop dropping capture audio at resampler and APM boundaries

### DIFF
--- a/lib/MumbleVoiceEngine/Audio/R8BrainResampler.cs
+++ b/lib/MumbleVoiceEngine/Audio/R8BrainResampler.cs
@@ -21,20 +21,32 @@ public sealed class R8BrainResampler : IDisposable
     }
 
     public int Process(double[] input, out double[] output)
+        => Process(input, input.Length, out output);
+
+    /// <summary>
+    /// Resample the first <paramref name="inputLength"/> samples of
+    /// <paramref name="input"/>. The backing array may be larger than the
+    /// actual sample count (callers reuse growing scratch buffers).
+    /// </summary>
+    public int Process(double[] input, int inputLength, out double[] output)
     {
         if (_handle == IntPtr.Zero)
             throw new ObjectDisposedException(nameof(R8BrainResampler));
 
-        if (input.Length > _maxInLen)
+        if (inputLength > _maxInLen)
             throw new ArgumentException(
-                $"Input length {input.Length} exceeds maxInLen {_maxInLen} configured at construction",
-                nameof(input));
+                $"Input length {inputLength} exceeds maxInLen {_maxInLen} configured at construction",
+                nameof(inputLength));
+        if (inputLength > input.Length)
+            throw new ArgumentException(
+                $"Input length {inputLength} exceeds array length {input.Length}",
+                nameof(inputLength));
 
         var pinned = GCHandle.Alloc(input, GCHandleType.Pinned);
         try
         {
             int outSamples = R8BrainNative.r8b_process(
-                _handle, pinned.AddrOfPinnedObject(), input.Length, out IntPtr outPtr);
+                _handle, pinned.AddrOfPinnedObject(), inputLength, out IntPtr outPtr);
 
             if (outSamples > 0 && outPtr != IntPtr.Zero)
             {

--- a/lib/MumbleVoiceEngine/Audio/R8BrainResampler.cs
+++ b/lib/MumbleVoiceEngine/Audio/R8BrainResampler.cs
@@ -33,6 +33,9 @@ public sealed class R8BrainResampler : IDisposable
         if (_handle == IntPtr.Zero)
             throw new ObjectDisposedException(nameof(R8BrainResampler));
 
+        if (inputLength < 0)
+            throw new ArgumentException(
+                $"Input length {inputLength} is negative", nameof(inputLength));
         if (inputLength > _maxInLen)
             throw new ArgumentException(
                 $"Input length {inputLength} exceeds maxInLen {_maxInLen} configured at construction",

--- a/src/Brmble.Audio/Processing/WebRtcApmProcessor.cs
+++ b/src/Brmble.Audio/Processing/WebRtcApmProcessor.cs
@@ -114,6 +114,13 @@ public sealed class WebRtcApmProcessor : IDisposable
         return outWritten;
     }
 
+    /// <summary>
+    /// Discard any buffered sub-frame leftover. Call between voice
+    /// transmissions so the stale tail of the previous one is not prepended
+    /// to the first frame of the next.
+    /// </summary>
+    public void Reset() => _pendingBytes = 0;
+
     private void ProcessOneFrame(ReadOnlySpan<byte> inPcm16, Span<byte> outPcm16)
     {
         var inFloat = _frameIn[0];

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -702,8 +702,14 @@ internal sealed class AudioManager : IDisposable
         }
         _encodePipeline?.Dispose();
         _encodePipeline = null;
-        _deviceResampler?.Dispose();
-        _deviceResampler = null;
+        // Keep the resampler instance across transmissions (recreating it per
+        // PTT press re-primes its FIR filter, clipping the start of speech);
+        // just reset its internal state so no stale tail leaks into the next one.
+        try { _deviceResampler?.Clear(); }
+        catch (Exception ex) { AudioLog.Write($"[Audio] Resampler clear failed: {ex.Message}"); }
+        // Same for the APM: drop its buffered sub-frame leftover so the stale
+        // tail of this transmission is not prepended to the next one.
+        lock (_processorLock) { _processor?.Reset(); }
         _micStarted = false;
         uint capturedUserId = _localUserId;
         bool wasSpeaking = capturedUserId != 0 && _currentlySpeaking.Remove(capturedUserId);
@@ -716,6 +722,7 @@ internal sealed class AudioManager : IDisposable
     [ThreadStatic] private static float[]? _wasapiMonoScratch;
     [ThreadStatic] private static byte[]? _wasapiInt16Scratch;
     [ThreadStatic] private static double[]? _resampleDoubleScratch;
+    [ThreadStatic] private static float[]? _resampleOutScratch;
     [ThreadStatic] private static bool _threadPriorityBoosted;
 
     private void OnMicData(object? sender, WaveInEventArgs e)
@@ -767,31 +774,50 @@ internal sealed class AudioManager : IDisposable
             int srcRate = fmt.SampleRate;
             if (srcRate != 48000)
             {
-                // Create or recreate r8brain resampler if device rate changed or buffer exceeds maxInLen
-                if (_deviceResampler == null || _deviceSampleRate != srcRate || monoFrames > _deviceMaxInLen)
+                // Create the resampler once per device rate with 100ms of input
+                // headroom. Recreating it mid-stream (as the old size-based
+                // condition did when WASAPI callbacks coalesced under load)
+                // drops the samples buffered in its FIR state and re-primes,
+                // splicing an audible gap into the outgoing stream.
+                if (_deviceResampler == null || _deviceSampleRate != srcRate)
                 {
                     _deviceResampler?.Dispose();
                     _deviceSampleRate = srcRate;
-                    _deviceMaxInLen = monoFrames;
-                    _deviceResampler = new R8BrainResampler(srcRate, 48000, monoFrames);
+                    _deviceMaxInLen = Math.Max(srcRate / 10, monoFrames);
+                    _deviceResampler = new R8BrainResampler(srcRate, 48000, _deviceMaxInLen);
                 }
 
-                // Convert float→double for r8brain
-                if (_resampleDoubleScratch == null || _resampleDoubleScratch.Length < monoFrames)
-                    _resampleDoubleScratch = new double[monoFrames];
-                for (int i = 0; i < monoFrames; i++)
-                    _resampleDoubleScratch[i] = _wasapiMonoScratch[i];
+                // Process in chunks of at most maxInLen; larger-than-headroom
+                // callbacks are handled without touching the resampler state.
+                int totalOut = 0;
+                int processedFrames = 0;
+                while (processedFrames < monoFrames)
+                {
+                    int chunk = Math.Min(_deviceMaxInLen, monoFrames - processedFrames);
+                    if (_resampleDoubleScratch == null || _resampleDoubleScratch.Length < chunk)
+                        _resampleDoubleScratch = new double[chunk];
+                    for (int i = 0; i < chunk; i++)
+                        _resampleDoubleScratch[i] = _wasapiMonoScratch[processedFrames + i];
 
-                int outSamples = _deviceResampler.Process(_resampleDoubleScratch, out double[] resampledDouble);
+                    int outSamples = _deviceResampler.Process(_resampleDoubleScratch, chunk, out double[] resampledDouble);
 
-                // Reuse mono scratch buffer for float conversion
-                if (_wasapiMonoScratch == null || _wasapiMonoScratch.Length < outSamples)
-                    _wasapiMonoScratch = new float[outSamples];
-                for (int i = 0; i < outSamples; i++)
-                    _wasapiMonoScratch[i] = (float)resampledDouble[i];
+                    // Accumulate into a separate output scratch; the mono scratch
+                    // still holds unprocessed input for subsequent chunks.
+                    if (_resampleOutScratch == null || _resampleOutScratch.Length < totalOut + outSamples)
+                    {
+                        var grown = new float[totalOut + outSamples];
+                        if (_resampleOutScratch != null)
+                            Array.Copy(_resampleOutScratch, grown, totalOut);
+                        _resampleOutScratch = grown;
+                    }
+                    for (int i = 0; i < outSamples; i++)
+                        _resampleOutScratch[totalOut + i] = (float)resampledDouble[i];
+                    totalOut += outSamples;
+                    processedFrames += chunk;
+                }
 
-                monoAt48k = _wasapiMonoScratch;
-                monoFrames = outSamples;
+                monoAt48k = _resampleOutScratch ?? Array.Empty<float>();
+                monoFrames = totalOut;
             }
             else
             {

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -814,7 +814,11 @@ internal sealed class AudioManager : IDisposable
                         // still holds unprocessed input for subsequent chunks.
                         if (_resampleOutScratch == null || _resampleOutScratch.Length < totalOut + outSamples)
                         {
-                            var grown = new float[totalOut + outSamples];
+                            // Amortized doubling: converges to the steady-state
+                            // size after the first few callbacks instead of
+                            // reallocating per chunk on a large callback.
+                            int newCap = Math.Max(totalOut + outSamples, (_resampleOutScratch?.Length ?? 0) * 2);
+                            var grown = new float[newCap];
                             if (_resampleOutScratch != null)
                                 Array.Copy(_resampleOutScratch, grown, totalOut);
                             _resampleOutScratch = grown;

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -202,7 +202,10 @@ internal sealed class AudioManager : IDisposable
         public int LostUnits;
     }
 
-    // Device→48kHz resampler (r8brain)
+    // Device→48kHz resampler (r8brain). _resamplerLock serializes the native
+    // handle between the capture thread (Process) and stop/dispose paths
+    // (Clear/Dispose) — StopRecording() doesn't wait for the capture thread.
+    private readonly object _resamplerLock = new();
     private R8BrainResampler? _deviceResampler;
     private int _deviceSampleRate;
     private int _deviceMaxInLen;
@@ -705,7 +708,7 @@ internal sealed class AudioManager : IDisposable
         // Keep the resampler instance across transmissions (recreating it per
         // PTT press re-primes its FIR filter, clipping the start of speech);
         // just reset its internal state so no stale tail leaks into the next one.
-        try { _deviceResampler?.Clear(); }
+        try { lock (_resamplerLock) { _deviceResampler?.Clear(); } }
         catch (Exception ex) { AudioLog.Write($"[Audio] Resampler clear failed: {ex.Message}"); }
         // Same for the APM: drop its buffered sub-frame leftover so the stale
         // tail of this transmission is not prepended to the next one.
@@ -779,41 +782,48 @@ internal sealed class AudioManager : IDisposable
                 // condition did when WASAPI callbacks coalesced under load)
                 // drops the samples buffered in its FIR state and re-primes,
                 // splicing an audible gap into the outgoing stream.
-                if (_deviceResampler == null || _deviceSampleRate != srcRate)
-                {
-                    _deviceResampler?.Dispose();
-                    _deviceSampleRate = srcRate;
-                    _deviceMaxInLen = Math.Max(srcRate / 10, monoFrames);
-                    _deviceResampler = new R8BrainResampler(srcRate, 48000, _deviceMaxInLen);
-                }
-
-                // Process in chunks of at most maxInLen; larger-than-headroom
-                // callbacks are handled without touching the resampler state.
+                // Hold _resamplerLock across create/process: StopRecording()
+                // doesn't wait for the capture thread, so StopMicLocked's
+                // Clear() (and Dispose) can otherwise race a Process() still
+                // running here on the native handle.
                 int totalOut = 0;
-                int processedFrames = 0;
-                while (processedFrames < monoFrames)
+                lock (_resamplerLock)
                 {
-                    int chunk = Math.Min(_deviceMaxInLen, monoFrames - processedFrames);
-                    if (_resampleDoubleScratch == null || _resampleDoubleScratch.Length < chunk)
-                        _resampleDoubleScratch = new double[chunk];
-                    for (int i = 0; i < chunk; i++)
-                        _resampleDoubleScratch[i] = _wasapiMonoScratch[processedFrames + i];
-
-                    int outSamples = _deviceResampler.Process(_resampleDoubleScratch, chunk, out double[] resampledDouble);
-
-                    // Accumulate into a separate output scratch; the mono scratch
-                    // still holds unprocessed input for subsequent chunks.
-                    if (_resampleOutScratch == null || _resampleOutScratch.Length < totalOut + outSamples)
+                    if (_deviceResampler == null || _deviceSampleRate != srcRate)
                     {
-                        var grown = new float[totalOut + outSamples];
-                        if (_resampleOutScratch != null)
-                            Array.Copy(_resampleOutScratch, grown, totalOut);
-                        _resampleOutScratch = grown;
+                        _deviceResampler?.Dispose();
+                        _deviceSampleRate = srcRate;
+                        _deviceMaxInLen = Math.Max(srcRate / 10, monoFrames);
+                        _deviceResampler = new R8BrainResampler(srcRate, 48000, _deviceMaxInLen);
                     }
-                    for (int i = 0; i < outSamples; i++)
-                        _resampleOutScratch[totalOut + i] = (float)resampledDouble[i];
-                    totalOut += outSamples;
-                    processedFrames += chunk;
+
+                    // Process in chunks of at most maxInLen; larger-than-headroom
+                    // callbacks are handled without touching the resampler state.
+                    int processedFrames = 0;
+                    while (processedFrames < monoFrames)
+                    {
+                        int chunk = Math.Min(_deviceMaxInLen, monoFrames - processedFrames);
+                        if (_resampleDoubleScratch == null || _resampleDoubleScratch.Length < chunk)
+                            _resampleDoubleScratch = new double[chunk];
+                        for (int i = 0; i < chunk; i++)
+                            _resampleDoubleScratch[i] = _wasapiMonoScratch[processedFrames + i];
+
+                        int outSamples = _deviceResampler.Process(_resampleDoubleScratch, chunk, out double[] resampledDouble);
+
+                        // Accumulate into a separate output scratch; the mono scratch
+                        // still holds unprocessed input for subsequent chunks.
+                        if (_resampleOutScratch == null || _resampleOutScratch.Length < totalOut + outSamples)
+                        {
+                            var grown = new float[totalOut + outSamples];
+                            if (_resampleOutScratch != null)
+                                Array.Copy(_resampleOutScratch, grown, totalOut);
+                            _resampleOutScratch = grown;
+                        }
+                        for (int i = 0; i < outSamples; i++)
+                            _resampleOutScratch[totalOut + i] = (float)resampledDouble[i];
+                        totalOut += outSamples;
+                        processedFrames += chunk;
+                    }
                 }
 
                 monoAt48k = _resampleOutScratch ?? Array.Empty<float>();
@@ -1395,8 +1405,11 @@ internal sealed class AudioManager : IDisposable
 
     public void Dispose()
     {
-        _deviceResampler?.Dispose();
-        _deviceResampler = null;
+        lock (_resamplerLock)
+        {
+            _deviceResampler?.Dispose();
+            _deviceResampler = null;
+        }
         lock (_processorLock)
         {
             _processor?.Dispose();

--- a/tests/Brmble.Audio.Tests/Processing/WebRtcApmProcessorTests.cs
+++ b/tests/Brmble.Audio.Tests/Processing/WebRtcApmProcessorTests.cs
@@ -35,6 +35,22 @@ public class WebRtcApmProcessorTests
     }
 
     [TestMethod]
+    public void Reset_DiscardsBufferedSubFrame()
+    {
+        using var proc = new WebRtcApmProcessor();
+        byte[] half = new byte[WebRtcApmProcessor.FrameBytes / 2];
+        byte[] output = new byte[WebRtcApmProcessor.FrameBytes * 2];
+
+        proc.Process(half, output);
+        proc.Reset();
+
+        // After Reset the previous half frame must be gone: another half frame
+        // should buffer again instead of completing a (stale) frame.
+        int written = proc.Process(half, output);
+        Assert.AreEqual(0, written, "Reset should discard the buffered leftover from the previous transmission");
+    }
+
+    [TestMethod]
     public void Process_SilenceInSilenceOut()
     {
         using var proc = new WebRtcApmProcessor();

--- a/tests/MumbleVoiceEngine.Tests/Audio/R8BrainResamplerTest.cs
+++ b/tests/MumbleVoiceEngine.Tests/Audio/R8BrainResamplerTest.cs
@@ -66,6 +66,35 @@ namespace MumbleVoiceEngine.Tests.Audio
         }
 
         [TestMethod]
+        public void Process_WithExplicitLength_UsesOnlyThatManySamples()
+        {
+            // The capture path reuses a growing scratch array, so the backing
+            // array can be larger than both the real sample count and maxInLen.
+            using var resampler = new R8BrainResampler(48000, 48000, 960);
+            var backing = new double[4096]; // > maxInLen; tail is garbage
+            for (int i = 0; i < 960; i++)
+                backing[i] = Math.Sin(2.0 * Math.PI * 400 * i / 48000);
+            for (int i = 960; i < backing.Length; i++)
+                backing[i] = 99.0;
+
+            int outSamples = resampler.Process(backing, 960, out double[] output);
+
+            Assert.IsTrue(Math.Abs(outSamples - 960) <= 1,
+                $"Same-rate resample of 960 samples should return ~960, got {outSamples}");
+            for (int i = 0; i < outSamples; i++)
+                Assert.IsTrue(Math.Abs(output[i]) <= 1.5,
+                    $"Output sample {i} = {output[i]} — garbage tail leaked into resample");
+        }
+
+        [TestMethod]
+        public void Process_LengthAboveMaxInLen_Throws()
+        {
+            using var resampler = new R8BrainResampler(48000, 48000, 960);
+            Assert.ThrowsException<ArgumentException>(() =>
+                resampler.Process(new double[2000], 2000, out _));
+        }
+
+        [TestMethod]
         public void Clear_ResetsState()
         {
             using var resampler = new R8BrainResampler(48000, 16000, 960);

--- a/tests/MumbleVoiceEngine.Tests/Audio/R8BrainResamplerTest.cs
+++ b/tests/MumbleVoiceEngine.Tests/Audio/R8BrainResamplerTest.cs
@@ -95,6 +95,15 @@ namespace MumbleVoiceEngine.Tests.Audio
         }
 
         [TestMethod]
+        public void Process_NegativeLength_Throws()
+        {
+            // A negative length must never reach the native resampler.
+            using var resampler = new R8BrainResampler(48000, 48000, 960);
+            Assert.ThrowsException<ArgumentException>(() =>
+                resampler.Process(new double[960], -1, out _));
+        }
+
+        [TestMethod]
         public void Clear_ResetsState()
         {
             using var resampler = new R8BrainResampler(48000, 16000, 960);


### PR DESCRIPTION
Three related capture-path defects (found in a multi-agent audio pipeline review) that spliced gaps or stale audio into the outgoing stream for devices not capturing at 48kHz:

1. **Mid-stream resampler recreation.** The r8brain resampler was disposed and recreated whenever a coalesced WASAPI callback exceeded the first callback's size, discarding its buffered FIR state and re-priming — an audible gap mid-word. Because it was also disposed on every PTT release while the learned max size was thrown away, this repeated every transmission. It is now created once per device rate with 100ms of input headroom, and larger callbacks are processed in chunks without touching resampler state.

2. **Whole-scratch-array resample.** `Process()` was fed the entire reused scratch array instead of the actual sample count, resampling garbage tail samples into the stream and risking `ArgumentException` in the capture callback once the scratch had grown past `maxInLen`. A length-aware `Process(input, inputLength, out output)` overload is now used.

3. **Backwards lifecycle across PTT transmissions.** The resampler (whose state we want to keep) was disposed each release, while the APM's buffered 10ms leftover (which we want to drop) was kept — prepending the stale tail of the previous transmission to the next one. The resampler now survives transmissions (`Clear()` between them) and the APM leftover is discarded via a new `Reset()`.

## Tests

- `Process_WithExplicitLength_UsesOnlyThatManySamples` / `Process_LengthAboveMaxInLen_Throws` (r8brain wrapper)
- `Reset_DiscardsBufferedSubFrame` (APM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)