### PR TITLE
fix: PTT press/release races that stop the mic while the key is held

### DIFF
--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -146,8 +146,6 @@ internal sealed class AudioManager : IDisposable
     private volatile bool _pttActive;
     private System.Threading.Timer? _pttSilenceTailTimer;
     private int _pttSilenceTailGeneration; // incremented each time the timer is cancelled/replaced
-    private long _pttLastToggleMs;
-    private const int MinPttToggleThresholdMs = 100; // debounce to prevent WASAPI stress
 
     // Speaking detection (polls per-user JitterBuffer.IsSpeaking directly)
     private readonly HashSet<uint> _currentlySpeaking = new();
@@ -660,6 +658,9 @@ internal sealed class AudioManager : IDisposable
                 recheck.CaptureState != NAudio.CoreAudioApi.CaptureState.Stopped)
             {
                 AudioLog.Write($"[Audio] WASAPI capture still stopping after wait, skipping StartRecording");
+                // Recording never started: clear _micStarted so the next
+                // StartMic retries instead of no-opping against a dead mic.
+                _micStarted = false;
                 return;
             }
         }
@@ -953,7 +954,18 @@ internal sealed class AudioManager : IDisposable
         // Software gate: for PTT+, send audio to the server only when PTT is active
         if (shouldSubmitPcm)
         {
-            pipeline?.SubmitPcm(new ReadOnlySpan<byte>(processedBuffer, 0, processedBytes));
+            try
+            {
+                pipeline?.SubmitPcm(new ReadOnlySpan<byte>(processedBuffer, 0, processedBytes));
+            }
+            catch (Exception ex)
+            {
+                // The pipeline can be disposed by a concurrent settings change,
+                // and the packet callback runs the network send. An unhandled
+                // exception here kills the NAudio capture thread and silently
+                // deadens the mic — drop the frame instead.
+                AudioLog.Write($"[Audio] SubmitPcm failed, dropping frame: {ex.Message}");
+            }
         }
         // else: encoded audio is ignored (the encoder keeps running)
     }
@@ -1203,28 +1215,22 @@ internal sealed class AudioManager : IDisposable
     private void SetPttActive(bool active)
     {
         bool startMic = false;
-        bool scheduleSilenceTail = false;
-        int silenceTailGeneration = 0;
-        int holdMs = 200;
         bool fireSpeakingEvent = false;
         bool fireSilentEvent = false;
 
         lock (_lock)
         {
-            long now = Environment.TickCount64;
-
-            // Debounce: Ignore rapid activations to prevent WASAPI stress and socket buffer exhaustion,
-            // but never drop a deactivation. Releasing PTT must always clear _pttActive and
-            // schedule the silence tail so the mic cannot be left running.
-            if (active && now - _pttLastToggleMs < MinPttToggleThresholdMs)
-                return;
-
-            // Coalesce: If state hasn't changed, do nothing
+            // Coalesce: If state hasn't changed, do nothing. Note there is
+            // deliberately no press-debounce here: the coalesce already absorbs
+            // repeated same-state events, so a debounce could only ever drop a
+            // press-after-release — leaving the user holding a dead key while
+            // the release's silence tail stops the mic under them. Rapid
+            // press/release cycles don't stress WASAPI either way, because the
+            // silence tail keeps the mic running between them.
             if (_pttActive == active)
                 return;
 
             AudioLog.Write($"[Audio] SetPttActive: active={active}, muted={_muted}");
-            _pttLastToggleMs = now;
             _pttActive = active;
 
             if (active && !_muted && _transmissionMode != TransmissionMode.PushToTalkPlus)
@@ -1269,10 +1275,14 @@ internal sealed class AudioManager : IDisposable
                 }
                 else
                 {
-                    // For regular PTT, schedule the silence tail after the hold delay
-                    silenceTailGeneration = Interlocked.Increment(ref _pttSilenceTailGeneration);
-                    scheduleSilenceTail = true;
-                    holdMs = _voiceHoldMs;
+                    // For regular PTT, schedule the silence tail after the hold
+                    // delay. Create the timer while still holding the lock so a
+                    // re-press can never interleave between scheduling decision
+                    // and timer assignment.
+                    int generation = Interlocked.Increment(ref _pttSilenceTailGeneration);
+                    _pttSilenceTailTimer = new System.Threading.Timer(
+                        _ => SilenceTailElapsed(generation), null,
+                        dueTime: _voiceHoldMs, period: Timeout.Infinite);
                 }
             }
             // else: active but muted - do nothing
