### PR TITLE
fix: make Brmble vs Mumble client detection robust

### DIFF
--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -58,7 +58,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private readonly Stopwatch _notifyThrottle = Stopwatch.StartNew();
     private string? _apiUrl;
     private string? _activeServerId;
-    private Dictionary<string, string> _userMappings = new();
     private readonly ConcurrentDictionary<uint, SessionMappingEntry> _sessionMappings = new();
     private readonly System.Collections.Concurrent.ConcurrentDictionary<uint, bool> _channelPasswordRestrictions = new();
     private CancellationTokenSource? _wsCts;
@@ -1922,18 +1921,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                     _bridge?.NotifyUiThread();
                 }
                 return;
-            }
-
-            // Parse user mappings (displayName -> matrixUserId) from the auth response
-            if (credentials.Value.TryGetProperty("userMappings", out var mappingsElement))
-            {
-                _userMappings = new Dictionary<string, string>();
-                foreach (var prop in mappingsElement.EnumerateObject())
-                {
-                    var matrixId = prop.Value.GetString();
-                    if (matrixId is not null)
-                        _userMappings[prop.Name] = matrixId;
-                }
             }
 
             // Parse session mappings (sessionId -> matrixUserId + mumbleName) from the auth response
@@ -4033,7 +4020,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 self = u == LocalUser,
                 comment = u.Comment,
                 certHash = u.CertificateHash ?? (hasMap ? sm!.CertHash : null),
-                matrixUserId = hasMap ? sm!.MatrixUserId : _userMappings.GetValueOrDefault(u.Name),
+                // No name-based fallback: a same-named session with a different cert
+                // must not inherit this user's Matrix identity.
+                matrixUserId = hasMap ? sm!.MatrixUserId : null,
                 companionId = hasMap ? sm!.CompanionId : null,
                 isBrmbleClient = hasMap && sm!.IsBrmbleClient
             };
@@ -4157,7 +4146,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             self = isSelf,
             comment = user?.Comment,
             certHash = user?.CertificateHash ?? (hasJoinMapping ? joinMapping!.CertHash : null),
-            matrixUserId = hasJoinMapping ? joinMapping!.MatrixUserId : _userMappings.GetValueOrDefault(joinedUserName),
+            matrixUserId = hasJoinMapping ? joinMapping!.MatrixUserId : null,
             companionId = hasJoinMapping ? joinMapping!.CompanionId : null,
             isBrmbleClient = hasJoinMapping && joinMapping!.IsBrmbleClient
         });

--- a/src/Brmble.Server/Auth/AuthService.cs
+++ b/src/Brmble.Server/Auth/AuthService.cs
@@ -276,18 +276,21 @@ public class AuthService : IActiveBrmbleSessions
         {
             _activeSessions.Remove(certHash);
             if (_certToName.Remove(certHash, out var name))
-            {
                 _activeNames.Remove(name);
-                // Broadcast Brmble client deactivation
-                if (_sessionMapping.TryGetSessionId(name, out var deactivatedSessionId))
+        }
+
+        // Demote by cert, not by name: _certToName may have been rebound to a newer
+        // session, which would de-flag the wrong session or silently miss.
+        foreach (var (sessionId, mapping) in _sessionMapping.GetSnapshot())
+        {
+            if (mapping.CertHash == certHash && mapping.IsBrmbleClient)
+            {
+                _sessionMapping.TryUpdateBrmbleStatus(sessionId, false);
+                _ = _eventBus.BroadcastAsync(new
                 {
-                    _sessionMapping.TryUpdateBrmbleStatus(deactivatedSessionId, false);
-                    _ = _eventBus.BroadcastAsync(new
-                    {
-                        type = "brmbleClientDeactivated",
-                        sessionId = deactivatedSessionId
-                    });
-                }
+                    type = "brmbleClientDeactivated",
+                    sessionId
+                });
             }
         }
     }

--- a/src/Brmble.Server/Events/SessionMappingHandler.cs
+++ b/src/Brmble.Server/Events/SessionMappingHandler.cs
@@ -38,7 +38,10 @@ public class SessionMappingHandler : IMumbleEventHandler
 
         var mappingAdded = _sessionMapping.TryAddMatrixUser(user.SessionId, dbUser.MatrixUserId, user.Name, dbUser.Id, companionId);
         _sessionMapping.TryUpdateCertHash(user.SessionId, user.CertHash);
