### PR TITLE
fix: bound per-client WebSocket delivery queues

### DIFF
--- a/src/Brmble.Server/Events/BrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/BrmbleEventBus.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 
 namespace Brmble.Server.Events;
 
@@ -12,6 +13,7 @@ public class BrmbleEventBus : IBrmbleEventBus
     private readonly ILogger<BrmbleEventBus> _logger;
     private readonly IChannelMembershipService _channelMembership;
     private readonly ISessionMappingService _sessionMapping;
+    private readonly int _socketQueueCapacity;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
     private sealed record QueuedMessage(ArraySegment<byte> Bytes, TaskCompletionSource Completion);
@@ -32,11 +34,18 @@ public class BrmbleEventBus : IBrmbleEventBus
     public BrmbleEventBus(
         ILogger<BrmbleEventBus> logger,
         IChannelMembershipService channelMembership,
-        ISessionMappingService sessionMapping)
+        ISessionMappingService sessionMapping,
+        IOptions<EventBusSettings> settings)
     {
         _logger = logger;
         _channelMembership = channelMembership;
         _sessionMapping = sessionMapping;
+        _socketQueueCapacity = settings.Value.SocketQueueCapacity;
+        if (_socketQueueCapacity < 1)
+            throw new ArgumentOutOfRangeException(
+                nameof(settings),
+                _socketQueueCapacity,
+                $"{nameof(EventBusSettings.SocketQueueCapacity)} must be at least 1.");
     }
 
     public void RemoveClient(WebSocket ws)
@@ -227,6 +236,8 @@ public class BrmbleEventBus : IBrmbleEventBus
     /// Enqueues a payload for a single socket. The returned task completes once the
     /// payload has actually been written to the socket, preserving the back-pressure
     /// the callers relied on when they awaited <see cref="WebSocket.SendAsync"/> directly.
+    /// A client that has stopped draining is disconnected once its queue is full, rather
+    /// than being allowed to accumulate payloads without bound.
     /// </summary>
     private Task QueueSendAsync(WebSocket ws, ArraySegment<byte> bytes)
     {
@@ -235,15 +246,37 @@ public class BrmbleEventBus : IBrmbleEventBus
 
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         bool startDrain;
+        Exception? overflow = null;
         lock (delivery.Gate)
         {
             if (delivery.Failure is not null)
                 return Task.FromException(delivery.Failure);
 
-            delivery.Queue.AddLast(new QueuedMessage(bytes, completion));
-            startDrain = !delivery.Draining;
-            if (startDrain)
-                delivery.Draining = true;
+            if (delivery.Queue.Count >= _socketQueueCapacity)
+            {
+                overflow = new WebSocketException(
+                    $"WebSocket delivery queue is full ({_socketQueueCapacity} payloads).");
+                FailDeliveryLocked(delivery, overflow);
+                startDrain = false;
+            }
+            else
+            {
+                delivery.Queue.AddLast(new QueuedMessage(bytes, completion));
+                startDrain = !delivery.Draining;
+                if (startDrain)
+                    delivery.Draining = true;
+            }
+        }
+
+        if (overflow is not null)
+        {
+            // Events have been skipped, so the client can no longer be brought up to date
+            // incrementally. Drop the connection and let it reconnect onto a fresh snapshot.
+            _logger.LogWarning(
+                "WebSocket client exceeded its delivery queue capacity of {Capacity}; disconnecting to force a resync.",
+                _socketQueueCapacity);
+            RemoveClientAndAbort(ws);
+            return Task.FromException(overflow);
         }
 
         // Started outside the gate so the first send does not run under the lock.
@@ -251,6 +284,23 @@ public class BrmbleEventBus : IBrmbleEventBus
             _ = DrainSocketAsync(ws, delivery);
 
         return completion.Task;
+    }
+
+    /// <summary>
+    /// Removes a client and tears down its socket. Aborting also fails whatever send is
+    /// currently in flight, which a plain removal cannot reach.
+    /// </summary>
+    private void RemoveClientAndAbort(WebSocket ws)
+    {
+        RemoveClient(ws);
+        try
+        {
+            ws.Abort();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to abort WebSocket client");
+        }
     }
 
     private static async Task DrainSocketAsync(WebSocket ws, SocketDelivery delivery)

