### PR TITLE
fix: render one-point paint strokes

### DIFF
--- a/src/Brmble.Web/src/components/Paint/PaintEditor.test.tsx
+++ b/src/Brmble.Web/src/components/Paint/PaintEditor.test.tsx
@@ -29,7 +29,7 @@ async function renderLoadedEditor(onSave: (png: Blob) => Promise<void>) {
   Object.defineProperty(HTMLImageElement.prototype, 'decode', { configurable: true, value: vi.fn().mockResolvedValue(undefined) });
   const drawImage = vi.fn();
   vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-    clearRect: vi.fn(), drawImage, beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(),
+    clearRect: vi.fn(), drawImage, beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(), arc: vi.fn(), fill: vi.fn(),
   } as unknown as CanvasRenderingContext2D);
   vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(callback => callback(new Blob(['png'], { type: 'image/png' })));
 
@@ -116,6 +116,8 @@ describe('PaintEditor', () => {
       moveTo: vi.fn(),
       lineTo: vi.fn(),
       stroke,
+      arc: vi.fn(),
+      fill: vi.fn(),
     } as unknown as CanvasRenderingContext2D);
     const paintApi = fakePaintApi();
     render(<PaintEditor sessionId="session-1" paintApi={paintApi} snapshot={activeSnapshot} currentUserId={1} />);
@@ -211,6 +213,8 @@ describe('PaintEditor', () => {
       moveTo: vi.fn(),
       lineTo: vi.fn(),
       stroke,
+      arc: vi.fn(),
+      fill: vi.fn(),
     } as unknown as CanvasRenderingContext2D);
     const paintApi = fakePaintApi();
     const { rerender } = render(<PaintEditor sessionId="session-1" paintApi={paintApi} snapshot={activeSnapshot} previews={[]} currentUserId={1} />);
@@ -248,6 +252,8 @@ describe('PaintEditor', () => {
       moveTo: vi.fn(),
       lineTo,
       stroke,
+      arc: vi.fn(),
+      fill: vi.fn(),
     } as unknown as CanvasRenderingContext2D);
     const paintApi = fakePaintApi();
     const { rerender } = render(<PaintEditor sessionId="session-1" paintApi={paintApi} snapshot={activeSnapshot} previews={[]} currentUserId={1} />);