-        _sessionMapping.TryUpdateBrmbleStatus(user.SessionId, isBrmbleClient);
+        // Upgrade-only: a concurrent Authenticate may have already flagged this session
+        // Brmble; writing false here would race that away. Demotion goes via Deactivate.
+        if (isBrmbleClient)
+            _sessionMapping.TryUpdateBrmbleStatus(user.SessionId, true);
 
         _logger.LogInformation(
             "Mapped session {Session} ({Name}) to {MatrixUserId} via cert (brmbleClient={IsBrmble}, added={Added})",
@@ -64,7 +67,21 @@ public class SessionMappingHandler : IMumbleEventHandler
         }
     }
 
-    public Task OnUserDisconnected(MumbleUser user) => Task.CompletedTask;
+    public async Task OnUserDisconnected(MumbleUser user)
+    {
+        // Crash safety net: if the Mumble session ends and no Brmble WebSocket is
+        // alive for this user, the cert must not stay marked Brmble-active — a later
+        // plain-Mumble connect with the same cert would be shown as a Brmble user.
+        if (string.IsNullOrEmpty(user.CertHash)) return;
+        if (!_activeSessions.IsBrmbleClient(user.CertHash)) return;
+
+        var dbUser = await _userRepository.GetByCertHash(user.CertHash);
+        if (dbUser is not null && _eventBus.HasConnectedClient(dbUser.Id)) return;
+
+        _activeSessions.Deactivate(user.CertHash);
+        _logger.LogInformation("Deactivated Brmble cert for {Name} (session {Session} disconnected, no live WebSocket)",
+            user.Name, user.SessionId);
+    }
     public Task OnUserTextureAvailable(MumbleUser user, byte[] textureData) => Task.CompletedTask;
     public Task OnUserTextMessage(MumbleUser sender, string text, int channelId) => Task.CompletedTask;
     public Task OnChannelCreated(MumbleChannel channel) => Task.CompletedTask;

--- a/src/Brmble.Server/Events/SessionMappingService.cs
+++ b/src/Brmble.Server/Events/SessionMappingService.cs
@@ -79,35 +79,24 @@ public class SessionMappingService : ISessionMappingService
         return false;
     }
 
-    public bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient)
+    public bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient) =>
+        TryUpdateMapping(sessionId, m => m with { IsBrmbleClient = isBrmbleClient });
+
+    public bool TryUpdateCompanionId(int sessionId, string companionId) =>
+        TryUpdateMapping(sessionId, m => m with { CompanionId = companionId });
+
+    public bool TryUpdateCertHash(int sessionId, string certHash) =>
+        TryUpdateMapping(sessionId, m => m with { CertHash = certHash });
+
+    // CAS loop: concurrent field updates from the Ice, auth, and WebSocket threads
+    // must not overwrite each other via a plain read-modify-write.
+    private bool TryUpdateMapping(int sessionId, Func<SessionMapping, SessionMapping> update)
     {
-        if (_sessionToMapping.TryGetValue(sessionId, out var existing))
+        while (_sessionToMapping.TryGetValue(sessionId, out var existing))
         {
-            _sessionToMapping[sessionId] = existing with { IsBrmbleClient = isBrmbleClient };
-            return true;
+            if (_sessionToMapping.TryUpdate(sessionId, update(existing), existing))
+                return true;
         }
-        return false;
-    }
-
-    public bool TryUpdateCompanionId(int sessionId, string companionId)
-    {
-        if (_sessionToMapping.TryGetValue(sessionId, out var existing))
-        {
-            _sessionToMapping[sessionId] = existing with { CompanionId = companionId };
-            return true;
-        }
-
-        return false;
-    }
-
-    public bool TryUpdateCertHash(int sessionId, string certHash)
-    {
-        if (_sessionToMapping.TryGetValue(sessionId, out var existing))
-        {
-            _sessionToMapping[sessionId] = existing with { CertHash = certHash };
-            return true;
-        }
-
         return false;
     }
 

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -38,10 +38,17 @@ public static class BrmbleWebSocketHandler
         var eventBus = context.RequestServices.GetRequiredService<IBrmbleEventBus>();
         var activeSessions = context.RequestServices.GetRequiredService<IActiveBrmbleSessions>();
 
