### PR TITLE
fix: broadcast companion changes to all clients

### DIFF
--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -267,7 +267,6 @@ public static class AuthEndpoints
             CustomCompanionEventCoordinator customCompanionEventCoordinator,
             CustomCompanionRepository customCompanionRepository,
             ISessionMappingService sessionMapping,
-            IChannelMembershipService channelMembership,
             IBrmbleEventBus eventBus,
             ILogger<AuthService> logger) =>
         {
@@ -299,7 +298,7 @@ public static class AuthEndpoints
 
                     return await PersistCompanionSelectionAsync(
                         user, companionId!, userRepository, sessionMapping,
-                        channelMembership, eventBus, logger);
+                        eventBus, logger);
                 }
             }
 
@@ -308,7 +307,7 @@ public static class AuthEndpoints
 
             return await PersistCompanionSelectionAsync(
                 user, normalized, userRepository, sessionMapping,
-                channelMembership, eventBus, logger);
+                eventBus, logger);
         });
 
         return app;
@@ -319,7 +318,6 @@ public static class AuthEndpoints
         string companionId,
         UserRepository userRepository,
         ISessionMappingService sessionMapping,
-        IChannelMembershipService channelMembership,
         IBrmbleEventBus eventBus,
         ILogger<AuthService> logger)
     {
@@ -328,18 +326,18 @@ public static class AuthEndpoints
         if (sessionMapping.TryGetSessionByUserId(user.Id, out var sessionId))
         {
             sessionMapping.TryUpdateCompanionId(sessionId, companionId);
-            if (channelMembership.TryGetChannel(sessionId, out var channelId))
+            var wire = CompanionWireSelection.FromPersisted(companionId);
+            // Broadcast server-wide: clients keep a server-wide user list, and channel-scoped
+            // delivery left everyone outside the user's channel with a stale selection until
+            // their next reconnect (nothing re-delivers it on channel move).
+            await eventBus.BroadcastAsync(new
             {
-                var wire = CompanionWireSelection.FromPersisted(companionId);
-                await eventBus.BroadcastToChannelAsync(channelId, new
-                {
-                    type = "companionChanged",
-                    sessionId,
-                    matrixUserId = user.MatrixUserId,
-                    companionId = wire.CompanionId,
-                    customCompanionId = wire.CustomCompanionId
-                });
-            }
+                type = "companionChanged",
+                sessionId,
+                matrixUserId = user.MatrixUserId,
+                companionId = wire.CompanionId,
+                customCompanionId = wire.CustomCompanionId
+            });
         }
 
         logger.LogInformation(

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -323,9 +323,14 @@ public static class AuthEndpoints
     {
         await userRepository.SetCompanionId(user.Id, companionId);
 
-        if (sessionMapping.TryGetSessionByUserId(user.Id, out var sessionId))
+        // Resolve through TryGetMappingByUserId rather than TryGetSessionByUserId: the
+        // userId→session index can outlive or disagree with the session→mapping table, so a
+        // bare session lookup can point at a session with no mapping, or one that has since
+        // been recycled to a different user. Announcing either would publish a change that
+        // did not happen — or attribute it to somebody else.
+        if (sessionMapping.TryGetMappingByUserId(user.Id, out var sessionId, out _)
+            && sessionMapping.TryUpdateCompanionId(sessionId, companionId))
         {
-            sessionMapping.TryUpdateCompanionId(sessionId, companionId);
             var wire = CompanionWireSelection.FromPersisted(companionId);
             // Broadcast server-wide: clients keep a server-wide user list, and channel-scoped
             // delivery left everyone outside the user's channel with a stale selection until

--- a/src/Brmble.Server/Companions/CustomCompanionEndpoints.cs
+++ b/src/Brmble.Server/Companions/CustomCompanionEndpoints.cs
@@ -27,7 +27,6 @@ public static class CustomCompanionEndpoints
             CustomCompanionRepository repository,
             IMatrixAppService matrixAppService,
             ISessionMappingService sessionMapping,
-            IChannelMembershipService channelMembership,
             IBrmbleEventBus eventBus,
             ILogger<CustomCompanionGalleryService> logger) =>
         {
@@ -69,10 +68,11 @@ public static class CustomCompanionEndpoints
                     }
 
                     if (sessionMapping.TryUpdateCompanionIdIfCurrent(
-                            sessionId, deletedCompanionId, "floppy") &&
-                        channelMembership.TryGetChannel(sessionId, out var channelId))
+                            sessionId, deletedCompanionId, "floppy"))
                     {
-                        await eventBus.BroadcastToChannelAsync(channelId, new
+                        // Broadcast server-wide: a channel lookup failure previously swallowed
+                        // the event, and out-of-channel clients were never told at all.
+                        await eventBus.BroadcastAsync(new
                         {
                             type = "companionChanged",
                             sessionId,

--- a/tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs
@@ -38,10 +38,12 @@ public class AuthEndpointsCompanionTests : IDisposable
         channelMembership.Update(42, 7);
 
         _factory.SessionMappingMock
-            .Setup(m => m.TryGetSessionByUserId(It.IsAny<long>(), out It.Ref<int>.IsAny))
-            .Returns((long _, out int sid) =>
+            .Setup(m => m.TryGetMappingByUserId(
+                It.IsAny<long>(), out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
+            .Returns((long userId, out int sid, out SessionMapping? mapping) =>
             {
                 sid = 42;
+                mapping = new SessionMapping("@alice:test", "Alice", userId, "floppy");
                 return true;
             });
         _factory.SessionMappingMock
@@ -69,10 +71,12 @@ public class AuthEndpointsCompanionTests : IDisposable
         // Deliberately no channelMembership.Update: the session has no resolvable channel,
         // which previously suppressed the broadcast entirely.
         _factory.SessionMappingMock
-            .Setup(m => m.TryGetSessionByUserId(It.IsAny<long>(), out It.Ref<int>.IsAny))
-            .Returns((long _, out int sid) =>
+            .Setup(m => m.TryGetMappingByUserId(
+                It.IsAny<long>(), out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
+            .Returns((long userId, out int sid, out SessionMapping? mapping) =>
             {
                 sid = 99;
+                mapping = new SessionMapping("@alice:test", "Alice", userId, "floppy");
                 return true;
             });
         _factory.SessionMappingMock
@@ -86,6 +90,44 @@ public class AuthEndpointsCompanionTests : IDisposable
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         _factory.EventBusMock.Verify(b => b.BroadcastAsync(It.Is<object>(payload =>
             JsonSerializer.Serialize(payload).Contains("\"sessionId\":99"))), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task PostAuthCompanion_DoesNotBroadcastWhenSessionMappingIsMissing()
+    {
+        var tokenResponse = await _client.PostAsync("/auth/token", null);
+        tokenResponse.EnsureSuccessStatusCode();
+
+        // _userIdToSession can outlive _sessionToMapping (TryAddMatrixUser writes the
+        // userId index even when the mapping add fails), so a userId lookup can resolve
+        // to a session that has no mapping — or one now owned by a different user.
+        _factory.SessionMappingMock
+            .Setup(m => m.TryGetSessionByUserId(It.IsAny<long>(), out It.Ref<int>.IsAny))
+            .Returns((long _, out int sid) =>
+            {
+                sid = 42;
+                return true;
+            });
+        _factory.SessionMappingMock
+            .Setup(m => m.TryGetMappingByUserId(
+                It.IsAny<long>(), out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
+            .Returns((long _, out int sid, out SessionMapping? mapping) =>
+            {
+                sid = 0;
+                mapping = null;
+                return false;
+            });
+
+        var response = await _client.PostAsync(
+            "/auth/companion",
+            new StringContent(JsonSerializer.Serialize(new { companionId = "bee" }), Encoding.UTF8, "application/json"));
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual("bee", await _factory.Services
+            .GetRequiredService<Brmble.Server.Auth.UserRepository>().GetCompanionId(1));
+        _factory.EventBusMock.Verify(b => b.BroadcastAsync(It.IsAny<object>()), Times.Never);
+        _factory.SessionMappingMock.Verify(
+            m => m.TryUpdateCompanionId(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs
@@ -29,7 +29,7 @@ public class AuthEndpointsCompanionTests : IDisposable
     }
 
     [TestMethod]
-    public async Task PostAuthCompanion_PersistsAndBroadcastsChannelScopedUpdate()
+    public async Task PostAuthCompanion_PersistsAndBroadcastsToAllClients()
     {
         var tokenResponse = await _client.PostAsync("/auth/token", null);
         tokenResponse.EnsureSuccessStatusCode();
@@ -54,8 +54,38 @@ public class AuthEndpointsCompanionTests : IDisposable
 
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         _factory.SessionMappingMock.Verify(m => m.TryUpdateCompanionId(42, "floppy"), Times.Once);
-        _factory.EventBusMock.Verify(b => b.BroadcastToChannelAsync(7, It.Is<object>(payload =>
+        _factory.EventBusMock.Verify(b => b.BroadcastAsync(It.Is<object>(payload =>
             JsonSerializer.Serialize(payload).Contains("\"type\":\"companionChanged\""))), Times.Once);
+        _factory.EventBusMock.Verify(
+            b => b.BroadcastToChannelAsync(It.IsAny<int>(), It.IsAny<object>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task PostAuthCompanion_BroadcastsEvenWhenChannelIsUnknown()
+    {
+        var tokenResponse = await _client.PostAsync("/auth/token", null);
+        tokenResponse.EnsureSuccessStatusCode();
+
+        // Deliberately no channelMembership.Update: the session has no resolvable channel,
+        // which previously suppressed the broadcast entirely.
+        _factory.SessionMappingMock
+            .Setup(m => m.TryGetSessionByUserId(It.IsAny<long>(), out It.Ref<int>.IsAny))
+            .Returns((long _, out int sid) =>
+            {
+                sid = 99;
+                return true;
+            });
+        _factory.SessionMappingMock
+            .Setup(m => m.TryUpdateCompanionId(99, "retro"))
+            .Returns(true);
+
+        var response = await _client.PostAsync(
+            "/auth/companion",
+            new StringContent(JsonSerializer.Serialize(new { companionId = "retro" }), Encoding.UTF8, "application/json"));
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        _factory.EventBusMock.Verify(b => b.BroadcastAsync(It.Is<object>(payload =>
+            JsonSerializer.Serialize(payload).Contains("\"sessionId\":99"))), Times.Once);
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Companions/CustomCompanionDeletionTests.cs
+++ b/tests/Brmble.Server.Tests/Companions/CustomCompanionDeletionTests.cs
@@ -58,7 +58,7 @@ public sealed class CustomCompanionDeletionTests : IDisposable
     }
 
     [TestMethod]
-    public async Task Delete_ActiveRecordBroadcastsFloppyChangeToAffectedUserChannel()
+    public async Task Delete_ActiveRecordBroadcastsFloppyChangeToAllClients()
     {
         await InsertActiveAsync();
         _factory.SessionMappingMock.Object.TryAddMatrixUser(42, "@alice:test", "Alice", 1, "custom:$sprite:test");
@@ -71,9 +71,30 @@ public sealed class CustomCompanionDeletionTests : IDisposable
         var response = await _client.DeleteAsync("/companions/%24sprite%3Atest");
 
         Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
-        _factory.EventBusMock.Verify(bus => bus.BroadcastToChannelAsync(7, It.Is<object>(payload =>
+        _factory.EventBusMock.Verify(bus => bus.BroadcastAsync(It.Is<object>(payload =>
             JsonSerializer.Serialize(payload) ==
             "{\"type\":\"companionChanged\",\"sessionId\":42,\"matrixUserId\":\"@alice:test\",\"companionId\":\"floppy\",\"customCompanionId\":null}")), Times.Once);
+        _factory.EventBusMock.Verify(
+            bus => bus.BroadcastToChannelAsync(It.IsAny<int>(), It.IsAny<object>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Delete_BroadcastsEvenWhenAffectedUserChannelIsUnknown()
+    {
+        await InsertActiveAsync();
+        _factory.SessionMappingMock.Object.TryAddMatrixUser(42, "@alice:test", "Alice", 1, "custom:$sprite:test");
+        // Deliberately no channel membership: a failed channel lookup previously
+        // swallowed the event, leaving other clients with a stale selection.
+        _factory.AclAuthorizationMock.Setup(service => service.CanModerateServerAsync(1)).ReturnsAsync(true);
+        _factory.MatrixAppMock.Setup(service => service.RedactRoomEvent(
+                "!gallery:test", "$sprite:test", It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var response = await _client.DeleteAsync("/companions/%24sprite%3Atest");
+
+        Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+        _factory.EventBusMock.Verify(bus => bus.BroadcastAsync(It.Is<object>(payload =>
+            JsonSerializer.Serialize(payload).Contains("\"sessionId\":42"))), Times.Once);
     }
 
     [TestMethod]
@@ -106,7 +127,7 @@ public sealed class CustomCompanionDeletionTests : IDisposable
         Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
         Assert.AreEqual("bee", await userRepository.GetCompanionId(1));
         Assert.AreEqual("bee", _factory.SessionMappingMock.Object.GetSnapshot()[42].CompanionId);
-        _factory.EventBusMock.Verify(bus => bus.BroadcastToChannelAsync(7, It.IsAny<object>()), Times.Never);
+        _factory.EventBusMock.Verify(bus => bus.BroadcastAsync(It.IsAny<object>()), Times.Never);
     }
 
     [TestMethod]
@@ -219,8 +240,10 @@ public sealed class CustomCompanionDeletionTests : IDisposable
         Assert.AreEqual(HttpStatusCode.NoContent, deletionResponse.StatusCode);
         Assert.AreEqual(HttpStatusCode.BadRequest, selectionResponse.StatusCode);
         Assert.AreEqual("floppy", _factory.SessionMappingMock.Object.GetSnapshot()[42].CompanionId);
+        // The broadcast payload is the last argument for both BroadcastAsync and
+        // BroadcastToChannelAsync, so this holds regardless of the fan-out method.
         Assert.IsFalse(_factory.EventBusMock.Invocations.Any(invocation =>
-            JsonSerializer.Serialize(invocation.Arguments[1])
+            JsonSerializer.Serialize(invocation.Arguments[^1])
                 .Contains("\"customCompanionId\":\"custom:$sprite:test\"", StringComparison.Ordinal)));
     }
 


### PR DESCRIPTION
## Summary

`companionChanged` was delivered only to clients sharing the affected user's voice channel. Clients keep a **server-wide** user list, and nothing re-delivers mapping state on channel move, so out-of-channel observers rendered a stale companion until their next reconnect brought a fresh `sessionMappingSnapshot` — including after moving *into* the same channel.

Both producers also gated the broadcast on a successful channel lookup, so a session with no resolvable channel was silently never announced at all.

This broadcasts server-wide instead and drops the channel-lookup gate.

## Changes

- `AuthEndpoints.PersistCompanionSelectionAsync` — `BroadcastToChannelAsync` → `BroadcastAsync`, gate removed
- `CustomCompanionEndpoints` DELETE handler — same; the `TryUpdateCompanionIdIfCurrent` CAS guard is **preserved**, so users who already switched away from a deleted skin are still skipped
- `IChannelMembershipService` became unused in both files and was dropped from the signatures
- Payload shape unchanged; no client changes required

## Notes for reviewers

**No privacy boundary is crossed.** Every client already receives the full mapping table for all sessions in `sessionMappingSnapshot` on WebSocket registration — this event carries nothing new.

**Fan-out change worth a sanity check.** Companion selections now reach all connected clients rather than a channel subset. These are infrequent, user-initiated events, so the extra traffic should be negligible — but flagging it in case anyone knows something about deployment scale that argues otherwise.

**This is not a moderation fix.** An earlier reading suggested redactions failed to reach out-of-channel clients; that turned out to be wrong. Every client is force-joined to the gallery room (`AuthEndpoints.cs:149` → `EnsureUserInRoom`) and `useCustomCompanionGallery` listens on Matrix sync, so a redaction propagates independently of this event and does delete the cached atlas from IndexedDB. For deletions this fix only clears a stale `companionId` string with no visual effect. The visible bug it fixes is **selection** staleness.

## Testing

Tests were written first and observed failing. The two "channel unknown" cases failed with an empty `Performed invocations:` list, confirming the silent-drop path was real:

- `PostAuthCompanion_PersistsAndBroadcastsToAllClients` (updated)
- `PostAuthCompanion_BroadcastsEvenWhenChannelIsUnknown` (new)
- `Delete_ActiveRecordBroadcastsFloppyChangeToAllClients` (updated)
- `Delete_BroadcastsEvenWhenAffectedUserChannelIsUnknown` (new)
- `Delete_DoesNotOverwriteOrBroadcastWhenLiveSelectionChangesAfterReset` — CAS-failure case still asserts no broadcast
- `Delete_WinningRacePreventsCustomSelectionPublication` — now reads `Arguments[^1]` since `BroadcastAsync` takes one argument; intent unchanged

`dotnet build` clean (0 warnings). `dotnet test`: **1225 passed, 0 failed** (Server 753, Client 300, MumbleVoiceEngine 99, Audio 73).

## Context

This is a prerequisite for planned work on a single authoritative user projection: gap detection via a table revision counter requires every client to observe every mapping mutation, which channel-scoped delivery would break.
