### PR TITLE
Rock Paper Scissors minigame, head-to-head stats, and AFK/unsupported-game hardening

### DIFF
--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -200,8 +200,18 @@ Rules:
    (`myPick` set) and show a "waiting for opponent" hint. Keep the opponent's choice
    hidden (`opponentPicked` boolean only) until the round resolves (`lastRound`), then
    reveal both picks and the round outcome. Show running round wins against
-   `targetWins` / `bestOf`.
-6. A modal may show a **Head-to-head** panel (see the Head-to-head pattern) below the
+   `targetWins` / `bestOf`. Pick buttons use `btn-secondary` at rest and `btn-primary`
+   when selected (plus `aria-pressed`), each with its own choice icon (`rps-rock`,
+   `rps-paper`, `rps-scissors`) so the options read as distinct, clickable controls.
+6. **Reveal suspense (simultaneous-commit games):** a resolved round arrives instantly
+   from the server (and, on the deciding round, `game.ended` immediately after — which
+   nulls the view). Don't reveal the result raw. Freeze the pre-resolution board, run a
+   short token-styled `3…2…1` countdown in the status area, then reveal the updated
+   score, `lastRound`, and — only after the countdown — the end result banner. Gate this
+   with local state (the raw `view` prop is the source of truth; a `display` copy lags
+   during the reveal). Key the modal on the match id in App so this reveal state resets
+   between matches.
+7. A modal may show a **Head-to-head** panel (see the Head-to-head pattern) below the
    result, scoped to the current opponent.
 
 ### Minigame Invite Pattern
