### PR TITLE
fix: serialize WebSocket sends and close snapshot registration race

### DIFF
--- a/src/Brmble.Server/Events/BrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/BrmbleEventBus.cs
@@ -80,17 +80,27 @@ public class BrmbleEventBus : IBrmbleEventBus
         Task initial = Task.CompletedTask;
         if (initialMessage is not null)
         {
-            var json = JsonSerializer.Serialize(initialMessage(), JsonOptions);
-            var bytes = new ArraySegment<byte>(Encoding.UTF8.GetBytes(json));
-            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
-            lock (delivery.Gate)
+            try
             {
-                delivery.Queue.Enqueue(new QueuedMessage(bytes, completion));
-                delivery.Draining = true;
-            }
+                var json = JsonSerializer.Serialize(initialMessage(), JsonOptions);
+                var bytes = new ArraySegment<byte>(Encoding.UTF8.GetBytes(json));
+                var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            initial = completion.Task;
+                lock (delivery.Gate)
+                {
+                    delivery.Queue.Enqueue(new QueuedMessage(bytes, completion));
+                    delivery.Draining = true;
+                }
+
+                initial = completion.Task;
+            }
+            catch
+            {
+                // The client was never published to _clients, so RemoveClient will never run
+                // for it. Drop the delivery here or it leaks for the lifetime of the process.
+                _deliveries.TryRemove(ws, out _);
+                throw;
+            }
         }
 
         _clients[ws] = userId;

