### PR TITLE
fix: wire adaptive FEC from server ping crypt stats

### DIFF
--- a/lib/MumbleVoiceEngine/Pipeline/EncodePipeline.cs
+++ b/lib/MumbleVoiceEngine/Pipeline/EncodePipeline.cs
@@ -69,10 +69,18 @@ public class EncodePipeline : IDisposable
 
     public long CurrentSequence => _sequenceNumber;
 
+    // -1 = no pending update. Written from any thread, consumed on the encode thread.
+    private int _pendingLossPercent = -1;
+
+    /// <summary>
+    /// Thread-safe: may be called from the network thread. The value is stashed
+    /// and applied on the encoding thread at the next frame, because
+    /// opus_encoder_ctl must not run concurrently with opus_encode.
+    /// </summary>
     public void UpdatePacketLoss(int observedLossPercent)
     {
         int clamped = Math.Clamp(observedLossPercent + 5, 5, 25);
-        _encoder.PacketLossPercentage = clamped;
+        Interlocked.Exchange(ref _pendingLossPercent, clamped);
     }
 
     /// <summary>
@@ -146,6 +154,10 @@ public class EncodePipeline : IDisposable
 
     private void EncodeAndEmit(bool terminator)
     {
+        int pendingLoss = Interlocked.Exchange(ref _pendingLossPercent, -1);
+        if (pendingLoss >= 0)
+            _encoder.PacketLossPercentage = pendingLoss;
+
         byte[] scaled;
 
         if (_volume != 1.0f)

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -249,6 +249,22 @@ internal sealed class AudioManager : IDisposable
         OnLossReport?.Invoke(null);
     }
 
+    // Last observed outbound loss percent (server ping crypt stats); -1 = no data yet.
+    private int _outboundLossPercent = -1;
+
+    /// <summary>
+    /// Feed observed outbound packet loss to the Opus encoder so FEC redundancy
+    /// scales with actual network conditions (#596). Survives pipeline recreation.
+    /// </summary>
+    public void UpdatePacketLoss(int lossPercent)
+    {
+        lock (_lock)
+        {
+            _outboundLossPercent = lossPercent;
+            _encodePipeline?.UpdatePacketLoss(lossPercent);
+        }
+    }
+
     // Allowed Opus bitrates (bps). Must match the UI options in AudioSettingsTab.tsx.
     private static readonly int[] AllowedBitrates = { 24000, 40000, 56000, 72000, 96000, 128000 };
 
@@ -328,6 +344,8 @@ internal sealed class AudioManager : IDisposable
                 dtx: _dtxEnabled,
                 initialSequence: seq);
             _encodePipeline.SetVolume(_inputVolume);
+            if (_outboundLossPercent >= 0)
+                _encodePipeline.UpdatePacketLoss(_outboundLossPercent);
         }
     }
 

--- a/src/Brmble.Client/Services/Voice/AudioManager.cs
+++ b/src/Brmble.Client/Services/Voice/AudioManager.cs
@@ -246,6 +246,10 @@ internal sealed class AudioManager : IDisposable
     public void ResetLossStats()
     {
         _smoothedLoss = -1;
+        lock (_lock)
+        {
+            _outboundLossPercent = -1;
+        }
         OnLossReport?.Invoke(null);
     }
 
@@ -258,6 +262,7 @@ internal sealed class AudioManager : IDisposable
     /// </summary>
     public void UpdatePacketLoss(int lossPercent)
     {
+        lossPercent = Math.Clamp(lossPercent, 0, 100);
         lock (_lock)
         {
             _outboundLossPercent = lossPercent;

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -330,6 +330,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         // stale state if a previous connection dropped before ServerSync.
         _isReconnect = false;
 
+        // New connection = new server crypt counters; a delta spanning two
+        // connections would be meaningless.
+        _hasPingBase = false;
+
         if (apiUrl is not null)
             _apiUrl = apiUrl;
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -265,7 +265,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         goodBase = good; lateBase = late; lostBase = lost;
         // Good already includes late packets (CryptState increments Good for every
         // accepted packet), so the denominator is delivered + lost — not + late.
-        uint total = dGood + dLost;
+        // ulong so extreme deltas (e.g. first sample after hours of uptime on a
+        // rebaselined counter) cannot wrap the sum.
+        ulong total = (ulong)dGood + dLost;
         // Ping keepalives keep the counters moving even when the mic is idle,
         // so total is rarely 0. Require a real sample: at ~50 voice packets/s,
         // fewer than 10 packets per interval means silence (only pings), where

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -274,6 +274,13 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         // one dropped ping would otherwise spike the estimate to 50-100%.
         if (total < 10)
             return null;
+        // Murmur's uiLost-- on a late packet can wrap to ~2^32 when the counter
+        // is 0 (e.g. a pre-resync straggler); a wrapped value passes the
+        // regression guard as an increase. 100k packets in one ~5s ping
+        // interval is far beyond any real rate — drop the bogus sample
+        // (baselines are already updated, so the next delta self-corrects).
+        if (total > 100_000)
+            return null;
         return (int)(dLost * 100UL / total);
     }
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -226,6 +226,45 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         };
     }
 