@@ -908,7 +918,7 @@ The component sets `aria-hidden="true"` automatically. Color inherits from `curr
 | **Window** | `window-minimize`, `window-maximize`, `window-close` | Title bar controls (custom viewBox) |
 | **Brmblegotchi — Actions** | `gotchi-food`, `gotchi-play`, `gotchi-clean` | Pet interaction buttons |
 | **Brmblegotchi — Stats** | `gotchi-hunger`, `gotchi-happiness`, `gotchi-cleanliness` | Pet stat indicators |
-| **Games** | `swords`, `game-deathroll`, `game-rps` | `swords` = the "Challenge to a duel" menu parent; `game-*` are per-game avatars/menu icons keyed by `gameType` (see `utils/games.ts`) |
+| **Games** | `swords`, `game-deathroll`, `game-rps`, `rps-rock`, `rps-paper`, `rps-scissors` | `swords` = the "Challenge to a duel" menu parent; `game-*` are per-game avatars/menu icons keyed by `gameType` (see `utils/games.ts`); `rps-*` are the RPS choice-button icons (object metaphors) |
 
 Brmblegotchi icons are prefixed `gotchi-` and shared across all pet themes (`original`, `dino`, `cat`). If a pet theme needs unique icons, add them under a sub-header like `/* ── gotchi · dino ── */` in the icon map.
 

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -167,16 +167,22 @@ Rules:
 
 ### Minigame Modal Pattern
 
-Reference: `components/Games/DeathrollModal.tsx`, `DeathrollModal.module.css`
+Reference: `components/Games/DeathrollModal.tsx`, `DeathrollModal.module.css`,
+`components/Games/RpsModal.tsx`, `RpsModal.module.css`
 
-Real-time minigame modals (e.g. Deathroll) reuse the shared modal shell — global
-`div.modal-overlay`, `.glass-panel.animate-slide-up`, `.modal-close`, `.modal-header`,
+Real-time minigame modals (e.g. Deathroll, Rock Paper Scissors) reuse the shared modal shell —
+global `div.modal-overlay`, `.glass-panel.animate-slide-up`, `.modal-close`, `.modal-header`,
 `h2.heading-title.modal-title` — and add game-specific content styling via a colocated
 CSS module (`*.module.css`). Do not build a bespoke overlay/positioning system.
 
+Each game gets its **own** modal component (Deathroll and RPS do not share a body). The
+`view` prop is the generic `GameView` union from `useGameState`; each modal narrows it to its
+own shape with the `isRpsView` guard and ignores views it doesn't understand. App picks which
+modal to render from `activeMatch?.gameType ?? ended?.gameType`.
+
 Rules:
 1. Reuse the shared modal shell classes above; only game-board content (player rows,
-   stat tiles, countdown bar, result banner) lives in the CSS module.
+   stat tiles, countdown bar, pick buttons, result banner) lives in the CSS module.
 2. All module CSS uses tokens (`--bg-surface`, `--glass-border`, `--accent-primary`,
    `--radius-*`, `--space-*`, `--text-*`, `--font-*`) — no hardcoded visual values.
 3. Turn countdowns render as a token-styled shrinking bar plus a seconds label; drive
@@ -189,6 +195,14 @@ Rules:
 4. Action buttons use the shared `.btn` classes (`btn-primary` for the main action,
    `btn-danger` for forfeit). Disable the primary action when it is not the local
    player's turn.
+5. **Simultaneous-commit games (RPS):** both players act at once, so there is no "your
+   turn" gate — instead disable the pick buttons once the local player has committed
+   (`myPick` set) and show a "waiting for opponent" hint. Keep the opponent's choice
+   hidden (`opponentPicked` boolean only) until the round resolves (`lastRound`), then
+   reveal both picks and the round outcome. Show running round wins against
+   `targetWins` / `bestOf`.
+6. A modal may show a **Head-to-head** panel (see the Head-to-head pattern) below the
+   result, scoped to the current opponent.
 
 ### Minigame Invite Pattern
 
@@ -213,10 +227,42 @@ needs a visible countdown without client-side dismissal.
 The per-user "Challenge to a duel" entry point is a `ContextMenu` item on the user row
 (same menu as Direct Message / User Info), shown only when the target `isBrmbleClient` and
 shares the local user's voice channel. It is a submenu of game types: **Deathroll** challenges
-immediately; **Rock Paper Scissors** opens a further "Best of 3 / 5 / 7" submenu whose options
-are disabled ("coming soon") until an RPS engine exists server-side. The menu is assembled by
-the shared `buildChallengeMenuItem` helper (`components/Games/challengeMenu.tsx`) and reused by
-both `Sidebar` and `ChannelTree` — add new games there so both user-row menus stay in sync.
+immediately; **Rock Paper Scissors** opens a further "Best of 3 / 5 / 7" submenu, each option
+inviting with that best-of length (`invite(session, 'rps', { bestOf })`). The menu is assembled
+by the shared `buildChallengeMenuItem` helper (`components/Games/challengeMenu.tsx`) and reused
+by both `Sidebar` and `ChannelTree` — add new games there so both user-row menus stay in sync.
+
+#### Challenger pending-invite notification
+
+While an outgoing challenge is awaiting an answer, the challenger sees a single `info`
+notification under the queue id `game-pending` (driven by `useGameState.outgoingInvite`), with a
+`btn-danger` **Cancel** action that withdraws the challenge (`cancelInvite`). Like the incoming
+invite it uses `duration={null}` + `countdownMs` (the server owns the window) — never a
+client-side timer. `×`/Cancel both cancel. The matchId needed to cancel arrives from the
+server's `game.invitePending` event (the fire-and-forget WebView invite can't return it).
+
+#### One duel per channel + duel badge
+
+The server allows only one live duel per channel and rejects a second with the reason
+`channelBusy` (surfaced to the challenger via the standard `game-error` notification). Channels
+with a live duel show a swords badge (`<Icon name="swords">`, `--accent-primary`) on the channel
+row, sourced from the server's channel-scoped `game.duelState` events (`{ channelId, active }`).
+App maintains the `Set<number>` of busy channels and threads it as `duelChannelIds` through
+`Sidebar` → `ChannelTree` (cleared on voice disconnect). Keep the badge inside the channel-row
+header next to the access-lock icon; do not invent a new row-status container.
+
+#### Head-to-head record
+
+Reference: `components/Games/HeadToHead.tsx`, `HeadToHead.css`
+
+The `<HeadToHead opponentSession opponentName>` component shows the local user's lifetime record
+versus one opponent (all games), with a per-game breakdown, fetched via `getHeadToHead` (server
+resolves the local identity from the client certificate). It reuses the stat-tile / ratio visual
+language of `GameStats` (tokens only) and renders loading / empty / error inline states. It
+appears in two places: (1) below the result inside the active game modal, scoped to the current
+opponent; (2) as a second **"Head-to-head"** tab in `UserInfoDialog` (shown only for other
+users, not self). The dialog's tab bar uses `.user-info-tab` buttons styled like the
+`GameStats` window toggle — active tab uses `--accent-primary`.
 
 #### Challenger invite-outcome notifications
 

--- a/docs/superpowers/plans/2026-07-19-deathrolling-minigame.md
+++ b/docs/superpowers/plans/2026-07-19-deathrolling-minigame.md
@@ -12,6 +12,8 @@
 
 **Scope:** Deathrolling only (build-order phases 1–5). RPS (phase 6) is a follow-up plan once the `IGameEngine` abstraction is proven.
 
+> **Implementation status (2026-07-23):** Deathrolling shipped. The `IGameEngine` abstraction is proven and RPS (phase 6) has now been implemented on branch `feature/rps-minigame-and-stats` — server `RpsEngine`, best-of 3/5/7 matches, per-channel one-duel enforcement (`channelBusy`), pending-invite UI + cancel, disconnect state cleanup, channel-tree duel badge, and head-to-head record panels (in-modal + `UserInfoDialog` tab). Streaks/leaderboards remain deferred.
+
 ---
 
 ## File Structure

--- a/docs/superpowers/plans/2026-07-23-rps-afk-draw-and-unsupported-game.md
+++ b/docs/superpowers/plans/2026-07-23-rps-afk-draw-and-unsupported-game.md
@@ -1,0 +1,571 @@
+# RPS AFK Draw + Unsupported-Game Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** End RPS matches as a real draw after two consecutive both-idle rounds, and make clients auto-decline invites for game types they don't support.
+
+**Architecture:** Server-authoritative RPS engine gains a consecutive-double-timeout counter that flips a match-level `Drawn` flag; `CompleteMatchAsync` derives `Outcome`/`winner` from participant results so draws persist through the existing pipeline and emit `game.ended { draw: true }`. The web client renders a draw end-state and auto-declines unknown game types in `handleInvited`.
+
+**Tech Stack:** C# / ASP.NET Core (MSTest), React + TypeScript (Vite).
+
+Spec: `docs/superpowers/specs/2026-07-23-rps-afk-draw-and-unsupported-game-design.md`
+
+---
+
+## File Structure
+
+- `src/Brmble.Server/Games/Engines/RpsEngine.cs` — add `ConsecutiveDoubleTimeouts` + `Drawn` state, draw outcome, draw feed line.
+- `src/Brmble.Server/Games/GameSessionManager.cs` — derive draw `Outcome`/`winner` in `CompleteMatchAsync`; add `draw` to `game.ended`; add internal test hook to fire a turn timeout.
+- `tests/Brmble.Server.Tests/Games/RpsEngineTests.cs` — engine-level draw + streak-reset tests.
+- `tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs` — manager-level draw persistence + `game.ended` draw flag.
+- `src/Brmble.Web/src/components/Games/useGameState.ts` — `EndedMatch.draw`, `handleEnded` reads `draw`, `handleInvited` auto-declines unknown games, `SUPPORTED_GAMES` const.
+- `src/Brmble.Web/src/components/Games/RpsModal.tsx` — draw branch in `renderResult`.
+
+---
+
+## Task 1: RPS engine — draw state fields
+
+**Files:**
+- Modify: `src/Brmble.Server/Games/Engines/RpsEngine.cs`
+
+- [ ] **Step 1: Add state fields**
+
+In the `private sealed class State` block (after `public long? WinnerId;`), add:
+
+```csharp
+        public long? WinnerId;
+        public int ConsecutiveDoubleTimeouts;   // back-to-back rounds where both idle
+        public bool Drawn;                        // match ended in a mutual-AFK draw
+```
+
+- [ ] **Step 2: Update `ResolveRound` to track the streak and flip Drawn**
+
+Replace the both-idle branch and add a reset in the decisive/other branches. Change the branch cascade in `ResolveRound`:
+
+```csharp
+        if (p0 is null && p1 is null)
+        {
+            // Both idle on timeout: draw, replay the same round number. After two
+            // consecutive idle rounds, end the whole match as a draw (anti-grief).
+            roundWinner = null;
+            tie = true;
+            s.ConsecutiveDoubleTimeouts++;
+            if (s.ConsecutiveDoubleTimeouts >= 2) s.Drawn = true;
+        }
+        else if (p0 is null)
+        {
+            roundWinner = s.Players[1];
+            tie = false;
+            s.ConsecutiveDoubleTimeouts = 0;
+        }
+        else if (p1 is null)
+        {
+            roundWinner = s.Players[0];
+            tie = false;
+            s.ConsecutiveDoubleTimeouts = 0;
+        }
+        else if (p0 == p1)
+        {
+            roundWinner = null;
+            tie = true;
+            s.ConsecutiveDoubleTimeouts = 0;
+        }
+        else
+        {
+            var zeroBeatsOne = Beats(p0.Value, p1.Value);
+            roundWinner = zeroBeatsOne ? s.Players[0] : s.Players[1];
+            tie = false;
+            s.ConsecutiveDoubleTimeouts = 0;
+        }
+```
+
+- [ ] **Step 3: Update `GetOutcome` to return a draw**
+
+Replace the body of `GetOutcome`:
+
+```csharp
+    public GameOutcome GetOutcome(object state)
+    {
+        var s = (State)state;
+        if (s.Drawn)
+        {
+            return new GameOutcome.Finished(new[]
+            {
+                new CompletedParticipant(s.Players[0], Placement: 1, Score: s.RoundWins[0], Result: "draw"),
+                new CompletedParticipant(s.Players[1], Placement: 1, Score: s.RoundWins[1], Result: "draw"),
+            });
+        }
+        if (s.WinnerId is null) return new GameOutcome.InProgress();
+        var winnerId = s.WinnerId.Value;
+        var loserId = s.Players[0] == winnerId ? s.Players[1] : s.Players[0];
+        var wIdx = IndexOf(s, winnerId);
+        var lIdx = IndexOf(s, loserId);
+        return new GameOutcome.Finished(new[]
+        {
+            new CompletedParticipant(winnerId, Placement: 1, Score: s.RoundWins[wIdx], Result: "win"),
+            new CompletedParticipant(loserId, Placement: 2, Score: s.RoundWins[lIdx], Result: "loss"),
+        });
+    }
+```
+
+- [ ] **Step 4: Add a draw branch to `EndFeedLine`**
+
+Replace `EndFeedLine`:
+
+```csharp
+    public string? EndFeedLine(object state, Func<long, string> nameOf)
+    {
+        var s = (State)state;
+        if (s.Drawn)
+            return $"✊✋✌️ {nameOf(s.Players[0])} vs {nameOf(s.Players[1])} — Rock Paper Scissors ended in a draw (both idle)";
+        if (s.WinnerId is null) return null;
+        var winner = s.WinnerId.Value;
+        var wIdx = IndexOf(s, winner);
+        return $"🏆 {nameOf(winner)} wins Rock Paper Scissors {s.RoundWins[wIdx]}–{s.RoundWins[wIdx ^ 1]}!";
+    }
+```
+
+- [ ] **Step 5: Build to confirm it compiles**
+
+Run: `dotnet build src/Brmble.Server/Brmble.Server.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Server/Games/Engines/RpsEngine.cs
+git commit -m "feat: RPS draws after two consecutive both-idle rounds"
+```
+
+---
+
+## Task 2: RPS engine draw tests
+
+**Files:**
+- Modify: `tests/Brmble.Server.Tests/Games/RpsEngineTests.cs`
+
+- [ ] **Step 1: Add the failing tests**
+
+Add these three methods before the private helpers at the end of the class:
+
+```csharp
+    [TestMethod]
+    public void TwoConsecutiveBothIdleTimeoutsEndsInDraw()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+
+        engine.ApplyTimeoutPenalty(state, Rng); // 1st both-idle: replay
+        Assert.IsInstanceOfType(engine.GetOutcome(state), typeof(GameOutcome.InProgress));
+
+        engine.ApplyTimeoutPenalty(state, Rng); // 2nd consecutive both-idle: draw
+        var raw = engine.GetOutcome(state);
+        Assert.IsInstanceOfType(raw, typeof(GameOutcome.Finished));
+        var outcome = (GameOutcome.Finished)raw;
+        Assert.IsTrue(outcome.Participants.All(p => p.Result == "draw"));
+        Assert.AreEqual(2, outcome.Participants.Count);
+    }
+
+    [TestMethod]
+    public void APickBetweenIdleTimeoutsResetsTheDrawStreak()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+
+        engine.ApplyTimeoutPenalty(state, Rng); // 1st both-idle
+
+        // A decisive round happens (10 beats 20) — resets the streak.
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        engine.ApplyAction(state, 20, Pick("scissors"), Rng);
+
+        engine.ApplyTimeoutPenalty(state, Rng); // both-idle again, but streak was reset
+        Assert.IsInstanceOfType(engine.GetOutcome(state), typeof(GameOutcome.InProgress),
+            "a pick between idle rounds must reset the streak so no premature draw");
+    }
+
+    [TestMethod]
+    public void DrawEmitsEndFeedLine()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        engine.ApplyTimeoutPenalty(state, Rng);
+        engine.ApplyTimeoutPenalty(state, Rng);
+        var line = engine.EndFeedLine(state, id => $"user{id}");
+        Assert.IsNotNull(line);
+        StringAssert.Contains(line, "draw");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "TestCategory=none|FullyQualifiedName~RpsEngineTests"`
+Expected: PASS (all RpsEngineTests pass, including the 3 new ones).
+
+If the filter above is awkward, run the whole file's class:
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~RpsEngineTests"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Brmble.Server.Tests/Games/RpsEngineTests.cs
+git commit -m "test: RPS draw after two consecutive idle rounds + streak reset"
+```
+
+---
+
+## Task 3: Manager derives draw outcome + emits draw flag
+
+**Files:**
+- Modify: `src/Brmble.Server/Games/GameSessionManager.cs`
+
+- [ ] **Step 1: Derive draw in `CompleteMatchAsync`**
+
+In `CompleteMatchAsync`, replace the block that builds `completed` and computes `winner`. Currently (around lines 382-402):
+
+```csharp
+        var completed = new CompletedMatch(
+            GameType: match.GameType,
+            ChannelId: match.ChannelId,
+            Format: match.Engine.MatchFormat(match.State),
+            Outcome: "decided",
+            AbandonReason: null,
+            StartedAt: match.StartedAt,
+            EndedAt: DateTimeOffset.UtcNow,
+            Participants: persistedParticipants,
+            MetadataJson: BuildMatchMetadata(match));
+
+        await _repository.SaveCompletedMatchAsync(completed);
+
+        var winner = outcome.Participants.FirstOrDefault(p => p.Placement == 1);
+
+        // winner.UserId is still a Mumble session id here (translation to db ids
+        // happens in persistedParticipants above), which is what the client compares
+        // against its own session id — so emit it directly as winnerId.
+        await _publisher.PublishToUsersAsync(
+            RouteSet(match),
+            new { type = "game.ended", matchId = match.MatchId, gameType = match.GameType, winnerId = winner?.UserId });
+```
+
+Replace with:
+
+```csharp
+        // A match with no single winner (all participants "draw") is a real draw:
+        // persist Outcome "draw" and emit no winnerId.
+        var isDraw = outcome.Participants.All(p => p.Result == "draw");
+
+        var completed = new CompletedMatch(
+            GameType: match.GameType,
+            ChannelId: match.ChannelId,
+            Format: match.Engine.MatchFormat(match.State),
+            Outcome: isDraw ? "draw" : "decided",
+            AbandonReason: null,
+            StartedAt: match.StartedAt,
+            EndedAt: DateTimeOffset.UtcNow,
+            Participants: persistedParticipants,
+            MetadataJson: BuildMatchMetadata(match));
+
+        await _repository.SaveCompletedMatchAsync(completed);
+
+        var winner = isDraw ? null : outcome.Participants.FirstOrDefault(p => p.Placement == 1);
+
+        // winner.UserId is still a Mumble session id here (translation to db ids
+        // happens in persistedParticipants above), which is what the client compares
+        // against its own session id — so emit it directly as winnerId.
+        await _publisher.PublishToUsersAsync(
+            RouteSet(match),
+            new { type = "game.ended", matchId = match.MatchId, gameType = match.GameType, winnerId = winner?.UserId, draw = isDraw });
+```
+
+- [ ] **Step 2: Add an internal test hook to fire a turn timeout**
+
+Directly after the existing `ExpireInviteForTestAsync` line (line 181):
+
+```csharp
+    internal Task ExpireInviteForTestAsync(long matchId) => EndPendingAsync(matchId, "game.expired");
+
+    // Test-only: synchronously drive a turn-timeout for the current turn generation,
+    // mirroring what the real TurnTimer callback does. Lets tests exercise AFK paths
+    // without waiting on wall-clock timers.
+    internal Task FireTurnTimeoutForTestAsync(long matchId)
+    {
+        if (!_matches.TryGetValue(matchId, out var match)) return Task.CompletedTask;
+        var generation = Interlocked.Read(ref match.TurnGeneration);
+        return HandleTurnTimeoutAsync(matchId, generation);
+    }
+```
+
+- [ ] **Step 3: Build to confirm it compiles**
+
+Run: `dotnet build src/Brmble.Server/Brmble.Server.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Server/Games/GameSessionManager.cs
+git commit -m "feat: persist RPS draw outcome and emit game.ended draw flag"
+```
+
+---
+
+## Task 4: Manager-level draw persistence test
+
+**Files:**
+- Modify: `tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs`
+
+- [ ] **Step 1: Add a helper to read the draw flag and the failing test**
+
+Add this helper next to the other private helpers (after `DuelStates`):
+
+```csharp
+    // The `draw` flag of a game.ended message, or null if none was sent.
+    private static bool? EndedDraw(IEnumerable<(string kind, object msg)> sent)
+    {
+        var ended = sent.LastOrDefault(s => s.msg.GetType().GetProperty("type")?.GetValue(s.msg) as string == "game.ended");
+        if (ended.msg is null) return null;
+        return ended.msg.GetType().GetProperty("draw")?.GetValue(ended.msg) as bool?;
+    }
+```
+
+Add this test method to the class:
+
+```csharp
+    [TestMethod]
+    public async Task Rps_BothIdleTwice_EndsAsDraw_PersistsAndFlags()
+    {
+        var presence = new FakePresence();
+        presence.Users[10] = (1, true, 10);
+        presence.Users[20] = (1, true, 20);
+        var repo = GameTestHelpers.NewRepo();
+        var pub = new FakePublisher();
+        var mgr = NewManager(presence, pub, repo);
+
+        var invite = await mgr.InviteAsync(10, 20, "rps",
+            new Dictionary<string, object?> { ["bestOf"] = 3 });
+        await mgr.RespondAsync(invite.MatchId, targetSession: 20, accept: true);
+
+        // Both players go AFK for two consecutive rounds.
+        await mgr.FireTurnTimeoutForTestAsync(invite.MatchId);
+        await mgr.FireTurnTimeoutForTestAsync(invite.MatchId);
+
+        Assert.IsTrue(SentType(pub.Sent, "game.ended"), "match should end");
+        Assert.AreEqual(true, EndedDraw(pub.Sent), "game.ended should carry draw: true");
+
+        var s10 = await repo.GetUserStatsAsync(10, "rps");
+        var s20 = await repo.GetUserStatsAsync(20, "rps");
+        Assert.AreEqual(1, s10.Draws, "player 10 records a draw");
+        Assert.AreEqual(1, s20.Draws, "player 20 records a draw");
+        Assert.AreEqual(0, s10.Wins);
+        Assert.AreEqual(0, s20.Wins);
+    }
+```
+
+Note: `InviteAsync` overload with options and `RespondAsync` are already exercised at
+`GameSessionManagerTests.cs:347` and `:80`. `GetUserStatsAsync` returns `UserGameStats`
+with a `Draws` property (`GameMatchModels.cs:42-49`).
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~Rps_BothIdleTwice"`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full server suite to check for regressions**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj`
+Expected: PASS (all tests, 371+).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs
+git commit -m "test: RPS mutual-AFK match ends as a persisted draw"
+```
+
+---
+
+## Task 5: Client — draw end-state
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Games/useGameState.ts`
+- Modify: `src/Brmble.Web/src/components/Games/RpsModal.tsx`
+
+- [ ] **Step 1: Add `draw` to the `EndedMatch` interface**
+
+In `useGameState.ts`, update the interface (currently lines 73-79):
+
+```typescript
+export interface EndedMatch {
+  matchId: number;
+  gameType: string;
+  abandoned?: boolean;
+  reason?: string;
+  winnerId?: number;
+  draw?: boolean;
+}
+```
+
+- [ ] **Step 2: Read the `draw` flag in `handleEnded`**
+
+In `handleEnded`, update the destructure type and the `setEnded` call:
+
+```typescript
+    const handleEnded = (data: unknown) => {
+      const d = data as { matchId?: number; gameType?: string; abandoned?: boolean; reason?: string; winnerId?: number; draw?: boolean };
+      // Prefer the server-supplied winnerId (authoritative, and correct even for
+      // forfeits where the local view has no loserId). Fall back to deriving it
+      // from the local view for older servers that omit it.
+      let winnerId: number | undefined = d.winnerId;
+      if (winnerId == null && !d.draw) {
+        const currentView = viewRef.current;
+        if (currentView && !isRpsView(currentView) && currentView.loserId != null) {
+          winnerId = currentView.players.find(p => p !== currentView.loserId);
+        }
+      }
+      setEnded({
+        matchId: d.matchId ?? activeMatchRef.current?.matchId ?? 0,
+        gameType: d.gameType ?? activeMatchRef.current?.gameType ?? 'deathroll',
+        abandoned: d.abandoned,
+        reason: d.reason,
+        winnerId,
+        draw: d.draw,
+      });
+      setActiveMatch(null);
+      setView(null);
+      setTurnDeadline(null);
+      setPenalty(false);
+      setAccepting(false);
+    };
+```
+
+- [ ] **Step 3: Add a draw branch to `RpsModal.renderResult`**
+
+In `RpsModal.tsx`, update `renderResult` (lines 153-168):
+
+```typescript
+  const renderResult = () => {
+    if (!showResult) return null;
+    let message: string;
+    if (ended.abandoned) {
+      message = ended.reason ? `Match abandoned: ${ended.reason}` : 'The match was abandoned.';
+    } else if (ended.draw) {
+      message = 'Draw — both players idle.';
+    } else if (ended.winnerId != null) {
+      message = ended.winnerId === myUserId ? 'You win!' : `${resolveName(ended.winnerId)} wins!`;
+    } else {
+      message = 'The match has ended.';
+    }
+    return (
+      <div className={styles.result}>
+        <p className={styles.resultText}>{message}</p>
+      </div>
+    );
+  };
+```
+
+- [ ] **Step 4: Build the frontend to confirm it typechecks**
+
+Run: `cd src/Brmble.Web; npm run build`
+Expected: build succeeds (tsc + vite, no type errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Games/useGameState.ts src/Brmble.Web/src/components/Games/RpsModal.tsx
+git commit -m "feat: show draw end-state for RPS mutual-AFK matches"
+```
+
+---
+
+## Task 6: Client — auto-decline unsupported game types
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Games/useGameState.ts`
+
+- [ ] **Step 1: Add the supported-games constant**
+
+Near the top of `useGameState.ts` (after the imports, before the hook), add:
+
+```typescript
+// Game types this client build knows how to render. Invites for anything else are
+// auto-declined so an outdated peer can't open the wrong modal. Forward-compat only.
+const SUPPORTED_GAMES = ['deathroll', 'rps'];
+```
+
+- [ ] **Step 2: Auto-decline unknown game types in `handleInvited`**
+
+Replace `handleInvited` (lines 176-180):
+
+```typescript
+    const handleInvited = (data: unknown) => {
+      const d = data as { matchId?: number; gameType?: string; from?: number; inviteMs?: number };
+      if (d.matchId == null || d.from == null) return;
+      const gameType = d.gameType ?? 'deathroll';
+      if (!SUPPORTED_GAMES.includes(gameType)) {
+        // This client build doesn't know this game — decline instead of opening the
+        // wrong modal. (Old clients that predate this check can't reach here.)
+        void gamesApi.respond(d.matchId, false);
+        return;
+      }
+      setIncomingInvite({ matchId: d.matchId, gameType, from: d.from, inviteMs: d.inviteMs });
+    };
+```
+
+Confirm `gamesApi` is already imported at the top of the file (it is — `gamesApi.invite` is used in `invite()`). If the import alias differs, use the existing alias.
+
+- [ ] **Step 3: Build the frontend to confirm it typechecks**
+
+Run: `cd src/Brmble.Web; npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Run the UI-guide compliance test (no new emoji/glyphs in components)**
+
+Run: `cd src/Brmble.Web; npm run test -- uiGuideCompliance`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Games/useGameState.ts
+git commit -m "feat: auto-decline game invites for unsupported game types"
+```
+
+---
+
+## Task 7: Full verification + deploy for two-client test
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full server suite**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj`
+Expected: PASS.
+
+- [ ] **Step 2: Run the full frontend suite**
+
+Run: `cd src/Brmble.Web; npm run test`
+Expected: PASS (1051+ tests).
+
+- [ ] **Step 3: Rebuild the docker server (draw logic is server-side)**
+
+Run: `docker compose -f docker-local/docker-compose.yml up -d --build brmble`
+Expected: container recreated; `docker compose -f docker-local/docker-compose.yml logs --tail 20 brmble` shows "Connected to Mumble" and "Now listening on: https://[::]:8080".
+
+- [ ] **Step 4: Update the multi-client test worktree to the latest commit**
+
+Run: `git rev-parse HEAD` then `git -C .worktrees/multi-share-test checkout <that-sha>`
+Expected: worktree HEAD at the new commit.
+
+- [ ] **Step 5: Manual two-client check**
+
+- Start an RPS match between two clients; both stay idle. After two 15s round windows (~30s), the match ends showing "Draw — both players idle." in both modals and a draw feed line; the channel duel badge clears and a new game can start.
+- Head-to-head between the two players shows the draw counted (`…D`).
+- (Optional forward-compat) confirm no regression to normal RPS win/loss and Deathroll.
+
+---
+
+## Notes for the implementer
+
+- Do NOT push or open a PR — commit to `feature/rps-minigame-and-stats` only (per `CLAUDE.md`).
+- Server-generated feed text lives in `RpsEngine.cs` and requires the docker server rebuild to take effect; client changes require `npm run build` + client restart.
+- WebView2 cannot render 🪨/📄; the draw line reuses the known-safe `✊✋✌️` set — do not introduce new emoji.

--- a/docs/superpowers/specs/2026-07-23-rps-afk-draw-and-unsupported-game-design.md
+++ b/docs/superpowers/specs/2026-07-23-rps-afk-draw-and-unsupported-game-design.md
@@ -1,0 +1,134 @@
+# RPS AFK Draw + Unsupported-Game Handling — Design
+
+Date: 2026-07-23
+Branch: `feature/rps-minigame-and-stats`
+
+## Problem
+
+Two gaps surfaced during two-client testing of the Rock Paper Scissors minigame:
+
+1. **Mutual-AFK matches never end.** RPS uses `InteractionModel.SimultaneousCommit`
+   with a 15s server-side `TurnTimer`. When *both* players fail to pick,
+   `RpsEngine.ResolveRound` treats it as a round-level tie and replays the *same*
+   round number. `RoundWins` never increments, `WinnerId` is never set, and
+   `GetOutcome` stays `InProgress` forever. The 15s timer keeps re-arming, so a
+   fully-idle match loops indefinitely — holding the one-duel-per-channel slot and
+   blocking everyone else in the channel from starting a game.
+
+2. **Challenging a client that lacks the chosen game.** There is no capability or
+   version handshake anywhere (client↔server or client↔client). The server only
+   validates that *it* knows the `gameType`; it never checks the target client. A
+   client that doesn't recognise a `gameType` stores the invite without validation
+   and its modal switch (`App.tsx`) falls through to the wrong `DeathrollModal`
+   rather than refusing the game.
+
+## Decisions
+
+- **AFK draw trigger:** end the match as a draw after **2 consecutive** rounds
+  where *neither* player picks. A single pick by either player resets the streak.
+- **Draw recording:** a real draw — persist both participants as `Result: "draw"`,
+  `CompletedMatch.Outcome: "draw"`, count it in head-to-head stats, and show a draw
+  end-state in the feed and modal.
+- **Unsupported game:** **client-side auto-decline only.** RPS is unreleased and
+  clients auto-update, so there are effectively no old clients in the wild. This is
+  forward-compat insurance for future game types, not retroactive protection.
+  (Server-side capability gating was considered and rejected as unnecessary for the
+  current deployment reality; noted as a possible future enhancement.)
+
+## Part 1 — Forced draw on mutual AFK (RPS)
+
+### Engine — `src/Brmble.Server/Games/Engines/RpsEngine.cs`
+
+- Add two `State` fields:
+  - `int ConsecutiveDoubleTimeouts` — count of back-to-back rounds where both
+    players were idle at timeout.
+  - `bool Drawn` — match ended in a draw.
+- In `ResolveRound`:
+  - **Both idle on timeout** (`p0 is null && p1 is null`): increment
+    `ConsecutiveDoubleTimeouts`. If it reaches `2`, set `Drawn = true`. Otherwise
+    keep the existing behaviour (tie, replay the same round number).
+  - **Every other branch** (at least one player picked, whether decisive or a
+    matched-throw tie): reset `ConsecutiveDoubleTimeouts = 0`. A single pick breaks
+    the idle streak.
+- `GetOutcome`: if `Drawn`, return `GameOutcome.Finished` with **both**
+  participants `Placement: 1`, `Result: "draw"`, `Score = RoundWins[idx]`.
+  Otherwise unchanged.
+- `EndFeedLine`: add a draw branch. Keep WebView2-safe glyphs only (reuse the
+  existing `✊✋✌️` set — 🤝 is unverified in the WebView2 font). Example:
+  `✊✋✌️ {a} vs {b} — Rock Paper Scissors ended in a draw (both idle)`.
+
+The counter reaching 2 on a double-timeout ends the match **regardless of the
+current round score** — this is an anti-grief measure for stalled/idle matches and
+matches the "2nd time both don't choose" rule directly.
+
+### Match completion — `src/Brmble.Server/Games/GameSessionManager.cs`
+
+`CompleteMatchAsync` currently hardcodes `Outcome: "decided"` and derives
+`winner = Participants.First(p => p.Placement == 1)`. Change to derive from the
+participants so draws flow through the existing persistence path:
+
+- `isDraw = outcome.Participants.All(p => p.Result == "draw")`
+- `CompletedMatch.Outcome: isDraw ? "draw" : "decided"`
+- `winner = isDraw ? null : outcome.Participants.FirstOrDefault(p => p.Placement == 1)`
+- Add `draw = isDraw` to the `game.ended` payload so the client is explicit rather
+  than inferring a draw from a null `winnerId` (which also occurs in other paths).
+- Draw feed fallback if `EndFeedLine` returns null.
+
+No new timer wiring is needed: `HandleTurnTimeoutAsync` already re-checks
+`GetOutcome` after `ApplyTimeoutPenalty`, so once `Drawn` flips the outcome to
+`Finished`, the match completes and the channel/`duelState` badge clears normally.
+
+### Client — `src/Brmble.Web`
+
+- `useGameState.ts` `handleEnded`: carry the `draw` flag (and/or treat null
+  `winnerId` on a non-abandoned end as a draw).
+- `RpsModal.tsx`: render a "Draw" end banner when the match drew, instead of
+  win/loss. Respect the existing 3-2-1 reveal gating (the final double-timeout still
+  produces a `roundResult` before `game.ended`).
+- Head-to-head already surfaces `Draws` from `UserGameStats`; verify the RPS H2H
+  panel shows the draw. No stats-schema change.
+
+## Part 2 — Client-side auto-decline for unsupported games
+
+Purely forward-compat. In `src/Brmble.Web/src/components/Games/useGameState.ts`
+`handleInvited`:
+
+- Define `SUPPORTED_GAMES = ['deathroll', 'rps']` (single source of truth for the
+  client's known game types).
+- If an incoming invite's `gameType` is not in `SUPPORTED_GAMES`:
+  - Do **not** store `incoming` or open a modal.
+  - Immediately decline via the existing path (`gamesApi.respond(matchId,
+    accept: false)`).
+  - Optionally surface a low-key receiver-side notification: "Received an
+    unsupported game — auto-declined; you may need to update."
+- The inviter receives the standard `game.declined`. A friendlier "their client
+  doesn't support this game" reason would require a server relay and is out of
+  scope; noted as a possible later enhancement.
+
+## Testing
+
+### Server (`tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs`)
+
+- Two consecutive both-timeouts end the match: `game.ended` carries `draw: true`
+  and null `winnerId`; persisted `CompletedMatch.Outcome == "draw"` with both
+  participants `Result == "draw"`.
+- A pick by one player between two timeouts resets the streak (no premature draw;
+  the match continues).
+- Draw is recorded in head-to-head/`UserGameStats` as a draw for both players.
+
+The test harness uses `HalvingRandom` and `FakePublisher`; timeouts are driven via
+the existing `ExpireInviteForTestAsync`-style helpers / `HandleTurnTimeout` path —
+confirm/extend a test hook to fire a turn timeout deterministically.
+
+### Client
+
+- No Games component tests exist today. Keep changes minimal; rely on
+  `uiGuideCompliance.test.ts` (no new emoji/glyphs in component code) plus a manual
+  two-client check: (a) both players idle → match draws and clears the channel;
+  (b) auto-decline path when handed an unknown `gameType`.
+
+## Out of scope
+
+- Server-side capability/version handshake (rejected for current deployment).
+- Forwarding a decline reason to the inviter for unsupported games.
+- Match-level draws for Deathroll (not applicable to its rules).

--- a/src/Brmble.Client/Services/Games/GameService.cs
+++ b/src/Brmble.Client/Services/Games/GameService.cs
@@ -121,6 +121,21 @@ internal sealed class GameService : IService
                     SendResponse(requestId, result.Success, result.Body, result.StatusCode, result.Error);
                     break;
                 }
+                case "head-to-head":
+                {
+                    var opponentSession = data.TryGetProperty("opponentSession", out var oppEl)
+                        && oppEl.ValueKind == JsonValueKind.Number
+                        ? oppEl.GetInt64()
+                        : (long?)null;
+                    if (opponentSession is null)
+                    {
+                        SendResponse(requestId, false, null, 0, "Missing opponentSession for head-to-head request");
+                        return;
+                    }
+                    var result = await _getAsync(cert, new Uri(baseUri, $"games/head-to-head/{opponentSession}"));
+                    SendResponse(requestId, result.Success, result.Body, result.StatusCode, result.Error);
+                    break;
+                }
                 default:
                     SendResponse(requestId, false, null, 0, $"Unknown games request action '{action}'");
                     break;

--- a/src/Brmble.Server/Games/Engines/DeathrollEngine.cs
+++ b/src/Brmble.Server/Games/Engines/DeathrollEngine.cs
@@ -142,6 +142,29 @@ public sealed class DeathrollEngine : IGameEngine
 
     public int? CurrentCeiling(object state) => ((State)state).Ceiling;
 
+    public string? StartFeedLine(object state, Func<long, string> nameOf)
+    {
+        var s = (State)state;
+        return $"⚔️ {nameOf(s.Players[0])} vs {nameOf(s.Players[1])} — Deathroll started (ceiling {s.StartingCeiling})";
+    }
+
+    public string? EventFeedLine(GameEvent e, Func<long, string> nameOf) => e.Kind switch
+    {
+        "roll" => $"🎲 {nameOf(Convert.ToInt64(e.Data["userId"]))} rolled {e.Data["value"]} (1–{e.Data["ceiling"]})",
+        "penalty" when e.Data.ContainsKey("userId") =>
+            $"🎲 {nameOf(Convert.ToInt64(e.Data["userId"]))} ran out of time — ceiling drops to {e.Data["ceiling"]}",
+        _ => null,
+    };
+
+    public string? EndFeedLine(object state, Func<long, string> nameOf)
+    {
+        var s = (State)state;
+        if (s.LoserId is null) return null;
+        var loser = s.LoserId.Value;
+        var winner = s.Players[0] == loser ? s.Players[1] : s.Players[0];
+        return $"💀 {nameOf(loser)} rolled {s.LastRoll ?? 1} — {nameOf(winner)} wins!";
+    }
+
     public object? MatchSummary(object state)
     {
         var s = (State)state;

--- a/src/Brmble.Server/Games/Engines/RpsEngine.cs
+++ b/src/Brmble.Server/Games/Engines/RpsEngine.cs
@@ -253,13 +253,23 @@ public sealed class RpsEngine : IGameEngine
         var wins0 = e.Data["wins0"];
         var wins1 = e.Data["wins1"];
         if (tie)
-            return $"✊ Round {round}: {nameOf(p0)} and {nameOf(p1)} both picked {pick0} — tie, replay";
+            return $"{Glyph(pick0)} Round {round}: {nameOf(p0)} and {nameOf(p1)} both picked {pick0} — tie, replay";
         var winnerId = Convert.ToInt64(e.Data["winnerId"]);
         var loserId = winnerId == p0 ? p1 : p0;
         var winnerPick = winnerId == p0 ? pick0 : pick1;
         var loserPick = winnerId == p0 ? pick1 : pick0;
-        return $"✊ Round {round}: {nameOf(winnerId)}'s {winnerPick} beats {nameOf(loserId)}'s {loserPick} ({wins0}–{wins1})";
+        return $"{Glyph(winnerPick)} Round {round}: {nameOf(winnerId)}'s {winnerPick} beats {nameOf(loserId)}'s {loserPick} ({wins0}–{wins1})";
     }
+
+    /// <summary>Feed glyph for a throw ("rock"/"paper"/"scissors"), matching the
+    /// ✊✋✌️ set used in the start line. Falls back to the fist for unknown values.</summary>
+    private static string Glyph(object? pick) => pick?.ToString() switch
+    {
+        "rock" => "✊",
+        "paper" => "✋",
+        "scissors" => "✌️",
+        _ => "✊",
+    };
 
     public string? EndFeedLine(object state, Func<long, string> nameOf)
     {

--- a/src/Brmble.Server/Games/Engines/RpsEngine.cs
+++ b/src/Brmble.Server/Games/Engines/RpsEngine.cs
@@ -1,0 +1,320 @@
+using System.Text.Json;
+
+namespace Brmble.Server.Games.Engines;
+
+/// <summary>
+/// Rock-Paper-Scissors — the framework's first <see cref="InteractionModel.SimultaneousCommit"/>
+/// game. Both players commit a hidden pick within a shared round window; the round
+/// resolves once both have committed (or the window times out). First to a majority
+/// of a best-of-N series wins. Ties replay the round.
+/// </summary>
+public sealed class RpsEngine : IGameEngine
+{
+    private const int DefaultBestOf = 3;
+    private static readonly int[] AllowedBestOf = { 3, 5, 7 };
+
+    public string GameType => "rps";
+    public InteractionModel InteractionModel => InteractionModel.SimultaneousCommit;
+
+    private enum Throw { Rock, Paper, Scissors }
+
+    private sealed class State
+    {
+        public required long[] Players;
+        public int BestOf;
+        public int TargetWins;
+        public readonly int[] RoundWins = new int[2];
+        public int RoundNumber = 1;          // decisive-round counter (ties don't advance it)
+        public readonly Throw?[] Picks = new Throw?[2];
+        public long? WinnerId;
+        public LastRound? Last;
+        // Per-player throw tallies keyed by session id for flavour stats.
+        public readonly Dictionary<long, int[]> Throws = new();
+    }
+
+    private sealed record LastRound(int RoundNumber, Throw P0, Throw P1, long? WinnerId, bool Tie);
+
+    public object InitialState(IReadOnlyList<GamePlayer> players, IRandomSource rng, IReadOnlyDictionary<string, object?>? options)
+    {
+        if (players.Count != 2) throw new InvalidGameActionException("RPS requires exactly 2 players.");
+        var bestOf = ParseBestOf(options);
+        return new State
+        {
+            Players = new[] { players[0].UserId, players[1].UserId },
+            BestOf = bestOf,
+            TargetWins = bestOf / 2 + 1,
+            Throws =
+            {
+                [players[0].UserId] = new int[3],
+                [players[1].UserId] = new int[3],
+            },
+        };
+    }
+
+    private static int ParseBestOf(IReadOnlyDictionary<string, object?>? options)
+    {
+        if (options is null || !options.TryGetValue("bestOf", out var raw) || raw is null)
+            return DefaultBestOf;
+        int value = raw switch
+        {
+            int i => i,
+            long l => (int)l,
+            string s when int.TryParse(s, out var p) => p,
+            JsonElement e when e.ValueKind == JsonValueKind.Number => e.GetInt32(),
+            JsonElement e when e.ValueKind == JsonValueKind.String && int.TryParse(e.GetString(), out var p) => p,
+            _ => DefaultBestOf,
+        };
+        return Array.IndexOf(AllowedBestOf, value) >= 0 ? value : DefaultBestOf;
+    }
+
+    private int IndexOf(State s, long userId)
+    {
+        if (s.Players[0] == userId) return 0;
+        if (s.Players[1] == userId) return 1;
+        return -1;
+    }
+
+    public bool IsUsersTurn(object state, long userId)
+    {
+        var s = (State)state;
+        if (s.WinnerId is not null) return false;
+        var idx = IndexOf(s, userId);
+        return idx >= 0 && s.Picks[idx] is null;
+    }
+
+    public IReadOnlyList<GameEvent> ApplyAction(object state, long userId, IReadOnlyDictionary<string, object?> action, IRandomSource rng)
+    {
+        var s = (State)state;
+        if (s.WinnerId is not null) throw new InvalidGameActionException("Game already finished.");
+        var idx = IndexOf(s, userId);
+        if (idx < 0) throw new InvalidGameActionException("You are not in this match.");
+        if (s.Picks[idx] is not null) throw new InvalidGameActionException("You already picked this round.");
+        if (!TryParseThrow(action, out var pick)) throw new InvalidGameActionException("Invalid pick.");
+
+        s.Picks[idx] = pick;
+        s.Throws[userId][(int)pick]++;
+
+        // Round only resolves once both players have committed.
+        if (s.Picks[0] is null || s.Picks[1] is null)
+            return new[] { Event("committed", ("userId", userId)) };
+
+        return ResolveRound(s);
+    }
+
+    public IReadOnlyList<GameEvent> ApplyTimeoutPenalty(object state, IRandomSource rng)
+    {
+        var s = (State)state;
+        if (s.WinnerId is not null) return Array.Empty<GameEvent>();
+        // Non-committers auto-lose the round. If both failed to pick it's a draw and
+        // the round replays; otherwise the committer takes the round.
+        return ResolveRound(s, timeout: true);
+    }
+
+    private IReadOnlyList<GameEvent> ResolveRound(State s, bool timeout = false)
+    {
+        var p0 = s.Picks[0];
+        var p1 = s.Picks[1];
+        long? roundWinner;
+        bool tie;
+
+        if (p0 is null && p1 is null)
+        {
+            // Both idle on timeout: draw, replay the same round number.
+            roundWinner = null;
+            tie = true;
+        }
+        else if (p0 is null)
+        {
+            roundWinner = s.Players[1];
+            tie = false;
+        }
+        else if (p1 is null)
+        {
+            roundWinner = s.Players[0];
+            tie = false;
+        }
+        else if (p0 == p1)
+        {
+            roundWinner = null;
+            tie = true;
+        }
+        else
+        {
+            var zeroBeatsOne = Beats(p0.Value, p1.Value);
+            roundWinner = zeroBeatsOne ? s.Players[0] : s.Players[1];
+            tie = false;
+        }
+
+        // Use a neutral placeholder for reveal when a player timed out without a pick.
+        var reveal0 = p0 ?? Throw.Rock;
+        var reveal1 = p1 ?? Throw.Rock;
+        var recordedRound = s.RoundNumber;
+        s.Last = new LastRound(recordedRound, reveal0, reveal1, roundWinner, tie);
+
+        var events = new List<GameEvent>();
+        if (!tie && roundWinner is not null)
+        {
+            var widx = IndexOf(s, roundWinner.Value);
+            s.RoundWins[widx]++;
+            s.RoundNumber++;
+        }
+
+        events.Add(new GameEvent("roundResult", new Dictionary<string, object>
+        {
+            ["roundNumber"] = recordedRound,
+            ["p0"] = s.Players[0],
+            ["pick0"] = p0?.ToString().ToLowerInvariant() ?? "none",
+            ["p1"] = s.Players[1],
+            ["pick1"] = p1?.ToString().ToLowerInvariant() ?? "none",
+            ["winnerId"] = roundWinner ?? 0L,
+            ["tie"] = tie,
+            ["timeout"] = timeout,
+            ["wins0"] = s.RoundWins[0],
+            ["wins1"] = s.RoundWins[1],
+        }));
+
+        // Match over?
+        if (s.RoundWins[0] >= s.TargetWins) s.WinnerId = s.Players[0];
+        else if (s.RoundWins[1] >= s.TargetWins) s.WinnerId = s.Players[1];
+
+        // Clear picks for the next round.
+        s.Picks[0] = null;
+        s.Picks[1] = null;
+        return events;
+    }
+
+    private static bool Beats(Throw a, Throw b) =>
+        (a == Throw.Rock && b == Throw.Scissors) ||
+        (a == Throw.Scissors && b == Throw.Paper) ||
+        (a == Throw.Paper && b == Throw.Rock);
+
+    public GameOutcome GetOutcome(object state)
+    {
+        var s = (State)state;
+        if (s.WinnerId is null) return new GameOutcome.InProgress();
+        var winnerId = s.WinnerId.Value;
+        var loserId = s.Players[0] == winnerId ? s.Players[1] : s.Players[0];
+        var wIdx = IndexOf(s, winnerId);
+        var lIdx = IndexOf(s, loserId);
+        return new GameOutcome.Finished(new[]
+        {
+            new CompletedParticipant(winnerId, Placement: 1, Score: s.RoundWins[wIdx], Result: "win"),
+            new CompletedParticipant(loserId, Placement: 2, Score: s.RoundWins[lIdx], Result: "loss"),
+        });
+    }
+
+    public object PublicView(object state, long forUserId)
+    {
+        var s = (State)state;
+        var idx = IndexOf(s, forUserId);
+        return new
+        {
+            players = s.Players,
+            bestOf = s.BestOf,
+            targetWins = s.TargetWins,
+            roundNumber = s.RoundNumber,
+            roundWins = s.RoundWins,
+            finished = s.WinnerId is not null,
+            winnerId = s.WinnerId,
+            // Reveal only the requesting player's own current pick; the opponent's is
+            // hidden (boolean only) until the round resolves.
+            myPick = idx >= 0 ? s.Picks[idx]?.ToString().ToLowerInvariant() : null,
+            opponentPicked = idx >= 0 && s.Picks[idx ^ 1] is not null,
+            lastRound = s.Last is null ? null : new
+            {
+                roundNumber = s.Last.RoundNumber,
+                p0 = s.Players[0],
+                pick0 = s.Last.P0.ToString().ToLowerInvariant(),
+                p1 = s.Players[1],
+                pick1 = s.Last.P1.ToString().ToLowerInvariant(),
+                winnerId = s.Last.WinnerId,
+                tie = s.Last.Tie,
+            },
+        };
+    }
+
+    public string MatchFormat(object state) => $"bo{((State)state).BestOf}";
+
+    public string? StartFeedLine(object state, Func<long, string> nameOf)
+    {
+        var s = (State)state;
+        return $"🪨📄✂️ {nameOf(s.Players[0])} vs {nameOf(s.Players[1])} — Rock Paper Scissors (best of {s.BestOf}) started";
+    }
+
+    public string? EventFeedLine(GameEvent e, Func<long, string> nameOf)
+    {
+        if (e.Kind != "roundResult") return null;
+        var round = e.Data["roundNumber"];
+        var p0 = Convert.ToInt64(e.Data["p0"]);
+        var p1 = Convert.ToInt64(e.Data["p1"]);
+        var pick0 = e.Data["pick0"];
+        var pick1 = e.Data["pick1"];
+        var tie = e.Data["tie"] is bool b && b;
+        var wins0 = e.Data["wins0"];
+        var wins1 = e.Data["wins1"];
+        if (tie)
+            return $"✊ Round {round}: {nameOf(p0)} and {nameOf(p1)} both picked {pick0} — tie, replay";
+        var winnerId = Convert.ToInt64(e.Data["winnerId"]);
+        var loserId = winnerId == p0 ? p1 : p0;
+        var winnerPick = winnerId == p0 ? pick0 : pick1;
+        var loserPick = winnerId == p0 ? pick1 : pick0;
+        return $"✊ Round {round}: {nameOf(winnerId)}'s {winnerPick} beats {nameOf(loserId)}'s {loserPick} ({wins0}–{wins1})";
+    }
+
+    public string? EndFeedLine(object state, Func<long, string> nameOf)
+    {
+        var s = (State)state;
+        if (s.WinnerId is null) return null;
+        var winner = s.WinnerId.Value;
+        var wIdx = IndexOf(s, winner);
+        return $"🏆 {nameOf(winner)} wins Rock Paper Scissors {s.RoundWins[wIdx]}–{s.RoundWins[wIdx ^ 1]}!";
+    }
+
+    public object? MatchSummary(object state)
+    {
+        var s = (State)state;
+        return new
+        {
+            bestOf = s.BestOf,
+            roundsPlayed = s.RoundWins[0] + s.RoundWins[1],
+        };
+    }
+
+    public object? ParticipantStats(object state, long userId)
+    {
+        var s = (State)state;
+        if (!s.Throws.TryGetValue(userId, out var t)) return null;
+        var favIdx = 0;
+        for (var i = 1; i < 3; i++) if (t[i] > t[favIdx]) favIdx = i;
+        var total = t[0] + t[1] + t[2];
+        return new
+        {
+            rock = t[0],
+            paper = t[1],
+            scissors = t[2],
+            favoriteThrow = total == 0 ? null : ((Throw)favIdx).ToString().ToLowerInvariant(),
+        };
+    }
+
+    private static bool TryParseThrow(IReadOnlyDictionary<string, object?> action, out Throw pick)
+    {
+        pick = Throw.Rock;
+        if (!action.TryGetValue("pick", out var raw) || raw is null) return false;
+        var text = raw switch
+        {
+            string s => s,
+            JsonElement e when e.ValueKind == JsonValueKind.String => e.GetString(),
+            _ => null,
+        };
+        switch (text?.ToLowerInvariant())
+        {
+            case "rock": pick = Throw.Rock; return true;
+            case "paper": pick = Throw.Paper; return true;
+            case "scissors": pick = Throw.Scissors; return true;
+            default: return false;
+        }
+    }
+
+    private static GameEvent Event(string kind, params (string, object)[] data)
+        => new(kind, data.ToDictionary(d => d.Item1, d => d.Item2));
+}

--- a/src/Brmble.Server/Games/Engines/RpsEngine.cs
+++ b/src/Brmble.Server/Games/Engines/RpsEngine.cs
@@ -27,6 +27,8 @@ public sealed class RpsEngine : IGameEngine
         public int RoundNumber = 1;          // decisive-round counter (ties don't advance it)
         public readonly Throw?[] Picks = new Throw?[2];
         public long? WinnerId;
+        public int ConsecutiveDoubleTimeouts;   // back-to-back rounds where both idle
+        public bool Drawn;                        // match ended in a mutual-AFK draw
         public LastRound? Last;
         // Per-player throw tallies keyed by session id for flavour stats.
         public readonly Dictionary<long, int[]> Throws = new();
@@ -119,30 +121,37 @@ public sealed class RpsEngine : IGameEngine
 
         if (p0 is null && p1 is null)
         {
-            // Both idle on timeout: draw, replay the same round number.
+            // Both idle on timeout: draw, replay the same round number. After two
+            // consecutive idle rounds, end the whole match as a draw (anti-grief).
             roundWinner = null;
             tie = true;
+            s.ConsecutiveDoubleTimeouts++;
+            if (s.ConsecutiveDoubleTimeouts >= 2) s.Drawn = true;
         }
         else if (p0 is null)
         {
             roundWinner = s.Players[1];
             tie = false;
+            s.ConsecutiveDoubleTimeouts = 0;
         }
         else if (p1 is null)
         {
             roundWinner = s.Players[0];
             tie = false;
+            s.ConsecutiveDoubleTimeouts = 0;
         }
         else if (p0 == p1)
         {
             roundWinner = null;
             tie = true;
+            s.ConsecutiveDoubleTimeouts = 0;
         }
         else
         {
             var zeroBeatsOne = Beats(p0.Value, p1.Value);
             roundWinner = zeroBeatsOne ? s.Players[0] : s.Players[1];
             tie = false;
+            s.ConsecutiveDoubleTimeouts = 0;
         }
 
         // Use a neutral placeholder for reveal when a player timed out without a pick.
@@ -191,6 +200,14 @@ public sealed class RpsEngine : IGameEngine
     public GameOutcome GetOutcome(object state)
     {
         var s = (State)state;
+        if (s.Drawn)
+        {
+            return new GameOutcome.Finished(new[]
+            {
+                new CompletedParticipant(s.Players[0], Placement: 1, Score: s.RoundWins[0], Result: "draw"),
+                new CompletedParticipant(s.Players[1], Placement: 1, Score: s.RoundWins[1], Result: "draw"),
+            });
+        }
         if (s.WinnerId is null) return new GameOutcome.InProgress();
         var winnerId = s.WinnerId.Value;
         var loserId = s.Players[0] == winnerId ? s.Players[1] : s.Players[0];
@@ -274,6 +291,8 @@ public sealed class RpsEngine : IGameEngine
     public string? EndFeedLine(object state, Func<long, string> nameOf)
     {
         var s = (State)state;
+        if (s.Drawn)
+            return $"✊✋✌️ {nameOf(s.Players[0])} vs {nameOf(s.Players[1])} — Rock Paper Scissors ended in a draw (both idle)";
         if (s.WinnerId is null) return null;
         var winner = s.WinnerId.Value;
         var wIdx = IndexOf(s, winner);

--- a/src/Brmble.Server/Games/Engines/RpsEngine.cs
+++ b/src/Brmble.Server/Games/Engines/RpsEngine.cs
@@ -238,7 +238,7 @@ public sealed class RpsEngine : IGameEngine
     public string? StartFeedLine(object state, Func<long, string> nameOf)
     {
         var s = (State)state;
-        return $"⚔️ {nameOf(s.Players[0])} vs {nameOf(s.Players[1])} — Rock Paper Scissors (best of {s.BestOf}) started";
+        return $"✊✋✌️ {nameOf(s.Players[0])} vs {nameOf(s.Players[1])} — Rock Paper Scissors (best of {s.BestOf}) started";
     }
 
     public string? EventFeedLine(GameEvent e, Func<long, string> nameOf)

--- a/src/Brmble.Server/Games/Engines/RpsEngine.cs
+++ b/src/Brmble.Server/Games/Engines/RpsEngine.cs
@@ -238,7 +238,7 @@ public sealed class RpsEngine : IGameEngine
     public string? StartFeedLine(object state, Func<long, string> nameOf)
     {
         var s = (State)state;
-        return $"🪨📄✂️ {nameOf(s.Players[0])} vs {nameOf(s.Players[1])} — Rock Paper Scissors (best of {s.BestOf}) started";
+        return $"⚔️ {nameOf(s.Players[0])} vs {nameOf(s.Players[1])} — Rock Paper Scissors (best of {s.BestOf}) started";
     }
 
     public string? EventFeedLine(GameEvent e, Func<long, string> nameOf)

--- a/src/Brmble.Server/Games/Engines/RpsEngine.cs
+++ b/src/Brmble.Server/Games/Engines/RpsEngine.cs
@@ -34,7 +34,9 @@ public sealed class RpsEngine : IGameEngine
         public readonly Dictionary<long, int[]> Throws = new();
     }
 
-    private sealed record LastRound(int RoundNumber, Throw P0, Throw P1, long? WinnerId, bool Tie);
+    // P0/P1 are null when that player timed out without picking, so the client can
+    // show "None" rather than a misleading default throw.
+    private sealed record LastRound(int RoundNumber, Throw? P0, Throw? P1, long? WinnerId, bool Tie);
 
     public object InitialState(IReadOnlyList<GamePlayer> players, IRandomSource rng, IReadOnlyDictionary<string, object?>? options)
     {
@@ -154,11 +156,10 @@ public sealed class RpsEngine : IGameEngine
             s.ConsecutiveDoubleTimeouts = 0;
         }
 
-        // Use a neutral placeholder for reveal when a player timed out without a pick.
-        var reveal0 = p0 ?? Throw.Rock;
-        var reveal1 = p1 ?? Throw.Rock;
+        // Preserve nulls for players who timed out without a pick so the reveal shows
+        // "None" instead of a misleading throw.
         var recordedRound = s.RoundNumber;
-        s.Last = new LastRound(recordedRound, reveal0, reveal1, roundWinner, tie);
+        s.Last = new LastRound(recordedRound, p0, p1, roundWinner, tie);
 
         var events = new List<GameEvent>();
         if (!tie && roundWinner is not null)
@@ -241,9 +242,9 @@ public sealed class RpsEngine : IGameEngine
             {
                 roundNumber = s.Last.RoundNumber,
                 p0 = s.Players[0],
-                pick0 = s.Last.P0.ToString().ToLowerInvariant(),
+                pick0 = s.Last.P0?.ToString().ToLowerInvariant() ?? "none",
                 p1 = s.Players[1],
-                pick1 = s.Last.P1.ToString().ToLowerInvariant(),
+                pick1 = s.Last.P1?.ToString().ToLowerInvariant() ?? "none",
                 winnerId = s.Last.WinnerId,
                 tie = s.Last.Tie,
             },
@@ -270,7 +271,12 @@ public sealed class RpsEngine : IGameEngine
         var wins0 = e.Data["wins0"];
         var wins1 = e.Data["wins1"];
         if (tie)
+        {
+            var bothIdle = pick0?.ToString() == "none" && pick1?.ToString() == "none";
+            if (bothIdle)
+                return $"✊✋✌️ Round {round}: {nameOf(p0)} and {nameOf(p1)} both idled — tie, replay";
             return $"{Glyph(pick0)} Round {round}: {nameOf(p0)} and {nameOf(p1)} both picked {pick0} — tie, replay";
+        }
         var winnerId = Convert.ToInt64(e.Data["winnerId"]);
         var loserId = winnerId == p0 ? p1 : p0;
         var winnerPick = winnerId == p0 ? pick0 : pick1;

--- a/src/Brmble.Server/Games/Engines/RpsEngine.cs
+++ b/src/Brmble.Server/Games/Engines/RpsEngine.cs
@@ -25,6 +25,7 @@ public sealed class RpsEngine : IGameEngine
         public int TargetWins;
         public readonly int[] RoundWins = new int[2];
         public int RoundNumber = 1;          // decisive-round counter (ties don't advance it)
+        public int ResolvedCount;            // total rounds resolved incl. ties (reveal sequence)
         public readonly Throw?[] Picks = new Throw?[2];
         public long? WinnerId;
         public int ConsecutiveDoubleTimeouts;   // back-to-back rounds where both idle
@@ -35,8 +36,10 @@ public sealed class RpsEngine : IGameEngine
     }
 
     // P0/P1 are null when that player timed out without picking, so the client can
-    // show "None" rather than a misleading default throw.
-    private sealed record LastRound(int RoundNumber, Throw? P0, Throw? P1, long? WinnerId, bool Tie);
+    // show "None" rather than a misleading default throw. Seq is a monotonic counter
+    // over every resolution (ties included) so the client can reliably detect a new
+    // round to reveal even when the decisive RoundNumber didn't advance (a tie).
+    private sealed record LastRound(int RoundNumber, int Seq, Throw? P0, Throw? P1, long? WinnerId, bool Tie);
 
     public object InitialState(IReadOnlyList<GamePlayer> players, IRandomSource rng, IReadOnlyDictionary<string, object?>? options)
     {
@@ -159,7 +162,8 @@ public sealed class RpsEngine : IGameEngine
         // Preserve nulls for players who timed out without a pick so the reveal shows
         // "None" instead of a misleading throw.
         var recordedRound = s.RoundNumber;
-        s.Last = new LastRound(recordedRound, p0, p1, roundWinner, tie);
+        s.ResolvedCount++;
+        s.Last = new LastRound(recordedRound, s.ResolvedCount, p0, p1, roundWinner, tie);
 
         var events = new List<GameEvent>();
         if (!tie && roundWinner is not null)
@@ -241,6 +245,7 @@ public sealed class RpsEngine : IGameEngine
             lastRound = s.Last is null ? null : new
             {
                 roundNumber = s.Last.RoundNumber,
+                seq = s.Last.Seq,
                 p0 = s.Players[0],
                 pick0 = s.Last.P0?.ToString().ToLowerInvariant() ?? "none",
                 p1 = s.Players[1],

--- a/src/Brmble.Server/Games/Engines/RpsEngine.cs
+++ b/src/Brmble.Server/Games/Engines/RpsEngine.cs
@@ -84,7 +84,7 @@ public sealed class RpsEngine : IGameEngine
     public bool IsUsersTurn(object state, long userId)
     {
         var s = (State)state;
-        if (s.WinnerId is not null) return false;
+        if (s.WinnerId is not null || s.Drawn) return false;
         var idx = IndexOf(s, userId);
         return idx >= 0 && s.Picks[idx] is null;
     }
@@ -92,7 +92,7 @@ public sealed class RpsEngine : IGameEngine
     public IReadOnlyList<GameEvent> ApplyAction(object state, long userId, IReadOnlyDictionary<string, object?> action, IRandomSource rng)
     {
         var s = (State)state;
-        if (s.WinnerId is not null) throw new InvalidGameActionException("Game already finished.");
+        if (s.WinnerId is not null || s.Drawn) throw new InvalidGameActionException("Game already finished.");
         var idx = IndexOf(s, userId);
         if (idx < 0) throw new InvalidGameActionException("You are not in this match.");
         if (s.Picks[idx] is not null) throw new InvalidGameActionException("You already picked this round.");
@@ -111,7 +111,7 @@ public sealed class RpsEngine : IGameEngine
     public IReadOnlyList<GameEvent> ApplyTimeoutPenalty(object state, IRandomSource rng)
     {
         var s = (State)state;
-        if (s.WinnerId is not null) return Array.Empty<GameEvent>();
+        if (s.WinnerId is not null || s.Drawn) return Array.Empty<GameEvent>();
         // Non-committers auto-lose the round. If both failed to pick it's a draw and
         // the round replays; otherwise the committer takes the round.
         return ResolveRound(s, timeout: true);
@@ -236,7 +236,7 @@ public sealed class RpsEngine : IGameEngine
             targetWins = s.TargetWins,
             roundNumber = s.RoundNumber,
             roundWins = s.RoundWins,
-            finished = s.WinnerId is not null,
+            finished = s.WinnerId is not null || s.Drawn,
             winnerId = s.WinnerId,
             // Reveal only the requesting player's own current pick; the opponent's is
             // hidden (boolean only) until the round resolves.

--- a/src/Brmble.Server/Games/GameEndpoints.cs
+++ b/src/Brmble.Server/Games/GameEndpoints.cs
@@ -6,7 +6,7 @@ namespace Brmble.Server.Games;
 
 public static class GameEndpoints
 {
-    public record InviteDto(long TargetSessionId, string GameType);
+    public record InviteDto(long TargetSessionId, string GameType, Dictionary<string, object?>? Options = null);
     public record RespondDto(long MatchId, bool Accept);
     public record ActionDto(long MatchId, Dictionary<string, object?> Action);
     public record ForfeitDto(long MatchId);
@@ -23,13 +23,14 @@ public static class GameEndpoints
             if (!sessions.TryGetSessionByUserId(user.UserId, out var session))
                 return Results.BadRequest(new { error = "You must be connected to Brmble to start a game." });
             // dto.TargetSessionId is a Mumble session id supplied by the web client.
-            var r = await mgr.InviteAsync(session, dto.TargetSessionId, dto.GameType);
+            var r = await mgr.InviteAsync(session, dto.TargetSessionId, dto.GameType, dto.Options);
             if (r.Success) return Results.Ok(new { matchId = r.MatchId });
             // Emit a stable machine-readable reason code alongside the human text so
             // the client can branch without regex-matching the message string.
             var reason = r.Reason switch
             {
                 InviteRejectReason.Blocked => "blocked",
+                InviteRejectReason.ChannelBusy => "channelBusy",
                 _ => (string?)null,
             };
             return Results.BadRequest(new { error = r.Error, reason });
@@ -79,6 +80,20 @@ public static class GameEndpoints
             var (from, to) = ResolveWindow(window);
             var s = await stats.GetWindowedStatsAsync(user.UserId, gameType, from, to);
             return Results.Ok(s);
+        });
+
+        app.MapGet("/games/head-to-head/{opponentSessionId}", async (long opponentSessionId, HttpContext ctx,
+            ICertificateHashExtractor certs, UserRepository users, GameStatsService stats,
+            ISessionMappingService sessions) =>
+        {
+            var user = await ResolveUserAsync(ctx, certs, users);
+            if (user is null) return Results.Unauthorized();
+            // The web client only knows the opponent's Mumble session id; resolve it to
+            // the stable user id the head-to-head cache is keyed on.
+            if (!sessions.GetSnapshot().TryGetValue((int)opponentSessionId, out var mapping))
+                return Results.Ok(new HeadToHeadStats(0, 0, 0, Array.Empty<HeadToHeadGame>()));
+            var h2h = await stats.GetHeadToHeadAsync(user.UserId, mapping.UserId);
+            return Results.Ok(h2h);
         });
 
         app.MapGet("/games/settings", async (HttpContext ctx,

--- a/src/Brmble.Server/Games/GameSessionManager.cs
+++ b/src/Brmble.Server/Games/GameSessionManager.cs
@@ -180,6 +180,16 @@ public sealed class GameSessionManager
     // Test hook: simulate the 30s invite timer firing.
     internal Task ExpireInviteForTestAsync(long matchId) => EndPendingAsync(matchId, "game.expired");
 
+    // Test-only: synchronously drive a turn-timeout for the current turn generation,
+    // mirroring what the real TurnTimer callback does. Lets tests exercise AFK paths
+    // without waiting on wall-clock timers.
+    internal Task FireTurnTimeoutForTestAsync(long matchId)
+    {
+        if (!_matches.TryGetValue(matchId, out var match)) return Task.CompletedTask;
+        var generation = Interlocked.Read(ref match.TurnGeneration);
+        return HandleTurnTimeoutAsync(matchId, generation);
+    }
+
     public async Task RespondAsync(long matchId, long targetSession, bool accept)
     {
         if (!_matches.TryGetValue(matchId, out var match)) return;
@@ -379,11 +389,15 @@ public sealed class GameSessionManager
                 return p with { UserId = dbId, MetadataJson = meta };
             })
             .ToArray();
+        // A match with no single winner (all participants "draw") is a real draw:
+        // persist Outcome "draw" and emit no winnerId.
+        var isDraw = outcome.Participants.All(p => p.Result == "draw");
+
         var completed = new CompletedMatch(
             GameType: match.GameType,
             ChannelId: match.ChannelId,
             Format: match.Engine.MatchFormat(match.State),
-            Outcome: "decided",
+            Outcome: isDraw ? "draw" : "decided",
             AbandonReason: null,
             StartedAt: match.StartedAt,
             EndedAt: DateTimeOffset.UtcNow,
@@ -392,14 +406,14 @@ public sealed class GameSessionManager
 
         await _repository.SaveCompletedMatchAsync(completed);
 
-        var winner = outcome.Participants.FirstOrDefault(p => p.Placement == 1);
+        var winner = isDraw ? null : outcome.Participants.FirstOrDefault(p => p.Placement == 1);
 
         // winner.UserId is still a Mumble session id here (translation to db ids
         // happens in persistedParticipants above), which is what the client compares
         // against its own session id — so emit it directly as winnerId.
         await _publisher.PublishToUsersAsync(
             RouteSet(match),
-            new { type = "game.ended", matchId = match.MatchId, gameType = match.GameType, winnerId = winner?.UserId });
+            new { type = "game.ended", matchId = match.MatchId, gameType = match.GameType, winnerId = winner?.UserId, draw = isDraw });
 
         await PublishDuelStateAsync(match, active: false);
 

--- a/src/Brmble.Server/Games/GameSessionManager.cs
+++ b/src/Brmble.Server/Games/GameSessionManager.cs
@@ -159,6 +159,11 @@ public sealed class GameSessionManager
 
         match.InviteTimer = new Timer(_ => OnInviteExpired(matchId), null, InviteTimeout, Timeout.InfiniteTimeSpan);
 
+        // Mark the channel busy as soon as the invite is pending (not just when it goes
+        // live): the server already treats a pending duel as busy for enforcement, so the
+        // channel-tree badge should reflect that too.
+        await PublishDuelStateAsync(match, active: true);
+
         return new InviteResult(true, matchId, null);
     }
 
@@ -235,6 +240,8 @@ public sealed class GameSessionManager
         await _publisher.PublishToUsersAsync(
             RouteSet(match),
             new { type = eventType, matchId });
+        // The pending invite made the channel busy; clear the badge now that it's gone.
+        await PublishDuelStateAsync(match, active: false);
         foreach (var p in match.Players) _userToMatch.TryRemove(p, out _);
         _matches.TryRemove(matchId, out _);
     }
@@ -516,8 +523,9 @@ public sealed class GameSessionManager
         }
     }
 
-    // Signals the whole channel that a live duel started/ended so clients can show
-    // a "duel in progress" indicator. Only fired for actually-live matches.
+    // Signals the whole channel that a duel is pending/live or has ended so clients can
+    // show a "duel in progress" indicator. Fired when an invite is created (pending),
+    // when it goes live, and when it ends (declined/expired/completed/abandoned).
     private Task PublishDuelStateAsync(LiveMatch match, bool active)
         => _publisher.PublishToChannelAsync(match.ChannelId, new
         {

--- a/src/Brmble.Server/Games/GameSessionManager.cs
+++ b/src/Brmble.Server/Games/GameSessionManager.cs
@@ -25,7 +25,7 @@ public interface IGamePresence
     Task<bool> AreChallengesBlockedAsync(long sessionId);
 }
 
-public enum InviteRejectReason { None, Blocked }
+public enum InviteRejectReason { None, Blocked, ChannelBusy }
 
 public record InviteResult(bool Success, long MatchId, string? Error, InviteRejectReason Reason = InviteRejectReason.None);
 
@@ -81,7 +81,8 @@ public sealed class GameSessionManager
         public readonly object Lock = new();
     }
 
-    public async Task<InviteResult> InviteAsync(long inviterSession, long targetSession, string gameType)
+    public async Task<InviteResult> InviteAsync(long inviterSession, long targetSession, string gameType,
+        IReadOnlyDictionary<string, object?>? options = null)
     {
         if (inviterSession == targetSession)
             return new InviteResult(false, 0, "You cannot invite yourself.");
@@ -101,6 +102,11 @@ public sealed class GameSessionManager
         if (inviterChannel != targetChannel)
             return new InviteResult(false, 0, "You must be in the same channel to start a game.");
 
+        // One duel per channel: the spectator feed posts to the whole channel, so a
+        // second concurrent (or even pending) duel would interleave confusingly.
+        if (_matches.Values.Any(m => m.ChannelId == inviterChannel && m.Status != "done"))
+            return new InviteResult(false, 0, "A duel is already in progress in this channel.", InviteRejectReason.ChannelBusy);
+
         if (_userToMatch.ContainsKey(inviterSession))
             return new InviteResult(false, 0, "You already have an active game.");
 
@@ -114,7 +120,7 @@ public sealed class GameSessionManager
             MatchId = matchId,
             GameType = gameType,
             Engine = engine,
-            State = engine.InitialState(players, _rng),
+            State = engine.InitialState(players, _rng, options),
             Players = new[] { inviterSession, targetSession },
             SessionToUser = new Dictionary<long, long>
             {
@@ -142,6 +148,14 @@ public sealed class GameSessionManager
         await _publisher.PublishToUsersAsync(
             new HashSet<long> { targetUserId },
             new { type = "game.invited", matchId, gameType, from = inviterSession, inviteMs = (int)InviteTimeout.TotalMilliseconds });
+
+        // Tell the challenger their invite is pending so they can show a "waiting for
+        // opponent" notification and cancel it. The WebView client posts invites
+        // fire-and-forget (no response body), so this event is how it learns the
+        // matchId of its own outgoing invite.
+        await _publisher.PublishToUsersAsync(
+            new HashSet<long> { inviterUserId },
+            new { type = "game.invitePending", matchId, gameType, target = targetSession, inviteMs = (int)InviteTimeout.TotalMilliseconds });
 
         match.InviteTimer = new Timer(_ => OnInviteExpired(matchId), null, InviteTimeout, Timeout.InfiniteTimeSpan);
 
@@ -187,13 +201,15 @@ public sealed class GameSessionManager
                     type = "game.started",
                     matchId,
                     gameType = match.GameType,
-                    firstTurn = CurrentPlayer(match),
+                    firstTurn = IsSimultaneous(match) ? (long?)null : CurrentPlayer(match),
                     turnMs = (int)TurnTimeout.TotalMilliseconds,
                     penalty = false,
                     views,
                 });
-            await PublishFeedAsync(match,
-                $"⚔️ {NameOf(match, match.Players[0])} vs {NameOf(match, match.Players[1])} — {GameName(match.GameType)} started (ceiling {CeilingOf(match)})");
+            await PublishDuelStateAsync(match, active: true);
+            var startLine = match.Engine.StartFeedLine(match.State, sid => NameOf(match, sid))
+                ?? $"⚔️ {NameOf(match, match.Players[0])} vs {NameOf(match, match.Players[1])} — {GameName(match.GameType)} started";
+            await PublishFeedAsync(match, startLine);
             StartTurnTimer(match, TurnTimeout);
         }
         else
@@ -248,8 +264,11 @@ public sealed class GameSessionManager
                 return;
             }
             finished = match.Engine.GetOutcome(match.State) is GameOutcome.Finished;
-            if (!finished) StartTurnTimer(match, TurnTimeout);
-            else DisposeTimers(match);
+            if (finished) DisposeTimers(match);
+            // Alternating games advance the turn every action, so the timer always
+            // restarts. Simultaneous games keep one commit window per round: only
+            // restart when a round actually resolved (both players committed).
+            else if (ShouldRestartTurnTimer(match, events)) StartTurnTimer(match, TurnTimeout);
             // Capture the snapshot inside the lock so a concurrent mutation can't
             // cause an inconsistent view to be broadcast.
             views = match.Players
@@ -294,6 +313,7 @@ public sealed class GameSessionManager
 
         IReadOnlyList<GameEvent> events;
         bool finished;
+        bool simultaneous;
         object[] views;
         lock (match.Lock)
         {
@@ -302,9 +322,13 @@ public sealed class GameSessionManager
             // this timeout firing and acquiring the lock. Don't penalise the new
             // current player for the previous player's inaction.
             if (Interlocked.Read(ref match.TurnGeneration) != generation) return;
+            simultaneous = IsSimultaneous(match);
             events = match.Engine.ApplyTimeoutPenalty(match.State, _rng);
             finished = match.Engine.GetOutcome(match.State) is GameOutcome.Finished;
-            if (!finished) StartTurnTimer(match, PenaltyTimeout);
+            // Alternating (Deathroll): escalate with a shorter 5s penalty window.
+            // Simultaneous (RPS): the round just resolved by timeout — the next round
+            // gets a full commit window.
+            if (!finished) StartTurnTimer(match, simultaneous ? TurnTimeout : PenaltyTimeout);
             else DisposeTimers(match);
             views = match.Players
                 .Select(p => (object)new { userId = p, view = match.Engine.PublicView(match.State, p) })
@@ -318,8 +342,8 @@ public sealed class GameSessionManager
                 type = "game.stateUpdated",
                 matchId,
                 gameType = match.GameType,
-                turnMs = (int)PenaltyTimeout.TotalMilliseconds,
-                penalty = true,
+                turnMs = (int)(simultaneous ? TurnTimeout : PenaltyTimeout).TotalMilliseconds,
+                penalty = !simultaneous,
                 views,
                 events = events.Select(e => new { e.Kind, e.Data }).ToArray(),
             });
@@ -351,7 +375,7 @@ public sealed class GameSessionManager
         var completed = new CompletedMatch(
             GameType: match.GameType,
             ChannelId: match.ChannelId,
-            Format: "1v1",
+            Format: match.Engine.MatchFormat(match.State),
             Outcome: "decided",
             AbandonReason: null,
             StartedAt: match.StartedAt,
@@ -362,7 +386,6 @@ public sealed class GameSessionManager
         await _repository.SaveCompletedMatchAsync(completed);
 
         var winner = outcome.Participants.FirstOrDefault(p => p.Placement == 1);
-        var loser = outcome.Participants.FirstOrDefault(p => p.Placement == 2);
 
         // winner.UserId is still a Mumble session id here (translation to db ids
         // happens in persistedParticipants above), which is what the client compares
@@ -371,9 +394,12 @@ public sealed class GameSessionManager
             RouteSet(match),
             new { type = "game.ended", matchId = match.MatchId, gameType = match.GameType, winnerId = winner?.UserId });
 
-        var feedText = winner is not null && loser is not null
-            ? $"💀 {NameOf(match, loser.UserId)} rolled {loser.Score ?? 1} — {NameOf(match, winner.UserId)} wins!"
-            : $"💀 {GameName(match.GameType)} over.";
+        await PublishDuelStateAsync(match, active: false);
+
+        var feedText = match.Engine.EndFeedLine(match.State, sid => NameOf(match, sid))
+            ?? (winner is not null
+                ? $"🏆 {NameOf(match, winner.UserId)} wins!"
+                : $"{GameName(match.GameType)} over.");
         await PublishFeedAsync(match, feedText);
 
         foreach (var p in match.Players) _userToMatch.TryRemove(p, out _);
@@ -419,7 +445,7 @@ public sealed class GameSessionManager
         var completed = new CompletedMatch(
             GameType: match.GameType,
             ChannelId: match.ChannelId,
-            Format: "1v1",
+            Format: match.Engine.MatchFormat(match.State),
             Outcome: "abandoned",
             AbandonReason: reason,
             StartedAt: match.StartedAt,
@@ -432,6 +458,8 @@ public sealed class GameSessionManager
         await _publisher.PublishToUsersAsync(
             RouteSet(match),
             new { type = "game.ended", matchId, gameType = match.GameType, abandoned = true, reason, winnerId = otherId });
+
+        await PublishDuelStateAsync(match, active: false);
 
         await PublishFeedAsync(match,
             $"🏳️ {NameOf(match, sessionId)} forfeited — {NameOf(match, otherId)} wins!");
@@ -476,28 +504,41 @@ public sealed class GameSessionManager
             text,
         });
 
-    // Turns non-terminal engine events (rolls, timeout penalties) into feed lines.
-    // Terminal loss/forfeit lines are emitted by CompleteMatchAsync/ForfeitAsync.
+    // Turns non-terminal engine events (rolls, RPS rounds, timeout penalties) into
+    // feed lines using the engine's own wording. Terminal loss/forfeit lines are
+    // emitted by CompleteMatchAsync/ForfeitAsync.
     private async Task BroadcastRollFeedAsync(LiveMatch match, IReadOnlyList<GameEvent> events)
     {
         foreach (var e in events)
         {
-            string? text = e.Kind switch
-            {
-                "roll" => $"🎲 {NameOf(match, Convert.ToInt64(e.Data["userId"]))} rolled {e.Data["value"]} (1–{e.Data["ceiling"]})",
-                "penalty" when e.Data.ContainsKey("userId") =>
-                    $"🎲 {NameOf(match, Convert.ToInt64(e.Data["userId"]))} ran out of time — ceiling drops to {e.Data["ceiling"]}",
-                _ => null,
-            };
+            var text = match.Engine.EventFeedLine(e, sid => NameOf(match, sid));
             if (text is not null) await PublishFeedAsync(match, text);
         }
     }
 
+    // Signals the whole channel that a live duel started/ended so clients can show
+    // a "duel in progress" indicator. Only fired for actually-live matches.
+    private Task PublishDuelStateAsync(LiveMatch match, bool active)
+        => _publisher.PublishToChannelAsync(match.ChannelId, new
+        {
+            type = "game.duelState",
+            channelId = match.ChannelId,
+            gameType = match.GameType,
+            matchId = match.MatchId,
+            active,
+        });
+
+    private static bool IsSimultaneous(LiveMatch match)
+        => match.Engine.InteractionModel == InteractionModel.SimultaneousCommit;
+
+    // Whether an applied action should restart the turn timer. Alternating games
+    // advance the turn every action; simultaneous games keep one commit window per
+    // round and only restart when a round resolves (signalled by a roundResult event).
+    private static bool ShouldRestartTurnTimer(LiveMatch match, IReadOnlyList<GameEvent> events)
+        => !IsSimultaneous(match) || events.Any(e => e.Kind == "roundResult");
+
     private static string GameName(string gameType)
         => string.IsNullOrEmpty(gameType) ? gameType : char.ToUpperInvariant(gameType[0]) + gameType[1..];
-
-    private static int CeilingOf(LiveMatch match)
-        => match.Engine.CurrentCeiling(match.State) ?? 0;
 
     public bool TryGetActiveMatch(long userId, out long matchId)
         => _userToMatch.TryGetValue(userId, out matchId);

--- a/src/Brmble.Server/Games/GameSessionManager.cs
+++ b/src/Brmble.Server/Games/GameSessionManager.cs
@@ -263,6 +263,10 @@ public sealed class GameSessionManager
         IReadOnlyList<GameEvent> events;
         bool finished;
         object[] views;
+        // Whether this action (re)started the shared commit window. Simultaneous games
+        // (RPS) keep one 15s window for the whole round, so the first player's pick must
+        // NOT restart the timer for the opponent — only a resolved round does.
+        bool turnStarted = false;
         lock (match.Lock)
         {
             if (match.Status != "live") return;
@@ -285,7 +289,11 @@ public sealed class GameSessionManager
             // Alternating games advance the turn every action, so the timer always
             // restarts. Simultaneous games keep one commit window per round: only
             // restart when a round actually resolved (both players committed).
-            else if (ShouldRestartTurnTimer(match, events)) StartTurnTimer(match, TurnTimeout);
+            else if (ShouldRestartTurnTimer(match, events))
+            {
+                StartTurnTimer(match, TurnTimeout);
+                turnStarted = true;
+            }
             // Capture the snapshot inside the lock so a concurrent mutation can't
             // cause an inconsistent view to be broadcast.
             views = match.Players
@@ -301,6 +309,7 @@ public sealed class GameSessionManager
                 matchId,
                 gameType = match.GameType,
                 turnMs = (int)TurnTimeout.TotalMilliseconds,
+                turnStarted,
                 penalty = false,
                 views,
                 events = events.Select(e => new { e.Kind, e.Data }).ToArray(),
@@ -360,6 +369,7 @@ public sealed class GameSessionManager
                 matchId,
                 gameType = match.GameType,
                 turnMs = (int)(simultaneous ? TurnTimeout : PenaltyTimeout).TotalMilliseconds,
+                turnStarted = !finished,
                 penalty = !simultaneous,
                 views,
                 events = events.Select(e => new { e.Kind, e.Data }).ToArray(),

--- a/src/Brmble.Server/Games/GameStatsService.cs
+++ b/src/Brmble.Server/Games/GameStatsService.cs
@@ -8,6 +8,17 @@ public record WindowedStats(int Wins, int Losses, int Draws, int Abandons, int G
     public double WinRatio => GamesPlayed == 0 ? 0 : (double)Wins / GamesPlayed;
 }
 
+public record HeadToHeadGame(string GameType, int Wins, int Losses, int Draws)
+{
+    public int GamesPlayed => Wins + Losses + Draws;
+}
+
+public record HeadToHeadStats(int Wins, int Losses, int Draws, IReadOnlyList<HeadToHeadGame> Games)
+{
+    public int GamesPlayed => Wins + Losses + Draws;
+    public double WinRatio => GamesPlayed == 0 ? 0 : (double)Wins / GamesPlayed;
+}
+
 public class GameStatsService
 {
     private readonly Database _db;
@@ -34,5 +45,37 @@ public class GameStatsService
             new { userId, gameType, from = from.ToString("o"), to = to.ToString("o") });
 
         return new WindowedStats((int)row.wins, (int)row.losses, (int)row.draws, (int)row.abandons, (int)row.played);
+    }
+
+    /// <summary>
+    /// Lifetime head-to-head record for <paramref name="selfUserId"/> against
+    /// <paramref name="opponentUserId"/>, per game type plus a rolled-up total. Wins/losses
+    /// are from self's perspective. Reads the canonical (low &lt; high) aggregate cache and
+    /// flips it when self is the high id.
+    /// </summary>
+    public async Task<HeadToHeadStats> GetHeadToHeadAsync(long selfUserId, long opponentUserId)
+    {
+        var (low, high) = selfUserId < opponentUserId ? (selfUserId, opponentUserId) : (opponentUserId, selfUserId);
+        var selfIsLow = selfUserId == low;
+
+        using var conn = _db.CreateConnection();
+        var rows = await conn.QueryAsync<(string gameType, long lowWins, long highWins, long draws)>("""
+            SELECT game_type AS gameType, low_wins AS lowWins, high_wins AS highWins, draws AS draws
+            FROM game_head_to_head
+            WHERE player_low_id = @low AND player_high_id = @high;
+            """, new { low, high });
+
+        var games = new List<HeadToHeadGame>();
+        int totalW = 0, totalL = 0, totalD = 0;
+        foreach (var r in rows)
+        {
+            var wins = (int)(selfIsLow ? r.lowWins : r.highWins);
+            var losses = (int)(selfIsLow ? r.highWins : r.lowWins);
+            var draws = (int)r.draws;
+            games.Add(new HeadToHeadGame(r.gameType, wins, losses, draws));
+            totalW += wins; totalL += losses; totalD += draws;
+        }
+
+        return new HeadToHeadStats(totalW, totalL, totalD, games);
     }
 }

--- a/src/Brmble.Server/Games/GamesExtensions.cs
+++ b/src/Brmble.Server/Games/GamesExtensions.cs
@@ -8,6 +8,7 @@ public static class GamesExtensions
     {
         services.AddSingleton<IRandomSource, CryptoRandomSource>();
         services.AddSingleton<IGameEngine, DeathrollEngine>();
+        services.AddSingleton<IGameEngine, RpsEngine>();
         services.AddSingleton<GameRepository>();
         services.AddSingleton<GameStatsService>();
         services.AddSingleton<IGamePresence, SessionMappingGamePresence>();

--- a/src/Brmble.Server/Games/IGameEngine.cs
+++ b/src/Brmble.Server/Games/IGameEngine.cs
@@ -22,7 +22,13 @@ public interface IGameEngine
     InteractionModel InteractionModel { get; }
 
     // Creates the initial opaque state for a match with the given ordered players.
-    object InitialState(IReadOnlyList<GamePlayer> players, IRandomSource rng);
+    // `options` carries optional match parameters supplied with the invite (e.g. RPS
+    // best-of-N). Engines that need no options ignore it. Default overload keeps
+    // existing engines/tests source-compatible.
+    object InitialState(IReadOnlyList<GamePlayer> players, IRandomSource rng)
+        => InitialState(players, rng, null);
+    object InitialState(IReadOnlyList<GamePlayer> players, IRandomSource rng, IReadOnlyDictionary<string, object?>? options)
+        => InitialState(players, rng);
 
     // Returns true if it is this user's turn (alternating games).
     bool IsUsersTurn(object state, long userId);
@@ -49,6 +55,25 @@ public interface IGameEngine
     // Current ceiling/upper-bound for games that have one (e.g. Deathroll), used
     // for feed lines. Returns null when the game has no such concept. Default: none.
     int? CurrentCeiling(object state) => null;
+
+    // --- Engine-driven spectator feed lines ---------------------------------
+    // These let each engine own its feed wording so GameSessionManager stays
+    // game-neutral. `nameOf` resolves a session id to a display name. Returning
+    // null falls back to the manager's generic line.
+
+    // Line broadcast when the match starts (after accept). Default: none.
+    string? StartFeedLine(object state, Func<long, string> nameOf) => null;
+
+    // Line for a non-terminal in-play event (a roll, a resolved RPS round, a
+    // timeout penalty). Returning null suppresses a feed line for that event.
+    string? EventFeedLine(GameEvent e, Func<long, string> nameOf) => null;
+
+    // Line broadcast when the match ends normally (decided). Default: none.
+    string? EndFeedLine(object state, Func<long, string> nameOf) => null;
+
+    // Persisted match format tag (game_matches.format), e.g. "1v1" or "bo3".
+    // Default: "1v1".
+    string MatchFormat(object state) => "1v1";
 }
 
 public sealed class InvalidGameActionException : Exception

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4477,6 +4477,7 @@ const handleConnect = (serverData: SavedServer) => {
       {(gameState.activeMatch || gameState.ended) && (
         (gameState.activeMatch?.gameType ?? gameState.ended?.gameType) === 'rps' ? (
           <RpsModal
+            key={`rps-${gameState.activeMatch?.matchId ?? gameState.ended?.matchId ?? 'none'}`}
             view={gameState.view}
             ended={gameState.ended}
             myUserId={selfSession}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4535,12 +4535,15 @@ const handleConnect = (serverData: SavedServer) => {
             duration={null}
             countdownMs={gameState.outgoingInvite.inviteMs ?? 30000}
             visible={!!gameState.outgoingInvite}
-            title="Waiting for opponent"
-            detail={`${resolveGamePlayerName(gameState.outgoingInvite.targetSession)} was challenged to ${gameDisplayName(gameState.outgoingInvite.gameType)}.`}
+            title={gameState.outgoingInvite.canceling ? 'Canceling challenge' : 'Waiting for opponent'}
+            detail={gameState.outgoingInvite.canceling
+              ? `Canceling your ${gameDisplayName(gameState.outgoingInvite.gameType)} challenge to ${resolveGamePlayerName(gameState.outgoingInvite.targetSession)}\u2026`
+              : `${resolveGamePlayerName(gameState.outgoingInvite.targetSession)} was challenged to ${gameDisplayName(gameState.outgoingInvite.gameType)}.`}
             actions={
               <button
                 className="btn btn-sm btn-danger"
                 onClick={() => gameState.cancelInvite()}
+                disabled={gameState.outgoingInvite.canceling}
               >
                 Cancel
               </button>

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1867,6 +1867,12 @@ function App() {
       setSelfCanRejoin(false);
       setSelfSession(0);
       setSpeakingUsers(new Map());
+      // Clear any in-flight game state (pending invite notification, active match,
+      // errors) so a dropped/kicked connection doesn't leave a stale challenge that
+      // would produce a spurious "Not connected" error when Accept can no longer
+      // reach the server. The server tears the match down on its side.
+      gameStateRef.current.reset();
+      setDuelChannelIds(new Set());
       hasMatrixCredentialsForSessionRef.current = false;
       setMatrixCredentials(null);
       setBrmbleDMUsers([]);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -39,6 +39,7 @@ import { DMContactList } from './components/DMContactList/DMContactList';
 import { usePrompt, confirm, prompt } from './hooks/usePrompt';
 import { NeonDGame } from './components/NeonD/NeonDGame';
 import { DeathrollModal } from './components/Games/DeathrollModal';
+import { RpsModal } from './components/Games/RpsModal';
 import { useGameState } from './components/Games/useGameState';
 import { ProfileProvider } from './contexts/ProfileContext';
 import { UpdateNotification } from './components/UpdateNotification/UpdateNotification';
@@ -941,6 +942,10 @@ function App() {
   const [selfCanRejoin, setSelfCanRejoin] = useState(false);
   const [selfSession, setSelfSession] = useState<number>(0);
   const gameState = useGameState(selfSession);
+  // Ref so long-lived bridge handlers (e.g. voice.disconnected) can reach the
+  // latest game actions without being in their dependency arrays.
+  const gameStateRef = useRef(gameState);
+  gameStateRef.current = gameState;
   const resolveGamePlayerName = useCallback(
     (userId: number) => usersRef.current.find(u => u.session === userId)?.name ?? `Player ${userId}`,
     [],
@@ -974,6 +979,30 @@ function App() {
     if (gameState.lastError) notifQueueRef.current.register('game-error', 'error');
     else notifQueueRef.current.unregister('game-error');
   }, [gameState.lastError]);
+  useEffect(() => {
+    if (gameState.outgoingInvite) notifQueueRef.current.register('game-pending', 'info', 2);
+    else notifQueueRef.current.unregister('game-pending');
+  }, [gameState.outgoingInvite]);
+  // Channels with a live duel — drives the swords badge on channel rows. Sourced
+  // from the server's channel-scoped `game.duelState` events (active true/false).
+  const [duelChannelIds, setDuelChannelIds] = useState<Set<number>>(new Set());
+  useEffect(() => {
+    const handleDuelState = (data: unknown) => {
+      const d = data as { channelId?: number; active?: boolean };
+      if (d.channelId == null) return;
+      setDuelChannelIds(prev => {
+        const has = prev.has(d.channelId!);
+        if (d.active && has) return prev;
+        if (!d.active && !has) return prev;
+        const next = new Set(prev);
+        if (d.active) next.add(d.channelId!);
+        else next.delete(d.channelId!);
+        return next;
+      });
+    };
+    bridge.on('game.duelState', handleDuelState);
+    return () => bridge.off('game.duelState', handleDuelState);
+  }, []);
   const [speakingUsers, setSpeakingUsers] = useState<Map<number, boolean>>(new Map());
   const [pendingChannelAction, setPendingChannelAction] = useState<number | 'leave' | null>(null);
   const hasMatrixCredentialsForSessionRef = useRef(false);
@@ -3232,7 +3261,13 @@ const handleConnect = (serverData: SavedServer) => {
         setSelfLeftVoice(false);
         setSelfCanRejoin(false);
         setSelfSession(0);
-        setSpeakingUsers(new Map());
+      setSpeakingUsers(new Map());
+      // Clear any in-flight game state (pending invite, active match, errors) so a
+      // disconnect doesn't leave a stale challenge notification or produce spurious
+      // errors when actions can no longer reach the server. The server tears the
+      // match down on its side, so this is purely a local UI reset.
+      gameStateRef.current.reset();
+      setDuelChannelIds(new Set());
         hasMatrixCredentialsForSessionRef.current = false;
         setMatrixCredentials(null);
         setBrmbleDMUsers([]);
@@ -4232,6 +4267,8 @@ const handleConnect = (serverData: SavedServer) => {
           onDisconnect={handleDisconnect}
           onStartDM={handleStartDMFromContextMenu}
           onChallengeDeathroll={(session) => gameState.invite(session)}
+          onChallengeRps={(session, bestOf) => gameState.invite(session, 'rps', { bestOf })}
+          duelChannelIds={duelChannelIds}
           speakingUsers={speakingUsers}
           voiceIdle={voiceIdle}
           connectionStatus={connectionStatus}
@@ -4432,18 +4469,33 @@ const handleConnect = (serverData: SavedServer) => {
       />
 
       {(gameState.activeMatch || gameState.ended) && (
-        <DeathrollModal
-          view={gameState.view}
-          ended={gameState.ended}
-          myUserId={selfSession}
-          turnDeadline={gameState.turnDeadline}
-          turnWindowMs={gameState.turnWindowMs}
-          penalty={gameState.penalty}
-          resolveName={resolveGamePlayerName}
-          onRoll={gameState.roll}
-          onForfeit={confirmForfeit}
-          onClose={gameState.ended ? gameState.dismissEnded : confirmForfeit}
-        />
+        (gameState.activeMatch?.gameType ?? gameState.ended?.gameType) === 'rps' ? (
+          <RpsModal
+            view={gameState.view}
+            ended={gameState.ended}
+            myUserId={selfSession}
+            turnDeadline={gameState.turnDeadline}
+            turnWindowMs={gameState.turnWindowMs}
+            penalty={gameState.penalty}
+            resolveName={resolveGamePlayerName}
+            onPick={(pick) => gameState.sendAction({ pick })}
+            onForfeit={confirmForfeit}
+            onClose={gameState.ended ? gameState.dismissEnded : confirmForfeit}
+          />
+        ) : (
+          <DeathrollModal
+            view={gameState.view}
+            ended={gameState.ended}
+            myUserId={selfSession}
+            turnDeadline={gameState.turnDeadline}
+            turnWindowMs={gameState.turnWindowMs}
+            penalty={gameState.penalty}
+            resolveName={resolveGamePlayerName}
+            onRoll={gameState.roll}
+            onForfeit={confirmForfeit}
+            onClose={gameState.ended ? gameState.dismissEnded : confirmForfeit}
+          />
+        )
       )}
 
       <div className="notification-stack">
@@ -4454,8 +4506,8 @@ const handleConnect = (serverData: SavedServer) => {
             duration={null}
             countdownMs={gameState.incomingInvite.inviteMs ?? 30000}
             visible={!!gameState.incomingInvite}
-            title="Deathroll challenge"
-            detail={`${resolveGamePlayerName(gameState.incomingInvite.from)} challenged you to Deathroll.`}
+            title={`${gameDisplayName(gameState.incomingInvite.gameType)} challenge`}
+            detail={`${resolveGamePlayerName(gameState.incomingInvite.from)} challenged you to ${gameDisplayName(gameState.incomingInvite.gameType)}.`}
             actions={
               <button
                 className="btn btn-sm btn-primary"
@@ -4469,11 +4521,32 @@ const handleConnect = (serverData: SavedServer) => {
             onExited={() => notifQueue.unregister('game-invite')}
           />
         )}
+        {gameState.outgoingInvite && notifQueue.isVisible('game-pending') && (
+          <Notification
+            status="info"
+            position="top-right"
+            duration={null}
+            countdownMs={gameState.outgoingInvite.inviteMs ?? 30000}
+            visible={!!gameState.outgoingInvite}
+            title="Waiting for opponent"
+            detail={`${resolveGamePlayerName(gameState.outgoingInvite.targetSession)} was challenged to ${gameDisplayName(gameState.outgoingInvite.gameType)}.`}
+            actions={
+              <button
+                className="btn btn-sm btn-danger"
+                onClick={() => gameState.cancelInvite()}
+              >
+                Cancel
+              </button>
+            }
+            onDismiss={() => gameState.cancelInvite()}
+            onExited={() => notifQueue.unregister('game-pending')}
+          />
+        )}
         {gameState.inviteOutcome && notifQueue.isVisible('game-outcome') && (() => {
           const o = gameState.inviteOutcome;
           const name = o.targetSession != null ? resolveGamePlayerName(o.targetSession) : 'The player';
           const copy = o.kind === 'declined'
-            ? { title: 'Challenge declined', detail: `${name} declined your Deathroll challenge.` }
+            ? { title: 'Challenge declined', detail: `${name} declined your challenge.` }
             : o.kind === 'expired'
               ? { title: 'No response', detail: `${name} didn't respond to your challenge.` }
               : { title: 'Challenge blocked', detail: `${name} isn't accepting challenges.` };

--- a/src/Brmble.Web/src/api/games.ts
+++ b/src/Brmble.Web/src/api/games.ts
@@ -13,6 +13,30 @@ export interface GameSettings {
   challengesBlocked: boolean;
 }
 
+/** Per-game head-to-head record from the requesting user's perspective. */
+export interface HeadToHeadGame {
+  gameType: string;
+  wins: number;
+  losses: number;
+  draws: number;
+  gamesPlayed: number;
+}
+
+/** Lifetime head-to-head totals vs one opponent, plus a per-game breakdown. */
+export interface HeadToHeadStats {
+  wins: number;
+  losses: number;
+  draws: number;
+  gamesPlayed: number;
+  winRatio: number;
+  games: HeadToHeadGame[];
+}
+
+/** Optional per-game invite options (e.g. RPS best-of length). */
+export interface InviteOptions {
+  bestOf?: number;
+}
+
 function isWebViewBridgeAvailable(): boolean {
   return !!(window as Window & { chrome?: { webview?: unknown } }).chrome?.webview;
 }
@@ -60,16 +84,21 @@ async function unwrap(response: Response): Promise<void> {
   throw await toGameApiError(response);
 }
 
-export async function invite(targetSessionId: number, gameType: string): Promise<void> {
+export async function invite(
+  targetSessionId: number,
+  gameType: string,
+  options?: InviteOptions,
+): Promise<void> {
+  const payload = options ? { targetSessionId, gameType, options } : { targetSessionId, gameType };
   if (isWebViewBridgeAvailable()) {
-    bridge.send('game.invite', { targetSessionId, gameType });
+    bridge.send('game.invite', payload);
     return;
   }
 
   const response = await fetch('/games/invite', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ targetSessionId, gameType }),
+    body: JSON.stringify(payload),
   });
   return unwrap(response);
 }