-        using var ws = await context.WebSockets.AcceptWebSocketAsync();
-        if (sessionMapping.TryGetMappingByUserId(user.Id, out var currentSessionId, out var currentMapping))
+        // Keepalive so a dead peer (crash, network drop) tears the socket down promptly
+        // instead of leaving the cert marked Brmble-active until TCP gives up.
+        using var ws = await context.WebSockets.AcceptWebSocketAsync(new WebSocketAcceptContext
         {
-            activeSessions.TrackMumbleName(currentMapping!.MumbleName, hash, active: true);
+            KeepAliveInterval = TimeSpan.FromSeconds(30),
+            KeepAliveTimeout = TimeSpan.FromSeconds(15)
+        });
+        if (sessionMapping.TryGetMappingByUserId(user.Id, out var currentSessionId, out var currentMapping)
+            && (currentMapping!.CertHash is null || currentMapping.CertHash == hash))
+        {
+            activeSessions.TrackMumbleName(currentMapping.MumbleName, hash, active: true);
             sessionMapping.TryUpdateBrmbleStatus(currentSessionId, true);
             sessionMapping.TryUpdateCertHash(currentSessionId, hash);
             await eventBus.BroadcastAsync(CreateUserMappingAddedPayload(currentSessionId, currentMapping, hash));
@@ -95,6 +102,7 @@ public static class BrmbleWebSocketHandler
         sessionId,
         matrixUserId = mapping.MatrixUserId,
         mumbleName = mapping.MumbleName,
+        companionId = mapping.CompanionId,
         certHash,
         isBrmbleClient = true
     };

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -9,6 +9,7 @@ namespace Brmble.Server.WebSockets;
 public static class BrmbleWebSocketHandler
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    internal static TimeSpan DeactivationGracePeriod = TimeSpan.FromSeconds(10);
 
     public static async Task HandleAsync(HttpContext context)
     {
@@ -92,7 +93,18 @@ public static class BrmbleWebSocketHandler
         {
             eventBus.RemoveClient(ws);
             if (!eventBus.HasConnectedClient(user.Id))
-                activeSessions.Deactivate(hash);
+            {
+                // Grace period: a webview reload or brief network blip reconnects within
+                // seconds; deactivating immediately would flap the user to "Mumble user"
+                // and back for everyone. All captured services are singletons.
+                var userId = user.Id;
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(DeactivationGracePeriod);
+                    if (!eventBus.HasConnectedClient(userId))
+                        activeSessions.Deactivate(hash);
+                });
+            }
         }
     }
 

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -78,7 +78,6 @@ internal static class MumbleAdapterTestHarness
         SetField(adapter, "_certService", certService);
         SetField(adapter, "_appConfigService", appConfigService);
         SetField(adapter, "_audioManager", audioManager);
-        SetField(adapter, "_userMappings", new Dictionary<string, string>());
         SetField(adapter, "_sessionMappings", new ConcurrentDictionary<uint, MumbleAdapter.SessionMappingEntry>());
         SetField(adapter, "_channelPasswordRestrictions", new ConcurrentDictionary<uint, bool>());
         return adapter;

--- a/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
@@ -43,6 +43,8 @@ public class AuthServiceTests
                    .ReturnsAsync("syt_refresh_token");
         _mockMumbleReg = new Mock<IMumbleRegistrationService>();
         _mockSessionMapping = new Mock<ISessionMappingService>();