+    // Baseline for the server's cumulative crypt receive counters (client→server
+    // direction), reported back in every TCP Ping reply. Deltas between replies
+    // give the outbound packet loss the encoder's FEC should protect against.
+    private uint _pingGoodBase, _pingLateBase, _pingLostBase;
+    private bool _hasPingBase;
+
+    /// <summary>
+    /// Ping reply from the server. Murmur fills good/late/lost with its own
+    /// crypt receive counters for this client, so the lost delta measures
+    /// outbound voice loss — fed to the Opus encoder for adaptive FEC (#596).
+    /// </summary>
+    public override void Ping(Ping ping)
+    {
+        base.Ping(ping);
+        if (!ping.ShouldSerializeGood() && !ping.ShouldSerializeLate() && !ping.ShouldSerializeLost())
+            return;
+        int? loss = ComputeOutboundLossPercent(ping.Good, ping.Late, ping.Lost,
+            ref _pingGoodBase, ref _pingLateBase, ref _pingLostBase, ref _hasPingBase);
+        if (loss is int pct)
+            _audioManager?.UpdatePacketLoss(pct);
+    }
+
+    internal static int? ComputeOutboundLossPercent(uint good, uint late, uint lost,
+        ref uint goodBase, ref uint lateBase, ref uint lostBase, ref bool hasBase)
+    {
+        // First sample, or counter regression (reconnect / server restart): re-baseline.
+        if (!hasBase || good < goodBase || late < lateBase || lost < lostBase)
+        {
+            goodBase = good; lateBase = late; lostBase = lost; hasBase = true;
+            return null;
+        }
+        uint dGood = good - goodBase, dLate = late - lateBase, dLost = lost - lostBase;
+        goodBase = good; lateBase = late; lostBase = lost;
+        uint total = dGood + dLate + dLost;
+        if (total == 0)
+            return null; // nothing sent since the last ping (mic idle)
+        return (int)(dLost * 100 / total);
+    }
+
     /// <summary>
     /// Dispatches a shortcut action when its key is released. Previously lived
     /// in AudioManager; moved here as part of Task 13 (InputRouter ownership).

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -240,7 +240,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     public override void Ping(Ping ping)
     {
         base.Ping(ping);
-        if (!ping.ShouldSerializeGood() && !ping.ShouldSerializeLate() && !ping.ShouldSerializeLost())
+        // All three counters must be present: absent optional fields read as 0
+        // and would fake a counter regression or a bogus loss figure.
+        if (!ping.ShouldSerializeGood() || !ping.ShouldSerializeLate() || !ping.ShouldSerializeLost())
             return;
         int? loss = ComputeOutboundLossPercent(ping.Good, ping.Late, ping.Lost,
             ref _pingGoodBase, ref _pingLateBase, ref _pingLostBase, ref _hasPingBase);
@@ -252,17 +254,25 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         ref uint goodBase, ref uint lateBase, ref uint lostBase, ref bool hasBase)
     {
         // First sample, or counter regression (reconnect / server restart): re-baseline.
+        // Note: lost legitimately decreases when a late packet arrives (late = -1 lost
+        // in Murmur's CryptState); that just costs one skipped sample here.
         if (!hasBase || good < goodBase || late < lateBase || lost < lostBase)
         {
             goodBase = good; lateBase = late; lostBase = lost; hasBase = true;
             return null;
         }
-        uint dGood = good - goodBase, dLate = late - lateBase, dLost = lost - lostBase;
+        uint dGood = good - goodBase, dLost = lost - lostBase;
         goodBase = good; lateBase = late; lostBase = lost;
-        uint total = dGood + dLate + dLost;
-        if (total == 0)
-            return null; // nothing sent since the last ping (mic idle)
-        return (int)(dLost * 100 / total);
+        // Good already includes late packets (CryptState increments Good for every
+        // accepted packet), so the denominator is delivered + lost — not + late.
+        uint total = dGood + dLost;
+        // Ping keepalives keep the counters moving even when the mic is idle,
+        // so total is rarely 0. Require a real sample: at ~50 voice packets/s,
+        // fewer than 10 packets per interval means silence (only pings), where
+        // one dropped ping would otherwise spike the estimate to 50-100%.
+        if (total < 10)
+            return null;
+        return (int)(dLost * 100UL / total);
     }
 
     /// <summary>

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterLossTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterLossTests.cs
@@ -35,6 +35,15 @@ public class MumbleAdapterLossTests
     }
 
     [TestMethod]