--- a/src/Brmble.Server/Events/EventBusSettings.cs
+++ b/src/Brmble.Server/Events/EventBusSettings.cs
@@ -1,0 +1,16 @@
+namespace Brmble.Server.Events;
+
+public class EventBusSettings
+{
+    /// <summary>
+    /// Maximum number of payloads that may be queued for a single WebSocket client before
+    /// that client is disconnected. Sends are serialized per socket, so a client that stops
+    /// draining would otherwise accumulate payloads without bound.
+    /// </summary>
+    /// <remarks>
+    /// Sized to absorb legitimate bursts such as a mass reconnect or an ACL sweep, while
+    /// still bounding per-client memory. Raising it increases the worst-case memory a single
+    /// stalled client can hold; lowering it disconnects slow clients sooner.
+    /// </remarks>
+    public int SocketQueueCapacity { get; init; } = 256;
+}

--- a/src/Brmble.Server/Mumble/MumbleExtensions.cs
+++ b/src/Brmble.Server/Mumble/MumbleExtensions.cs
@@ -11,6 +11,8 @@ public static class MumbleExtensions
             .BindConfiguration("Ice");
         services.AddSingleton<ISessionMappingService, SessionMappingService>();
         services.AddSingleton<IChannelMembershipService, ChannelMembershipService>();
+        services.AddOptions<EventBusSettings>()
+            .BindConfiguration("EventBus");
         services.AddSingleton<IBrmbleEventBus, BrmbleEventBus>();
         services.AddSingleton<IMumbleEventHandler, SessionMappingHandler>();
         services.AddSingleton<MumbleRegistrationService>();

--- a/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
+++ b/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Brmble.Server.Events;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -20,10 +21,20 @@ public class BrmbleEventBusTests
     {
         _channelMembership = new Mock<IChannelMembershipService>();
         _sessionMapping = new Mock<ISessionMappingService>();
-        _bus = new BrmbleEventBus(
+        _bus = CreateBus();
+    }
+
+    private BrmbleEventBus CreateBus(int? socketQueueCapacity = null)
+    {
+        var settings = new EventBusSettings();
+        if (socketQueueCapacity is { } capacity)
+            settings = new EventBusSettings { SocketQueueCapacity = capacity };
+
+        return new BrmbleEventBus(
             NullLogger<BrmbleEventBus>.Instance,
             _channelMembership.Object,
-            _sessionMapping.Object);
+            _sessionMapping.Object,
+            Options.Create(settings));
     }
 
     [TestMethod]
@@ -310,6 +321,83 @@ public class BrmbleEventBusTests
             It.IsAny<WebSocketMessageType>(),
             It.IsAny<bool>(),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task BroadcastAsync_FullQueueDisconnectsSlowClientAndLeavesOthersHealthy()
