### PR TITLE
fix: UDP voice robustness — liveness fallback, crypt gate, resync, stats

### DIFF
--- a/docs/mumble-integration-guide.md
+++ b/docs/mumble-integration-guide.md
@@ -287,9 +287,15 @@ channel.SendMessage("<b>bold</b> text", recursive: false);
 
 ### Transport
 
+Voice transport is selected automatically: packets go over UDP only while
+the encrypted UDP path has recently proven itself (ping echo or incoming
+voice within 12s) and fall back to the TCP tunnel otherwise, recovering
+automatically when UDP comes back. There is no manual override (the old
+`ForceTcp` property was removed).
+
 ```csharp
-// Force TCP tunnel for voice (instead of UDP)
-connection.ForceTcp = true;
+// Observe the current UDP path health
+if (connection.UdpHealthy) { }
 
 // Check connection state
 if (connection.State == ConnectionStates.Connected) { }

--- a/lib/MumbleSharp/MumbleSharp/InternalsVisibleTo.cs
+++ b/lib/MumbleSharp/MumbleSharp/InternalsVisibleTo.cs
@@ -1,2 +1,3 @@
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("MumbleSharpTest")]
+[assembly: InternalsVisibleTo("Brmble.Client.Tests")]

--- a/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
+++ b/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
@@ -20,9 +20,18 @@ namespace MumbleSharp
     {
         private static double PING_DELAY_MILLISECONDS = 5000;
 
+        // UDP is considered alive while the last successfully decrypted UDP
+        // packet (ping echo or voice) is younger than this. Two missed ping
+        // intervals plus margin, matching the reference client's behaviour.
+        internal const double UDP_LIVENESS_TIMEOUT_MILLISECONDS = 12000;
+
         public float? TcpPingAverage { get; set; }
         public float? TcpPingVariance { get; set; }
         public uint? TcpPingPackets { get; set; }
+
+        public float? UdpPingAverage { get; private set; }
+        public float? UdpPingVariance { get; private set; }
+        public uint? UdpPingPackets { get; private set; }
 
         public ConnectionStates State { get; private set; }
 
@@ -45,6 +54,37 @@ namespace MumbleSharp
         }
 
         readonly CryptState _cryptState = new CryptState();
+        internal CryptState CryptState => _cryptState;
+
+        // Ticks (DateTime.UtcNow) of the last successfully decrypted UDP packet.
+        // Written from the process thread, read from the capture thread (SendVoice).
+        private long _lastGoodUdpTicks;
+
+        // Client-initiated crypt resync state (see MaybeRequestCryptResync).
+        private int _consecutiveDecryptFailures;
+        private long _lastResyncRequestTicks;
+        internal uint ResyncRequests { get; private set; }
+
+        /// <summary>
+        /// True while UDP voice is confirmed working: an encrypted ping echo or
+        /// voice packet round-tripped recently. Voice is only committed to UDP
+        /// while healthy; otherwise it goes over the TCP tunnel. Pings keep
+        /// probing, so this recovers automatically when UDP comes back.
+        /// </summary>
+        public bool UdpHealthy =>
+            (DateTime.UtcNow - new DateTime(System.Threading.Volatile.Read(ref _lastGoodUdpTicks), DateTimeKind.Utc))
+                .TotalMilliseconds < UDP_LIVENESS_TIMEOUT_MILLISECONDS;
+
+        internal void MarkUdpAlive() =>
+            System.Threading.Volatile.Write(ref _lastGoodUdpTicks, DateTime.UtcNow.Ticks);
+
+        /// <summary>
+        /// Called by UdpSocket when the OS reports the UDP path unusable
+        /// (e.g. ICMP port unreachable surfacing as a SocketException).
+        /// Voice falls back to the TCP tunnel immediately; pings keep probing.
+        /// </summary>
+        internal void MarkUdpUnusable() =>
+            System.Threading.Volatile.Write(ref _lastGoodUdpTicks, 0);
 
         /// <summary>
         /// Creates a connection to the server using the given address and port.
@@ -138,29 +178,28 @@ namespace MumbleSharp
             if (!_cryptState.Initialized)
                 return;
 
-            // Build the raw ping payload (same format as UdpSocket.SendPing)
-            long timestamp = DateTime.UtcNow.Ticks;
-            byte[] pingData = new byte[9];
-            pingData[0] = 1 << 5; // Ping type
-            pingData[1] = (byte)((timestamp >> 56) & 0xFF);
-            pingData[2] = (byte)((timestamp >> 48) & 0xFF);
-            pingData[3] = (byte)((timestamp >> 40) & 0xFF);
-            pingData[4] = (byte)((timestamp >> 32) & 0xFF);
-            pingData[5] = (byte)((timestamp >> 24) & 0xFF);
-            pingData[6] = (byte)((timestamp >> 16) & 0xFF);
-            pingData[7] = (byte)((timestamp >> 8) & 0xFF);
-            pingData[8] = (byte)((timestamp) & 0xFF);
+            byte[] pingData = BuildUdpPing(DateTime.UtcNow.Ticks);
 
             // Encrypt before sending — server requires all UDP to be OCB-AES128 encrypted
             byte[] encrypted = _cryptState.Encrypt(pingData, pingData.Length);
             if (encrypted != null)
-                _udp.Send(encrypted, encrypted.Length);
+                _udp.TrySend(encrypted, encrypted.Length);
         }
 
         /// <summary>
-        /// When true, voice is sent via TCP tunnel even if UDP is connected.
+        /// Builds a UDP ping packet: type header + timestamp as a Mumble varint.
+        /// Always uses the 8-byte varint form (0xF4 prefix) since a tick count
+        /// never fits the short forms anyway.
         /// </summary>
-        public bool ForceTcp { get; set; }
+        internal static byte[] BuildUdpPing(long timestamp)
+        {
+            byte[] pingData = new byte[10];
+            pingData[0] = 1 << 5; // Ping type
+            pingData[1] = 0xF4;   // varint prefix: 111101__ = 8-byte value follows
+            for (int i = 0; i < 8; i++)
+                pingData[2 + i] = (byte)(timestamp >> (56 - 8 * i));
+            return pingData;
+        }
 
         public void SendVoice(ArraySegment<byte> packet)
         {
@@ -170,31 +209,56 @@ namespace MumbleSharp
             if (!VoiceSupportEnabled)
                 throw new InvalidOperationException("Voice Support is disabled with this connection");
 
-            if (!ForceTcp && _udp != null && _udp.IsConnected)
+            // Commit voice to UDP only when crypt is ready and the UDP path has
+            // recently proven itself (ping echo / incoming voice). Everything
+            // else goes through the TCP tunnel, like the reference client.
+            if (_udp != null && _udp.IsConnected && _cryptState.Initialized && UdpHealthy)
             {
-                // Encrypt and send via UDP
                 byte[] voiceData = new byte[packet.Count];
                 Buffer.BlockCopy(packet.Array, packet.Offset, voiceData, 0, packet.Count);
                 byte[] encrypted = _cryptState.Encrypt(voiceData, voiceData.Length);
-                if (encrypted != null)
-                    _udp.Send(encrypted, encrypted.Length);
-                else
-                    _tcp.SendVoice(PacketType.UDPTunnel, packet); // Encryption failed, fallback to TCP
+                if (encrypted != null && _udp.TrySend(encrypted, encrypted.Length))
+                    return;
             }
-            else
-            {
-                _tcp.SendVoice(PacketType.UDPTunnel, packet); // TCP tunnel fallback
-            }
+
+            _tcp.SendVoice(PacketType.UDPTunnel, packet); // TCP tunnel fallback
         }
 
         internal void ReceivedEncryptedUdp(byte[] packet)
         {
+            if (!_cryptState.Initialized)
+                return;
+
             byte[] plaintext = _cryptState.Decrypt(packet, packet.Length);
 
             if (plaintext == null)
+            {
+                _consecutiveDecryptFailures++;
+                MaybeRequestCryptResync();
                 return;
+            }
 
+            _consecutiveDecryptFailures = 0;
+            MarkUdpAlive();
             ReceiveDecryptedUdp(plaintext);
+        }
+
+        /// <summary>
+        /// A nonce desync silently kills UDP receive: every packet fails to
+        /// decrypt and is dropped. After a burst of consecutive failures, ask
+        /// the server for its current nonce by sending an empty CryptSetup
+        /// (rate-limited to one request per 5 seconds).
+        /// </summary>
+        private void MaybeRequestCryptResync()
+        {
+            if (_consecutiveDecryptFailures < 10)
+                return;
+            var now = DateTime.UtcNow.Ticks;
+            if (TimeSpan.FromTicks(now - _lastResyncRequestTicks).TotalMilliseconds < 5000)
+                return;
+            _lastResyncRequestTicks = now;
+            ResyncRequests++;
+            SendControl<CryptSetup>(PacketType.CryptSetup, new CryptSetup());
         }
 
         internal void ReceiveDecryptedUdp(byte[] packet)
@@ -202,13 +266,38 @@ namespace MumbleSharp
             var type = packet[0] >> 5 & 0x7;
 
             if (type == 1)
+            {
+                ReceiveUdpPingEcho(packet);
                 Protocol.UdpPing(packet);
+            }
             else if(VoiceSupportEnabled)
                 UnpackVoicePacket(packet, type);
         }
 
-        private void PackVoicePacket(ArraySegment<byte> packet)
+        private void ReceiveUdpPingEcho(byte[] packet)
         {
+            MarkUdpAlive();
+            try
+            {
+                using (var reader = new UdpPacketReader(new MemoryStream(packet, 1, packet.Length - 1)))
+                {
+                    long sentTicks = reader.ReadVarInt64();
+                    float rttMs = (float)TimeSpan.FromTicks(DateTime.UtcNow.Ticks - sentTicks).TotalMilliseconds;
+                    if (rttMs < 0 || rttMs > 60000)
+                        return; // garbage or foreign timestamp format — liveness already noted
+
+                    var previousMean = _meanOfUdpPings;
+                    _countOfUdpPings++;
+                    _meanOfUdpPings = _meanOfUdpPings + ((rttMs - _meanOfUdpPings) / _countOfUdpPings);
+                    _varianceTimesCountOfUdpPings = _varianceTimesCountOfUdpPings +
+                                                    ((rttMs - _meanOfUdpPings) * (rttMs - previousMean));
+
+                    UdpPingPackets = (uint)_countOfUdpPings;
+                    UdpPingAverage = _meanOfUdpPings;
+                    UdpPingVariance = _varianceTimesCountOfUdpPings / _countOfUdpPings;
+                }
+            }
+            catch (IOException) { /* malformed echo payload — liveness already noted */ }
         }
 
         private void UnpackVoicePacket(byte[] packet, int type)
@@ -265,6 +354,10 @@ namespace MumbleSharp
         private float _meanOfPings;
         private float _varianceTimesCountOfPings;
         private int _countOfPings;
+
+        private float _meanOfUdpPings;
+        private float _varianceTimesCountOfUdpPings;
+        private int _countOfUdpPings;
 
         /// <summary>
         /// Gets a value indicating whether ping stats should set timestamp when pinging.

--- a/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
+++ b/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
@@ -210,17 +210,16 @@ namespace MumbleSharp
         }
 
         /// <summary>
-        /// Builds a UDP ping packet: type header + timestamp as a Mumble varint.
-        /// Always uses the 8-byte varint form (0xF4 prefix) since a tick count
-        /// never fits the short forms anyway.
+        /// Builds a UDP ping packet: type header + timestamp as a Mumble varint
+        /// (in practice the 0xF4 8-byte form, since a tick count never fits the
+        /// short forms).
         /// </summary>
         internal static byte[] BuildUdpPing(long timestamp)
         {
-            byte[] pingData = new byte[10];
+            byte[] varint = Var64.writeVarint64_alternative((ulong)timestamp);
+            byte[] pingData = new byte[1 + varint.Length];
             pingData[0] = 1 << 5; // Ping type
-            pingData[1] = 0xF4;   // varint prefix: 111101__ = 8-byte value follows
-            for (int i = 0; i < 8; i++)
-                pingData[2 + i] = (byte)(timestamp >> (56 - 8 * i));
+            Array.Copy(varint, 0, pingData, 1, varint.Length);
             return pingData;
         }
 

--- a/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
+++ b/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
@@ -56,13 +56,23 @@ namespace MumbleSharp
         readonly CryptState _cryptState = new CryptState();
         internal CryptState CryptState => _cryptState;
 
-        // Ticks (DateTime.UtcNow) of the last successfully decrypted UDP packet.
+        // Sentinel meaning "never" that stays far away from any real monotonic
+        // timestamp (which starts near 0 at boot), without subtraction overflow.
+        private const long NeverMs = long.MinValue / 2;
+
+        // Monotonic milliseconds (Stopwatch is wall-clock independent;
+        // Environment.TickCount64 is unavailable on netstandard2.0/2.1).
+        private static long MonotonicMs =>
+            System.Diagnostics.Stopwatch.GetTimestamp() * 1000 / System.Diagnostics.Stopwatch.Frequency;
+
+        // Monotonic ms (wall-clock adjustments must not affect liveness)
+        // of the last successfully decrypted UDP packet.
         // Written from the process thread, read from the capture thread (SendVoice).
-        private long _lastGoodUdpTicks;
+        private long _lastGoodUdpMs = NeverMs;
 
         // Client-initiated crypt resync state (see MaybeRequestCryptResync).
         private int _consecutiveDecryptFailures;
-        private long _lastResyncRequestTicks;
+        private long _lastResyncRequestMs = NeverMs;
         internal uint ResyncRequests { get; private set; }
 
         /// <summary>
@@ -72,11 +82,11 @@ namespace MumbleSharp
         /// probing, so this recovers automatically when UDP comes back.
         /// </summary>
         public bool UdpHealthy =>
-            (DateTime.UtcNow - new DateTime(System.Threading.Volatile.Read(ref _lastGoodUdpTicks), DateTimeKind.Utc))
-                .TotalMilliseconds < UDP_LIVENESS_TIMEOUT_MILLISECONDS;
+            MonotonicMs - System.Threading.Volatile.Read(ref _lastGoodUdpMs)
+                < UDP_LIVENESS_TIMEOUT_MILLISECONDS;
 
         internal void MarkUdpAlive() =>
-            System.Threading.Volatile.Write(ref _lastGoodUdpTicks, DateTime.UtcNow.Ticks);
+            System.Threading.Volatile.Write(ref _lastGoodUdpMs, MonotonicMs);
 
         /// <summary>
         /// Called by UdpSocket when the OS reports the UDP path unusable
@@ -84,7 +94,7 @@ namespace MumbleSharp
         /// Voice falls back to the TCP tunnel immediately; pings keep probing.
         /// </summary>
         internal void MarkUdpUnusable() =>
-            System.Threading.Volatile.Write(ref _lastGoodUdpTicks, 0);
+            System.Threading.Volatile.Write(ref _lastGoodUdpMs, NeverMs);
 
         /// <summary>
         /// Creates a connection to the server using the given address and port.
@@ -253,10 +263,10 @@ namespace MumbleSharp
         {
             if (_consecutiveDecryptFailures < 10)
                 return;
-            var now = DateTime.UtcNow.Ticks;
-            if (TimeSpan.FromTicks(now - _lastResyncRequestTicks).TotalMilliseconds < 5000)
+            var now = MonotonicMs;
+            if (now - _lastResyncRequestMs < 5000)
                 return;
-            _lastResyncRequestTicks = now;
+            _lastResyncRequestMs = now;
             ResyncRequests++;
             SendControl<CryptSetup>(PacketType.CryptSetup, new CryptSetup());
         }

--- a/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
+++ b/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
@@ -130,6 +130,19 @@ namespace MumbleSharp
             State = ConnectionStates.Connecting;
             Protocol.Initialise(this);
 
+            // Connect-after-Close reuses this instance: evidence from the
+            // previous session must not authorize UDP or skew statistics.
+            MarkUdpUnusable();
+            _consecutiveDecryptFailures = 0;
+            _lastResyncRequestMs = NeverMs;
+            ResyncRequests = 0;
+            UdpPingAverage = null;
+            UdpPingVariance = null;
+            UdpPingPackets = null;
+            _meanOfUdpPings = 0;
+            _varianceTimesCountOfUdpPings = 0;
+            _countOfUdpPings = 0;
+
             _tcp = new TcpSocket(Host, Protocol, this);
             _tcp.Connect(username, password, tokens, serverName);
 

--- a/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
+++ b/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
@@ -308,6 +308,7 @@ namespace MumbleSharp
                 }
             }
             catch (IOException) { /* malformed echo payload — liveness already noted */ }
+            catch (InvalidDataException) { /* invalid varint in echo payload */ }
         }
 
         private void UnpackVoicePacket(byte[] packet, int type)

--- a/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
+++ b/lib/MumbleSharp/MumbleSharp/MumbleConnection.cs
@@ -286,7 +286,10 @@ namespace MumbleSharp
 
         private void ReceiveUdpPingEcho(byte[] packet)
         {
-            MarkUdpAlive();
+            // No MarkUdpAlive here: this method is also reached via the TCP
+            // tunnel path (TcpSocket forwards UDPTunnel payloads), which proves
+            // nothing about UDP. Liveness is recorded in ReceivedEncryptedUdp,
+            // the UDP-only receive path.
             try
             {
                 using (var reader = new UdpPacketReader(new MemoryStream(packet, 1, packet.Length - 1)))

--- a/lib/MumbleSharp/MumbleSharp/TcpSocket.cs
+++ b/lib/MumbleSharp/MumbleSharp/TcpSocket.cs
@@ -173,6 +173,31 @@ namespace MumbleSharp
                 ping.TcpPackets = _connection.TcpPingPackets.Value;
             }
 
+            if (_connection.UdpPingAverage.HasValue)
+            {
+                ping.UdpPingAvg = _connection.UdpPingAverage.Value;
+            }
+            if (_connection.UdpPingVariance.HasValue)
+            {
+                ping.UdpPingVar = _connection.UdpPingVariance.Value;
+            }
+            if (_connection.UdpPingPackets.HasValue)
+            {
+                ping.UdpPackets = _connection.UdpPingPackets.Value;
+            }
+
+            // Our crypt receive counters (server→client direction) plus how often
+            // we asked for a resync — this is what makes the server-side user
+            // info dialog show real numbers for Brmble clients instead of zeros.
+            var crypt = _connection.CryptState;
+            if (crypt.Initialized)
+            {
+                ping.Good = (uint)crypt.Good;
+                ping.Late = (uint)crypt.Late;
+                ping.Lost = (uint)crypt.Lost;
+                ping.Resync = _connection.ResyncRequests;
+            }
+
             lock (_sendLock)
                 Send<Ping>(PacketType.Ping, ping);
         }

--- a/lib/MumbleSharp/MumbleSharp/UdpPacketReader.cs
+++ b/lib/MumbleSharp/MumbleSharp/UdpPacketReader.cs
@@ -36,9 +36,16 @@ namespace MumbleSharp
             return buffer;
         }
 
-        public long ReadVarInt64()
+        public long ReadVarInt64() => ReadVarInt64(0);
+
+        private long ReadVarInt64(int depth)
         {
-            //My implementation, neater (imo) but broken
+            // The 0xF8 (negative-recursive) prefix nests another varint. A real
+            // encoder emits it at most once; unbounded recursion on a network
+            // packet full of 0xF8 bytes would exhaust the stack.
+            if (depth > 4)
+                throw new InvalidDataException("Varint recursion too deep");
+
             byte b = ReadByte();
             int leadingOnes = LeadingOnes(b);
             switch (leadingOnes)
@@ -74,7 +81,7 @@ namespace MumbleSharp
                     }
                 case 5:
                     //111110 + varint (negative)
-                    return ~ReadVarInt64();
+                    return ~ReadVarInt64(depth + 1);
                 case 6:
                 case 7:
                 case 8:

--- a/lib/MumbleSharp/MumbleSharp/UdpPacketReader.cs
+++ b/lib/MumbleSharp/MumbleSharp/UdpPacketReader.cs
@@ -61,12 +61,16 @@ namespace MumbleSharp
                     if ((b & 4) == 4)
                     {
                         //111101__ + long (8 bytes)
-                        return ReadByte() << 56 | ReadByte() << 48 | ReadByte() << 40 | ReadByte() << 32 | ReadByte() << 24 | ReadByte() << 16 | ReadByte() << 8 | ReadByte();
+                        //Shifts must be on long: an int shift count is masked to 0-31,
+                        //so `byte << 56` silently became `<< 24` and scrambled the value.
+                        return (long)ReadByte() << 56 | (long)ReadByte() << 48 | (long)ReadByte() << 40 | (long)ReadByte() << 32
+                             | (long)ReadByte() << 24 | (long)ReadByte() << 16 | (long)ReadByte() << 8 | ReadByte();
                     }
                     else
                     {
                         //111100__ + int (4 bytes)
-                        return ReadByte() << 24 | ReadByte() << 16 | ReadByte() << 8 | ReadByte();
+                        //Widen before shifting so values ≥ 2^31 don't sign-extend negative.
+                        return (long)ReadByte() << 24 | (long)ReadByte() << 16 | (long)ReadByte() << 8 | ReadByte();
                     }
                 case 5:
                     //111110 + varint (negative)

--- a/lib/MumbleSharp/MumbleSharp/UdpSocket.cs
+++ b/lib/MumbleSharp/MumbleSharp/UdpSocket.cs
@@ -42,41 +42,56 @@ namespace MumbleSharp
             _client.Close();
         }
 
-        public void SendPing()
+        /// <summary>
+        /// Send a datagram. A refused/unreachable UDP path (e.g. ICMP port
+        /// unreachable surfacing as SocketException on Windows) is not fatal to
+        /// the session — it just means UDP is down; the caller falls back to
+        /// the TCP tunnel and pings keep probing for recovery.
+        /// </summary>
+        public bool TrySend(byte[] data, int length)
         {
-            long timestamp = DateTime.UtcNow.Ticks;
-
-            byte[] buffer = new byte[9];
-            buffer[0] = 1 << 5;
-            buffer[1] = (byte)((timestamp >> 56) & 0xFF);
-            buffer[2] = (byte)((timestamp >> 48) & 0xFF);
-            buffer[3] = (byte)((timestamp >> 40) & 0xFF);
-            buffer[4] = (byte)((timestamp >> 32) & 0xFF);
-            buffer[5] = (byte)((timestamp >> 24) & 0xFF);
-            buffer[6] = (byte)((timestamp >> 16) & 0xFF);
-            buffer[7] = (byte)((timestamp >> 8) & 0xFF);
-            buffer[8] = (byte)((timestamp) & 0xFF);
-
-            _client.Send(buffer, buffer.Length);
-        }
-
-        public void Send(byte[] data, int length)
-        {
-            _client.Send(data, length);
+            try
+            {
+                _client.Send(data, length);
+                return true;
+            }
+            catch (SocketException)
+            {
+                _connection.MarkUdpUnusable();
+                return false;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
         }
 
         public bool Process()
         {
-            if (_client.Client == null
-                || _client.Available == 0)
+            try
+            {
+                if (_client.Client == null
+                    || _client.Available == 0)
+                    return false;
+
+                IPEndPoint sender = _host;
+                byte[] data = _client.Receive(ref sender);
+
+                _connection.ReceivedEncryptedUdp(data);
+
+                return true;
+            }
+            catch (SocketException)
+            {
+                // ICMP port unreachable from a previous send is delivered on
+                // the next receive call. UDP down, session stays up.
+                _connection.MarkUdpUnusable();
                 return false;
-
-            IPEndPoint sender = _host;
-            byte[] data = _client.Receive(ref sender);
-
-            _connection.ReceivedEncryptedUdp(data);
-
-            return true;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
         }
     }
 }

--- a/tests/Brmble.Client.Tests/Services/MumbleConnectionUdpTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleConnectionUdpTests.cs
@@ -18,14 +18,13 @@ public class MumbleConnectionUdpTests
     }
 
     [TestMethod]
-    public void PingEcho_MarksUdpHealthy_AndMeasuresRtt()
+    public void PingEcho_MeasuresRtt()
     {
         var conn = CreateConnection();
         var echo = MumbleConnection.BuildUdpPing(DateTime.UtcNow.Ticks);
 
         conn.ReceiveDecryptedUdp(echo);
 
-        Assert.IsTrue(conn.UdpHealthy);
         Assert.IsNotNull(conn.UdpPingAverage);
         Assert.IsTrue(conn.UdpPingAverage.Value >= 0 && conn.UdpPingAverage.Value < 1000,
             $"RTT should be near zero for a same-instant echo, got {conn.UdpPingAverage}");
@@ -33,10 +32,22 @@ public class MumbleConnectionUdpTests
     }
 
     [TestMethod]
+    public void TunneledPingEcho_DoesNotProveUdpLiveness()
+    {
+        var conn = CreateConnection();
+
+        // ReceiveDecryptedUdp is the shared path also fed by TCP UDPTunnel
+        // packets — a type-1 payload arriving there must not mark UDP healthy.
+        conn.ReceiveDecryptedUdp(MumbleConnection.BuildUdpPing(DateTime.UtcNow.Ticks));
+
+        Assert.IsFalse(conn.UdpHealthy, "Only the encrypted UDP receive path may prove liveness");
+    }
+
+    [TestMethod]
     public void MarkUdpUnusable_RevertsToUnhealthy()
     {
         var conn = CreateConnection();
-        conn.ReceiveDecryptedUdp(MumbleConnection.BuildUdpPing(DateTime.UtcNow.Ticks));
+        conn.MarkUdpAlive();
         Assert.IsTrue(conn.UdpHealthy);
 
         conn.MarkUdpUnusable();

--- a/tests/Brmble.Client.Tests/Services/MumbleConnectionUdpTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleConnectionUdpTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using MumbleSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class MumbleConnectionUdpTests
+{
+    private static MumbleConnection CreateConnection() =>
+        new(new IPEndPoint(IPAddress.Loopback, 64738), new BasicMumbleProtocol());
+
+    [TestMethod]
+    public void UdpHealthy_InitiallyFalse()
+    {
+        Assert.IsFalse(CreateConnection().UdpHealthy,
+            "Voice must start on the TCP tunnel until UDP proves itself");
+    }
+
+    [TestMethod]
+    public void PingEcho_MarksUdpHealthy_AndMeasuresRtt()
+    {
+        var conn = CreateConnection();
+        var echo = MumbleConnection.BuildUdpPing(DateTime.UtcNow.Ticks);
+
+        conn.ReceiveDecryptedUdp(echo);
+
+        Assert.IsTrue(conn.UdpHealthy);
+        Assert.IsNotNull(conn.UdpPingAverage);
+        Assert.IsTrue(conn.UdpPingAverage.Value >= 0 && conn.UdpPingAverage.Value < 1000,
+            $"RTT should be near zero for a same-instant echo, got {conn.UdpPingAverage}");
+        Assert.AreEqual(1u, conn.UdpPingPackets!.Value);
+    }
+
+    [TestMethod]
+    public void MarkUdpUnusable_RevertsToUnhealthy()
+    {
+        var conn = CreateConnection();
+        conn.ReceiveDecryptedUdp(MumbleConnection.BuildUdpPing(DateTime.UtcNow.Ticks));
+        Assert.IsTrue(conn.UdpHealthy);
+
+        conn.MarkUdpUnusable();
+
+        Assert.IsFalse(conn.UdpHealthy, "SocketException on the UDP path must drop voice back to the tunnel");
+    }
+
+    [TestMethod]
+    public void BuildUdpPing_TimestampRoundTripsThroughVarintReader()
+    {
+        long timestamp = DateTime.UtcNow.Ticks;
+        var packet = MumbleConnection.BuildUdpPing(timestamp);
+
+        Assert.AreEqual(0x20, packet[0], "Ping type header");
+        using var reader = new UdpPacketReader(new MemoryStream(packet, 1, packet.Length - 1));
+        Assert.AreEqual(timestamp, reader.ReadVarInt64(),
+            "8-byte varint decode must return the exact tick count (regression: int shifts were masked to <<24)");
+    }
+
+    [TestMethod]
+    public void SustainedDecryptFailures_RequestOneCryptResync()
+    {
+        var conn = CreateConnection();
+        // Initialized crypt with garbage traffic → every decrypt fails.
+        conn.CryptState.SetKeys(new byte[16], new byte[16], new byte[16]);
+        var garbage = new byte[32];
+
+        for (int i = 0; i < 25; i++)
+            conn.ReceivedEncryptedUdp(garbage);
+
+        // Rate limiter: one request per burst, not one per failing packet.
+        Assert.AreEqual(1u, conn.ResyncRequests);
+        Assert.IsFalse(conn.UdpHealthy, "Failed decrypts are not liveness evidence");
+    }
+
+    [TestMethod]
+    public void DecryptFailuresBelowThreshold_DoNotRequestResync()
+    {
+        var conn = CreateConnection();
+        conn.CryptState.SetKeys(new byte[16], new byte[16], new byte[16]);
+        var garbage = new byte[32];
+
+        for (int i = 0; i < 9; i++)
+            conn.ReceivedEncryptedUdp(garbage);
+
+        Assert.AreEqual(0u, conn.ResyncRequests);
+    }
+}


### PR DESCRIPTION
## Summary
Implements the full scope of #595. Previously, voice was committed to UDP on a purely local socket connect: on a network where UDP is filtered, outgoing voice went into a black hole with no recovery, a UDP socket error tore down the healthy TCP session, a nonce desync silently killed UDP receive forever, and server-side stats for Brmble clients read all zeros.

- **UDP liveness state machine**: voice only goes over UDP while an encrypted ping echo or incoming voice packet arrived within the last 12s; otherwise it uses the TCP tunnel. Pings keep probing, so UDP recovers automatically. Fresh connections start tunneled until the first echo round-trips (matching the reference client).
- **Crypt gate**: `SendVoice` now checks `CryptState.Initialized`, making the previously unreachable tunnel fallback real instead of NRE-ing in `Encrypt` pre-CryptSetup.
- **SocketException no longer fatal**: `UdpSocket.TrySend`/`Process` catch it (ICMP port unreachable surfaces as `SocketException` on Windows), mark UDP unusable, and fall back to the tunnel instead of killing the session.
- **UDP stats in TCP Ping**: crypt good/late/lost/resync counters plus measured UDP ping RTT avg/var — the server user-info dialog now shows real numbers for Brmble clients.
- **Client-initiated crypt resync**: after 10 consecutive decrypt failures, send an empty `CryptSetup` (rate-limited to one per 5s) so the server re-syncs its nonce.
- **Varint decoder fix**: `UdpPacketReader`'s 4/8-byte branches shifted on `int`, so shift counts were masked (`<<56` became `<<24`) and values ≥ 2³¹ sign-extended negative. The ping echo parse relies on this path.
- **Cleanup**: removed unused `ForceTcp`, dead `UdpSocket.SendPing`, and the empty `PackVoicePacket` stub; the UDP ping timestamp is now encoded as a proper Mumble varint (0xF4 8-byte form) instead of raw fixed 8 bytes.

## Notes
- `lib/MumbleSharp/MumbleSharpTest` turned out not to be in the solution and has 6 pre-existing failing tests — deliberately out of scope here; new tests live in `Brmble.Client.Tests` (which runs in CI) via a new `InternalsVisibleTo`.

## Test plan
- 6 new unit tests (`MumbleConnectionUdpTests`): initial-unhealthy, echo→healthy+RTT, unusable→unhealthy, varint round-trip regression, resync rate-limiting, below-threshold no-resync.
- Full solution suite: 752/752 pass (MumbleVoiceEngine 99, Brmble.Audio 72, Brmble.Client 258, Brmble.Server 323).

Fixes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)