@@ -227,4 +256,21 @@ export async function setGameSettings(settings: GameSettings): Promise<GameSetti
     throw await toGameApiError(response);
   }
   return response.json() as Promise<GameSettings>;
+}
+
+/**
+ * Lifetime head-to-head record vs the given opponent (identified by live Mumble
+ * session id), from the requesting user's perspective. Returns an all-zero record
+ * when the players have never met.
+ */
+export async function getHeadToHead(opponentSession: number): Promise<HeadToHeadStats> {
+  if (isWebViewBridgeAvailable()) {
+    return bridgeRequest<HeadToHeadStats>({ action: 'head-to-head', opponentSession });
+  }
+
+  const response = await fetch(`/games/head-to-head/${encodeURIComponent(opponentSession)}`);
+  if (!response.ok) {
+    throw await toGameApiError(response);
+  }
+  return response.json() as Promise<HeadToHeadStats>;
 }

--- a/src/Brmble.Web/src/components/Games/DeathrollModal.tsx
+++ b/src/Brmble.Web/src/components/Games/DeathrollModal.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Icon } from '../Icon/Icon';
-import type { DeathrollView, EndedMatch } from './useGameState';
+import type { DeathrollView, EndedMatch, GameView } from './useGameState';
+import { isRpsView } from './useGameState';
+import { HeadToHead } from './HeadToHead';
 import styles from './DeathrollModal.module.css';
 
 interface DeathrollModalProps {
-  view: DeathrollView | null;
+  view: GameView | null;
   ended: EndedMatch | null;
   myUserId: number;
   turnDeadline: number | null;
@@ -17,7 +19,7 @@ interface DeathrollModalProps {
 }
 
 export function DeathrollModal({
-  view,
+  view: rawView,
   ended,
   myUserId,
   turnDeadline,
@@ -29,6 +31,8 @@ export function DeathrollModal({
   onClose,
 }: DeathrollModalProps) {
   const [now, setNow] = useState(() => Date.now());
+  // This modal only understands the Deathroll view shape; ignore any other.
+  const view: DeathrollView | null = rawView && !isRpsView(rawView) ? rawView : null;
 
   // Drive the countdown while a live turn is in progress.
   useEffect(() => {
@@ -46,6 +50,7 @@ export function DeathrollModal({
   const canRoll = isMyTurn && !ended;
 
   const players = view?.players ?? [];
+  const opponentId = players.find((p) => p !== myUserId) ?? null;
 
   const renderResult = () => {
     if (!ended) return null;
@@ -128,6 +133,13 @@ export function DeathrollModal({
         )}
 
         {renderResult()}
+
+        {opponentId != null && (
+          <div className={styles.headToHead}>
+            <span className={styles.headToHeadTitle}>Head-to-head</span>
+            <HeadToHead opponentSession={opponentId} opponentName={resolveName(opponentId)} />
+          </div>
+        )}
 
         <div className={styles.footer}>
           {ended ? (

--- a/src/Brmble.Web/src/components/Games/HeadToHead.css
+++ b/src/Brmble.Web/src/components/Games/HeadToHead.css
@@ -86,10 +86,13 @@
   font-family: var(--font-body);
   font-weight: 600;
   color: var(--text-primary);
+  min-width: 0;
 }
 
 .head-to-head-breakdown-record {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   color: var(--text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
 }

--- a/src/Brmble.Web/src/components/Games/HeadToHead.css
+++ b/src/Brmble.Web/src/components/Games/HeadToHead.css
@@ -1,0 +1,95 @@
+.head-to-head {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.head-to-head-message {
+  padding: var(--space-md);
+  text-align: center;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.head-to-head-error {
+  color: var(--accent-danger);
+}
+
+.head-to-head-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-sm);
+}
+
+.head-to-head-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-md) var(--space-sm);
+  background: var(--bg-surface);
+  border: var(--glass-border);
+  border-radius: var(--radius-md);
+}
+
+.head-to-head-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xl);
+  color: var(--text-primary);
+}
+
+.head-to-head-label {
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.head-to-head-ratio {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--bg-surface);
+  border: var(--glass-border);
+  border-radius: var(--radius-md);
+}
+
+.head-to-head-ratio-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xl);
+  color: var(--accent-primary);
+}
+
+.head-to-head-ratio-label {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.head-to-head-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.head-to-head-breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-surface);
+  border: var(--glass-border);
+  border-radius: var(--radius-md);
+}
+
+.head-to-head-breakdown-game {
+  font-family: var(--font-body);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.head-to-head-breakdown-record {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}

--- a/src/Brmble.Web/src/components/Games/HeadToHead.tsx
+++ b/src/Brmble.Web/src/components/Games/HeadToHead.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react';
+import { getHeadToHead, type HeadToHeadStats } from '../../api/games';
+import { gameDisplayName } from '../../utils/games';
+import './HeadToHead.css';
+
+interface HeadToHeadProps {
+  /** Live Mumble session id of the opponent to compare against. */
+  opponentSession: number;
+  /** Opponent display name, for the summary copy. */
+  opponentName: string;
+}
+
+/**
+ * Lifetime head-to-head record versus one opponent, from the local user's
+ * perspective, with a per-game breakdown. Reads via {@link getHeadToHead} (the
+ * server resolves the local identity from the client certificate).
+ */
+export function HeadToHead({ opponentSession, opponentName }: HeadToHeadProps) {
+  const [stats, setStats] = useState<HeadToHeadStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Track the latest request so out-of-order responses don't clobber state.
+  const requestSeq = useRef(0);
+
+  useEffect(() => {
+    const seq = ++requestSeq.current;
+    setLoading(true);
+    setError(null);
+    getHeadToHead(opponentSession)
+      .then((result) => {
+        if (requestSeq.current !== seq) return;
+        setStats(result);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        if (requestSeq.current !== seq) return;
+        setError(e instanceof Error ? e.message : 'Failed to load head-to-head record.');
+        setLoading(false);
+      });
+  }, [opponentSession]);
+
+  const winRatioPct = stats ? Math.round(stats.winRatio * 100) : 0;
+
+  if (error) {
+    return <div className="head-to-head-message head-to-head-error">{error}</div>;
+  }
+  if (loading) {
+    return <div className="head-to-head-message">Loading…</div>;
+  }
+  if (!stats || stats.gamesPlayed === 0) {
+    return <div className="head-to-head-message">No games played against {opponentName} yet.</div>;
+  }
+
+  return (
+    <div className="head-to-head">
+      <div className="head-to-head-grid">
+        <div className="head-to-head-cell">
+          <span className="head-to-head-value">{stats.wins}</span>
+          <span className="head-to-head-label">Wins</span>
+        </div>
+        <div className="head-to-head-cell">
+          <span className="head-to-head-value">{stats.losses}</span>
+          <span className="head-to-head-label">Losses</span>
+        </div>
+        <div className="head-to-head-cell">
+          <span className="head-to-head-value">{stats.draws}</span>
+          <span className="head-to-head-label">Draws</span>
+        </div>
+      </div>
+
+      <div className="head-to-head-ratio">
+        <span className="head-to-head-ratio-value">{winRatioPct}%</span>
+        <span className="head-to-head-ratio-label">
+          Win ratio over {stats.gamesPlayed} game{stats.gamesPlayed === 1 ? '' : 's'} vs {opponentName}
+        </span>
+      </div>
+
+      {stats.games.length > 0 && (
+        <div className="head-to-head-breakdown">
+          {stats.games.map((g) => (
+            <div key={g.gameType} className="head-to-head-breakdown-row">
+              <span className="head-to-head-breakdown-game">{gameDisplayName(g.gameType)}</span>
+              <span className="head-to-head-breakdown-record">
+                {g.wins}W · {g.losses}L · {g.draws}D
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default HeadToHead;

--- a/src/Brmble.Web/src/components/Games/RpsModal.module.css
+++ b/src/Brmble.Web/src/components/Games/RpsModal.module.css
@@ -14,17 +14,12 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: var(--space-2xs);
   padding: var(--space-sm) var(--space-md);
   background: var(--bg-surface);
   border: var(--glass-border);
   border-radius: var(--radius-md);
-  transition: background var(--transition-fast), border-color var(--transition-fast);
-}
-
-.playerActive {
-  background: var(--bg-surface-active);
-  border-color: var(--accent-primary);
 }
 
 .playerName {
@@ -33,53 +28,60 @@
   color: var(--text-primary);
 }
 
-.playerTurn {
-  font-size: var(--text-2xs);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+.playerScore {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xl);
   color: var(--accent-primary);
 }
 
-.board {
-  display: flex;
-  gap: var(--space-md);
-  margin-top: var(--space-lg);
-}
-
-.stat {
-  flex: 1;
+.status {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--space-2xs);
-  padding: var(--space-md);
-  background: var(--bg-surface);
-  border: var(--glass-border);
-  border-radius: var(--radius-md);
+  margin-top: var(--space-lg);
 }
 
-.statLabel {
+.statusLabel {
   font-size: var(--text-2xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
 }
 
-.statValue {
+.statusHint {
+  font-family: var(--font-body);
+  color: var(--text-secondary);
+}
+
+.lastRound {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2xs);
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  background: var(--bg-surface);
+  border: var(--glass-border);
+  border-radius: var(--radius-md);
+}
+
+.lastRoundLabel {
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.lastRoundPicks {
   font-family: var(--font-mono);
-  font-size: var(--text-2xl);
+  font-size: var(--text-lg);
   color: var(--text-primary);
 }
 
-.statCeiling {
-  font-family: var(--font-mono);
-  font-size: var(--text-2xl);
-  color: var(--accent-primary);
-}
-
-/* Escalation: ceiling shrinks under timeout penalties — signal urgency. */
-.statCeilingPenalty {
-  color: var(--accent-danger);
+.lastRoundOutcome {
+  font-family: var(--font-body);
+  color: var(--text-secondary);
 }
 
 .countdown {
@@ -104,7 +106,6 @@
   transition: width var(--transition-fast) linear;
 }
 
-/* Escalation (5s penalty turns): draw attention with the danger token. */
 .countdownBarPenalty {
   background: var(--accent-danger);
 }
@@ -119,6 +120,30 @@
 
 .countdownLabelPenalty {
   color: var(--accent-danger-text);
+}
+
+.picks {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-lg);
+}
+
+.pick {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-md) var(--space-sm);
+}
+
+.pickSelected {
+  border-color: var(--accent-primary);
+}
+
+.pickLabel {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
 }
 
 .result {

--- a/src/Brmble.Web/src/components/Games/RpsModal.module.css
+++ b/src/Brmble.Web/src/components/Games/RpsModal.module.css
@@ -133,17 +133,65 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--space-2xs);
+  gap: var(--space-xs);
   padding: var(--space-md) var(--space-sm);
+  height: auto;
+  border-radius: var(--radius-md);
+  transition: transform var(--transition-fast) ease, border-color var(--transition-fast) ease;
+}
+
+.pick:not(:disabled):hover {
+  transform: translateY(-2px);
+  border-color: var(--accent-primary);
+}
+
+.pick:not(:disabled):active {
+  transform: translateY(0);
 }
 
 .pickSelected {
   border-color: var(--accent-primary);
+  transform: translateY(-2px);
 }
 
 .pickLabel {
   font-family: var(--font-body);
   font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.reveal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2xs);
+}
+
+.revealCount {
+  font-family: var(--font-mono);
+  font-size: var(--text-3xl);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--accent-primary);
+  animation: rpsRevealPulse var(--transition-base) ease;
+}
+
+.revealHint {
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+@keyframes rpsRevealPulse {
+  from {
+    opacity: 0.3;
+    transform: scale(0.7);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .result {

--- a/src/Brmble.Web/src/components/Games/RpsModal.tsx
+++ b/src/Brmble.Web/src/components/Games/RpsModal.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useState } from 'react';
+import { Icon } from '../Icon/Icon';
+import type { RpsView, EndedMatch, GameView } from './useGameState';
+import { isRpsView } from './useGameState';
+import { HeadToHead } from './HeadToHead';
+import styles from './RpsModal.module.css';
+
+interface RpsModalProps {
+  view: GameView | null;
+  ended: EndedMatch | null;
+  myUserId: number;
+  turnDeadline: number | null;
+  turnWindowMs: number;
+  penalty: boolean;
+  resolveName: (userId: number) => string;
+  onPick: (pick: string) => void;
+  onForfeit: () => void;
+  onClose: () => void;
+}
+
+/** The three RPS choices, in canonical order (matches the server engine). */
+const PICKS: { id: string; label: string; icon: 'game-rps' }[] = [
+  { id: 'rock', label: 'Rock', icon: 'game-rps' },
+  { id: 'paper', label: 'Paper', icon: 'game-rps' },
+  { id: 'scissors', label: 'Scissors', icon: 'game-rps' },
+];
+
+function pickLabel(pick: string): string {
+  return pick.charAt(0).toUpperCase() + pick.slice(1);
+}
+
+export function RpsModal({
+  view: rawView,
+  ended,
+  myUserId,
+  turnDeadline,
+  turnWindowMs,
+  penalty,
+  resolveName,
+  onPick,
+  onForfeit,
+  onClose,
+}: RpsModalProps) {
+  const [now, setNow] = useState(() => Date.now());
+  // This modal only understands the RPS view shape; ignore any other.
+  const view: RpsView | null = rawView && isRpsView(rawView) ? rawView : null;
+
+  // Drive the countdown while a live round is in progress.
+  useEffect(() => {
+    if (ended || turnDeadline == null) return;
+    const id = window.setInterval(() => setNow(Date.now()), 200);
+    return () => window.clearInterval(id);
+  }, [ended, turnDeadline]);
+
+  const remainingMs = turnDeadline != null ? Math.max(0, turnDeadline - now) : 0;
+  const remainingSec = Math.ceil(remainingMs / 1000);
+  const windowMs = turnWindowMs > 0 ? turnWindowMs : 1;
+  const remainingRatio = turnDeadline != null ? Math.max(0, Math.min(1, remainingMs / windowMs)) : 0;
+
+  const players = view?.players ?? [];
+  const myIndex = view ? view.players.indexOf(myUserId) : -1;
+  const opponentId = players.find((p) => p !== myUserId) ?? null;
+
+  const hasPicked = !!view?.myPick;
+  const canPick = !!view && !view.finished && !ended && !hasPicked;
+
+  const roundWinsFor = (userId: number): number => {
+    if (!view) return 0;
+    const idx = view.players.indexOf(userId);
+    return idx >= 0 ? (view.roundWins[idx] ?? 0) : 0;
+  };
+
+  const renderLastRound = () => {
+    const last = view?.lastRound;
+    if (!last) return null;
+    const myPick = myIndex === 0 ? last.pick0 : last.pick1;
+    const oppPick = myIndex === 0 ? last.pick1 : last.pick0;
+    let outcome: string;
+    if (last.tie) {
+      outcome = 'Tie';
+    } else if (last.winnerId === myUserId) {
+      outcome = 'You won the round';
+    } else {
+      outcome = 'You lost the round';
+    }
+    return (
+      <div className={styles.lastRound}>
+        <span className={styles.lastRoundLabel}>Round {last.roundNumber}</span>
+        <span className={styles.lastRoundPicks}>
+          {pickLabel(myPick)} vs {pickLabel(oppPick)}
+        </span>
+        <span className={styles.lastRoundOutcome}>{outcome}</span>
+      </div>
+    );
+  };
+
+  const renderResult = () => {
+    if (!ended) return null;
+    let message: string;
+    if (ended.abandoned) {
+      message = ended.reason ? `Match abandoned: ${ended.reason}` : 'The match was abandoned.';
+    } else if (ended.winnerId != null) {
+      message = ended.winnerId === myUserId ? 'You win!' : `${resolveName(ended.winnerId)} wins!`;
+    } else {
+      message = 'The match has ended.';
+    }
+    return (
+      <div className={styles.result}>
+        <p className={styles.resultText}>{message}</p>
+      </div>
+    );
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className={`rps-modal glass-panel animate-slide-up ${styles.modal}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button className="modal-close" onClick={onClose} aria-label="Close rock paper scissors">
+          <Icon name="x" size={20} />
+        </button>
+
+        <div className="modal-header">
+          <h2 className="heading-title modal-title">Rock Paper Scissors</h2>
+          <p className="modal-subtitle">
+            {view ? `Best of ${view.bestOf} — first to ${view.targetWins}` : 'Pick your move.'}
+          </p>
+        </div>
+
+        {players.length > 0 && (
+          <div className={styles.players}>
+            {players.map((playerId) => (
+              <div key={playerId} className={styles.player}>
+                <span className={styles.playerName}>
+                  {playerId === myUserId ? 'You' : resolveName(playerId)}
+                </span>
+                <span className={styles.playerScore}>{roundWinsFor(playerId)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {view && !ended && (
+          <div className={styles.status}>
+            <span className={styles.statusLabel}>Round {view.roundNumber}</span>
+            <span className={styles.statusHint}>
+              {hasPicked
+                ? view.opponentPicked
+                  ? 'Revealing…'
+                  : `Waiting for ${opponentId != null ? resolveName(opponentId) : 'opponent'}…`
+                : 'Make your pick'}
+            </span>
+          </div>
+        )}
+
+        {renderLastRound()}
+
+        {view && !ended && !view.finished && (
+          <div className={styles.countdown} aria-hidden="true">
+            <div className={styles.countdownTrack}>
+              <div
+                className={`${styles.countdownBar} ${penalty ? styles.countdownBarPenalty : ''}`}
+                style={{ width: `${remainingRatio * 100}%` }}
+              />
+            </div>
+            <span className={`${styles.countdownLabel} ${penalty ? styles.countdownLabelPenalty : ''}`}>
+              {remainingSec}s
+            </span>
+          </div>
+        )}
+
+        {view && !ended && (
+          <div className={styles.picks}>
+            {PICKS.map((p) => {
+              const selected = view.myPick === p.id;
+              return (
+                <button
+                  key={p.id}
+                  className={`btn ${selected ? 'btn-primary' : ''} ${styles.pick} ${selected ? styles.pickSelected : ''}`}
+                  onClick={() => onPick(p.id)}
+                  disabled={!canPick}
+                >
+                  <Icon name={p.icon} size={24} />
+                  <span className={styles.pickLabel}>{p.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {renderResult()}
+
+        {opponentId != null && (
+          <div className={styles.headToHead}>
+            <span className={styles.headToHeadTitle}>Head-to-head</span>
+            <HeadToHead opponentSession={opponentId} opponentName={resolveName(opponentId)} />
+          </div>
+        )}
+
+        <div className={styles.footer}>
+          {ended ? (
+            <button className="btn btn-primary" onClick={onClose}>Close</button>
+          ) : (
+            <button className="btn btn-danger" onClick={onForfeit}>Forfeit</button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Brmble.Web/src/components/Games/RpsModal.tsx
+++ b/src/Brmble.Web/src/components/Games/RpsModal.tsx
@@ -55,7 +55,7 @@ export function RpsModal({
   // `display` is the gated view actually rendered; `incoming` is the raw latest.
   const [display, setDisplay] = useState<RpsView | null>(incoming);
   const [revealCount, setRevealCount] = useState<number | null>(null);
-  const shownRoundRef = useRef(0);
+  const shownSeqRef = useRef(0);
   const initedRef = useRef(false);
   const pendingRef = useRef<RpsView | null>(null);
 
@@ -64,13 +64,15 @@ export function RpsModal({
     if (!initedRef.current) {
       // First view for this match: adopt it without suspense (covers joining mid-game).
       initedRef.current = true;
-      shownRoundRef.current = incoming.lastRound?.roundNumber ?? 0;
+      shownSeqRef.current = incoming.lastRound?.seq ?? 0;
       setDisplay(incoming);
       return;
     }
     const last = incoming.lastRound;
-    if (last && last.roundNumber > shownRoundRef.current) {
+    if (last && last.seq > shownSeqRef.current) {
       // A round just resolved — freeze the old board and start the reveal countdown.
+      // Key off `seq` (increments on every resolution incl. ties) so a tie/draw round
+      // still triggers the 3-2-1 reveal for the following round.
       pendingRef.current = incoming;
       setRevealCount(REVEAL_SECONDS);
     } else {
@@ -84,7 +86,7 @@ export function RpsModal({
     if (revealCount <= 0) {
       const pv = pendingRef.current;
       if (pv) {
-        shownRoundRef.current = pv.lastRound?.roundNumber ?? shownRoundRef.current;
+        shownSeqRef.current = pv.lastRound?.seq ?? shownSeqRef.current;
         setDisplay(pv);
         pendingRef.current = null;
       }

--- a/src/Brmble.Web/src/components/Games/RpsModal.tsx
+++ b/src/Brmble.Web/src/components/Games/RpsModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Icon } from '../Icon/Icon';
+import type { IconName } from '../Icon/Icon';
 import type { RpsView, EndedMatch, GameView } from './useGameState';
 import { isRpsView } from './useGameState';
 import { HeadToHead } from './HeadToHead';
@@ -19,11 +20,14 @@ interface RpsModalProps {
 }
 
 /** The three RPS choices, in canonical order (matches the server engine). */
-const PICKS: { id: string; label: string; icon: 'game-rps' }[] = [
-  { id: 'rock', label: 'Rock', icon: 'game-rps' },
-  { id: 'paper', label: 'Paper', icon: 'game-rps' },
-  { id: 'scissors', label: 'Scissors', icon: 'game-rps' },
+const PICKS: { id: string; label: string; icon: IconName }[] = [
+  { id: 'rock', label: 'Rock', icon: 'rps-rock' },
+  { id: 'paper', label: 'Paper', icon: 'rps-paper' },
+  { id: 'scissors', label: 'Scissors', icon: 'rps-scissors' },
 ];
+
+/** Seconds of anticipation shown before a resolved round is revealed. */
+const REVEAL_SECONDS = 3;
 
 function pickLabel(pick: string): string {
   return pick.charAt(0).toUpperCase() + pick.slice(1);
@@ -42,15 +46,63 @@ export function RpsModal({
   onClose,
 }: RpsModalProps) {
   const [now, setNow] = useState(() => Date.now());
-  // This modal only understands the RPS view shape; ignore any other.
-  const view: RpsView | null = rawView && isRpsView(rawView) ? rawView : null;
+  const incoming: RpsView | null = rawView && isRpsView(rawView) ? rawView : null;
 
-  // Drive the countdown while a live round is in progress.
+  // Reveal suspense: when a round resolves, the server sends the updated view (and,
+  // on the final round, `game.ended` right after — which nulls the view). We hold the
+  // pre-resolution board frozen, run a short 3…2…1 countdown, then reveal the result.
+  // `display` is the gated view actually rendered; `incoming` is the raw latest.
+  const [display, setDisplay] = useState<RpsView | null>(incoming);
+  const [revealCount, setRevealCount] = useState<number | null>(null);
+  const shownRoundRef = useRef(0);
+  const initedRef = useRef(false);
+  const pendingRef = useRef<RpsView | null>(null);
+
   useEffect(() => {
-    if (ended || turnDeadline == null) return;
+    if (!incoming) return; // ignore the null the server sends on game.ended
+    if (!initedRef.current) {
+      // First view for this match: adopt it without suspense (covers joining mid-game).
+      initedRef.current = true;
+      shownRoundRef.current = incoming.lastRound?.roundNumber ?? 0;
+      setDisplay(incoming);
+      return;
+    }
+    const last = incoming.lastRound;
+    if (last && last.roundNumber > shownRoundRef.current) {
+      // A round just resolved — freeze the old board and start the reveal countdown.
+      pendingRef.current = incoming;
+      setRevealCount(REVEAL_SECONDS);
+    } else {
+      setDisplay(incoming);
+    }
+  }, [incoming]);
+
+  // Ticks the reveal countdown; on reaching 0 it commits the pending resolved view.
+  useEffect(() => {
+    if (revealCount == null) return;
+    if (revealCount <= 0) {
+      const pv = pendingRef.current;
+      if (pv) {
+        shownRoundRef.current = pv.lastRound?.roundNumber ?? shownRoundRef.current;
+        setDisplay(pv);
+        pendingRef.current = null;
+      }
+      setRevealCount(null);
+      return;
+    }
+    const id = window.setTimeout(() => setRevealCount((c) => (c == null ? null : c - 1)), 1000);
+    return () => window.clearTimeout(id);
+  }, [revealCount]);
+
+  const revealing = revealCount != null;
+  const view = display;
+
+  // Drive the turn countdown while a live round is in progress (not during reveal).
+  useEffect(() => {
+    if (ended || revealing || turnDeadline == null) return;
     const id = window.setInterval(() => setNow(Date.now()), 200);
     return () => window.clearInterval(id);
-  }, [ended, turnDeadline]);
+  }, [ended, revealing, turnDeadline]);
 
   const remainingMs = turnDeadline != null ? Math.max(0, turnDeadline - now) : 0;
   const remainingSec = Math.ceil(remainingMs / 1000);
@@ -62,7 +114,9 @@ export function RpsModal({
   const opponentId = players.find((p) => p !== myUserId) ?? null;
 
   const hasPicked = !!view?.myPick;
-  const canPick = !!view && !view.finished && !ended && !hasPicked;
+  const canPick = !!view && !view.finished && !ended && !hasPicked && !revealing;
+  // Hold the end result banner until the final round's reveal has finished.
+  const showResult = !!ended && !revealing;
 
   const roundWinsFor = (userId: number): number => {
     if (!view) return 0;
@@ -71,6 +125,8 @@ export function RpsModal({
   };
 
   const renderLastRound = () => {
+    // Suppress the previous round's summary while a new one is being revealed.
+    if (revealing) return null;
     const last = view?.lastRound;
     if (!last) return null;
     const myPick = myIndex === 0 ? last.pick0 : last.pick1;
@@ -95,7 +151,7 @@ export function RpsModal({
   };
 
   const renderResult = () => {
-    if (!ended) return null;
+    if (!showResult) return null;
     let message: string;
     if (ended.abandoned) {
       message = ended.reason ? `Match abandoned: ${ended.reason}` : 'The match was abandoned.';
@@ -141,22 +197,29 @@ export function RpsModal({
           </div>
         )}
 
-        {view && !ended && (
+        {view && !showResult && (
           <div className={styles.status}>
             <span className={styles.statusLabel}>Round {view.roundNumber}</span>
-            <span className={styles.statusHint}>
-              {hasPicked
-                ? view.opponentPicked
-                  ? 'Revealing…'
-                  : `Waiting for ${opponentId != null ? resolveName(opponentId) : 'opponent'}…`
-                : 'Make your pick'}
-            </span>
+            {revealing ? (
+              <div className={styles.reveal} aria-live="assertive">
+                <span className={styles.revealCount}>{revealCount}</span>
+                <span className={styles.revealHint}>Revealing…</span>
+              </div>
+            ) : (
+              <span className={styles.statusHint}>
+                {hasPicked
+                  ? view.opponentPicked
+                    ? 'Revealing…'
+                    : `Waiting for ${opponentId != null ? resolveName(opponentId) : 'opponent'}…`
+                  : 'Make your pick'}
+              </span>
+            )}
           </div>
         )}
 
         {renderLastRound()}
 
-        {view && !ended && !view.finished && (
+        {view && !showResult && !view.finished && !revealing && (
           <div className={styles.countdown} aria-hidden="true">
             <div className={styles.countdownTrack}>
               <div
@@ -170,18 +233,19 @@ export function RpsModal({
           </div>
         )}
 
-        {view && !ended && (
+        {view && !showResult && (
           <div className={styles.picks}>
             {PICKS.map((p) => {
               const selected = view.myPick === p.id;
               return (
                 <button
                   key={p.id}
-                  className={`btn ${selected ? 'btn-primary' : ''} ${styles.pick} ${selected ? styles.pickSelected : ''}`}
+                  className={`btn ${selected ? 'btn-primary' : 'btn-secondary'} ${styles.pick} ${selected ? styles.pickSelected : ''}`}
                   onClick={() => onPick(p.id)}
                   disabled={!canPick}
+                  aria-pressed={selected}
                 >
-                  <Icon name={p.icon} size={24} />
+                  <Icon name={p.icon} size={28} />
                   <span className={styles.pickLabel}>{p.label}</span>
                 </button>
               );
@@ -199,7 +263,7 @@ export function RpsModal({
         )}
 
         <div className={styles.footer}>
-          {ended ? (
+          {showResult ? (
             <button className="btn btn-primary" onClick={onClose}>Close</button>
           ) : (
             <button className="btn btn-danger" onClick={onForfeit}>Forfeit</button>

--- a/src/Brmble.Web/src/components/Games/RpsModal.tsx
+++ b/src/Brmble.Web/src/components/Games/RpsModal.tsx
@@ -30,6 +30,7 @@ const PICKS: { id: string; label: string; icon: IconName }[] = [
 const REVEAL_SECONDS = 3;
 
 function pickLabel(pick: string): string {
+  if (pick === 'none') return 'None';
   return pick.charAt(0).toUpperCase() + pick.slice(1);
 }
 

--- a/src/Brmble.Web/src/components/Games/RpsModal.tsx
+++ b/src/Brmble.Web/src/components/Games/RpsModal.tsx
@@ -155,6 +155,8 @@ export function RpsModal({
     let message: string;
     if (ended.abandoned) {
       message = ended.reason ? `Match abandoned: ${ended.reason}` : 'The match was abandoned.';
+    } else if (ended.draw) {
+      message = 'Draw — both players idle.';
     } else if (ended.winnerId != null) {
       message = ended.winnerId === myUserId ? 'You win!' : `${resolveName(ended.winnerId)} wins!`;
     } else {

--- a/src/Brmble.Web/src/components/Games/challengeMenu.tsx
+++ b/src/Brmble.Web/src/components/Games/challengeMenu.tsx
@@ -6,9 +6,8 @@ import { Icon } from '../Icon/Icon';
  *
  * The entry is a submenu of game types:
  *   - Deathroll — challenges immediately (no rounds/best-of).
- *   - Rock Paper Scissors — a further submenu of "Best of N" rounds. RPS is not yet
- *     implemented server-side, so its options are disabled ("coming soon"). When the
- *     server gains an RPS engine, wire the onClick handlers to invite('rps', { bestOf }).
+ *   - Rock Paper Scissors — a further submenu of "Best of N" rounds, each of which
+ *     invites with the chosen best-of length.
  *
  * Eligibility (same channel, Brmble client, not self) is decided by the caller; this
  * helper only assembles the menu item.
@@ -16,12 +15,12 @@ import { Icon } from '../Icon/Icon';
 export function buildChallengeMenuItem(
   session: number,
   onChallengeDeathroll: (session: number) => void,
+  onChallengeRps: (session: number, bestOf: number) => void,
 ): ContextMenuItem {
   const rpsBestOf = (n: number): ContextMenuItem => ({
     type: 'item',
     label: `Best of ${n}`,
-    disabled: true, // RPS not implemented yet
-    onClick: () => {},
+    onClick: () => onChallengeRps(session, n),
   });
 
   return {

--- a/src/Brmble.Web/src/components/Games/useGameState.ts
+++ b/src/Brmble.Web/src/components/Games/useGameState.ts
@@ -22,6 +22,9 @@ export interface DeathrollView {
 /** Resolved result of the most recent RPS round (both picks revealed). */
 export interface RpsLastRound {
   roundNumber: number;
+  /** Monotonic sequence over every resolution (ties included) — used to detect a
+   *  new round to reveal even when the decisive roundNumber didn't advance. */
+  seq: number;
   p0: number;
   pick0: string;
   p1: number;

--- a/src/Brmble.Web/src/components/Games/useGameState.ts
+++ b/src/Brmble.Web/src/components/Games/useGameState.ts
@@ -75,6 +75,9 @@ export interface OutgoingInvite {
   targetSession: number;
   gameType: string;
   inviteMs?: number;
+  // Set when the user requested a cancel before the server's matchId arrived; the
+  // pending UI stays visible (as "canceling") until game.invitePending lets us forfeit.
+  canceling?: boolean;
 }
 
 export interface EndedMatch {
@@ -162,6 +165,11 @@ export function useGameState(myUserId: number): GameState {
   // "opponent didn't respond". This flag suppresses that outcome exactly once.
   const selfCanceledRef = useRef(false);
 
+  // Set when the user requests a cancel before the server has confirmed the invite
+  // (no matchId yet). Once game.invitePending arrives we immediately forfeit that
+  // matchId so the server actually tears the pending invite down.
+  const pendingCancelRef = useRef(false);
+
   // Refs so bridge handlers (registered once) can read current values.
   const myUserIdRef = useRef(myUserId);
   myUserIdRef.current = myUserId;
@@ -201,6 +209,25 @@ export function useGameState(myUserId: number): GameState {
       const d = data as { matchId?: number; gameType?: string; target?: number; inviteMs?: number };
       if (d.matchId == null) return;
       const existing = outgoingInviteRef.current;
+      // The user asked to cancel before this confirmation arrived. Now that we have
+      // a matchId, actually forfeit it server-side. Keep the pending ("canceling")
+      // UI until the resulting game.expired clears it.
+      if (pendingCancelRef.current) {
+        pendingCancelRef.current = false;
+        selfCanceledRef.current = true;
+        setOutgoing({
+          matchId: d.matchId,
+          targetSession: d.target ?? existing?.targetSession ?? 0,
+          gameType: d.gameType ?? existing?.gameType ?? 'deathroll',
+          inviteMs: d.inviteMs,
+          canceling: true,
+        });
+        gamesApi.forfeit(d.matchId).catch(e => {
+          selfCanceledRef.current = false;
+          setLastError(e instanceof Error ? e.message : 'Failed to cancel invite.');
+        });
+        return;
+      }
       setOutgoing({
         matchId: d.matchId,
         targetSession: d.target ?? existing?.targetSession ?? 0,
@@ -395,14 +422,18 @@ export function useGameState(myUserId: number): GameState {
     const out = outgoingInviteRef.current;
     if (!out) return;
     if (out.matchId == null) {
-      // The pending confirmation hasn't arrived yet; just drop the local state.
-      setOutgoing(null);
+      // The server hasn't confirmed the invite yet, so we don't know what to
+      // forfeit. Keep the pending UI (as "canceling") and defer the actual
+      // server-side cancel until game.invitePending delivers the matchId, rather
+      // than clearing locally while the server still holds a pending invite.
+      pendingCancelRef.current = true;
+      setOutgoing({ ...out, canceling: true });
       return;
     }
     // Mark this as a self-cancel so the resulting server `game.expired` isn't shown
-    // as "opponent didn't respond", and clear the pending UI optimistically.
+    // as "opponent didn't respond", and keep the pending UI as "canceling" until it.
     selfCanceledRef.current = true;
-    setOutgoing(null);
+    setOutgoing({ ...out, canceling: true });
     gamesApi.forfeit(out.matchId).catch(e => {
       selfCanceledRef.current = false;
       setLastError(e instanceof Error ? e.message : 'Failed to cancel invite.');
@@ -462,6 +493,7 @@ export function useGameState(myUserId: number): GameState {
   // would produce spurious errors when actions can no longer reach the server.
   const reset = useCallback(() => {
     selfCanceledRef.current = false;
+    pendingCancelRef.current = false;
     setIncomingInvite(null);
     setActiveMatch(null);
     setView(null);

--- a/src/Brmble.Web/src/components/Games/useGameState.ts
+++ b/src/Brmble.Web/src/components/Games/useGameState.ts
@@ -5,6 +5,10 @@ import * as gamesApi from '../../api/games';
 /** Fallback turn window in ms if the server omits `turnMs` (normal turn). */
 const DEFAULT_TURN_MS = 15000;
 
+// Game types this client build knows how to render. Invites for anything else are
+// auto-declined so an outdated peer can't open the wrong modal. Forward-compat only.
+const SUPPORTED_GAMES = ['deathroll', 'rps'];
+
 /** Per-player Deathroll view (engine PublicView, camelCase). */
 export interface DeathrollView {
   players: number[];
@@ -177,7 +181,14 @@ export function useGameState(myUserId: number): GameState {
     const handleInvited = (data: unknown) => {
       const d = data as { matchId?: number; gameType?: string; from?: number; inviteMs?: number };
       if (d.matchId == null || d.from == null) return;
-      setIncomingInvite({ matchId: d.matchId, gameType: d.gameType ?? 'deathroll', from: d.from, inviteMs: d.inviteMs });
+      const gameType = d.gameType ?? 'deathroll';
+      if (!SUPPORTED_GAMES.includes(gameType)) {
+        // This client build doesn't know this game — decline instead of opening the
+        // wrong modal. (Old clients that predate this check can't reach here.)
+        gamesApi.respond(d.matchId, false).catch(() => {});
+        return;
+      }
+      setIncomingInvite({ matchId: d.matchId, gameType, from: d.from, inviteMs: d.inviteMs });
     };
 
     // Challenger side: the server confirms our outgoing invite and supplies its

--- a/src/Brmble.Web/src/components/Games/useGameState.ts
+++ b/src/Brmble.Web/src/components/Games/useGameState.ts
@@ -223,17 +223,24 @@ export function useGameState(myUserId: number): GameState {
     };
 
     const handleStateUpdated = (data: unknown) => {
-      const d = data as { matchId?: number; views?: unknown; turnMs?: number; penalty?: boolean };
+      const d = data as { matchId?: number; views?: unknown; turnMs?: number; turnStarted?: boolean; penalty?: boolean };
       // Ignore late/stray updates from a match that is no longer the active one
       // (e.g. a rapid rematch) so they can't corrupt the board or reset the timer.
       const active = activeMatchRef.current;
       if (d.matchId != null && active && d.matchId !== active.matchId) return;
       const nextView = pickMyView(d.views, myUserIdRef.current);
       if (nextView) setView(nextView);
-      const windowMs = d.turnMs ?? DEFAULT_TURN_MS;
-      setTurnWindowMs(windowMs);
       setPenalty(d.penalty ?? false);
-      setTurnDeadline(Date.now() + windowMs);
+      // Only (re)arm the countdown when the server actually started a new commit
+      // window. In simultaneous games (RPS) the first player's pick emits a state
+      // update WITHOUT restarting the shared window, so we must keep the running
+      // deadline instead of resetting it to a fresh 15s. Default true for other
+      // game types / older servers that omit the flag.
+      if (d.turnStarted ?? true) {
+        const windowMs = d.turnMs ?? DEFAULT_TURN_MS;
+        setTurnWindowMs(windowMs);
+        setTurnDeadline(Date.now() + windowMs);
+      }
     };
 
     const handleEnded = (data: unknown) => {

--- a/src/Brmble.Web/src/components/Games/useGameState.ts
+++ b/src/Brmble.Web/src/components/Games/useGameState.ts
@@ -149,6 +149,10 @@ export function useGameState(myUserId: number): GameState {
   const [outgoingInvite, setOutgoingInvite] = useState<OutgoingInvite | null>(null);
   const [accepting, setAccepting] = useState<boolean>(false);
   const outgoingInviteRef = useRef<OutgoingInvite | null>(null);
+  // Set when the local user cancels their own pending invite. The server responds
+  // to our forfeit with a `game.expired`, which would otherwise be misreported as
+  // "opponent didn't respond". This flag suppresses that outcome exactly once.
+  const selfCanceledRef = useRef(false);
 
   // Refs so bridge handlers (registered once) can read current values.
   const myUserIdRef = useRef(myUserId);
@@ -264,7 +268,21 @@ export function useGameState(myUserId: number): GameState {
     };
 
     const handleDeclined = () => resolveOutgoing('declined');
-    const handleExpired = () => resolveOutgoing('expired');
+    const handleExpired = () => {
+      // A self-initiated cancel produces a server `game.expired`; don't surface it as
+      // an "opponent didn't respond" outcome — just clear the (already-cleared) state.
+      if (selfCanceledRef.current) {
+        selfCanceledRef.current = false;
+        setIncomingInvite(null);
+        setOutgoing(null);
+        setActiveMatch(null);
+        setTurnDeadline(null);
+        setPenalty(false);
+        setAccepting(false);
+        return;
+      }
+      resolveOutgoing('expired');
+    };
 
     const handleActionRejected = (data: unknown) => {
       const d = data as { reason?: string };
@@ -358,7 +376,12 @@ export function useGameState(myUserId: number): GameState {
       setOutgoing(null);
       return;
     }
+    // Mark this as a self-cancel so the resulting server `game.expired` isn't shown
+    // as "opponent didn't respond", and clear the pending UI optimistically.
+    selfCanceledRef.current = true;
+    setOutgoing(null);
     gamesApi.forfeit(out.matchId).catch(e => {
+      selfCanceledRef.current = false;
       setLastError(e instanceof Error ? e.message : 'Failed to cancel invite.');
     });
   }, [setOutgoing]);
@@ -415,6 +438,7 @@ export function useGameState(myUserId: number): GameState {
   // invite notification, active modal, errors) rather than leaving stale state that
   // would produce spurious errors when actions can no longer reach the server.
   const reset = useCallback(() => {
+    selfCanceledRef.current = false;
     setIncomingInvite(null);
     setActiveMatch(null);
     setView(null);

--- a/src/Brmble.Web/src/components/Games/useGameState.ts
+++ b/src/Brmble.Web/src/components/Games/useGameState.ts
@@ -15,6 +15,40 @@ export interface DeathrollView {
   loserId: number | null;
 }
 
+/** Resolved result of the most recent RPS round (both picks revealed). */
+export interface RpsLastRound {
+  roundNumber: number;
+  p0: number;
+  pick0: string;
+  p1: number;
+  pick1: string;
+  winnerId: number | null;
+  tie: boolean;
+}
+
+/** Per-player RPS view (engine PublicView, camelCase). The opponent's current pick
+ * is hidden (`opponentPicked` boolean only) until the round resolves. */
+export interface RpsView {
+  players: number[];
+  bestOf: number;
+  targetWins: number;
+  roundNumber: number;
+  roundWins: number[];
+  finished: boolean;
+  winnerId: number | null;
+  myPick: string | null;
+  opponentPicked: boolean;
+  lastRound: RpsLastRound | null;
+}
+
+/** Any game's per-player view. Modals narrow this to their own game's shape. */
+export type GameView = DeathrollView | RpsView;
+
+/** Narrows a {@link GameView} to the RPS shape (by a distinctive RPS-only field). */
+export function isRpsView(view: GameView | null): view is RpsView {
+  return !!view && 'roundWins' in view;
+}
+
 export interface IncomingInvite {
   matchId: number;
   gameType: string;
@@ -28,8 +62,17 @@ export interface ActiveMatch {
   gameType: string;
 }
 
+/** Challenger-facing pending outgoing invite (waiting for the opponent to answer). */
+export interface OutgoingInvite {
+  matchId: number | null;
+  targetSession: number;
+  gameType: string;
+  inviteMs?: number;
+}
+
 export interface EndedMatch {
   matchId: number;
+  gameType: string;
   abandoned?: boolean;
   reason?: string;
   winnerId?: number;
@@ -45,7 +88,7 @@ export interface InviteOutcome {
 export interface GameState {
   incomingInvite: IncomingInvite | null;
   activeMatch: ActiveMatch | null;
-  view: DeathrollView | null;
+  view: GameView | null;
   ended: EndedMatch | null;
   lastError: string | null;
   turnDeadline: number | null;
@@ -55,24 +98,32 @@ export interface GameState {
   penalty: boolean;
   /** Challenger-facing result of the last outgoing invite; null when none. */
   inviteOutcome: InviteOutcome | null;
+  /** Challenger-facing pending outgoing invite; null when none is in flight. */
+  outgoingInvite: OutgoingInvite | null;
   /** True after Accept is pressed until the match starts (or the invite ends). */
   accepting: boolean;
   clearInviteOutcome: () => void;
-  invite: (targetSessionId: number) => void;
+  invite: (targetSessionId: number, gameType?: string, options?: gamesApi.InviteOptions) => void;
+  cancelInvite: () => void;
   acceptInvite: () => void;
   declineInvite: () => void;
+  /** Sends a raw game action for the active match (generic across games). */
+  sendAction: (action: Record<string, unknown>) => void;
+  /** Deathroll convenience wrapper around {@link sendAction}. */
   roll: () => void;
   forfeit: () => void;
   dismissEnded: () => void;
   clearError: () => void;
+  /** Clears all game state (e.g. on voice disconnect) without server calls. */
+  reset: () => void;
 }
 
 interface ViewEntry {
   userId: number;
-  view: DeathrollView;
+  view: GameView;
 }
 
-function pickMyView(views: unknown, myUserId: number): DeathrollView | null {
+function pickMyView(views: unknown, myUserId: number): GameView | null {
   if (!Array.isArray(views)) return null;
   const entry = (views as ViewEntry[]).find(v => v.userId === myUserId);
   return entry?.view ?? null;
@@ -88,15 +139,16 @@ function pickMyView(views: unknown, myUserId: number): DeathrollView | null {
 export function useGameState(myUserId: number): GameState {
   const [incomingInvite, setIncomingInvite] = useState<IncomingInvite | null>(null);
   const [activeMatch, setActiveMatch] = useState<ActiveMatch | null>(null);
-  const [view, setView] = useState<DeathrollView | null>(null);
+  const [view, setView] = useState<GameView | null>(null);
   const [ended, setEnded] = useState<EndedMatch | null>(null);
   const [lastError, setLastError] = useState<string | null>(null);
   const [turnDeadline, setTurnDeadline] = useState<number | null>(null);
   const [turnWindowMs, setTurnWindowMs] = useState<number>(DEFAULT_TURN_MS);
   const [penalty, setPenalty] = useState<boolean>(false);
   const [inviteOutcome, setInviteOutcome] = useState<InviteOutcome | null>(null);
+  const [outgoingInvite, setOutgoingInvite] = useState<OutgoingInvite | null>(null);
   const [accepting, setAccepting] = useState<boolean>(false);
-  const outgoingInviteRef = useRef<{ targetSession: number } | null>(null);
+  const outgoingInviteRef = useRef<OutgoingInvite | null>(null);
 
   // Refs so bridge handlers (registered once) can read current values.
   const myUserIdRef = useRef(myUserId);
@@ -105,16 +157,37 @@ export function useGameState(myUserId: number): GameState {
   activeMatchRef.current = activeMatch;
   const incomingInviteRef = useRef<IncomingInvite | null>(incomingInvite);
   incomingInviteRef.current = incomingInvite;
-  const viewRef = useRef<DeathrollView | null>(view);
+  const viewRef = useRef<GameView | null>(view);
   viewRef.current = view;
   const acceptingRef = useRef(accepting);
   acceptingRef.current = accepting;
+
+  // Keeps both the reactive state and the handler-facing ref in sync.
+  const setOutgoing = useCallback((next: OutgoingInvite | null) => {
+    outgoingInviteRef.current = next;
+    setOutgoingInvite(next);
+  }, []);
 
   useEffect(() => {
     const handleInvited = (data: unknown) => {
       const d = data as { matchId?: number; gameType?: string; from?: number; inviteMs?: number };
       if (d.matchId == null || d.from == null) return;
       setIncomingInvite({ matchId: d.matchId, gameType: d.gameType ?? 'deathroll', from: d.from, inviteMs: d.inviteMs });
+    };
+
+    // Challenger side: the server confirms our outgoing invite and supplies its
+    // matchId (which the fire-and-forget WebView invite couldn't return). Fill in
+    // the pending-invite state so the "waiting for opponent" UI and cancel work.
+    const handleInvitePending = (data: unknown) => {
+      const d = data as { matchId?: number; gameType?: string; target?: number; inviteMs?: number };
+      if (d.matchId == null) return;
+      const existing = outgoingInviteRef.current;
+      setOutgoing({
+        matchId: d.matchId,
+        targetSession: d.target ?? existing?.targetSession ?? 0,
+        gameType: d.gameType ?? existing?.gameType ?? 'deathroll',
+        inviteMs: d.inviteMs,
+      });
     };
 
     const handleStarted = (data: unknown) => {
@@ -129,6 +202,7 @@ export function useGameState(myUserId: number): GameState {
       setPenalty(false);
       setTurnDeadline(Date.now() + windowMs);
       outgoingInviteRef.current = null;
+      setOutgoingInvite(null);
       setAccepting(false);
     };
 
@@ -147,19 +221,20 @@ export function useGameState(myUserId: number): GameState {
     };
 
     const handleEnded = (data: unknown) => {
-      const d = data as { matchId?: number; abandoned?: boolean; reason?: string; winnerId?: number };
+      const d = data as { matchId?: number; gameType?: string; abandoned?: boolean; reason?: string; winnerId?: number };
       // Prefer the server-supplied winnerId (authoritative, and correct even for
       // forfeits where the local view has no loserId). Fall back to deriving it
       // from the local view for older servers that omit it.
       let winnerId: number | undefined = d.winnerId;
       if (winnerId == null) {
         const currentView = viewRef.current;
-        if (currentView?.loserId != null) {
+        if (currentView && !isRpsView(currentView) && currentView.loserId != null) {
           winnerId = currentView.players.find(p => p !== currentView.loserId);
         }
       }
       setEnded({
         matchId: d.matchId ?? activeMatchRef.current?.matchId ?? 0,
+        gameType: d.gameType ?? activeMatchRef.current?.gameType ?? 'deathroll',
         abandoned: d.abandoned,
         reason: d.reason,
         winnerId,
@@ -180,7 +255,7 @@ export function useGameState(myUserId: number): GameState {
       // Challenger side: we had an outgoing invite -> show the outcome.
       if (out) {
         setInviteOutcome({ kind, targetSession: out.targetSession });
-        outgoingInviteRef.current = null;
+        setOutgoing(null);
       }
       setActiveMatch(null);
       setTurnDeadline(null);
@@ -209,13 +284,14 @@ export function useGameState(myUserId: number): GameState {
       const isBlocked = d.reason === 'blocked' || /isn't accepting challenges/i.test(msg);
       if (outgoingInviteRef.current && isBlocked) {
         setInviteOutcome({ kind: 'blocked', targetSession: outgoingInviteRef.current.targetSession });
-        outgoingInviteRef.current = null;
+        setOutgoing(null);
         return;
       }
       setLastError(msg);
     };
 
     bridge.on('game.invited', handleInvited);
+    bridge.on('game.invitePending', handleInvitePending);
     bridge.on('game.started', handleStarted);
     bridge.on('game.stateUpdated', handleStateUpdated);
     bridge.on('game.ended', handleEnded);
@@ -226,6 +302,7 @@ export function useGameState(myUserId: number): GameState {
 
     return () => {
       bridge.off('game.invited', handleInvited);
+      bridge.off('game.invitePending', handleInvitePending);
       bridge.off('game.started', handleStarted);
       bridge.off('game.stateUpdated', handleStateUpdated);
       bridge.off('game.ended', handleEnded);
@@ -236,7 +313,7 @@ export function useGameState(myUserId: number): GameState {
     };
   }, []);
 
-  const invite = useCallback((targetSessionId: number) => {
+  const invite = useCallback((targetSessionId: number, gameType: string = 'deathroll', options?: gamesApi.InviteOptions) => {
     // Block starting a new duel while one is already in progress or pending, so a
     // user can't stack challenges (the server enforces this authoritatively too).
     if (activeMatchRef.current) {
@@ -251,9 +328,10 @@ export function useGameState(myUserId: number): GameState {
       setLastError('Respond to your pending challenge first.');
       return;
     }
-    outgoingInviteRef.current = { targetSession: targetSessionId };
+    // Optimistic pending state; the server's game.invitePending fills in the matchId.
+    setOutgoing({ matchId: null, targetSession: targetSessionId, gameType });
     setInviteOutcome(null);
-    gamesApi.invite(targetSessionId, 'deathroll').catch(e => {
+    gamesApi.invite(targetSessionId, gameType, options).catch(e => {
       // A blocked target comes back as a rejected invite; surface it as an outcome.
       // Prefer the server's structured reason code (GameApiError.reason); fall back
       // to matching the message text for older servers.
@@ -261,13 +339,29 @@ export function useGameState(myUserId: number): GameState {
       const reason = e instanceof gamesApi.GameApiError ? e.reason : undefined;
       if (reason === 'blocked' || /isn't accepting challenges/i.test(msg)) {
         setInviteOutcome({ kind: 'blocked', targetSession: outgoingInviteRef.current?.targetSession ?? null });
-        outgoingInviteRef.current = null;
+        setOutgoing(null);
       } else {
         setLastError(msg);
-        outgoingInviteRef.current = null;
+        setOutgoing(null);
       }
     });
-  }, []);
+  }, [setOutgoing]);
+
+  // Cancels a pending outgoing invite. Forfeiting a still-pending match cancels it
+  // server-side (emitting game.expired), which clears our outgoing state via the
+  // existing handler. Requires the matchId from game.invitePending.
+  const cancelInvite = useCallback(() => {
+    const out = outgoingInviteRef.current;
+    if (!out) return;
+    if (out.matchId == null) {
+      // The pending confirmation hasn't arrived yet; just drop the local state.
+      setOutgoing(null);
+      return;
+    }
+    gamesApi.forfeit(out.matchId).catch(e => {
+      setLastError(e instanceof Error ? e.message : 'Failed to cancel invite.');
+    });
+  }, [setOutgoing]);
 
   const acceptInvite = useCallback(() => {
     const inv = incomingInviteRef.current;
@@ -292,13 +386,17 @@ export function useGameState(myUserId: number): GameState {
     });
   }, []);
 
-  const roll = useCallback(() => {
+  const sendAction = useCallback((action: Record<string, unknown>) => {
     const match = activeMatchRef.current;
     if (!match) return;
-    gamesApi.sendAction(match.matchId, { roll: true }).catch(e => {
-      setLastError(e instanceof Error ? e.message : 'Failed to roll.');
+    gamesApi.sendAction(match.matchId, action).catch(e => {
+      setLastError(e instanceof Error ? e.message : 'Failed to send action.');
     });
   }, []);
+
+  const roll = useCallback(() => {
+    sendAction({ roll: true });
+  }, [sendAction]);
 
   const forfeit = useCallback(() => {
     const match = activeMatchRef.current;
@@ -312,6 +410,23 @@ export function useGameState(myUserId: number): GameState {
   const clearError = useCallback(() => setLastError(null), []);
   const clearInviteOutcome = useCallback(() => setInviteOutcome(null), []);
 
+  // Wipes all local game state without any server calls. Used on voice disconnect:
+  // the server tears matches down on its side, so we just clear the UI (pending
+  // invite notification, active modal, errors) rather than leaving stale state that
+  // would produce spurious errors when actions can no longer reach the server.
+  const reset = useCallback(() => {
+    setIncomingInvite(null);
+    setActiveMatch(null);
+    setView(null);
+    setEnded(null);
+    setLastError(null);
+    setTurnDeadline(null);
+    setPenalty(false);
+    setInviteOutcome(null);
+    setAccepting(false);
+    setOutgoing(null);
+  }, [setOutgoing]);
+
   return {
     incomingInvite,
     activeMatch,
@@ -322,14 +437,18 @@ export function useGameState(myUserId: number): GameState {
     turnWindowMs,
     penalty,
     inviteOutcome,
+    outgoingInvite,
     accepting,
     clearInviteOutcome,
     invite,
+    cancelInvite,
     acceptInvite,
     declineInvite,
+    sendAction,
     roll,
     forfeit,
     dismissEnded,
     clearError,
+    reset,
   };
 }

--- a/src/Brmble.Web/src/components/Games/useGameState.ts
+++ b/src/Brmble.Web/src/components/Games/useGameState.ts
@@ -76,6 +76,7 @@ export interface EndedMatch {
   abandoned?: boolean;
   reason?: string;
   winnerId?: number;
+  draw?: boolean;
 }
 
 export type InviteOutcomeKind = 'declined' | 'expired' | 'blocked';
@@ -225,12 +226,12 @@ export function useGameState(myUserId: number): GameState {
     };
 
     const handleEnded = (data: unknown) => {
-      const d = data as { matchId?: number; gameType?: string; abandoned?: boolean; reason?: string; winnerId?: number };
+      const d = data as { matchId?: number; gameType?: string; abandoned?: boolean; reason?: string; winnerId?: number; draw?: boolean };
       // Prefer the server-supplied winnerId (authoritative, and correct even for
       // forfeits where the local view has no loserId). Fall back to deriving it
       // from the local view for older servers that omit it.
       let winnerId: number | undefined = d.winnerId;
-      if (winnerId == null) {
+      if (winnerId == null && !d.draw) {
         const currentView = viewRef.current;
         if (currentView && !isRpsView(currentView) && currentView.loserId != null) {
           winnerId = currentView.players.find(p => p !== currentView.loserId);
@@ -242,6 +243,7 @@ export function useGameState(myUserId: number): GameState {
         abandoned: d.abandoned,
         reason: d.reason,
         winnerId,
+        draw: d.draw,
       });
       setActiveMatch(null);
       setView(null);

--- a/src/Brmble.Web/src/components/Icon/Icon.tsx
+++ b/src/Brmble.Web/src/components/Icon/Icon.tsx
@@ -530,6 +530,37 @@ const iconPaths: Record<string, IconDef> = {
       </>
     ),
   },
+
+  /* rps choice icons — object metaphors, drawn in the shared stroke style */
+  'rps-rock': {
+    paths: (
+      <>
+        <path d="M5 13.5 8 8l4-1 5 2 2 4.5-2 3.5-6 1.5-5-1.5z" />
+        <path d="m8 8 2 3 3-1 3 2" />
+      </>
+    ),
+  },
+  'rps-paper': {
+    paths: (
+      <>
+        <path d="M6 3h8l4 4v14H6z" />
+        <path d="M14 3v4h4" />
+        <path d="M9 12h6" />
+        <path d="M9 16h6" />
+      </>
+    ),
+  },
+  'rps-scissors': {
+    paths: (
+      <>
+        <circle cx="6" cy="6" r="3" />
+        <path d="M8.12 8.12 12 12" />
+        <path d="M20 4 8.12 15.88" />
+        <circle cx="6" cy="18" r="3" />
+        <path d="M14.8 14.8 20 20" />
+      </>
+    ),
+  },
 };
 
 // ── Exported type for autocompletion ──

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
@@ -112,6 +112,13 @@
   filter: drop-shadow(0 0 var(--glow-sm) var(--accent-danger));
 }
 
+.channel-duel-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--accent-primary);
+  margin-left: var(--space-2xs);
+}
+
 .user-count {
   font-size: var(--text-xs);
   color: var(--text-muted);

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -57,6 +57,9 @@ interface ChannelTreeProps {
   onSelectChannel?: (channelId: number) => void;
   onStartDM?: (userId: string, userName: string) => void;
   onChallengeDeathroll?: (session: number) => void;
+  onChallengeRps?: (session: number, bestOf: number) => void;
+  /** Channels with an active/pending duel — shows a swords badge on the row. */
+  duelChannelIds?: Set<number>;
   speakingUsers?: Map<number, boolean>;
   voiceIdle?: Record<number, number>;
   pendingChannelAction?: number | 'leave' | null;
@@ -88,7 +91,7 @@ function getManagedPasswordFromAclBody(body: string): string {
   }
 }
 
-export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, onSelectChannel, onStartDM, onChallengeDeathroll, speakingUsers, voiceIdle, pendingChannelAction, channelUnreads, sharingChannelId, sharingUserSession, onWatchScreenShare, onStopWatching, activeShares, watchingShares, onEditAvatar, onMoveUser }: ChannelTreeProps) {
+export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, onSelectChannel, onStartDM, onChallengeDeathroll, onChallengeRps, duelChannelIds, speakingUsers, voiceIdle, pendingChannelAction, channelUnreads, sharingChannelId, sharingUserSession, onWatchScreenShare, onStopWatching, activeShares, watchingShares, onEditAvatar, onMoveUser }: ChannelTreeProps) {
   const [sortByNamePerChannel, setSortByNamePerChannel] = useState<Record<number, boolean>>({});
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; userId: string; userName: string; isSelf: boolean; channelId?: number } | null>(null);
   const [channelContextMenu, setChannelContextMenu] = useState<{ x: number; y: number; channelId: number; channelName: string } | null>(null);
@@ -383,6 +386,13 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
               </span>
             </Tooltip>
           )}
+          {duelChannelIds?.has(channel.id) && (
+            <Tooltip content="Duel in progress">
+              <span className="channel-duel-icon" aria-label="Duel in progress">
+                <Icon name="swords" size={12} stroke="var(--accent-primary)" />
+              </span>
+            </Tooltip>
+          )}
         </div>
         
         {isExpanded && (
@@ -608,13 +618,13 @@ onClick: () => {
               onClick: () => onStartDM(contextMenu.userId, contextMenu.userName),
             }] : []),
             ...(() => {
-              if (contextMenu.isSelf || !onChallengeDeathroll) return [];
+              if (contextMenu.isSelf || !onChallengeDeathroll || !onChallengeRps) return [];
               const target = users.find(u => u.session === parseInt(contextMenu.userId));
               const eligible = !!target?.isBrmbleClient
                 && contextMenu.channelId != null
                 && contextMenu.channelId === currentChannelId;
               if (!eligible) return [];
-              return [buildChallengeMenuItem(parseInt(contextMenu.userId), onChallengeDeathroll)];
+              return [buildChallengeMenuItem(parseInt(contextMenu.userId), onChallengeDeathroll, onChallengeRps)];
             })(),
             {
               type: 'item' as const,

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -40,6 +40,8 @@ interface SidebarProps {
   onDisconnect?: () => void;
   onStartDM?: (userId: string, userName: string) => void;
   onChallengeDeathroll?: (session: number) => void;
+  onChallengeRps?: (session: number, bestOf: number) => void;
+  duelChannelIds?: Set<number>;
   speakingUsers?: Map<number, boolean>;
   voiceIdle?: Record<number, number>;
   pendingChannelAction?: number | 'leave' | null;
@@ -76,6 +78,8 @@ export function Sidebar({
   onDisconnect,
   onStartDM,
   onChallengeDeathroll,
+  onChallengeRps,
+  duelChannelIds,
   speakingUsers,
   voiceIdle,
   pendingChannelAction,
@@ -443,6 +447,8 @@ export function Sidebar({
           onSelectChannel={onSelectChannel}
           onStartDM={onStartDM}
           onChallengeDeathroll={onChallengeDeathroll}
+          onChallengeRps={onChallengeRps}
+          duelChannelIds={duelChannelIds}
           speakingUsers={speakingUsers}
           voiceIdle={voiceIdle}
           pendingChannelAction={pendingChannelAction}
@@ -471,14 +477,14 @@ export function Sidebar({
               onClick: () => onStartDM(contextMenu.userId, contextMenu.userName),
             }] : []),
             ...(() => {
-              if (contextMenu.isSelf || !onChallengeDeathroll) return [];
+              if (contextMenu.isSelf || !onChallengeDeathroll || !onChallengeRps) return [];
               const target = users.find(u => u.session === parseInt(contextMenu.userId));
               const selfChannelId = users.find(u => u.self)?.channelId;
               const eligible = !!target?.isBrmbleClient
                 && target.channelId != null
                 && target.channelId === selfChannelId;
               if (!eligible) return [];
-              return [buildChallengeMenuItem(parseInt(contextMenu.userId), onChallengeDeathroll)];
+              return [buildChallengeMenuItem(parseInt(contextMenu.userId), onChallengeDeathroll, onChallengeRps)];
             })(),
             {
               type: 'item' as const,

--- a/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.css
+++ b/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.css
@@ -25,6 +25,37 @@
   margin-bottom: var(--space-lg);
 }
 
+.user-info-tabs {
+  display: flex;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-lg);
+}
+
+.user-info-tab {
+  flex: 1;
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition-fast);
+}
+
+.user-info-tab:hover {
+  background: var(--bg-hover);
+}
+
+.user-info-tab.active {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: var(--text-primary);
+}
+
+.user-info-head-to-head {
+  margin-bottom: var(--space-lg);
+}
+
 .user-info-avatar {
   display: flex;
   align-items: center;

--- a/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.css
+++ b/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.css
@@ -12,7 +12,7 @@
 
 .user-info-card {
   padding: var(--space-lg) var(--space-xl) var(--space-lg);
-  width: 340px;
+  width: 380px;
   max-width: 90vw;
   display: flex;
   flex-direction: column;

--- a/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
+++ b/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import bridge from '../../bridge';
 import { Icon } from '../Icon/Icon';
 import Avatar from '../Avatar/Avatar';
+import { HeadToHead } from '../Games/HeadToHead';
 import { parseUserComment } from '../../utils/parseUserComment';
 import './UserInfoDialog.css';
 
@@ -33,8 +34,16 @@ export function UserInfoDialog({
   const [localMuted, setLocalMuted] = useState(false);
   const [editingComment, setEditingComment] = useState(false);
   const [commentDraft, setCommentDraft] = useState(comment || '');
+  // Head-to-head is only meaningful against another player, so the tab bar is only
+  // shown for other users; self view stays single-pane.
+  const [activeTab, setActiveTab] = useState<'info' | 'head-to-head'>('info');
   const parsedComment = parseUserComment(comment);
   const displayComment = parsedComment.text || 'No comment set';
+
+  // Reset to the info tab whenever the dialog opens for a (possibly different) user.
+  useEffect(() => {
+    if (isOpen) setActiveTab('info');
+  }, [isOpen, session]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -163,7 +172,36 @@ export function UserInfoDialog({
           </div>
         </div>
 
-        <div className="user-info-content">
+        {!isSelf && (
+          <div className="user-info-tabs" role="tablist">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'info'}
+              className={`user-info-tab ${activeTab === 'info' ? 'active' : ''}`}
+              onClick={() => setActiveTab('info')}
+            >
+              Info
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'head-to-head'}
+              className={`user-info-tab ${activeTab === 'head-to-head' ? 'active' : ''}`}
+              onClick={() => setActiveTab('head-to-head')}
+            >
+              Head-to-head
+            </button>
+          </div>
+        )}
+
+        {activeTab === 'head-to-head' ? (
+          <div className="user-info-head-to-head">
+            <HeadToHead opponentSession={session} opponentName={userName} />
+          </div>
+        ) : (
+          <>
+            <div className="user-info-content">
           {!isSelf && onStartDM && (
             <button
               className="btn btn-primary user-info-dm-btn"
@@ -230,6 +268,8 @@ export function UserInfoDialog({
             </div>
           )}
         </div>
+          </>
+        )}
 
         <div className="user-info-actions">
           {editingComment && (

--- a/tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs
+++ b/tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs
@@ -40,7 +40,7 @@ public class GameSessionManagerTests
 {
     private static GameSessionManager NewManager(IGamePresence presence, IGameEventPublisher pub, GameRepository repo)
     {
-        var engines = new IGameEngine[] { new DeathrollEngine() };
+        var engines = new IGameEngine[] { new DeathrollEngine(), new RpsEngine() };
         return new GameSessionManager(engines, new HalvingRandom(), presence, pub, repo);
     }
 
@@ -51,6 +51,21 @@ public class GameSessionManagerTests
         sent.Where(s => s.msg.GetType().GetProperty("type")?.GetValue(s.msg) as string == "game.feed")
             .Select(s => s.msg.GetType().GetProperty("text")?.GetValue(s.msg) as string ?? "")
             .ToList();
+
+    [TestMethod]
+    public async Task Invite_NotifiesInviter_WithPendingEvent()
+    {
+        var presence = new FakePresence();
+        presence.Users[10] = (1, true, 10);
+        presence.Users[20] = (1, true, 20);
+        var pub = new FakePublisher();
+        var mgr = NewManager(presence, pub, GameTestHelpers.NewRepo());
+
+        await mgr.InviteAsync(10, 20, "deathroll");
+
+        Assert.IsTrue(SentType(pub.Sent, "game.invited"), "target should be invited");
+        Assert.IsTrue(SentType(pub.Sent, "game.invitePending"), "inviter should get a pending event");
+    }
 
     [TestMethod]
     public async Task ExplicitDecline_EmitsGameDeclined()
@@ -260,6 +275,63 @@ public class GameSessionManagerTests
         // The invite is still pending, so the real target can accept it.
         await mgr.RespondAsync(invite.MatchId, targetSession: 20, accept: true);
         Assert.IsTrue(mgr.IsMatchLive(invite.MatchId));
+    }
+
+    [TestMethod]
+    public async Task Rps_SimultaneousMatch_PlaysToCompletion_PersistsAndFeeds()
+    {
+        var presence = new FakePresence();
+        presence.Users[10] = (1, true, 10);
+        presence.Users[20] = (1, true, 20);
+        var repo = GameTestHelpers.NewRepo();
+        var pub = new FakePublisher();
+        var mgr = NewManager(presence, pub, repo);
+
+        var invite = await mgr.InviteAsync(10, 20, "rps",
+            new Dictionary<string, object?> { ["bestOf"] = 3 });
+        Assert.IsTrue(invite.Success);
+        await mgr.RespondAsync(invite.MatchId, targetSession: 20, accept: true);
+
+        // Both players commit each round; session 10 (rock) always beats 20 (scissors),
+        // so 10 takes the best-of-3 in two decisive rounds.
+        for (var round = 0; round < 2 && mgr.IsMatchLive(invite.MatchId); round++)
+        {
+            await mgr.ActionAsync(invite.MatchId, 10, new Dictionary<string, object?> { ["pick"] = "rock" });
+            await mgr.ActionAsync(invite.MatchId, 20, new Dictionary<string, object?> { ["pick"] = "scissors" });
+        }
+
+        Assert.IsFalse(mgr.IsMatchLive(invite.MatchId), "match should be decided after two rounds");
+
+        var feed = FeedTexts(pub.Sent);
+        Assert.IsTrue(feed.Any(t => t.Contains("started")), "expected a start feed line");
+        Assert.IsTrue(feed.Any(t => t.StartsWith("✊")), "expected round feed lines");
+        Assert.AreEqual(1, feed.Count(t => t.StartsWith("🏆")), "expected one terminal feed line");
+
+        var s10 = await repo.GetUserStatsAsync(10, "rps");
+        var s20 = await repo.GetUserStatsAsync(20, "rps");
+        Assert.AreEqual(1, s10.GamesPlayed);
+        Assert.AreEqual(1, s20.GamesPlayed);
+        Assert.AreEqual(1, s10.Wins);
+        Assert.AreEqual(0, s20.Wins);
+    }
+
+    [TestMethod]
+    public async Task Invite_RejectsSecondDuelInSameChannel_WithChannelBusyReason()
+    {
+        var presence = new FakePresence();
+        presence.Users[10] = (1, true, 10);
+        presence.Users[20] = (1, true, 20);
+        presence.Users[30] = (1, true, 30);
+        presence.Users[40] = (1, true, 40);
+        var mgr = NewManager(presence, new FakePublisher(), GameTestHelpers.NewRepo());
+
+        // A pending invite already occupies the channel's single duel slot.
+        var first = await mgr.InviteAsync(10, 20, "deathroll");
+        Assert.IsTrue(first.Success);
+
+        var second = await mgr.InviteAsync(30, 40, "deathroll");
+        Assert.IsFalse(second.Success);
+        Assert.AreEqual(InviteRejectReason.ChannelBusy, second.Reason);
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs
+++ b/tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs
@@ -66,6 +66,14 @@ public class GameSessionManagerTests
             .Select(s => (bool)(s.msg.GetType().GetProperty("active")?.GetValue(s.msg) ?? false))
             .ToList();
 
+    // The `turnStarted` flag of the most recent game.stateUpdated, or null if none.
+    private static bool? LastTurnStarted(IEnumerable<(string kind, object msg)> sent)
+    {
+        var upd = sent.LastOrDefault(s => s.msg.GetType().GetProperty("type")?.GetValue(s.msg) as string == "game.stateUpdated");
+        if (upd.msg is null) return null;
+        return upd.msg.GetType().GetProperty("turnStarted")?.GetValue(upd.msg) as bool?;
+    }
+
     [TestMethod]
     public async Task Invite_NotifiesInviter_WithPendingEvent()
     {
@@ -421,6 +429,31 @@ public class GameSessionManagerTests
         using var conn = db.CreateConnection();
         var matches = await conn.QuerySingleAsync<long>("SELECT COUNT(*) FROM game_matches");
         Assert.AreEqual(0, matches, "a cancelled pending invite must not be persisted");
+    }
+
+    [TestMethod]
+    public async Task Rps_FirstPickDoesNotRestartSharedWindow()
+    {
+        var presence = new FakePresence();
+        presence.Users[10] = (1, true, 10);
+        presence.Users[20] = (1, true, 20);
+        var pub = new FakePublisher();
+        var mgr = NewManager(presence, pub, GameTestHelpers.NewRepo());
+
+        var invite = await mgr.InviteAsync(10, 20, "rps",
+            new Dictionary<string, object?> { ["bestOf"] = 3 });
+        await mgr.RespondAsync(invite.MatchId, targetSession: 20, accept: true);
+
+        // First player commits — the shared 15s window must NOT restart, so the
+        // opponent keeps their remaining time instead of getting a fresh 15s.
+        await mgr.ActionAsync(invite.MatchId, 10, new Dictionary<string, object?> { ["pick"] = "rock" });
+        Assert.AreEqual(false, LastTurnStarted(pub.Sent),
+            "first pick in a simultaneous round must not restart the commit window");
+
+        // Second player commits — the round resolves and the next window opens.
+        await mgr.ActionAsync(invite.MatchId, 20, new Dictionary<string, object?> { ["pick"] = "scissors" });
+        Assert.AreEqual(true, LastTurnStarted(pub.Sent),
+            "resolving the round starts a fresh commit window");
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs
+++ b/tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs
@@ -52,6 +52,12 @@ public class GameSessionManagerTests
             .Select(s => s.msg.GetType().GetProperty("text")?.GetValue(s.msg) as string ?? "")
             .ToList();
 
+    // The `active` flag of every game.duelState published to a channel, in order.
+    private static List<bool> DuelStates(IEnumerable<(string kind, object msg)> sent) =>
+        sent.Where(s => s.msg.GetType().GetProperty("type")?.GetValue(s.msg) as string == "game.duelState")
+            .Select(s => (bool)(s.msg.GetType().GetProperty("active")?.GetValue(s.msg) ?? false))
+            .ToList();
+
     [TestMethod]
     public async Task Invite_NotifiesInviter_WithPendingEvent()
     {
@@ -97,6 +103,57 @@ public class GameSessionManagerTests
 
         Assert.IsTrue(SentType(pub.Sent, "game.expired"));
         Assert.IsFalse(SentType(pub.Sent, "game.declined"));
+    }
+
+    [TestMethod]
+    public async Task Invite_MarksChannelBusy_WithActiveDuelState()
+    {
+        var presence = new FakePresence();
+        presence.Users[10] = (1, true, 10);
+        presence.Users[20] = (1, true, 20);
+        var pub = new FakePublisher();
+        var mgr = NewManager(presence, pub, GameTestHelpers.NewRepo());
+
+        await mgr.InviteAsync(10, 20, "deathroll");
+
+        var states = DuelStates(pub.Sent);
+        Assert.IsTrue(states.Count > 0, "invite should publish a duelState");
+        Assert.IsTrue(states[0], "a pending invite should mark the channel busy (active: true)");
+    }
+
+    [TestMethod]
+    public async Task Decline_ClearsChannelBusy_WithInactiveDuelState()
+    {
+        var presence = new FakePresence();
+        presence.Users[10] = (1, true, 10);
+        presence.Users[20] = (1, true, 20);
+        var pub = new FakePublisher();
+        var mgr = NewManager(presence, pub, GameTestHelpers.NewRepo());
+
+        var invite = await mgr.InviteAsync(10, 20, "deathroll");
+        await mgr.RespondAsync(invite.MatchId, targetSession: 20, accept: false);
+
+        var states = DuelStates(pub.Sent);
+        Assert.IsTrue(states.Count >= 2, "invite then decline should publish two duelStates");
+        Assert.IsTrue(states.First(), "invite marks the channel busy");
+        Assert.IsFalse(states.Last(), "decline clears the channel-busy badge (active: false)");
+    }
+
+    [TestMethod]
+    public async Task InviteExpiry_ClearsChannelBusy_WithInactiveDuelState()
+    {
+        var presence = new FakePresence();
+        presence.Users[10] = (1, true, 10);
+        presence.Users[20] = (1, true, 20);
+        var pub = new FakePublisher();
+        var mgr = NewManager(presence, pub, GameTestHelpers.NewRepo());
+
+        var invite = await mgr.InviteAsync(10, 20, "deathroll");
+        await mgr.ExpireInviteForTestAsync(invite.MatchId);
+
+        var states = DuelStates(pub.Sent);
+        Assert.IsTrue(states.First(), "invite marks the channel busy");
+        Assert.IsFalse(states.Last(), "expiry clears the channel-busy badge (active: false)");
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs
+++ b/tests/Brmble.Server.Tests/Games/GameSessionManagerTests.cs
@@ -52,6 +52,14 @@ public class GameSessionManagerTests
             .Select(s => s.msg.GetType().GetProperty("text")?.GetValue(s.msg) as string ?? "")
             .ToList();
 
+    // The `draw` flag of a game.ended message, or null if none was sent.
+    private static bool? EndedDraw(IEnumerable<(string kind, object msg)> sent)
+    {
+        var ended = sent.LastOrDefault(s => s.msg.GetType().GetProperty("type")?.GetValue(s.msg) as string == "game.ended");
+        if (ended.msg is null) return null;
+        return ended.msg.GetType().GetProperty("draw")?.GetValue(ended.msg) as bool?;
+    }
+
     // The `active` flag of every game.duelState published to a channel, in order.
     private static List<bool> DuelStates(IEnumerable<(string kind, object msg)> sent) =>
         sent.Where(s => s.msg.GetType().GetProperty("type")?.GetValue(s.msg) as string == "game.duelState")
@@ -413,5 +421,34 @@ public class GameSessionManagerTests
         using var conn = db.CreateConnection();
         var matches = await conn.QuerySingleAsync<long>("SELECT COUNT(*) FROM game_matches");
         Assert.AreEqual(0, matches, "a cancelled pending invite must not be persisted");
+    }
+
+    [TestMethod]
+    public async Task Rps_BothIdleTwice_EndsAsDraw_PersistsAndFlags()
+    {
+        var presence = new FakePresence();
+        presence.Users[10] = (1, true, 10);
+        presence.Users[20] = (1, true, 20);
+        var repo = GameTestHelpers.NewRepo();
+        var pub = new FakePublisher();
+        var mgr = NewManager(presence, pub, repo);
+
+        var invite = await mgr.InviteAsync(10, 20, "rps",
+            new Dictionary<string, object?> { ["bestOf"] = 3 });
+        await mgr.RespondAsync(invite.MatchId, targetSession: 20, accept: true);
+
+        // Both players go AFK for two consecutive rounds.
+        await mgr.FireTurnTimeoutForTestAsync(invite.MatchId);
+        await mgr.FireTurnTimeoutForTestAsync(invite.MatchId);
+
+        Assert.IsTrue(SentType(pub.Sent, "game.ended"), "match should end");
+        Assert.AreEqual(true, EndedDraw(pub.Sent), "game.ended should carry draw: true");
+
+        var s10 = await repo.GetUserStatsAsync(10, "rps");
+        var s20 = await repo.GetUserStatsAsync(20, "rps");
+        Assert.AreEqual(1, s10.Draws, "player 10 records a draw");
+        Assert.AreEqual(1, s20.Draws, "player 20 records a draw");
+        Assert.AreEqual(0, s10.Wins);
+        Assert.AreEqual(0, s20.Wins);
     }
 }

--- a/tests/Brmble.Server.Tests/Games/GameStatsServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Games/GameStatsServiceTests.cs
@@ -41,4 +41,59 @@ public class GameStatsServiceTests
         Assert.AreEqual(1, all.Wins);
         Assert.AreEqual(1, all.Losses);
     }
+
+    [TestMethod]
+    public async Task HeadToHead_AggregatesAcrossGames_FromSelfPerspective()
+    {
+        var db = NewDb();
+        var repo = new GameRepository(db);
+        var stats = new GameStatsService(db);
+        var now = DateTimeOffset.UtcNow;
+
+        // deathroll: 10 beats 20
+        await repo.SaveCompletedMatchAsync(new CompletedMatch("deathroll", 1, "1v1", "decided", null,
+            now, now.AddSeconds(10),
+            new[] { new CompletedParticipant(10, 1, 3, "win"), new CompletedParticipant(20, 2, 1, "loss") }));
+        // deathroll: 20 beats 10
+        await repo.SaveCompletedMatchAsync(new CompletedMatch("deathroll", 1, "1v1", "decided", null,
+            now, now.AddSeconds(10),
+            new[] { new CompletedParticipant(10, 2, 1, "loss"), new CompletedParticipant(20, 1, 5, "win") }));
+        // rps: 10 beats 20
+        await repo.SaveCompletedMatchAsync(new CompletedMatch("rps", 1, "bo3", "decided", null,
+            now, now.AddSeconds(10),
+            new[] { new CompletedParticipant(10, 1, 2, "win"), new CompletedParticipant(20, 2, 0, "loss") }));
+
+        // From 10's perspective: 2 wins (1 deathroll + 1 rps), 1 loss.
+        var self10 = await stats.GetHeadToHeadAsync(10, 20);
+        Assert.AreEqual(2, self10.Wins);
+        Assert.AreEqual(1, self10.Losses);
+        Assert.AreEqual(0, self10.Draws);
+        Assert.AreEqual(2, self10.Games.Count);
+        var dr10 = self10.Games.Single(g => g.GameType == "deathroll");
+        Assert.AreEqual(1, dr10.Wins);
+        Assert.AreEqual(1, dr10.Losses);
+        var rps10 = self10.Games.Single(g => g.GameType == "rps");
+        Assert.AreEqual(1, rps10.Wins);
+        Assert.AreEqual(0, rps10.Losses);
+
+        // From 20's perspective the record is mirrored: 1 win, 2 losses.
+        var self20 = await stats.GetHeadToHeadAsync(20, 10);
+        Assert.AreEqual(1, self20.Wins);
+        Assert.AreEqual(2, self20.Losses);
+    }
+
+    [TestMethod]
+    public async Task HeadToHead_NoMatches_ReturnsEmpty()
+    {
+        var db = NewDb();
+        var stats = new GameStatsService(db);
+
+        var h2h = await stats.GetHeadToHeadAsync(88, 99);
+
+        Assert.AreEqual(0, h2h.Wins);
+        Assert.AreEqual(0, h2h.Losses);
+        Assert.AreEqual(0, h2h.Draws);
+        Assert.AreEqual(0, h2h.GamesPlayed);
+        Assert.AreEqual(0, h2h.Games.Count);
+    }
 }

--- a/tests/Brmble.Server.Tests/Games/RpsEngineTests.cs
+++ b/tests/Brmble.Server.Tests/Games/RpsEngineTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Brmble.Server.Games;
+using Brmble.Server.Games.Engines;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.Games;
+
+file sealed class NoRandom : IRandomSource
+{
+    public int Roll(int maxInclusive) => maxInclusive;
+}
+
+[TestClass]
+public class RpsEngineTests
+{
+    private static readonly IReadOnlyList<GamePlayer> Players = new[] { new GamePlayer(10), new GamePlayer(20) };
+    private static readonly IRandomSource Rng = new NoRandom();
+
+    private static object NewState(int bestOf = 3)
+    {
+        var engine = new RpsEngine();
+        return engine.InitialState(Players, Rng, new Dictionary<string, object?> { ["bestOf"] = bestOf });
+    }
+
+    private static Dictionary<string, object?> Pick(string p) => new() { ["pick"] = p };
+
+    [TestMethod]
+    public void BothMustCommitBeforeRoundResolves()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        Assert.IsTrue(engine.IsUsersTurn(state, 10));
+        Assert.IsTrue(engine.IsUsersTurn(state, 20));
+        var ev = engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        Assert.IsFalse(ev.Any(e => e.Kind == "roundResult"));
+        Assert.IsFalse(engine.IsUsersTurn(state, 10)); // already picked
+        Assert.IsTrue(engine.IsUsersTurn(state, 20));
+        Assert.IsInstanceOfType(engine.GetOutcome(state), typeof(GameOutcome.InProgress));
+    }
+
+    [TestMethod]
+    public void RockBeatsScissors()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        var ev = engine.ApplyAction(state, 20, Pick("scissors"), Rng);
+        var result = ev.Single(e => e.Kind == "roundResult");
+        Assert.AreEqual(10L, Convert.ToInt64(result.Data["winnerId"]));
+        Assert.IsFalse((bool)result.Data["tie"]);
+    }
+
+    [TestMethod]
+    public void SamePickTiesAndReplaysWithoutCredit()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        engine.ApplyAction(state, 10, Pick("paper"), Rng);
+        var ev = engine.ApplyAction(state, 20, Pick("paper"), Rng);
+        var result = ev.Single(e => e.Kind == "roundResult");
+        Assert.IsTrue((bool)result.Data["tie"]);
+        Assert.AreEqual(0, Convert.ToInt32(result.Data["wins0"]));
+        Assert.AreEqual(0, Convert.ToInt32(result.Data["wins1"]));
+        Assert.IsInstanceOfType(engine.GetOutcome(state), typeof(GameOutcome.InProgress));
+        // Both should be able to pick again.
+        Assert.IsTrue(engine.IsUsersTurn(state, 10));
+        Assert.IsTrue(engine.IsUsersTurn(state, 20));
+    }
+
+    [TestMethod]
+    public void FirstToMajorityWinsBestOfThree()
+    {
+        var engine = new RpsEngine();
+        var state = NewState(bestOf: 3);
+        // 10 wins round 1 (rock>scissors)
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        engine.ApplyAction(state, 20, Pick("scissors"), Rng);
+        Assert.IsInstanceOfType(engine.GetOutcome(state), typeof(GameOutcome.InProgress));
+        // 10 wins round 2 (paper>rock) -> reaches 2 wins
+        engine.ApplyAction(state, 10, Pick("paper"), Rng);
+        engine.ApplyAction(state, 20, Pick("rock"), Rng);
+
+        var raw = engine.GetOutcome(state);
+        Assert.IsInstanceOfType(raw, typeof(GameOutcome.Finished));
+        var outcome = (GameOutcome.Finished)raw;
+        var winner = outcome.Participants.Single(p => p.Result == "win");
+        Assert.AreEqual(10L, winner.UserId);
+        Assert.AreEqual(2, winner.Score);
+        Assert.AreEqual(0, outcome.Participants.Single(p => p.Result == "loss").Score);
+    }
+
+    [TestMethod]
+    public void TimeoutWithOneCommitterGivesThemTheRound()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        var ev = engine.ApplyTimeoutPenalty(state, Rng);
+        var result = ev.Single(e => e.Kind == "roundResult");
+        Assert.AreEqual(10L, Convert.ToInt64(result.Data["winnerId"]));
+        Assert.IsTrue((bool)result.Data["timeout"]);
+    }
+
+    [TestMethod]
+    public void TimeoutWithBothIdleIsDrawAndReplays()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        var ev = engine.ApplyTimeoutPenalty(state, Rng);
+        var result = ev.Single(e => e.Kind == "roundResult");
+        Assert.IsTrue((bool)result.Data["tie"]);
+        Assert.IsInstanceOfType(engine.GetOutcome(state), typeof(GameOutcome.InProgress));
+    }
+
+    [TestMethod]
+    public void PublicViewHidesOpponentPickUntilResolved()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+
+        var view20 = engine.PublicView(state, 20);
+        // Opponent (10) has picked, but 20 must not see the actual pick, only the flag.
+        Assert.AreEqual(true, GetProp(view20, "opponentPicked"));
+        Assert.IsNull(GetProp(view20, "myPick"));
+
+        var view10 = engine.PublicView(state, 10);
+        Assert.AreEqual("rock", GetProp(view10, "myPick"));
+        Assert.AreEqual(false, GetProp(view10, "opponentPicked"));
+    }
+
+    [TestMethod]
+    public void CapturesFormatAndThrowStats()
+    {
+        var engine = new RpsEngine();
+        var state = NewState(bestOf: 5);
+        Assert.AreEqual("bo5", engine.MatchFormat(state));
+
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        engine.ApplyAction(state, 20, Pick("scissors"), Rng);
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        engine.ApplyAction(state, 20, Pick("paper"), Rng);
+
+        var p10 = engine.ParticipantStats(state, 10)!;
+        Assert.AreEqual(2, GetInt(p10, "rock"));
+        Assert.AreEqual("rock", GetProp(p10, "favoriteThrow"));
+    }
+
+    [TestMethod]
+    public void InvalidPickRejected()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        Assert.ThrowsException<InvalidGameActionException>(() =>
+            engine.ApplyAction(state, 10, Pick("lizard"), Rng));
+    }
+
+    [TestMethod]
+    public void CannotPickTwiceInSameRound()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        Assert.ThrowsException<InvalidGameActionException>(() =>
+            engine.ApplyAction(state, 10, Pick("paper"), Rng));
+    }
+
+    [TestMethod]
+    public void InvalidBestOfFallsBackToThree()
+    {
+        var engine = new RpsEngine();
+        var state = engine.InitialState(Players, Rng, new Dictionary<string, object?> { ["bestOf"] = 4 });
+        Assert.AreEqual("bo3", engine.MatchFormat(state));
+    }
+
+    private static object? GetProp(object o, string name)
+        => o.GetType().GetProperty(name)!.GetValue(o);
+    private static int GetInt(object o, string name)
+        => Convert.ToInt32(o.GetType().GetProperty(name)!.GetValue(o));
+}

--- a/tests/Brmble.Server.Tests/Games/RpsEngineTests.cs
+++ b/tests/Brmble.Server.Tests/Games/RpsEngineTests.cs
@@ -246,6 +246,28 @@ public class RpsEngineTests
         Assert.IsFalse(line!.Contains("picked none"));
     }
 
+    [TestMethod]
+    public void ResolutionSeqAdvancesOnEveryRoundIncludingTies()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+
+        // First resolution is a tie — the decisive RoundNumber stays at 1.
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        engine.ApplyAction(state, 20, Pick("rock"), Rng);
+        var tieLast = GetProp(engine.PublicView(state, 10), "lastRound")!;
+        Assert.AreEqual(1, GetProp(tieLast, "roundNumber"));
+        Assert.AreEqual(1, GetProp(tieLast, "seq"));
+
+        // Next resolution reuses roundNumber 1 (ties don't advance it) but seq must
+        // advance to 2 so the client still reveals the round after a tie/draw.
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        engine.ApplyAction(state, 20, Pick("scissors"), Rng);
+        var winLast = GetProp(engine.PublicView(state, 10), "lastRound")!;
+        Assert.AreEqual(1, GetProp(winLast, "roundNumber"));
+        Assert.AreEqual(2, GetProp(winLast, "seq"));
+    }
+
     private static object? GetProp(object o, string name)
         => o.GetType().GetProperty(name)!.GetValue(o);
     private static int GetInt(object o, string name)

--- a/tests/Brmble.Server.Tests/Games/RpsEngineTests.cs
+++ b/tests/Brmble.Server.Tests/Games/RpsEngineTests.cs
@@ -175,6 +175,52 @@ public class RpsEngineTests
         Assert.AreEqual("bo3", engine.MatchFormat(state));
     }
 
+    [TestMethod]
+    public void TwoConsecutiveBothIdleTimeoutsEndsInDraw()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+
+        engine.ApplyTimeoutPenalty(state, Rng); // 1st both-idle: replay
+        Assert.IsInstanceOfType(engine.GetOutcome(state), typeof(GameOutcome.InProgress));
+
+        engine.ApplyTimeoutPenalty(state, Rng); // 2nd consecutive both-idle: draw
+        var raw = engine.GetOutcome(state);
+        Assert.IsInstanceOfType(raw, typeof(GameOutcome.Finished));
+        var outcome = (GameOutcome.Finished)raw;
+        Assert.IsTrue(outcome.Participants.All(p => p.Result == "draw"));
+        Assert.AreEqual(2, outcome.Participants.Count);
+    }
+
+    [TestMethod]
+    public void APickBetweenIdleTimeoutsResetsTheDrawStreak()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+
+        engine.ApplyTimeoutPenalty(state, Rng); // 1st both-idle
+
+        // A decisive round happens (10 beats 20) — resets the streak.
+        engine.ApplyAction(state, 10, Pick("rock"), Rng);
+        engine.ApplyAction(state, 20, Pick("scissors"), Rng);
+
+        engine.ApplyTimeoutPenalty(state, Rng); // both-idle again, but streak was reset
+        Assert.IsInstanceOfType(engine.GetOutcome(state), typeof(GameOutcome.InProgress),
+            "a pick between idle rounds must reset the streak so no premature draw");
+    }
+
+    [TestMethod]
+    public void DrawEmitsEndFeedLine()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        engine.ApplyTimeoutPenalty(state, Rng);
+        engine.ApplyTimeoutPenalty(state, Rng);
+        var line = engine.EndFeedLine(state, id => $"user{id}");
+        Assert.IsNotNull(line);
+        StringAssert.Contains(line, "draw");
+    }
+
     private static object? GetProp(object o, string name)
         => o.GetType().GetProperty(name)!.GetValue(o);
     private static int GetInt(object o, string name)

--- a/tests/Brmble.Server.Tests/Games/RpsEngineTests.cs
+++ b/tests/Brmble.Server.Tests/Games/RpsEngineTests.cs
@@ -221,6 +221,31 @@ public class RpsEngineTests
         StringAssert.Contains(line, "draw");
     }
 
+    [TestMethod]
+    public void IdlePlayersRevealAsNoneNotADefaultThrow()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        engine.ApplyTimeoutPenalty(state, Rng); // both idle
+        var view = engine.PublicView(state, 10);
+        var last = GetProp(view, "lastRound")!;
+        Assert.AreEqual("none", GetProp(last, "pick0"));
+        Assert.AreEqual("none", GetProp(last, "pick1"));
+    }
+
+    [TestMethod]
+    public void BothIdleTieFeedLineSaysIdledNotPickedNone()
+    {
+        var engine = new RpsEngine();
+        var state = NewState();
+        var ev = engine.ApplyTimeoutPenalty(state, Rng);
+        var result = ev.Single(e => e.Kind == "roundResult");
+        var line = engine.EventFeedLine(result, id => $"user{id}");
+        Assert.IsNotNull(line);
+        StringAssert.Contains(line, "idled");
+        Assert.IsFalse(line!.Contains("picked none"));
+    }
+
     private static object? GetProp(object o, string name)
         => o.GetType().GetProperty(name)!.GetValue(o);
     private static int GetInt(object o, string name)


### PR DESCRIPTION
## Summary
Adds a full **Rock Paper Scissors** minigame with server-authoritative gameplay, **head-to-head stats**, and hardening for edge cases surfaced during two-client testing.

## Features
- **Rock Paper Scissors minigame** — server-authoritative `RpsEngine` (simultaneous-commit, 15s turn timer, best-of series), `RpsModal` UI with distinct ✊✋✌️ pick buttons and a 3-2-1 reveal countdown, winning-throw glyphs on feed lines.
- **Head-to-Head stats** — `GameStatsService` + `HeadToHead` component showing per-pairing win/loss/draw records in the user info dialog.
- **Pending-duel channel badge** — channel shows a duel badge while an invite is pending.
- **Mutual-AFK draw** — idle matches end as a real persisted draw after 2 consecutive both-idle rounds (previously looped forever, holding the channel's duel slot). Counted in stats with a draw end-state.
- **Auto-decline unsupported game invites** — client refuses invites for game types it doesn't support instead of rendering the wrong modal.

## Fixes (from two-client testing)
- Idle picks show **None** instead of a default Rock.
- H2H per-game record stays on one line; wider user info card.
- Shared 15s commit window no longer resets when the first player picks.
- Reveal 3-2-1 countdown now shows after a tie/draw round.

## Tests
- New `RpsEngineTests.cs`; expanded `GameSessionManagerTests.cs` and `GameStatsServiceTests.cs`.
- Server suite green; frontend builds clean.

## Manual testing status
Verified with two clients: core RPS gameplay, idle/None, mutual-AFK draw, shared-window timing, reveal countdown after ties, forfeit-on-leave/disconnect.
**Not yet manually verified** (covered by design + tests): unsupported-game auto-decline, one-duel-per-channel limit.

## Docs
Design + plan under `docs/superpowers/`; `UI_GUIDE.md` updated for new game UI patterns.