+    {
+        // A client that stops draining must not grow its queue without bound. It is
+        // disconnected so it reconnects and resyncs from a fresh snapshot, and that must
+        // not disturb delivery to anyone else or fault the broadcast callers.
+        var bus = CreateBus(socketQueueCapacity: 2);
+        var release = new TaskCompletionSource();
+        var slow = CreateMockWebSocket(WebSocketState.Open);
+        slow.Setup(w => w.SendAsync(
+            It.IsAny<ArraySegment<byte>>(),
+            It.IsAny<WebSocketMessageType>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(() => release.Task);
+        // Abort tears down the in-flight send, as a real socket would.
+        slow.Setup(w => w.Abort())
+            .Callback(() => release.TrySetException(new WebSocketException("aborted")));
+
+        var healthyPayloads = new List<string>();
+        var healthy = CreateRecordingWebSocket(healthyPayloads);
+
+        await bus.AddClientAsync(slow.Object, 1L);
+        await bus.AddClientAsync(healthy.Object, 2L);
+
+        // One send in flight plus two queued fills the capacity; the fourth overflows.
+        var broadcasts = new List<Task>();
+        for (var i = 0; i < 4; i++)
+            broadcasts.Add(bus.BroadcastAsync(new { type = $"event{i}" }));
+
+        await Task.WhenAll(broadcasts).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.IsFalse(bus.HasConnectedClient(1L), "The overflowing client must be disconnected.");
+        slow.Verify(w => w.Abort(), Times.Once);
+
+        Assert.IsTrue(bus.HasConnectedClient(2L), "A healthy client must survive another client overflowing.");
+        CollectionAssert.AreEqual(
+            new[] { "event0", "event1", "event2", "event3" },
+            healthyPayloads,
+            "A healthy client must receive every broadcast regardless of another client overflowing.");
+    }
+
+    [TestMethod]
+    public async Task BroadcastAsync_FullQueueDoesNotThrowToTheCaller()
+    {
+        // Callers such as the auth and LiveKit endpoints await broadcasts without guarding
+        // them. An overflowing client must never surface as a failed request for someone else.
+        var bus = CreateBus(socketQueueCapacity: 1);
+        var release = new TaskCompletionSource();
+        var slow = CreateMockWebSocket(WebSocketState.Open);
+        slow.Setup(w => w.SendAsync(
+            It.IsAny<ArraySegment<byte>>(),
+            It.IsAny<WebSocketMessageType>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(() => release.Task);
+        slow.Setup(w => w.Abort())
+            .Callback(() => release.TrySetException(new WebSocketException("aborted")));
+
+        await bus.AddClientAsync(slow.Object, 1L);
+
+        var broadcasts = new List<Task>();
+        for (var i = 0; i < 3; i++)
+            broadcasts.Add(bus.BroadcastAsync(new { type = $"event{i}" }));
+
+        // Must complete, not fault.
+        await Task.WhenAll(broadcasts).WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [TestMethod]
+    public void Constructor_RejectsNonPositiveQueueCapacity()
+    {
+        // A misconfigured capacity of zero would overflow on the first send and disconnect
+        // every client, so fail at startup rather than at runtime.
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => CreateBus(socketQueueCapacity: 0));
     }
 
     private static Mock<WebSocket> CreateRecordingWebSocket(List<string> recorded)


### PR DESCRIPTION
## Summary

Follow-up to #610. That PR serialized sends per socket, which introduced per-client queues — but left them **unbounded**. A client that stops draining (suspended laptop, stalled network, unresponsive frontend) accumulates payloads for as long as it stays connected. This PR bounds them.

This is the second of the WebSocket changes split out of #609 (collaborative paint). It contains no paint code.

## Behaviour

Queues are capped by `EventBus:SocketQueueCapacity`, default **256**. When a client exceeds it:

1. its queued sends are released (callers are not left awaiting a socket that will never drain),
2. the client is removed, and
3. the socket is **aborted**.

Abort rather than plain removal is deliberate: it also tears down the send currently *in flight*, which removal cannot reach, and it forces the client to reconnect onto a fresh snapshot. Once payloads have been skipped the client cannot be brought up to date incrementally, so dropping the connection is the only route back to a consistent view.

## Overflow is contained to the offending client

Explicitly **not** doing what the original implementation in #609 did — it rethrew a queue-full exception to the broadcast caller. Callers such as `AuthEndpoints`, `LiveKitEndpoints` and `ScreenShareReconciliationService` await broadcasts without guarding them, and `AuthService` uses fire-and-forget `_ = BroadcastAsync(...)`. Propagating would turn one slow client into failed requests for unrelated users and unobserved task exceptions.

Broadcasts still never throw to their callers, and delivery to every other client is unaffected. There is a test for exactly this.

## Scope

Deliberately **only** bounded queues. Coalescing (`CoalesceKey`) and ordered channel delivery were considered for this PR and deferred: neither has a production consumer until paint lands, and adding unused API to shared infrastructure is what made #609 hard to review. They belong in the paint PR alongside their callers and tests.

## Testing

Each test was confirmed to fail before implementing.

| Test | Failure without the fix |
|---|---|
| `BroadcastAsync_FullQueueDisconnectsSlowClientAndLeavesOthersHealthy` | `TimeoutException` |
| `BroadcastAsync_FullQueueDoesNotThrowToTheCaller` | did not compile |
| `Constructor_RejectsNonPositiveQueueCapacity` | `Expected ArgumentOutOfRangeException but none thrown` |

The first test''s initial failure was only a compile error, which proves nothing about its assertions, so it was re-run with the capacity raised to 1000 to confirm it genuinely times out when overflow is not enforced.

`dotnet test` across the solution: **822 passed, 0 failed** (Server 384, Client 266, MumbleVoiceEngine 99, Audio 73). Event bus tests run 5x to check the timing-sensitive cases — stable.

## Reviewer note

**256 is an estimate, not a measured figure.** It is sized to absorb bursts such as a mass reconnect or an ACL sweep while bounding per-client memory at roughly 256 x payload size. If real event rates are higher than assumed, the symptom would be legitimate clients being disconnected during bursts. It is config-tunable so that would be a config change rather than a deploy, but a better-informed default is welcome.

Capacity is validated at construction because a configured `0` would overflow on the first send and disconnect every client.