--- a/src/Brmble.Server/Events/BrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/BrmbleEventBus.cs
@@ -8,10 +8,26 @@ namespace Brmble.Server.Events;
 public class BrmbleEventBus : IBrmbleEventBus
 {
     private readonly ConcurrentDictionary<WebSocket, long> _clients = new();
+    private readonly ConcurrentDictionary<WebSocket, SocketDelivery> _deliveries = new();
     private readonly ILogger<BrmbleEventBus> _logger;
     private readonly IChannelMembershipService _channelMembership;
     private readonly ISessionMappingService _sessionMapping;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    private sealed record QueuedMessage(ArraySegment<byte> Bytes, TaskCompletionSource Completion);
+
+    /// <summary>
+    /// Per-socket send queue. <see cref="WebSocket.SendAsync"/> permits only one
+    /// outstanding call per socket, so every send is funnelled through a single
+    /// drain loop guarded by <see cref="Gate"/>.
+    /// </summary>
+    private sealed class SocketDelivery
+    {
+        public object Gate { get; } = new();
+        public Queue<QueuedMessage> Queue { get; } = new();
+        public bool Draining { get; set; }
+        public Exception? Failure { get; set; }
+    }
 
     public BrmbleEventBus(
         ILogger<BrmbleEventBus> logger,
@@ -23,9 +39,67 @@ public class BrmbleEventBus : IBrmbleEventBus
         _sessionMapping = sessionMapping;
     }
 
-    public void AddClient(WebSocket ws, long userId) => _clients[ws] = userId;
+    public void RemoveClient(WebSocket ws)
+    {
+        _clients.TryRemove(ws, out _);
+        if (!_deliveries.TryRemove(ws, out var delivery))
+            return;
 
-    public void RemoveClient(WebSocket ws) => _clients.TryRemove(ws, out _);
+        lock (delivery.Gate)
+        {
+            FailDeliveryLocked(delivery, new WebSocketException("WebSocket client is no longer connected."));
+        }
+    }
+
+    /// <summary>
+    /// Releases everything still queued for a socket. Callers awaiting those sends are
+    /// faulted rather than left waiting on a socket that will never drain. The send
+    /// already in flight is not tracked here and completes on its own.
+    /// </summary>
+    private static void FailDeliveryLocked(SocketDelivery delivery, Exception failure)
+    {
+        delivery.Failure ??= failure;
+        while (delivery.Queue.Count > 0)
+            delivery.Queue.Dequeue().Completion.TrySetException(delivery.Failure);
+        delivery.Draining = false;
+    }
+
+    /// <summary>
+    /// Registers a client, optionally queuing an initial payload as part of the same step.
+    /// The payload is enqueued before the socket is published to <see cref="_clients"/>, so
+    /// any broadcast that can observe the client is necessarily queued behind it. Registering
+    /// and sending separately would let a broadcast overtake the payload it amends, which is
+    /// why this is the only way to add a client. Returns a task that completes once the
+    /// initial payload has been written, or a completed task when there is none.
+    /// </summary>
+    public Task AddClientAsync(WebSocket ws, long userId, Func<object>? initialMessage = null)
+    {
+        var delivery = new SocketDelivery();
+        _deliveries[ws] = delivery;
+
+        Task initial = Task.CompletedTask;
+        if (initialMessage is not null)
+        {
+            var json = JsonSerializer.Serialize(initialMessage(), JsonOptions);
+            var bytes = new ArraySegment<byte>(Encoding.UTF8.GetBytes(json));
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            lock (delivery.Gate)
+            {
+                delivery.Queue.Enqueue(new QueuedMessage(bytes, completion));
+                delivery.Draining = true;
+            }
+
+            initial = completion.Task;
+        }
+
+        _clients[ws] = userId;
+
+        if (initialMessage is not null)
+            _ = DrainSocketAsync(ws, delivery);
+
+        return initial;
+    }
 
     public bool HasConnectedClient(long userId) => _clients.Values.Any(id => id == userId);
 
@@ -40,8 +114,7 @@ public class BrmbleEventBus : IBrmbleEventBus
             {
                 if (ws.State == WebSocketState.Open)
                 {
-                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                    await ws.SendAsync(bytes, WebSocketMessageType.Text, true, cts.Token);
+                    await QueueSendAsync(ws, bytes);
                 }
                 else
                 {
@@ -79,8 +152,7 @@ public class BrmbleEventBus : IBrmbleEventBus
             {
                 if (ws.State == WebSocketState.Open)
                 {
-                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                    await ws.SendAsync(bytes, WebSocketMessageType.Text, true, cts.Token);
+                    await QueueSendAsync(ws, bytes);
                 }
                 else
                 {
@@ -115,8 +187,7 @@ public class BrmbleEventBus : IBrmbleEventBus
             {
                 if (ws.State == WebSocketState.Open)
                 {
-                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                    await ws.SendAsync(bytes, WebSocketMessageType.Text, true, cts.Token);
+                    await QueueSendAsync(ws, bytes);
                 }
                 else
                 {
@@ -131,5 +202,67 @@ public class BrmbleEventBus : IBrmbleEventBus
         });
 
         await Task.WhenAll(tasks);
+    }
+
+    /// <summary>
+    /// Enqueues a payload for a single socket. The returned task completes once the
+    /// payload has actually been written to the socket, preserving the back-pressure
+    /// the callers relied on when they awaited <see cref="WebSocket.SendAsync"/> directly.
+    /// </summary>
+    private Task QueueSendAsync(WebSocket ws, ArraySegment<byte> bytes)
+    {
+        if (!_deliveries.TryGetValue(ws, out var delivery))
+            return Task.FromException(new WebSocketException("WebSocket client is no longer connected."));
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool startDrain;
+        lock (delivery.Gate)
+        {
+            if (delivery.Failure is not null)
+                return Task.FromException(delivery.Failure);
+
+            delivery.Queue.Enqueue(new QueuedMessage(bytes, completion));
+            startDrain = !delivery.Draining;
+            if (startDrain)
+                delivery.Draining = true;
+        }
+
+        // Started outside the gate so the first send does not run under the lock.
+        if (startDrain)
+            _ = DrainSocketAsync(ws, delivery);
+
+        return completion.Task;
+    }
+
+    private static async Task DrainSocketAsync(WebSocket ws, SocketDelivery delivery)
+    {
+        while (true)
+        {
+            QueuedMessage message;
+            lock (delivery.Gate)
+            {
+                if (delivery.Failure is not null)
+                    return;
+
+                if (delivery.Queue.Count == 0)
+                {
+                    delivery.Draining = false;
+                    return;
+                }
+
+                message = delivery.Queue.Dequeue();
+            }
+
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                await ws.SendAsync(message.Bytes, WebSocketMessageType.Text, true, cts.Token);
+                message.Completion.TrySetResult();
+            }
+            catch (Exception ex)
+            {
+                message.Completion.TrySetException(ex);
+            }
+        }
     }
 }

--- a/src/Brmble.Server/Events/BrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/BrmbleEventBus.cs
@@ -24,7 +24,7 @@ public class BrmbleEventBus : IBrmbleEventBus
     private sealed class SocketDelivery
     {
         public object Gate { get; } = new();
-        public Queue<QueuedMessage> Queue { get; } = new();
+        public LinkedList<QueuedMessage> Queue { get; } = new();
         public bool Draining { get; set; }
         public Exception? Failure { get; set; }
     }
@@ -60,55 +60,64 @@ public class BrmbleEventBus : IBrmbleEventBus
     {
         delivery.Failure ??= failure;
         while (delivery.Queue.Count > 0)
-            delivery.Queue.Dequeue().Completion.TrySetException(delivery.Failure);
+        {
+            var message = delivery.Queue.First!.Value;
+            delivery.Queue.RemoveFirst();
+            message.Completion.TrySetException(delivery.Failure);
+        }
+
         delivery.Draining = false;
     }
 
     /// <summary>
     /// Registers a client, optionally queuing an initial payload as part of the same step.
-    /// The payload is enqueued before the socket is published to <see cref="_clients"/>, so
-    /// any broadcast that can observe the client is necessarily queued behind it. Registering
-    /// and sending separately would let a broadcast overtake the payload it amends, which is
-    /// why this is the only way to add a client. Returns a task that completes once the
-    /// initial payload has been written, or a completed task when there is none.
+    /// The socket is published to <see cref="_clients"/> before the payload is built, so a
+    /// broadcast racing the build queues behind the payload rather than being dropped for a
+    /// client that is not yet visible. The payload is then placed at the head of the queue so
+    /// it still arrives first. A mutation the payload already reflects may therefore be
+    /// delivered twice, which these events tolerate; losing it entirely would not be.
+    /// Registering and sending separately would reintroduce both hazards, which is why this
+    /// is the only way to add a client. Returns a task that completes once the initial
+    /// payload has been written, or a completed task when there is none.
     /// </summary>
     public Task AddClientAsync(WebSocket ws, long userId, Func<object>? initialMessage = null)
     {
         var delivery = new SocketDelivery();
-        _deliveries[ws] = delivery;
-
-        Task initial = Task.CompletedTask;
         if (initialMessage is not null)
         {
-            try
-            {
-                var json = JsonSerializer.Serialize(initialMessage(), JsonOptions);
-                var bytes = new ArraySegment<byte>(Encoding.UTF8.GetBytes(json));
-                var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
-                lock (delivery.Gate)
-                {
-                    delivery.Queue.Enqueue(new QueuedMessage(bytes, completion));
-                    delivery.Draining = true;
-                }
-
-                initial = completion.Task;
-            }
-            catch
-            {
-                // The client was never published to _clients, so RemoveClient will never run
-                // for it. Drop the delivery here or it leaks for the lifetime of the process.
-                _deliveries.TryRemove(ws, out _);
-                throw;
-            }
+            // Claim the drain up front so broadcasts arriving during the build queue
+            // without starting to send ahead of the initial payload.
+            delivery.Draining = true;
         }
 
+        _deliveries[ws] = delivery;
         _clients[ws] = userId;
 
-        if (initialMessage is not null)
-            _ = DrainSocketAsync(ws, delivery);
+        if (initialMessage is null)
+            return Task.CompletedTask;
 
-        return initial;
+        try
+        {
+            var json = JsonSerializer.Serialize(initialMessage(), JsonOptions);
+            var bytes = new ArraySegment<byte>(Encoding.UTF8.GetBytes(json));
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            lock (delivery.Gate)
+            {
+                delivery.Queue.AddFirst(new QueuedMessage(bytes, completion));
+            }
+
+            _ = DrainSocketAsync(ws, delivery);
+            return completion.Task;
+        }
+        catch
+        {
+            // Nothing was queued ahead of the broadcasts that may have arrived during the
+            // build, and the client has no snapshot to make sense of them. Drop it entirely
+            // and fault those sends rather than leaving a half-registered client behind.
+            RemoveClient(ws);
+            throw;
+        }
     }
 
     public bool HasConnectedClient(long userId) => _clients.Values.Any(id => id == userId);
@@ -231,7 +240,7 @@ public class BrmbleEventBus : IBrmbleEventBus
             if (delivery.Failure is not null)
                 return Task.FromException(delivery.Failure);
 
-            delivery.Queue.Enqueue(new QueuedMessage(bytes, completion));
+            delivery.Queue.AddLast(new QueuedMessage(bytes, completion));
             startDrain = !delivery.Draining;
             if (startDrain)
                 delivery.Draining = true;
@@ -260,7 +269,8 @@ public class BrmbleEventBus : IBrmbleEventBus
                     return;
                 }
 
-                message = delivery.Queue.Dequeue();
+                message = delivery.Queue.First!.Value;
+                delivery.Queue.RemoveFirst();
             }
 
             try

