### PR TITLE
fix: tear down broken sockets and unblock registration on queue overflow

### DIFF
--- a/src/Brmble.Server/Events/BrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/BrmbleEventBus.cs
@@ -113,6 +113,13 @@ public class BrmbleEventBus : IBrmbleEventBus
 
             lock (delivery.Gate)
             {
+                // Broadcasts arriving during the build may have overflowed the queue and
+                // dropped this client. Queuing the snapshot behind a failed delivery would
+                // never drain, leaving the registration awaiting a payload that can no
+                // longer be sent, so surface the failure instead.
+                if (delivery.Failure is not null)
+                    return Task.FromException(delivery.Failure);
+
                 delivery.Queue.AddFirst(new QueuedMessage(bytes, completion));
             }
 
@@ -272,8 +279,10 @@ public class BrmbleEventBus : IBrmbleEventBus
         {
             // Events have been skipped, so the client can no longer be brought up to date
             // incrementally. Drop the connection and let it reconnect onto a fresh snapshot.
+            _clients.TryGetValue(ws, out var userId);
             _logger.LogWarning(
-                "WebSocket client exceeded its delivery queue capacity of {Capacity}; disconnecting to force a resync.",
+                "WebSocket client for user {UserId} exceeded its delivery queue capacity of {Capacity}; disconnecting to force a resync.",
+                userId,
                 _socketQueueCapacity);
             RemoveClientAndAbort(ws);
             return Task.FromException(overflow);

--- a/src/Brmble.Server/Events/BrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/BrmbleEventBus.cs
@@ -312,7 +312,12 @@ public class BrmbleEventBus : IBrmbleEventBus
         }
     }
 
-    private static async Task DrainSocketAsync(WebSocket ws, SocketDelivery delivery)
+    /// <summary>
+    /// Writes queued payloads one at a time. A failed send means the socket is broken for
+    /// everything behind it too, so the whole delivery is failed and the client torn down
+    /// here rather than retried payload by payload or left for a caller to notice.
+    /// </summary>
+    private async Task DrainSocketAsync(WebSocket ws, SocketDelivery delivery)
     {
         while (true)
         {
@@ -341,6 +346,23 @@ public class BrmbleEventBus : IBrmbleEventBus
             catch (Exception ex)
             {
                 message.Completion.TrySetException(ex);
+                bool alreadyFailed;
+                lock (delivery.Gate)
+                {
+                    // An overflow or an explicit removal may have failed this delivery
+                    // already, and whoever did that has torn the socket down. Doing it
+                    // again here would abort a socket that is already gone.
+                    alreadyFailed = delivery.Failure is not null;
+                    FailDeliveryLocked(delivery, ex);
+                }
+
+                if (!alreadyFailed)
+                {
+                    _logger.LogDebug(ex, "WebSocket send failed; disconnecting the client");
+                    RemoveClientAndAbort(ws);
+                }
+
+                return;
             }
         }
     }

--- a/src/Brmble.Server/appsettings.json
+++ b/src/Brmble.Server/appsettings.json
@@ -26,6 +26,9 @@
     "Port": "6502",
     "ConnectTimeoutMs": "3000"
   },