@@ -1295,20 +1305,24 @@ internal sealed class AudioManager : IDisposable
             UserStoppedSpeaking?.Invoke(_localUserId);
         }
 
-        // Schedule silence tail outside the lock
-        if (scheduleSilenceTail)
+    }
+
+    private void SilenceTailElapsed(int generation)
+    {
+        bool wasSpeaking;
+        uint capturedUserId;
+        lock (_lock)
         {
-            int generation = silenceTailGeneration;
-            _pttSilenceTailTimer = new System.Threading.Timer(_ =>
-            {
-                // Guard against the timer callback running after cancel/dispose.
-                // If generation has advanced, a newer cancel/restart supersedes this callback.
-                if (Interlocked.CompareExchange(ref _pttSilenceTailGeneration, generation, generation) != generation)
-                    return;
-                if (_pttActive || _muted) return;
-                StopMic();
-            }, null, dueTime: holdMs, period: Timeout.Infinite);
+            // Re-check generation and PTT state under the same lock that
+            // SetPttActive mutates them, so a press that lands between the
+            // timer firing and this callback running cannot have its freshly
+            // started mic stopped underneath it.
+            if (Volatile.Read(ref _pttSilenceTailGeneration) != generation) return;
+            if (_pttActive || _muted) return;
+            (wasSpeaking, capturedUserId) = StopMicLocked();
         }
+        if (wasSpeaking)
+            UserStoppedSpeaking?.Invoke(capturedUserId);
     }
 
     private void CheckSpeakingState(object? state)

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -970,7 +970,7 @@ internal sealed class AudioManager : IDisposable
                 // and the packet callback runs the network send. An unhandled
                 // exception here kills the NAudio capture thread and silently
                 // deadens the mic — drop the frame instead.