+    public void PingOnlyTraffic_ReturnsNull()
+    {
+        // Mic idle: only UDP keepalive pings moved the counters (~2 per interval).
+        // One lost ping among those must not spike the loss estimate.
+        Update(100, 0, 0);
+        Assert.IsNull(Update(102, 0, 1), "Fewer than 10 packets is not a usable sample");
+    }
+
+    [TestMethod]
     public void CounterRegression_Rebaselines()
     {
         Update(100, 0, 5);
@@ -45,10 +54,11 @@ public class MumbleAdapterLossTests
     }
 
     [TestMethod]
-    public void LateCountsAsDelivered()
+    public void LateIsNotDoubleCounted()
     {
         Update(0, 0, 0);
-        // 50 good + 30 late + 20 lost → 20% loss
-        Assert.AreEqual(20, Update(50, 30, 20));
+        // Good already includes the 30 late packets, so 50 delivered + 20 lost
+        // → 20/70 ≈ 28%, not 20/100.
+        Assert.AreEqual(28, Update(50, 30, 20));
     }
 }

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterLossTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterLossTests.cs
@@ -54,6 +54,18 @@ public class MumbleAdapterLossTests
     }
 
     [TestMethod]
+    public void WrappedServerLostCounter_IsRejected()
+    {
+        // Murmur's uiLost-- can wrap to ~2^32 when the counter is 0; the wrap
+        // looks like an increase so the regression guard passes. The sample
+        // must be dropped instead of pegging FEC at ~100% loss.
+        Update(100, 0, 0);
+        Assert.IsNull(Update(200, 1, uint.MaxValue));
+        // Next interval computes from the updated baselines and self-corrects.
+        Assert.AreEqual(0, Update(300, 1, uint.MaxValue));
+    }
+
+    [TestMethod]
     public void LateIsNotDoubleCounted()
     {
         Update(0, 0, 0);

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterLossTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterLossTests.cs
@@ -1,0 +1,54 @@
+using Brmble.Client.Services.Voice;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class MumbleAdapterLossTests
+{
+    private uint _good, _late, _lost;
+    private bool _hasBase;
+
+    private int? Update(uint good, uint late, uint lost) =>
+        MumbleAdapter.ComputeOutboundLossPercent(good, late, lost,
+            ref _good, ref _late, ref _lost, ref _hasBase);
+
+    [TestMethod]
+    public void FirstSample_OnlyBaselines()
+    {
+        Assert.IsNull(Update(100, 0, 10));
+    }
+
+    [TestMethod]
+    public void Delta_ComputesLossPercent()
+    {
+        Update(100, 0, 0);
+        // 90 good + 10 lost since last ping → 10%
+        Assert.AreEqual(10, Update(190, 0, 10));
+    }
+
+    [TestMethod]
+    public void NoTraffic_ReturnsNull()
+    {
+        Update(100, 0, 5);
+        Assert.IsNull(Update(100, 0, 5), "No packets since last ping must not report loss");
+    }
+
+    [TestMethod]
+    public void CounterRegression_Rebaselines()
+    {
+        Update(100, 0, 5);
+        // Server restart / reconnect: counters drop → re-baseline, no bogus loss
+        Assert.IsNull(Update(10, 0, 0));
+        // Next delta computed from the new baseline
+        Assert.AreEqual(0, Update(110, 0, 0));
+    }
+
+    [TestMethod]
+    public void LateCountsAsDelivered()
+    {
+        Update(0, 0, 0);
+        // 50 good + 30 late + 20 lost → 20% loss
+        Assert.AreEqual(20, Update(50, 30, 20));
+    }
+}


### PR DESCRIPTION
## Summary
- `EncodePipeline.UpdatePacketLoss` existed but was never called, so Opus FEC redundancy stayed at the minimal 3% assumption regardless of network conditions.
- Murmur's TCP Ping reply carries its crypt receive counters (good/late/lost) for this client — i.e. **outbound** voice loss, exactly what our encoder's FEC protects.
- `MumbleAdapter.Ping` (previously an empty no-op) now computes loss percent from counter deltas per ping: re-baselines on counter regression (reconnect / server restart), skips updates when nothing was sent (mic idle).
- Flows through new `AudioManager.UpdatePacketLoss`, which also re-applies the last observed value when the encode pipeline is recreated on settings changes.

## Not included
- Second-stage bitrate reduction under sustained loss (can follow separately if FEC alone proves insufficient).

## Test plan
- 5 new unit tests on the delta logic (`MumbleAdapterLossTests`): baseline, delta percent, idle, counter regression, late-counts-as-delivered.
- Full `Brmble.Client.Tests` suite: 257/257 pass.

Fixes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)