### PR TITLE
fix: soft-limit APM output gain instead of hard-clipping

### DIFF
--- a/src/Brmble.Audio/Brmble.Audio.csproj
+++ b/src/Brmble.Audio/Brmble.Audio.csproj
@@ -6,6 +6,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Brmble.Audio.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="SoundFlow.Extensions.WebRtc.Apm" Version="1.4.0" />
   </ItemGroup>

--- a/src/Brmble.Audio/Processing/WebRtcApmProcessor.cs
+++ b/src/Brmble.Audio/Processing/WebRtcApmProcessor.cs
@@ -30,9 +30,12 @@ public sealed class WebRtcApmProcessor : IDisposable
     /// Linear gain applied after APM processing, before int16 conversion.
     /// AGC2 targets ~-19 dBFS which is quieter than typical VOIP expectations;
     /// a post-gain of ~1.6-2.0x (4-6 dB) brings output closer to -10 dBFS.
-    /// Hard-clipped at int16 bounds.
+    /// Peaks above the limiter knee are soft-limited instead of hard-clipped.
     /// </summary>
     public float OutputGain { get; set; } = 1.5f;
+
+    // Above this level the signal is compressed toward full scale instead of clipping.
+    private const float LimiterKnee = 0.85f;
 
     public WebRtcApmProcessor() : this(NoiseSuppressionLevel.High) { }
 
@@ -141,12 +144,26 @@ public sealed class WebRtcApmProcessor : IDisposable
         float gain = OutputGain;
         for (int i = 0; i < FrameSamples; i++)
         {
-            int s = (int)MathF.Round(outFloat[i] * gain * 32768f);
+            int s = (int)MathF.Round(SoftLimit(outFloat[i] * gain) * 32767f);
             if (s > short.MaxValue) s = short.MaxValue;
             else if (s < short.MinValue) s = short.MinValue;
             outPcm16[i * 2] = (byte)(s & 0xFF);
             outPcm16[i * 2 + 1] = (byte)((s >> 8) & 0xFF);
         }
+    }
+
+    /// <summary>
+    /// Soft limiter: identity up to <see cref="LimiterKnee"/>, then a tanh knee that
+    /// asymptotically approaches ±1. Continuous with slope 1 at the knee, so gained
+    /// peaks compress audibly cleanly instead of hard-clipping (issue #597).
+    /// </summary>
+    internal static float SoftLimit(float x)
+    {
+        float abs = MathF.Abs(x);
+        if (abs <= LimiterKnee) return x;
+        const float range = 1f - LimiterKnee;
+        float limited = LimiterKnee + range * MathF.Tanh((abs - LimiterKnee) / range);
+        return x < 0 ? -limited : limited;
     }
 
     public void Dispose()

--- a/src/Brmble.Audio/Processing/WebRtcApmProcessor.cs
+++ b/src/Brmble.Audio/Processing/WebRtcApmProcessor.cs
@@ -144,7 +144,7 @@ public sealed class WebRtcApmProcessor : IDisposable
         float gain = OutputGain;
         for (int i = 0; i < FrameSamples; i++)
         {
-            int s = (int)MathF.Round(SoftLimit(outFloat[i] * gain) * 32767f);
+            int s = (int)MathF.Round(SoftLimit(outFloat[i] * gain) * 32768f);
             if (s > short.MaxValue) s = short.MaxValue;
             else if (s < short.MinValue) s = short.MinValue;
             outPcm16[i * 2] = (byte)(s & 0xFF);

--- a/tests/Brmble.Audio.Tests/Processing/WebRtcApmProcessorTests.cs
+++ b/tests/Brmble.Audio.Tests/Processing/WebRtcApmProcessorTests.cs
@@ -73,4 +73,21 @@ public class WebRtcApmProcessorTests
         // Allow small residual from HPF and processing (but expect near-silence)
         Assert.IsTrue(maxAbs < 100, $"Expected silence, but found max absolute value: {maxAbs}");
     }
+
+    [TestMethod]
+    public void SoftLimit_PassesThroughBelowKnee_AndBoundsAboveIt()
+    {
+        // Identity below the knee
+        Assert.AreEqual(0.5f, WebRtcApmProcessor.SoftLimit(0.5f));
+        Assert.AreEqual(-0.5f, WebRtcApmProcessor.SoftLimit(-0.5f));
+
+        // A full-scale peak with 1.5x gain (the issue #597 scenario) must not hard-clip
+        float limited = WebRtcApmProcessor.SoftLimit(1.5f);
+        Assert.IsTrue(limited < 1f, $"Expected < 1.0, got {limited}");
+        Assert.IsTrue(limited > 0.85f, $"Expected above the knee, got {limited}");
+        Assert.AreEqual(-limited, WebRtcApmProcessor.SoftLimit(-1.5f), "Limiter must be symmetric");
+
+        // Monotonic: louder in stays louder out (no folding artifacts)
+        Assert.IsTrue(WebRtcApmProcessor.SoftLimit(1.2f) < WebRtcApmProcessor.SoftLimit(1.5f));
+    }
 }


### PR DESCRIPTION
## Summary
- Replaces the hard int16 clamp after the fixed 1.5x post-APM `OutputGain` with a tanh soft limiter (identity up to 0.85, continuous slope-1 knee approaching full scale).
- Loud speech that AGC2 has already normalized near full scale now compresses cleanly instead of hard-clipping audibly.
- The 1.5x gain itself is kept: it deliberately compensates AGC2's quiet ~-19 dBFS target, and the wrapper API (`SetGainController2(bool)`) exposes no target-level knob.

## Test plan
- New unit test `SoftLimit_PassesThroughBelowKnee_AndBoundsAboveIt` (pass-through below knee, bounded < 1.0 above it, symmetric, monotonic).
- Full `Brmble.Audio.Tests` suite: 73/73 pass.

Fixes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)