-                AudioLog.Write($"[Audio] SubmitPcm failed, dropping frame: {ex.Message}");
+                AudioLog.Write($"[Audio] SubmitPcm failed, dropping frame: {ex}");
             }
         }
         // else: encoded audio is ignored (the encoder keeps running)

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -657,6 +657,12 @@ internal sealed class AudioManager : IDisposable
             if (_waveIn is WasapiCapture recheck &&
                 recheck.CaptureState != NAudio.CoreAudioApi.CaptureState.Stopped)
             {
+                // Another start may have won the race while we were unlocked;
+                // if the capture is actively recording, the mic is live and
+                // _micStarted is correct — don't clear it.
+                if (recheck.CaptureState == NAudio.CoreAudioApi.CaptureState.Capturing)
+                    return;
+
                 AudioLog.Write($"[Audio] WASAPI capture still stopping after wait, skipping StartRecording");
                 // Recording never started: clear _micStarted so the next
                 // StartMic retries instead of no-opping against a dead mic.
@@ -1192,6 +1198,13 @@ internal sealed class AudioManager : IDisposable
 
         _pttActive = false;
         _transmissionMode = mode;
+
+        // A pending PTT silence tail belongs to the previous mode; cancel it
+        // (and advance the generation for an already-fired callback) so it
+        // cannot stop the mic the new mode is about to start.
+        _pttSilenceTailTimer?.Dispose();
+        _pttSilenceTailTimer = null;
+        Interlocked.Increment(ref _pttSilenceTailGeneration);
 
         // For PTT, start with mic off until key pressed
         if (mode == TransmissionMode.PushToTalk)

--- a/tests/Brmble.Client.Tests/Services/AudioManagerPttTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AudioManagerPttTests.cs
@@ -19,6 +19,31 @@ public class AudioManagerPttTests
             .GetField("_pttActive", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(audio)!;
 
+    private static object? GetField(AudioManager audio, string name)
+        => typeof(AudioManager)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(audio);
+
+    [TestMethod]
+    public void ModeSwitch_CancelsPendingSilenceTail()
+    {
+        // PTT release schedules a silence tail; switching transmission mode
+        // before it fires must invalidate it, or the tail stops the mic the
+        // new mode (e.g. Continuous) just started.
+        using var audio = new AudioManager();
+        audio.SetTransmissionMode(TransmissionMode.PushToTalk, key: "F1", hwnd: IntPtr.Zero);
+        audio.SetPttActiveExternal(true);
+        audio.SetPttActiveExternal(false); // schedules the tail
+
+        int generationBefore = (int)GetField(audio, "_pttSilenceTailGeneration")!;
+        audio.SetTransmissionMode(TransmissionMode.Continuous, key: null, hwnd: IntPtr.Zero);
+
+        Assert.IsNull(GetField(audio, "_pttSilenceTailTimer"),
+            "pending silence-tail timer must be disposed on mode switch");
+        Assert.IsTrue((int)GetField(audio, "_pttSilenceTailGeneration")! > generationBefore,
+            "generation must advance so an already-fired tail callback becomes a no-op");
+    }
+
     [TestMethod]
     public void QuickRePressAfterRelease_IsNotDropped()
     {

--- a/tests/Brmble.Client.Tests/Services/AudioManagerPttTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AudioManagerPttTests.cs
@@ -14,15 +14,18 @@ namespace Brmble.Client.Tests.Services;
 [TestClass]
 public class AudioManagerPttTests
 {
+    private static FieldInfo RequireField(string name)
+    {
+        var field = typeof(AudioManager).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(field, $"private field '{name}' not found on AudioManager — was it renamed?");
+        return field;
+    }
+
     private static bool GetPttActive(AudioManager audio)
-        => (bool)typeof(AudioManager)
-            .GetField("_pttActive", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(audio)!;
+        => (bool)RequireField("_pttActive").GetValue(audio)!;
 
     private static object? GetField(AudioManager audio, string name)
-        => typeof(AudioManager)
-            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(audio);
+        => RequireField(name).GetValue(audio);
 
     [TestMethod]
     public void ModeSwitch_CancelsPendingSilenceTail()

--- a/tests/Brmble.Client.Tests/Services/AudioManagerPttTests.cs
+++ b/tests/Brmble.Client.Tests/Services/AudioManagerPttTests.cs
@@ -1,0 +1,36 @@
+using Brmble.Client.Services.Voice;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Reflection;
+
+namespace Brmble.Client.Tests.Services;
+
+/// <summary>
+/// PTT press/release edge cases. A quick re-press after release (within what
+/// used to be the debounce window) must never be dropped: the release has
+/// already scheduled the silence tail, so a dropped re-press leaves the user
+/// holding a dead key while the tail stops the mic under them.
+/// </summary>
+[TestClass]
+public class AudioManagerPttTests
+{
+    private static bool GetPttActive(AudioManager audio)
+        => (bool)typeof(AudioManager)
+            .GetField("_pttActive", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(audio)!;
+
+    [TestMethod]
+    public void QuickRePressAfterRelease_IsNotDropped()
+    {
+        using var audio = new AudioManager();
+        audio.SetTransmissionMode(TransmissionMode.PushToTalk, key: "F1", hwnd: IntPtr.Zero);
+
+        audio.SetPttActiveExternal(true);
+        audio.SetPttActiveExternal(false);
+        // Immediate re-press, well within the old 100ms debounce window.
+        audio.SetPttActiveExternal(true);
+
+        Assert.IsTrue(GetPttActive(audio),
+            "re-press after release must set _pttActive; the silence tail from the release would otherwise stop the mic while the key is held");
+    }
+}


### PR DESCRIPTION
Four PTT/timing defects (found in a multi-agent audio pipeline review) that could leave the user talking into a dead mic:

1. **Press-debounce removed.** The same-state coalesce in `SetPttActive` already absorbs repeated presses, so the 100ms debounce could only ever drop a press-after-release — after which the release's silence tail stopped the mic while the key was held. Rapid press/release cycles don't stress WASAPI either way: the silence tail keeps the mic running between them.

2. **Silence-tail TOCTOU closed.** The tail timer was created after the lock was released and its callback checked `_pttActive` without the lock, so it could stop a mic that a fresh press had just started. The timer is now created inside the lock and the callback re-checks generation + PTT state under that same lock before stopping.

3. **WASAPI stop-wait timeout wedge.** When the 300ms stop-wait timed out, `StartMicLocked` returned with `_micStarted` still true — every subsequent press no-opped against a mic that never started. It now clears `_micStarted` so the next press retries.

4. **Capture-thread exception guard.** `SubmitPcm` runs outside the lock and races pipeline disposal on settings changes; an exception killed the NAudio capture thread and silently deadened the mic. The frame is now dropped and logged instead.

## Tests

- `QuickRePressAfterRelease_IsNotDropped` (written first, failed on the old debounce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)