+        _mockSessionMapping.Setup(m => m.GetSnapshot())
+                           .Returns(new Dictionary<int, SessionMapping>());
         var mockEventBus = new Mock<IBrmbleEventBus>();
         mockEventBus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
         _svc = new AuthService(repo, _mockMatrix.Object, NullLogger<AuthService>.Instance,
@@ -92,6 +94,23 @@ public class AuthServiceTests
         await _svc!.Authenticate("todeactivate");
         _svc.Deactivate("todeactivate");
         Assert.IsFalse(_svc.IsBrmbleClient("todeactivate"));
+    }
+
+    [TestMethod]
+    public void Deactivate_DemotesSessionsByCertHash_NotByName()
+    {
+        // Even after _certToName was rebound to a newer session, demotion must hit
+        // every session whose mapping carries this cert.
+        _mockSessionMapping!.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>
+        {
+            [5] = new SessionMapping("@1:test.local", "Alice", 1, "floppy", IsBrmbleClient: true, CertHash: "cert-a"),
+            [7] = new SessionMapping("@2:test.local", "Bob", 2, "floppy", IsBrmbleClient: true, CertHash: "cert-b"),
+        });
+
+        _svc!.Deactivate("cert-a");
+
+        _mockSessionMapping.Verify(m => m.TryUpdateBrmbleStatus(5, false), Times.Once);
+        _mockSessionMapping.Verify(m => m.TryUpdateBrmbleStatus(7, It.IsAny<bool>()), Times.Never);
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
@@ -112,13 +112,14 @@ public class SessionMappingHandlerTests
     {
         var user = await _repo.Insert("abc123", "Alice");
         _mapping.Setup(m => m.TryAddMatrixUser(1, user.MatrixUserId, "Alice", user.Id, "floppy")).Returns(false);
-        _mapping.Setup(m => m.TryUpdateBrmbleStatus(1, false)).Returns(true);
         _mapping.Setup(m => m.TryUpdateCertHash(1, "abc123")).Returns(true);
 
         await _handler.OnUserConnected(new MumbleUser("Alice", "abc123", 1));
 
         _mapping.Verify(m => m.TryAddMatrixUser(1, user.MatrixUserId, "Alice", user.Id, "floppy"), Times.Once);
-        _mapping.Verify(m => m.TryUpdateBrmbleStatus(1, false), Times.Once);
+        // Upgrade-only: a non-Brmble connect must not write false (could race away a
+        // concurrent Authenticate's true)
+        _mapping.Verify(m => m.TryUpdateBrmbleStatus(It.IsAny<int>(), false), Times.Never);
         _bus.Verify(b => b.BroadcastAsync(It.Is<object>(message =>
             message.GetType().GetProperty("type")!.GetValue(message)!.Equals("userMappingAdded") &&
             message.GetType().GetProperty("sessionId")!.GetValue(message)!.Equals(1) &&
@@ -153,5 +154,37 @@ public class SessionMappingHandlerTests
 
         _bus.Verify(b => b.BroadcastAsync(It.Is<object>(payload =>
             JsonSerializer.Serialize(payload).Contains("\"companionId\":\"engineer\""))), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task OnUserDisconnected_ActiveCertNoWebSocket_DeactivatesCert()
+    {
+        var user = await _repo.Insert("abc123", "Alice");
+        _activeSessions.Setup(s => s.IsBrmbleClient("abc123")).Returns(true);
+        _bus.Setup(b => b.HasConnectedClient(user.Id)).Returns(false);
+
+        await _handler.OnUserDisconnected(new MumbleUser("Alice", "abc123", 1));
+
+        _activeSessions.Verify(s => s.Deactivate("abc123"), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task OnUserDisconnected_LiveWebSocket_KeepsCertActive()
+    {
+        var user = await _repo.Insert("abc123", "Alice");
+        _activeSessions.Setup(s => s.IsBrmbleClient("abc123")).Returns(true);
+        _bus.Setup(b => b.HasConnectedClient(user.Id)).Returns(true);
+
+        await _handler.OnUserDisconnected(new MumbleUser("Alice", "abc123", 1));
+
+        _activeSessions.Verify(s => s.Deactivate(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task OnUserDisconnected_InactiveCert_DoesNothing()
+    {
+        await _handler.OnUserDisconnected(new MumbleUser("Bob", "plain-cert", 2));
+
+        _activeSessions.Verify(s => s.Deactivate(It.IsAny<string>()), Times.Never);
     }
 }


### PR DESCRIPTION
## Summary

Builds on #594. Fixes the reported issue that a user who connects via plain Mumble is still shown as a Brmble user when their cert (or nickname) was ever used with the Brmble client.

Root cause (multi-agent investigation, adversarially verified): "Brmble-active" was effectively a cert-lifetime property with several promotion paths and no reliable demotion path, plus a name-keyed fallback that let same-named sessions inherit a Brmble user's Matrix identity.

## Changes

- **Demote by cert, not name**: `AuthService.Deactivate` now scans session mappings for the matching `CertHash` instead of the rebindable `_certToName` lookup, so it can no longer de-flag the wrong session or silently miss.
- **Guard the WS-accept stamp**: the `isBrmbleClient=true` stamp on WebSocket accept only fires when the mapped session's cert matches the WS client cert.
- **Liveness (two layers)**: WebSocket keepalive (30s ping / 15s timeout) so dead peers tear down promptly, plus a crash safety net in `SessionMappingHandler.OnUserDisconnected` (previously a no-op) that deactivates the cert when the Mumble session ends with no live WebSocket.
- **Drop the name-based matrixUserId fallback** in `MumbleAdapter`: Matrix identity now only attaches via the per-session mapping, so a same-named session with a different cert cannot inherit it.
- **Concurrency**: `TryUpdateBrmbleStatus`/`TryUpdateCompanionId`/`TryUpdateCertHash` now use a CAS loop; the status write in `OnUserConnected` is upgrade-only (demotion goes through `Deactivate` exclusively).
- **companionId in WS payload**: `CreateUserMappingAddedPayload` now includes `companionId`, so WS reconnects no longer reset companions to the client-side default.

## Tests

- 4 new tests: cert-based demotion targeting, disconnect safety net (with/without live WS, inactive cert).
- 1 test updated to the upgrade-only contract (`OnUserConnected_AlreadyMapped_BroadcastsRouteUpsert` now asserts no `false` write).
- Full suite: 327/327 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