+  "EventBus": {
+    "SocketQueueCapacity": 256
+  },
   "ReverseProxy": {
     "Routes": {
       "matrix": {

--- a/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
+++ b/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
@@ -324,6 +324,35 @@ public class BrmbleEventBusTests
     }
 
     [TestMethod]
+    public async Task AddClientAsync_QueueOverflowDuringSnapshotBuildFaultsRegistration()
+    {
+        // The client is registered before the snapshot is built, so broadcasts arriving
+        // during the build can overflow its queue and drop it. Registration must observe
+        // that and fault instead of queuing a snapshot behind a failed delivery, which
+        // would never drain and would hang the WebSocket request forever.
+        var bus = CreateBus(socketQueueCapacity: 1);
+        var ws = CreateMockWebSocket(WebSocketState.Open);
+        ws.Setup(w => w.SendAsync(
+            It.IsAny<ArraySegment<byte>>(),
+            It.IsAny<WebSocketMessageType>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .Returns(() => new TaskCompletionSource().Task);
+
+        var registration = bus.AddClientAsync(ws.Object, 1L, () =>
+        {
+            // Capacity is 1 and nothing is draining yet, so the second broadcast overflows.
+            _ = bus.BroadcastAsync(new { type = "event0" });
+            _ = bus.BroadcastAsync(new { type = "event1" });
+            return new { type = "sessionMappingSnapshot" };
+        });
+
+        await Assert.ThrowsExceptionAsync<WebSocketException>(
+            () => registration.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.IsFalse(bus.HasConnectedClient(1L), "An overflowed client must not stay registered.");
+    }
+
+    [TestMethod]
     public async Task BroadcastAsync_FullQueueDisconnectsSlowClientAndLeavesOthersHealthy()
     {
         // A client that stops draining must not grow its queue without bound. It is

--- a/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
+++ b/tests/Brmble.Server.Tests/Events/BrmbleEventBusTests.cs
@@ -422,6 +422,41 @@ public class BrmbleEventBusTests
     }
 
     [TestMethod]
+    public async Task BroadcastAsync_SendFailureTearsDownTheClientWithoutRetryingTheRestOfTheQueue()
+    {
+        // A socket that fails a send is broken for every payload behind it. The drain must
+        // fail the whole delivery rather than walking the queue and burning a five second
+        // timeout per payload, and it must tear the socket down itself instead of relying
+        // on a caller noticing the fault.
+        var bus = CreateBus(socketQueueCapacity: 10);
+        var ws = CreateMockWebSocket(WebSocketState.Open);
+        ws.Setup(w => w.SendAsync(
+            It.IsAny<ArraySegment<byte>>(),
+            It.IsAny<WebSocketMessageType>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new WebSocketException("socket is broken"));
+
+        await bus.AddClientAsync(ws.Object, 1L);
+
+        var broadcasts = new List<Task>();
+        for (var i = 0; i < 3; i++)
+            broadcasts.Add(bus.BroadcastAsync(new { type = $"event{i}" }));
+
+        await Task.WhenAll(broadcasts).WaitAsync(TimeSpan.FromSeconds(5));
+
+        ws.Verify(w => w.SendAsync(
+            It.IsAny<ArraySegment<byte>>(),
+            It.IsAny<WebSocketMessageType>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once,
+            "Payloads queued behind a failed send must not each be retried against the broken socket.");
+        Assert.IsFalse(bus.HasConnectedClient(1L), "A client whose send failed must be deregistered by the drain.");
+        ws.Verify(w => w.Abort(), Times.Once);
+    }
+
+    [TestMethod]
     public void Constructor_RejectsNonPositiveQueueCapacity()
     {
         // A misconfigured capacity of zero would overflow on the first send and disconnect


### PR DESCRIPTION
## Summary

Two fixes to the bounded delivery queues added in #611. Both defects are live on `main` today.

## 1. Registration could hang permanently

`AddClientAsync` publishes the client before building its initial payload, so broadcasts arriving during the build queue against it. If those broadcasts overflowed the queue, the delivery was already faulted by the time the snapshot was ready — and `AddFirst` queued the snapshot behind a delivery that will never drain. The returned task never completed, leaving the WebSocket registration awaiting a payload that could no longer be sent.

`AddClientAsync` now surfaces the existing failure instead of queuing behind it.

## 2. Failed sends were retried against a dead socket

A send failure means the socket is broken for every payload behind it, but the drain loop faulted only the payload that failed and carried on to the next one — retrying each queued payload in turn against a socket that was already gone, and relying on some caller to notice the fault and remove the client.

The drain now fails the whole delivery and disconnects the client itself. Teardown is claimed by whichever failure lands first, so an overflow and an in-flight send failure cannot both abort the same socket.

## Also

- `EventBus:SocketQueueCapacity` is now present in `appsettings.json`. #611 added the setting but left it discoverable only as a code default, which is not much use to an operator trying to tune it.
- The queue-overflow warning now includes the client's user id, so disconnects can be correlated to a session.

## Testing

`dotnet test` across the solution: **824 passed, 0 failed** (Server 386, Client 266, MumbleVoiceEngine 99, Audio 73).

Both fixes ship with regression tests covering the hang and the teardown path.