--- a/src/Brmble.Server/Events/IBrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/IBrmbleEventBus.cs
@@ -4,7 +4,7 @@ namespace Brmble.Server.Events;
 
 public interface IBrmbleEventBus
 {
-    void AddClient(WebSocket ws, long userId);
+    Task AddClientAsync(WebSocket ws, long userId, Func<object>? initialMessage = null);
     void RemoveClient(WebSocket ws);
     bool HasConnectedClient(long userId);
     Task BroadcastAsync(object message);

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -1,6 +1,4 @@
 using System.Net.WebSockets;
-using System.Text;
-using System.Text.Json;
 using Brmble.Server.Auth;
 using Brmble.Server.Events;
 
@@ -8,8 +6,6 @@ namespace Brmble.Server.WebSockets;
 
 public static class BrmbleWebSocketHandler
 {
-    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
-
     public static async Task HandleAsync(HttpContext context)
     {
         if (!context.WebSockets.IsWebSocketRequest)
@@ -47,25 +43,25 @@ public static class BrmbleWebSocketHandler
             await eventBus.BroadcastAsync(CreateUserMappingAddedPayload(currentSessionId, currentMapping, hash));
         }
 
-        eventBus.AddClient(ws, user.Id);
-
         try
         {
-            // Send initial snapshot
-            var snapshot = sessionMapping.GetSnapshot()
-                .ToDictionary(
-                    kvp => kvp.Key.ToString(),
-                    kvp => new
-                    {
-                        matrixUserId = kvp.Value.MatrixUserId,
-                        mumbleName = kvp.Value.MumbleName,
-                        companionId = kvp.Value.CompanionId,
-                        certHash = kvp.Value.CertHash,
-                        isBrmbleClient = kvp.Value.IsBrmbleClient
-                    });
-            var snapshotJson = JsonSerializer.Serialize(new { type = "sessionMappingSnapshot", mappings = snapshot }, JsonOptions);
-            var snapshotBytes = Encoding.UTF8.GetBytes(snapshotJson);
-            await ws.SendAsync(snapshotBytes, WebSocketMessageType.Text, true, context.RequestAborted);
+            // Register the client and queue its snapshot atomically, so a concurrent
+            // broadcast cannot be delivered ahead of the snapshot it amends.
+            await eventBus.AddClientAsync(ws, user.Id, () =>
+            {
+                var snapshot = sessionMapping.GetSnapshot()
+                    .ToDictionary(
+                        kvp => kvp.Key.ToString(),
+                        kvp => new
+                        {
+                            matrixUserId = kvp.Value.MatrixUserId,
+                            mumbleName = kvp.Value.MumbleName,
+                            companionId = kvp.Value.CompanionId,
+                            certHash = kvp.Value.CertHash,
+                            isBrmbleClient = kvp.Value.IsBrmbleClient
+                        });
+                return new { type = "sessionMappingSnapshot", mappings = snapshot };
+            });
 
             // Read loop until close
             var buffer = new byte[1024];

--- a/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
+++ b/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
@@ -252,27 +252,64 @@ public class BrmbleEventBusTests
     }
 
     [TestMethod]
-    public async Task AddClientAsync_QueuesSnapshotBeforePublishingClient()
+    public async Task AddClientAsync_DeliversSnapshotBeforeLaterBroadcasts()
     {
-        // Registering the client and then sending the snapshot as two separate steps lets a
-        // broadcast slip in between, so the client can observe a mutation before the snapshot
-        // it amends. The snapshot must be queued before the client is visible to broadcasts.
         var recorded = new List<string>();
         var ws = CreateRecordingWebSocket(recorded);
-        var connectedDuringFactory = true;
 
-        await _bus.AddClientAsync(ws.Object, 1L, () =>
-        {
-            connectedDuringFactory = _bus.HasConnectedClient(1L);
-            return new { type = "sessionMappingSnapshot" };
-        });
+        await _bus.AddClientAsync(ws.Object, 1L, () => new { type = "sessionMappingSnapshot" });
         await _bus.BroadcastAsync(new { type = "userMappingAdded" });
 
-        Assert.IsFalse(connectedDuringFactory, "Client must not be broadcast-visible before its snapshot is queued.");
         CollectionAssert.AreEqual(
             new[] { "sessionMappingSnapshot", "userMappingAdded" },
             recorded,
             "The snapshot must be the first payload the client receives.");
+    }
+
+    [TestMethod]
+    public async Task AddClientAsync_DoesNotDropBroadcastsRacingTheSnapshotCapture()
+    {
+        // The snapshot is captured from live state, so a mutation broadcast during the
+        // capture may or may not be reflected in it. The client must be registered before
+        // the capture, so that such a broadcast queues behind the snapshot instead of being
+        // dropped for a client that is not yet visible to broadcasts. Redelivering a
+        // mutation the snapshot already contains is harmless; losing it is not.
+        var recorded = new List<string>();
+        var ws = CreateRecordingWebSocket(recorded);
+        Task racing = Task.CompletedTask;
+
+        await _bus.AddClientAsync(ws.Object, 1L, () =>
+        {
+            // BroadcastAsync enqueues synchronously before returning its task, so by the
+            // time this assignment completes the payload is queued for this socket.
+            racing = _bus.BroadcastAsync(new { type = "userMappingAdded" });
+            return new { type = "sessionMappingSnapshot" };
+        });
+        await racing.WaitAsync(TimeSpan.FromSeconds(2));
+
+        CollectionAssert.AreEqual(
+            new[] { "sessionMappingSnapshot", "userMappingAdded" },
+            recorded,
+            "A broadcast racing the snapshot capture must be delivered after the snapshot, not dropped.");
+    }
+
+    [TestMethod]
+    public async Task AddClientAsync_FailingSnapshotFactoryUnregistersTheClient()
+    {
+        var ws = CreateMockWebSocket(WebSocketState.Open);
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => _bus.AddClientAsync(ws.Object, 1L, () => throw new InvalidOperationException("boom")));
+
+        Assert.IsFalse(_bus.HasConnectedClient(1L), "A client whose snapshot failed must not stay registered.");
+
+        // The bus must remain usable and must not try to send to the abandoned socket.
+        await _bus.BroadcastAsync(new { type = "test" });
+        ws.Verify(w => w.SendAsync(
+            It.IsAny<ArraySegment<byte>>(),
+            It.IsAny<WebSocketMessageType>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static Mock<WebSocket> CreateRecordingWebSocket(List<string> recorded)

--- a/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
+++ b/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
@@ -1,4 +1,6 @@
 using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
 using Brmble.Server.Events;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -29,8 +31,8 @@ public class BrmbleEventBusTests
     {
         var ws1 = CreateMockWebSocket(WebSocketState.Open);
         var ws2 = CreateMockWebSocket(WebSocketState.Open);
-        _bus.AddClient(ws1.Object, 1L);
-        _bus.AddClient(ws2.Object, 2L);
+        await _bus.AddClientAsync(ws1.Object, 1L);
+        await _bus.AddClientAsync(ws2.Object, 2L);
 
         await _bus.BroadcastAsync(new { type = "test" });
 
@@ -50,7 +52,7 @@ public class BrmbleEventBusTests
     public async Task BroadcastAsync_RemovesClosedClients()
     {
         var dead = CreateMockWebSocket(WebSocketState.Closed);
-        _bus.AddClient(dead.Object, 1L);
+        await _bus.AddClientAsync(dead.Object, 1L);
 
         await _bus.BroadcastAsync(new { type = "test" });
 
@@ -71,12 +73,12 @@ public class BrmbleEventBusTests
             It.IsAny<bool>(),
             It.IsAny<CancellationToken>()))
             .ThrowsAsync(new WebSocketException("connection reset"));
-        _bus.AddClient(failing.Object, 1L);
+        await _bus.AddClientAsync(failing.Object, 1L);
 
         await _bus.BroadcastAsync(new { type = "first" });
 
         var healthy = CreateMockWebSocket(WebSocketState.Open);
-        _bus.AddClient(healthy.Object, 2L);
+        await _bus.AddClientAsync(healthy.Object, 2L);
         await _bus.BroadcastAsync(new { type = "second" });
 
         healthy.Verify(w => w.SendAsync(
@@ -93,21 +95,21 @@ public class BrmbleEventBusTests
     }
 
     [TestMethod]
-    public void RemoveClient_IsIdempotent()
+    public async Task RemoveClient_IsIdempotent()
     {
         var ws = CreateMockWebSocket(WebSocketState.Open);
-        _bus.AddClient(ws.Object, 1L);
+        await _bus.AddClientAsync(ws.Object, 1L);
         _bus.RemoveClient(ws.Object);
         _bus.RemoveClient(ws.Object);
     }
 
     [TestMethod]
-    public void HasConnectedClient_TracksRemainingClientsForUser()
+    public async Task HasConnectedClient_TracksRemainingClientsForUser()
     {
         var ws1 = CreateMockWebSocket(WebSocketState.Open);
         var ws2 = CreateMockWebSocket(WebSocketState.Open);
-        _bus.AddClient(ws1.Object, 1L);
-        _bus.AddClient(ws2.Object, 1L);
+        await _bus.AddClientAsync(ws1.Object, 1L);
+        await _bus.AddClientAsync(ws2.Object, 1L);
 
         _bus.RemoveClient(ws1.Object);
 
@@ -136,9 +138,9 @@ public class BrmbleEventBusTests
         var ws1 = CreateMockWebSocket(WebSocketState.Open);
         var ws2 = CreateMockWebSocket(WebSocketState.Open);
         var ws3 = CreateMockWebSocket(WebSocketState.Open);
-        _bus.AddClient(ws1.Object, 1L);
-        _bus.AddClient(ws2.Object, 2L);
-        _bus.AddClient(ws3.Object, 3L); // Not in channel
+        await _bus.AddClientAsync(ws1.Object, 1L);
+        await _bus.AddClientAsync(ws2.Object, 2L);
+        await _bus.AddClientAsync(ws3.Object, 3L); // Not in channel
 
         await _bus.BroadcastToChannelAsync(5, new { type = "channelEvent" });
 
@@ -173,7 +175,7 @@ public class BrmbleEventBusTests
             .Returns(new Dictionary<int, SessionMapping>());
 
         var ws = CreateMockWebSocket(WebSocketState.Open);
-        _bus.AddClient(ws.Object, 1L);
+        await _bus.AddClientAsync(ws.Object, 1L);
 
         await _bus.BroadcastToChannelAsync(99, new { type = "channelEvent" });
 
@@ -183,6 +185,144 @@ public class BrmbleEventBusTests
             It.IsAny<WebSocketMessageType>(),
             It.IsAny<bool>(),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task BroadcastAsync_DoesNotOverlapSendsOnTheSameSocket()
+    {
+        // WebSocket.SendAsync is not thread-safe: a second concurrent call on the same
+        // socket throws "There is already one outstanding 'SendAsync' call". Independent
+        // broadcasts (e.g. screen share and session mapping) must not collide.
+        var tracker = new ConcurrencyTracker();
+        var ws = CreateMockWebSocket(WebSocketState.Open);
+        ws.Setup(w => w.SendAsync(
+            It.IsAny<ArraySegment<byte>>(),
+            It.IsAny<WebSocketMessageType>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(() => tracker.RecordSendAsync());
+        await _bus.AddClientAsync(ws.Object, 1L);
+
+        var first = _bus.BroadcastAsync(new { type = "screenShare.stopped" });
+        var second = _bus.BroadcastAsync(new { type = "userMappingAdded" });
+        await Task.WhenAll(first, second);
+
+        Assert.AreEqual(1, tracker.MaxConcurrent, "Sends to a single socket must be serialized.");
+        Assert.AreEqual(2, tracker.TotalSends);
+    }
+
+    [TestMethod]
+    public async Task RemoveClient_CompletesQueuedBroadcastsWithoutWaitingForTheSocket()
+    {
+        // Serializing sends means a stalled socket can hold a queue behind it. When the
+        // client goes away, everything still queued must be released instead of waiting
+        // on a socket that will never drain.
+        var release = new TaskCompletionSource();
+        var firstSendStarted = new TaskCompletionSource();
+        var sendCount = 0;
+        var ws = CreateMockWebSocket(WebSocketState.Open);
+        ws.Setup(w => w.SendAsync(
+            It.IsAny<ArraySegment<byte>>(),
+            It.IsAny<WebSocketMessageType>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                if (Interlocked.Increment(ref sendCount) == 1)
+                {
+                    firstSendStarted.TrySetResult();
+                    return release.Task;
+                }
+
+                return Task.CompletedTask;
+            });
+        await _bus.AddClientAsync(ws.Object, 1L);
+
+        var blocked = _bus.BroadcastAsync(new { type = "first" });
+        await firstSendStarted.Task;
+        var queued = _bus.BroadcastAsync(new { type = "second" });
+
+        _bus.RemoveClient(ws.Object);
+
+        await queued.WaitAsync(TimeSpan.FromSeconds(2));
+
+        release.TrySetResult();
+        await blocked.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.AreEqual(1, Volatile.Read(ref sendCount), "A removed client must not receive queued payloads.");
+    }
+
+    [TestMethod]
+    public async Task AddClientAsync_QueuesSnapshotBeforePublishingClient()
+    {
+        // Registering the client and then sending the snapshot as two separate steps lets a
+        // broadcast slip in between, so the client can observe a mutation before the snapshot
+        // it amends. The snapshot must be queued before the client is visible to broadcasts.
+        var recorded = new List<string>();
+        var ws = CreateRecordingWebSocket(recorded);
+        var connectedDuringFactory = true;
+
+        await _bus.AddClientAsync(ws.Object, 1L, () =>
+        {
+            connectedDuringFactory = _bus.HasConnectedClient(1L);
+            return new { type = "sessionMappingSnapshot" };
+        });
+        await _bus.BroadcastAsync(new { type = "userMappingAdded" });
+
+        Assert.IsFalse(connectedDuringFactory, "Client must not be broadcast-visible before its snapshot is queued.");
+        CollectionAssert.AreEqual(
+            new[] { "sessionMappingSnapshot", "userMappingAdded" },
+            recorded,
+            "The snapshot must be the first payload the client receives.");
+    }
+
+    private static Mock<WebSocket> CreateRecordingWebSocket(List<string> recorded)
+    {
+        var mock = new Mock<WebSocket>();
+        mock.Setup(w => w.State).Returns(WebSocketState.Open);
+        mock.Setup(w => w.SendAsync(
+            It.IsAny<ArraySegment<byte>>(),
+            It.IsAny<WebSocketMessageType>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .Returns((ArraySegment<byte> buffer, WebSocketMessageType _, bool _, CancellationToken _) =>
+            {
+                var type = JsonDocument.Parse(Encoding.UTF8.GetString(buffer))
+                    .RootElement.GetProperty("type").GetString()!;
+                lock (recorded)
+                {
+                    recorded.Add(type);
+                }
+
+                return Task.CompletedTask;
+            });
+        return mock;
+    }
+
+    private sealed class ConcurrencyTracker
+    {
+        private readonly object _gate = new();
+        private int _current;
+
+        public int MaxConcurrent { get; private set; }
+        public int TotalSends { get; private set; }
+
+        public async Task RecordSendAsync()
+        {
+            lock (_gate)
+            {
+                _current++;
+                TotalSends++;
+                if (_current > MaxConcurrent)
+                    MaxConcurrent = _current;
+            }
+
+            await Task.Delay(25);
+
+            lock (_gate)
+            {
+                _current--;
+            }
+        }
     }
 
     private static Mock<WebSocket> CreateMockWebSocket(WebSocketState state)


### PR DESCRIPTION
## Summary

Two WebSocket delivery bugs that exist on `main` today. Split out of #609 (collaborative paint) so they can be reviewed and merged on their own merits — this PR contains no paint code and **no delivery policy changes**.

## Bug 1 — concurrent sends on one socket

`WebSocket.SendAsync` permits only one outstanding call per socket; a second concurrent call throws `There is already one outstanding 'SendAsync' call`. The event bus awaited it directly from all three broadcast methods with no serialization, so two *independent* broadcasts targeting the same client would collide — e.g. `screenShare.stopped` from `MumbleServerCallback` while `SessionMappingHandler` broadcasts a mapping update. `AuthService` makes this more likely still, using fire-and-forget `_ = BroadcastAsync(...)`.

The resulting exception was caught by the generic handler and turned into `RemoveClient(ws)`, so the symptom was **clients silently disappearing under concurrent events**, affecting screen share, games, ACL and session mapping alike.

This is demonstrated, not theorised — the new test fails on `main` with `Expected:<1>. Actual:<2>`.

Sends now go through a per-socket queue with a single drain loop.

## Bug 2 — snapshot registration race

`BrmbleWebSocketHandler` registered the client and then sent the initial session-mapping snapshot as two separate statements:

```csharp
eventBus.AddClient(ws, user.Id);   // client is now broadcast-visible
// a broadcast delivered here arrives before the snapshot it amends
await ws.SendAsync(snapshotBytes, ...);
```

Registration and the initial payload are now a single step. The payload is enqueued *before* the socket is published, so any broadcast that can observe the client is necessarily queued behind it.

## API change

`AddClient` and `AddClientWithInitialMessageAsync` are replaced by one method:

```csharp
Task AddClientAsync(WebSocket ws, long userId, Func<object>? initialMessage = null);
```

Keeping a register-only entry point would have left the Bug 2 race available to the next caller, so the two-step pattern is deliberately no longer expressible.

## Explicitly out of scope

Deferred to a follow-up PR: bounded queue capacity, preview coalescing, ordered channel delivery, `ws.Abort()`, and JSON serializer changes.

Queues are unbounded, nothing is dropped or coalesced, and **broadcasts still never throw to their callers** — the contract every existing call site relies on is unchanged. That is what keeps this reviewable as a pure bugfix.

## Testing

Built test-first; each test was confirmed to fail on `main` before implementing.

| Test | Failure on `main` |
|---|---|
| `BroadcastAsync_DoesNotOverlapSendsOnTheSameSocket` | `Expected:<1>. Actual:<2>` |
| `RemoveClient_CompletesQueuedBroadcastsWithoutWaitingForTheSocket` | `TimeoutException` |
| `AddClientAsync_QueuesSnapshotBeforePublishingClient` | did not compile (new API) |

`dotnet test` across the solution: **817 passed, 0 failed** (Server 379, Client 266, MumbleVoiceEngine 99, Audio 73). The timing-sensitive concurrency test was run 5x to check for flakiness — stable.

All pre-existing event bus assertions are unchanged, which is what confirms the API merge was behaviour-preserving.