@@ -280,7 +286,7 @@ describe('PaintEditor', () => {
   it('removes an optimistic stroke and reports a rejected commit', async () => {
     const stroke = vi.fn();
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-      clearRect: vi.fn(), drawImage: vi.fn(), beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke,
+      clearRect: vi.fn(), drawImage: vi.fn(), beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke, arc: vi.fn(), fill: vi.fn(),
     } as unknown as CanvasRenderingContext2D);
     const paintApi = { ...fakePaintApi(), commitStroke: vi.fn().mockRejectedValue(new Error('Stroke rejected')) };
     const { rerender } = render(<PaintEditor sessionId="session-1" paintApi={paintApi} snapshot={activeSnapshot} currentUserId={1} />);
@@ -313,7 +319,7 @@ describe('PaintEditor', () => {
   it('drops pending local strokes when the server advances the generation', () => {
     const stroke = vi.fn();
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-      clearRect: vi.fn(), drawImage: vi.fn(), beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke,
+      clearRect: vi.fn(), drawImage: vi.fn(), beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke, arc: vi.fn(), fill: vi.fn(),
     } as unknown as CanvasRenderingContext2D);
     const paintApi = { ...fakePaintApi(), commitStroke: vi.fn(() => new Promise(() => {})) };
     const { rerender } = render(<PaintEditor sessionId="session-1" paintApi={paintApi} snapshot={activeSnapshot} currentUserId={1} />);
@@ -356,7 +362,7 @@ describe('PaintEditor', () => {
     Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', { configurable: true, get: () => 100 });
     Object.defineProperty(HTMLImageElement.prototype, 'decode', { configurable: true, value: vi.fn().mockResolvedValue(undefined) });
     const draw = vi.fn();
-    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({ clearRect: vi.fn(), drawImage: draw, beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn() } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({ clearRect: vi.fn(), drawImage: draw, beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(), arc: vi.fn(), fill: vi.fn() } as unknown as CanvasRenderingContext2D);
 
     render(<PaintEditor sessionId="session-1" paintApi={{ commitStroke: vi.fn(), sendPreview: vi.fn(), undo: vi.fn(), clear: vi.fn(), end: vi.fn() }} snapshot={{ ...activeSnapshot, strokes }} previews={[preview]} currentUserId={1} matrixClient={matrixClient} />);
 

--- a/src/Brmble.Web/src/utils/paintCanvas.test.ts
+++ b/src/Brmble.Web/src/utils/paintCanvas.test.ts
@@ -16,6 +16,8 @@ describe('paintCanvas', () => {
       moveTo: () => operations.push('moveTo'),
       lineTo: () => operations.push('lineTo'),
       stroke: () => operations.push('stroke'),
+      arc: (...args: number[]) => operations.push(`arc:${args.join(',')}`),
+      fill: () => operations.push('fill'),
       set globalCompositeOperation(value: string) { operations.push(value); },
       set strokeStyle(value: string) { operations.push(value); },
       set lineWidth(value: number) { operations.push(String(value)); },
@@ -37,6 +39,31 @@ describe('paintCanvas', () => {
     });
 
     expect(operations).toContain('destination-out');
+    expect(operations).toContain('arc:10,20,3,0,6.283185307179586');
+    expect(operations).toContain('fill');
+  });
+
+  it('renders a one-point pen stroke as a filled dot', () => {
+    const operations: string[] = [];
+    const ctx = {
+      beginPath: () => operations.push('beginPath'),
+      moveTo: () => operations.push('moveTo'),
+      arc: (...args: number[]) => operations.push(`arc:${args.join(',')}`),
+      fill: () => operations.push('fill'),
+      set globalCompositeOperation(value: string) { operations.push(value); },
+      set fillStyle(value: string) { operations.push(value); },
+      set strokeStyle(_value: string) {}, set lineWidth(_value: number) {}, lineCap: 'round', lineJoin: 'round',
+    } as unknown as CanvasRenderingContext2D;
+
+    applyPaintStrokeToContext(ctx, 100, 50, {
+      id: 'stroke-pen-dot', correlationId: 'corr-pen-dot', authorUserId: 1, authorMatrixUserId: '@alice:server',
+      sequence: 1, generation: 0, tool: 'pen', color: '#ef4444', width: 6,
+      points: [{ x: 0.1, y: 0.2 }], active: true,
+    });
+
+    expect(operations).toContain('source-over');
+    expect(operations).toContain('arc:10,10,3,0,6.283185307179586');
+    expect(operations).toContain('fill');
   });
 
   it('keeps the source layer intact when composing an erased annotation into a PNG', async () => {
@@ -47,9 +74,9 @@ describe('paintCanvas', () => {
       set globalCompositeOperation(value: string) { compositionOperations.push(value); },
     } as unknown as CanvasRenderingContext2D;
     const annotationContext = {
-      beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(),
+      beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(), arc: vi.fn(), fill: vi.fn(),
       set globalCompositeOperation(value: string) { annotationOperations.push(value); },
-      set strokeStyle(_value: string) {}, set lineWidth(_value: number) {}, lineCap: 'round', lineJoin: 'round',
+      set strokeStyle(_value: string) {}, set fillStyle(_value: string) {}, set lineWidth(_value: number) {}, lineCap: 'round', lineJoin: 'round',
     } as unknown as CanvasRenderingContext2D;
     const output = { width: 0, height: 0, getContext: vi.fn(() => compositionContext), toBlob: (callback: BlobCallback) => callback(new Blob(['png'])) } as unknown as HTMLCanvasElement;
     const annotations = { width: 0, height: 0, getContext: vi.fn(() => annotationContext) } as unknown as HTMLCanvasElement;

--- a/src/Brmble.Web/src/utils/paintCanvas.ts
+++ b/src/Brmble.Web/src/utils/paintCanvas.ts
@@ -17,7 +17,15 @@ export function applyPaintStrokeToContext(ctx: CanvasRenderingContext2D, width: 
   ctx.lineCap = 'round';
   ctx.lineJoin = 'round';
   ctx.beginPath();
-  ctx.moveTo(first.x * width, first.y * height);
+  const x = first.x * width;
+  const y = first.y * height;
+  if (stroke.points.length === 1) {
+    ctx.fillStyle = stroke.color ?? '#000000';
+    ctx.arc(x, y, stroke.width / 2, 0, Math.PI * 2);
+    ctx.fill();
+    return;
+  }
+  ctx.moveTo(x, y);
   for (const point of stroke.points.slice(1)) ctx.lineTo(point.x * width, point.y * height);
   ctx.stroke();
 }


### PR DESCRIPTION
## Summary

Fixes one-point paint strokes disappearing when the user clicks or taps without moving.

- Renders single-point pen strokes as filled dots.
- Renders single-point eraser strokes using `destination-out`.
- Adds regression tests covering dot geometry and eraser behavior.
- Preserves PNG export behavior through the shared canvas helper.

## Testing

- Full web test suite
- Type-check
- Production build