### PR TITLE
feat: server wire contract for the user projection (Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md
+++ b/docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md
@@ -12,11 +12,17 @@
 
 **Scope note:** This is Phase 1 of three. Phase 2 builds the client-side `UserProjectionStore`; Phase 3 rewires `MumbleAdapter` and `App.tsx`. Phase 1 ships and is useful on its own — no client changes are required for it to be safe.
 
-**Dependency:** PR #617 (`fix/companion-broadcast-scope`) must be merged first. Gap detection requires every client to observe every mutation; the channel-scoped `companionChanged` that #617 removes would cause phantom gaps. Verify with:
+**Dependencies:**
+
+1. **PR #617 (`fix/companion-broadcast-scope`) — MERGED** as `a4c993fa`. Gap detection requires every client to observe every mutation; the channel-scoped `companionChanged` it removed would have caused phantom gaps.
+2. **`fix/companion-update-race` (`cd7b48fa`) must land first.** It adds `TryUpdateCompanionIdIfOwnedBy` and restructures the deletion endpoint. This plan is written against the post-`cd7b48fa` code. Verify both with:
 
 ```bash
 git log --oneline origin/main | Select-String "broadcast companion changes"
+Select-String -Path src/Brmble.Server/Events/ISessionMappingService.cs -Pattern TryUpdateCompanionIdIfOwnedBy
 ```
+
+If the second returns nothing, stop — Task 1 and Task 4 reference a method that does not exist yet.
 
 ---
 
@@ -24,9 +30,16 @@ git log --oneline origin/main | Select-String "broadcast companion changes"
 
 `SessionMappingService` (`src/Brmble.Server/Events/SessionMappingService.cs`) is an in-memory store of four `ConcurrentDictionary` indexes. It is a singleton (`Mumble/MumbleExtensions.cs:12`) and holds no persistence — a process restart empties it, which is exactly why `instanceId` is needed.
 
-`BrmbleEventBus.BroadcastCoreAsync` is deliberately **not** an `async` method: it serialises the payload and enqueues to every client's per-socket queue synchronously, then returns a `Task` you await for completion. This means calling it inside a `lock` is safe — no socket I/O happens under the lock — and it is why the ordering approach in Task 3 works.
+`BrmbleEventBus.BroadcastCoreAsync` is deliberately **not** an `async` method: it serialises the payload and enqueues to every client's per-socket queue synchronously, then returns a `Task` that completes when delivery finishes. The distinction matters enormously here:
 
-There are six mutation methods: `TryAddMatrixUser`, `RemoveSession`, `TryUpdateCompanionId`, `TryUpdateCompanionIdIfCurrent`, `TryUpdateBrmbleStatus`, `TryUpdateCertHash`.
+- **Calling** `BroadcastAsync` does no socket I/O — it only enqueues.
+- **Awaiting** the returned task waits for actual delivery.
+
+So holding a lock across the *call* is cheap and safe; holding it across the *await* is not. `MappingEventPublisher` (Task 3) enqueues under its lock and awaits outside it, which is what gives ordering without serialising I/O.
+
+**This is also why the publisher does not regress `cd7b48fa`.** That commit moved deletion broadcasts outside the event-coordinator lock because `await eventBus.BroadcastAsync(...)` was waiting on a full-server fan-out while holding it. Using the publisher inside that lock is fine — `PublishAsync` returns before any I/O — provided you collect the tasks and `await Task.WhenAll(...)` after releasing. Task 4 shows the shape.
+
+There are seven mutation methods: `TryAddMatrixUser`, `RemoveSession`, `TryUpdateCompanionId`, `TryUpdateCompanionIdIfCurrent`, `TryUpdateCompanionIdIfOwnedBy`, `TryUpdateBrmbleStatus`, `TryUpdateCertHash`.
 
 **JSON naming — read this before writing any payload.** `BrmbleEventBus` serialises with `PropertyNamingPolicy = JsonNamingPolicy.CamelCase` (`BrmbleEventBus.cs:17`), but the tests in this plan call `JsonSerializer.Serialize` with default options. The codebase convention sidesteps the mismatch by naming anonymous-type properties in camelCase directly (`sessionId = ...`, never `SessionId`). Follow it: always write `instanceId = envelope.InstanceId`, never the `envelope.InstanceId` property shorthand — the shorthand emits `InstanceId` under default options and every assertion in this plan would fail.
 
@@ -81,8 +94,11 @@ Append these to `SessionMappingServiceTests.cs`, inside the existing `SessionMap
         _svc.TryUpdateCertHash(1, "abc");
         Assert.AreEqual(4L, _svc.Revision);
 
-        _svc.RemoveSession(1);
+        _svc.TryUpdateCompanionIdIfOwnedBy(1, 1L, "pip");
         Assert.AreEqual(5L, _svc.Revision);
+
+        _svc.RemoveSession(1);
+        Assert.AreEqual(6L, _svc.Revision);
     }
 
     [TestMethod]
@@ -99,6 +115,9 @@ Append these to `SessionMappingServiceTests.cs`, inside the existing `SessionMap
 
         // A CAS whose expected value does not match must not bump either.
         Assert.IsFalse(_svc.TryUpdateCompanionIdIfCurrent(1, "notthecurrentone", "pip"));
+
+        // Nor one whose owning userId does not match.
+        Assert.IsFalse(_svc.TryUpdateCompanionIdIfOwnedBy(1, 999L, "pip"));
 
         Assert.AreEqual(before, _svc.Revision);
     }
@@ -227,7 +246,7 @@ In `TryUpdateBrmbleStatus`, `TryUpdateCompanionId` and `TryUpdateCertHash`, add 
 
 `TryUpdateBrmbleStatus` becomes the same shape with `IsBrmbleClient = isBrmbleClient`, and `TryUpdateCertHash` the same shape with `CertHash = certHash`.
 
-In `TryUpdateCompanionIdIfCurrent`, add `Bump();` immediately before its existing `return true;` inside the `if (_sessionToMapping.TryUpdate(...))` block.
+In `TryUpdateCompanionIdIfCurrent` and `TryUpdateCompanionIdIfOwnedBy`, add `Bump();` immediately before each existing `return true;` inside the `if (_sessionToMapping.TryUpdate(...))` block. Both are already CAS loops, so they need no other change.
 
 - [ ] **Step 5: Run the tests to verify they pass**
 
@@ -708,7 +727,7 @@ Declare `var activatedSessionId = 0;` above the call, since it is now assigned i
         var sessionId = 0;
         await publisher.PublishAsync(
             () => sessionMapping.TryGetMappingByUserId(user.Id, out sessionId, out _)
-                  && sessionMapping.TryUpdateCompanionId(sessionId, companionId),
+                  && sessionMapping.TryUpdateCompanionIdIfOwnedBy(sessionId, user.Id, companionId),
             envelope =>
             {
                 var wire = CompanionWireSelection.FromPersisted(companionId);
@@ -725,12 +744,33 @@ Declare `var activatedSessionId = 0;` above the call, since it is now assigned i
             });
 ```
 
+Keep `TryUpdateCompanionIdIfOwnedBy` — do not revert it to `TryUpdateCompanionId`. It is a CAS on the owning userId that stops a session recycled between the lookup and the write from having the new owner's companion overwritten.
+
 Add `IMappingEventPublisher publisher` to the `/auth/companion` endpoint's DI parameters and to `PersistCompanionSelectionAsync`'s signature, replacing `IBrmbleEventBus eventBus` if it becomes unused.
 
-`CustomCompanionEndpoints.cs:71-83` becomes:
+`CustomCompanionEndpoints` deletion. `cd7b48fa` restructured this into "mutate inside the coordinator lock, collect, broadcast after". Preserve that shape — but note the publisher must do the *mutation* too, since it is the mutation that assigns the revision. Collect the returned tasks and await them after the lock releases.
+
+Replace the `resetSessions` list and the loop that follows it with:
 
 ```csharp
-                    await publisher.PublishAsync(
+            var sends = new List<Task>();
+
+            using (await eventCoordinator.AcquireAsync(eventId, httpContext.RequestAborted))
+            {
+                // ... unchanged: record lookup, redaction, MarkDeletedAsync, ResetSelectionsAsync ...
+
+                foreach (var affectedUserId in affectedUserIds)
+                {
+                    if (!sessionMapping.TryGetMappingByUserId(affectedUserId, out var sessionId, out var mapping)
+                        || mapping is null)
+                    {
+                        continue;
+                    }
+
+                    // PublishAsync returns as soon as the payload is enqueued, so the
+                    // coordinator lock is not held across the fan-out. Awaiting these here
+                    // would reintroduce exactly what cd7b48fa removed.
+                    sends.Add(publisher.PublishAsync(
                         () => sessionMapping.TryUpdateCompanionIdIfCurrent(
                             sessionId, deletedCompanionId, "floppy"),
                         envelope => new
@@ -742,8 +782,15 @@ Add `IMappingEventPublisher publisher` to the `/auth/companion` endpoint's DI pa
                             matrixUserId = mapping.MatrixUserId,
                             companionId = "floppy",
                             customCompanionId = (string?)null
-                        });
+                        }));
+                }
+            }
+
+            await Task.WhenAll(sends);
+            return Results.NoContent();
 ```
+
+Add `IMappingEventPublisher publisher` to the DELETE endpoint's DI parameters and remove `IBrmbleEventBus eventBus` if it becomes unused.
 
 `MumbleServerCallback.cs:197` becomes:
 

--- a/docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md
+++ b/docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md
@@ -1042,6 +1042,7 @@ git commit -m "feat: stamp mapping snapshots and serve client resync requests"
 - [ ] `dotnet build` is clean with 0 warnings
 - [ ] `dotnet test` passes in all four projects
 - [ ] Every one of the six mapping payload types carries `instanceId` and `revision`
+- [ ] **Every revision bump is announced.** Cross-check each `Bump()` call site against a producer that broadcasts a stamped payload. A bump nobody hears manufactures a phantom gap in every connected client, which is worse than not bumping at all. In particular `RemoveSession` bumps, so `userMappingRemoved` (`MumbleServerCallback.cs:197`) must go through the publisher — it is not made redundant by snapshot reconciliation
 - [ ] `userMappingAdded` carries `isBrmbleClient: null` when no socket has registered
 - [ ] A `{"type":"requestSnapshot"}` frame returns a stamped `sessionMappingSnapshot`
 - [ ] An existing client build still connects and behaves normally — every change is additive, and the client ignores unknown fields

--- a/docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md
+++ b/docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md
@@ -1,0 +1,1022 @@
+# User Projection — Phase 1: Server Wire Contract
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Brmble server's session-mapping payloads self-describing and orderable — an `instanceId` to detect restarts, a monotonic `revision` to detect gaps, tri-state `isBrmbleClient` so "unknown" stops being sent as `false`, and a `requestSnapshot` message so a client can repair itself.
+
+**Architecture:** The revision counter lives inside `SessionMappingService`, which already owns every mutation. A new `MappingEventPublisher` performs "mutate, then enqueue the broadcast" under a single lock, so revision order always matches delivery order. All changes are additive on the wire; older clients ignore the new fields.
+
+**Tech Stack:** C# / .NET 10, ASP.NET Core minimal APIs, MSTest + Moq.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-user-projection-design.md` §4.1, §4.2, §4.5.
+
+**Scope note:** This is Phase 1 of three. Phase 2 builds the client-side `UserProjectionStore`; Phase 3 rewires `MumbleAdapter` and `App.tsx`. Phase 1 ships and is useful on its own — no client changes are required for it to be safe.
+
+**Dependency:** PR #617 (`fix/companion-broadcast-scope`) must be merged first. Gap detection requires every client to observe every mutation; the channel-scoped `companionChanged` that #617 removes would cause phantom gaps. Verify with:
+
+```bash
+git log --oneline origin/main | Select-String "broadcast companion changes"
+```
+
+---
+
+## Background you need
+
+`SessionMappingService` (`src/Brmble.Server/Events/SessionMappingService.cs`) is an in-memory store of four `ConcurrentDictionary` indexes. It is a singleton (`Mumble/MumbleExtensions.cs:12`) and holds no persistence — a process restart empties it, which is exactly why `instanceId` is needed.
+
+`BrmbleEventBus.BroadcastCoreAsync` is deliberately **not** an `async` method: it serialises the payload and enqueues to every client's per-socket queue synchronously, then returns a `Task` you await for completion. This means calling it inside a `lock` is safe — no socket I/O happens under the lock — and it is why the ordering approach in Task 3 works.
+
+There are six mutation methods: `TryAddMatrixUser`, `RemoveSession`, `TryUpdateCompanionId`, `TryUpdateCompanionIdIfCurrent`, `TryUpdateBrmbleStatus`, `TryUpdateCertHash`.
+
+**JSON naming — read this before writing any payload.** `BrmbleEventBus` serialises with `PropertyNamingPolicy = JsonNamingPolicy.CamelCase` (`BrmbleEventBus.cs:17`), but the tests in this plan call `JsonSerializer.Serialize` with default options. The codebase convention sidesteps the mismatch by naming anonymous-type properties in camelCase directly (`sessionId = ...`, never `SessionId`). Follow it: always write `instanceId = envelope.InstanceId`, never the `envelope.InstanceId` property shorthand — the shorthand emits `InstanceId` under default options and every assertion in this plan would fail.
+
+**Deliberately not in Phase 1.** Spec §4.1 also makes `companionId` tri-state, with `"floppy"` becoming a render-time fallback. That is *not* done here, because §4.4 ties it to client version negotiation: the server must keep sending the legacy `companionId` / `customCompanionId` split for clients that predate the projection. `CompanionWireSelection.FromPersisted` is therefore unchanged in Phase 1 and revisited in Phase 3. `isBrmbleClient` carries no such constraint — no existing client distinguishes `false` from absent — so widening it now is safe.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/Brmble.Server/Events/ISessionMappingService.cs` | *Modify* — `SessionMapping.IsBrmbleClient` becomes `bool?`; interface gains `InstanceId`, `Revision` |
+| `src/Brmble.Server/Events/SessionMappingService.cs` | *Modify* — revision increment on every successful mutation |
+| `src/Brmble.Server/Events/MappingEnvelope.cs` | *Create* — the `(instanceId, revision)` stamp |
+| `src/Brmble.Server/Events/IMappingEventPublisher.cs` | *Create* — interface for ordered mutate-then-broadcast |
+| `src/Brmble.Server/Events/MappingEventPublisher.cs` | *Create* — implementation holding the ordering lock |
+| `src/Brmble.Server/Events/SessionMappingHandler.cs` | *Modify* — publish `null` not `false`; route through publisher |
+| `src/Brmble.Server/Auth/AuthService.cs` | *Modify* — activation/deactivation through publisher |
+| `src/Brmble.Server/Auth/AuthEndpoints.cs` | *Modify* — companion change through publisher; stamp `/auth/token` snapshot |
+| `src/Brmble.Server/Companions/CustomCompanionEndpoints.cs` | *Modify* — deletion broadcast through publisher |
+| `src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs` | *Modify* — stamp snapshot, fix read loop, handle `requestSnapshot` |
+| `src/Brmble.Server/Mumble/MumbleExtensions.cs` | *Modify* — register `IMappingEventPublisher` |
+
+---
+
+## Task 1: Revision counter and instance id
+
+**Files:**
+- Modify: `src/Brmble.Server/Events/ISessionMappingService.cs`
+- Modify: `src/Brmble.Server/Events/SessionMappingService.cs`
+- Test: `tests/Brmble.Server.Tests/Events/SessionMappingServiceTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these to `SessionMappingServiceTests.cs`, inside the existing `SessionMappingServiceTests` class:
+
+```csharp
+    [TestMethod]
+    public void Revision_StartsAtZeroAndIncrementsOnEverySuccessfulMutation()
+    {
+        Assert.AreEqual(0L, _svc.Revision);
+
+        _svc.TryAddMatrixUser(1, "@1:server", "Alice", 1L, "bee");
+        Assert.AreEqual(1L, _svc.Revision);
+
+        _svc.TryUpdateCompanionId(1, "retro");
+        Assert.AreEqual(2L, _svc.Revision);
+
+        _svc.TryUpdateBrmbleStatus(1, true);
+        Assert.AreEqual(3L, _svc.Revision);
+
+        _svc.TryUpdateCertHash(1, "abc");
+        Assert.AreEqual(4L, _svc.Revision);
+
+        _svc.RemoveSession(1);
+        Assert.AreEqual(5L, _svc.Revision);
+    }
+
+    [TestMethod]
+    public void Revision_DoesNotIncrementWhenMutationDoesNotApply()
+    {
+        _svc.TryAddMatrixUser(1, "@1:server", "Alice", 1L, "bee");
+        var before = _svc.Revision;
+
+        // Session 99 has no mapping, so none of these change anything.
+        Assert.IsFalse(_svc.TryUpdateCompanionId(99, "retro"));
+        Assert.IsFalse(_svc.TryUpdateBrmbleStatus(99, true));
+        Assert.IsFalse(_svc.TryUpdateCertHash(99, "abc"));
+        _svc.RemoveSession(99);
+
+        // A CAS whose expected value does not match must not bump either.
+        Assert.IsFalse(_svc.TryUpdateCompanionIdIfCurrent(1, "notthecurrentone", "pip"));
+
+        Assert.AreEqual(before, _svc.Revision);
+    }
+
+    [TestMethod]
+    public void InstanceId_IsStableWithinAnInstanceAndDiffersAcrossInstances()
+    {
+        var first = _svc.InstanceId;
+
+        _svc.TryAddMatrixUser(1, "@1:server", "Alice", 1L, "bee");
+        Assert.AreEqual(first, _svc.InstanceId, "InstanceId must not change while the process lives");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(first));
+
+        var replacement = new SessionMappingService();
+        Assert.AreNotEqual(first, replacement.InstanceId, "a restart must be observable");
+        Assert.AreEqual(0L, replacement.Revision);
+    }
+
+    [TestMethod]
+    public void Revision_IsMonotonicUnderConcurrentMutations()
+    {
+        for (var i = 0; i < 200; i++)
+            _svc.TryAddMatrixUser(i, $"@{i}:server", $"U{i}", i, "bee");
+
+        Parallel.For(0, 200, i => _svc.TryUpdateCompanionId(i, "retro"));
+
+        // 200 adds + 200 updates, none of them lost to a read-modify-write race.
+        Assert.AreEqual(400L, _svc.Revision);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~SessionMappingServiceTests"`
+
+Expected: FAIL — compile error, `'ISessionMappingService' does not contain a definition for 'Revision'`.
+
+- [ ] **Step 3: Add the members to the interface**
+
+In `src/Brmble.Server/Events/ISessionMappingService.cs`, add to the `ISessionMappingService` interface, above `SetNameForSession`:
+
+```csharp
+    /// <summary>
+    /// Identifies this process's mapping table. Regenerated on every start, so a client that
+    /// sees a different value knows the server restarted and its cached server-owned fields
+    /// are worthless.
+    /// </summary>
+    string InstanceId { get; }
+
+    /// <summary>
+    /// Monotonic counter, incremented once per successful mutation. Stamped on every payload so
+    /// a client can detect a gap (revision > last + 1) and request a snapshot.
+    /// </summary>
+    long Revision { get; }
+```
+
+- [ ] **Step 4: Implement in the service**
+
+In `src/Brmble.Server/Events/SessionMappingService.cs`, add these fields directly below the existing `_userIdToSession` field:
+
+```csharp
+    private readonly string _instanceId = Guid.NewGuid().ToString("N");
+    private long _revision;
+
+    public string InstanceId => _instanceId;
+
+    public long Revision => Interlocked.Read(ref _revision);
+
+    private void Bump() => Interlocked.Increment(ref _revision);
+```
+
+Now call `Bump()` from each mutation, **only on the path that actually changed something**:
+
+In `TryAddMatrixUser`, inside the `if (_sessionToMapping.TryAdd(...))` block, before `return true;`:
+
+```csharp
+            _userIdToSession[userId] = sessionId;
+            Bump();
+            return true;
+```
+
+In `RemoveSession`, replace the body with:
+
+```csharp
+    public void RemoveSession(int sessionId)
+    {
+        var changed = false;
+        if (_sessionToMapping.TryRemove(sessionId, out var mapping))
+        {
+            // Only remove userId→session if it still points to this session
+            ((ICollection<KeyValuePair<long, int>>)_userIdToSession)
+                .Remove(new KeyValuePair<long, int>(mapping.UserId, sessionId));
+            changed = true;
+        }
+        if (_sessionToName.TryRemove(sessionId, out var name))
+        {
+            // Only remove name→session if it still points to this session
+            // (a newer session may have claimed the same name)
+            ((ICollection<KeyValuePair<string, int>>)_nameToSession)
+                .Remove(new KeyValuePair<string, int>(name, sessionId));
+        }
+        if (changed) Bump();
+    }
+```
+
+In `TryUpdateBrmbleStatus`, `TryUpdateCompanionId` and `TryUpdateCertHash`, add `Bump();` immediately before each `return true;`.
+
+`TryUpdateCompanionId` and `TryUpdateBrmbleStatus` currently use a non-atomic read-modify-write (`_sessionToMapping[sessionId] = existing with {...}`), which the concurrency test in Step 1 would expose. Replace both bodies with a CAS loop. `TryUpdateCompanionId` becomes:
+
+```csharp
+    public bool TryUpdateCompanionId(int sessionId, string companionId)
+    {
+        while (_sessionToMapping.TryGetValue(sessionId, out var existing))
+        {
+            var updated = existing with { CompanionId = companionId };
+            if (_sessionToMapping.TryUpdate(sessionId, updated, existing))
+            {
+                Bump();
+                return true;
+            }
+        }
+
+        return false;
+    }
+```
+
+`TryUpdateBrmbleStatus` becomes the same shape with `IsBrmbleClient = isBrmbleClient`, and `TryUpdateCertHash` the same shape with `CertHash = certHash`.
+
+In `TryUpdateCompanionIdIfCurrent`, add `Bump();` immediately before its existing `return true;` inside the `if (_sessionToMapping.TryUpdate(...))` block.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~SessionMappingServiceTests"`
+
+Expected: PASS, all tests in the class.
+
+- [ ] **Step 6: Run the whole server suite for regressions**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj`
+
+Expected: PASS. If a test double implements `ISessionMappingService` by hand it will now fail to compile — add `public string InstanceId => "test";` and `public long Revision => 0;` to it. Moq-generated mocks need no change.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Server/Events/ tests/Brmble.Server.Tests/Events/
+git commit -m "feat: add instance id and revision counter to session mappings"
+```
+
+---
+
+## Task 2: Tri-state isBrmbleClient
+
+**Files:**
+- Modify: `src/Brmble.Server/Events/ISessionMappingService.cs`
+- Modify: `src/Brmble.Server/Events/SessionMappingHandler.cs`
+- Test: `tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs`
+
+**Why:** `SessionMappingHandler` reads the flag from `IActiveBrmbleSessions`, which is in-memory and wiped by a restart. It currently publishes `false` — a positive assertion of the wrong value — when the truthful answer is "not known yet". Only a WebSocket registration proves `true`, and only an observed deactivation proves `false`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing test class in `tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs`:
+
+```csharp
+    [TestMethod]
+    public async Task OnUserConnected_PublishesUnknownBrmbleStatusWhenNoActiveSession()
+    {
+        // No WebSocket has registered for this cert, so IActiveBrmbleSessions returns false.
+        // That is absence of evidence, not evidence of absence: it must go out as null.
+        await _handler.OnUserConnected(new MumbleUser
+        {
+            SessionId = 42,
+            Name = "Alice",
+            CertHash = "cert-alice"
+        });
+
+        var payload = _eventBus.Broadcasts.Single(p =>
+            JsonSerializer.Serialize(p).Contains("\"type\":\"userMappingAdded\""));
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
+
+        Assert.AreEqual(JsonValueKind.Null,
+            doc.RootElement.GetProperty("isBrmbleClient").ValueKind);
+    }
+
+    [TestMethod]
+    public async Task OnUserConnected_PublishesTrueWhenSessionIsKnownActive()
+    {
+        _activeSessions.Activate("cert-alice");
+
+        await _handler.OnUserConnected(new MumbleUser
+        {
+            SessionId = 42,
+            Name = "Alice",
+            CertHash = "cert-alice"
+        });
+
+        var payload = _eventBus.Broadcasts.Single(p =>
+            JsonSerializer.Serialize(p).Contains("\"type\":\"userMappingAdded\""));
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
+
+        Assert.IsTrue(doc.RootElement.GetProperty("isBrmbleClient").GetBoolean());
+    }
+```
+
+Read the top of the existing file first and reuse whatever fixture fields it already defines for the handler, event bus and active sessions. If the existing fixture names differ from `_handler`, `_eventBus.Broadcasts` and `_activeSessions`, adapt these two tests to match rather than introducing a second fixture. Add `using System.Text.Json;` if absent.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~SessionMappingHandlerTests"`
+
+Expected: FAIL — `Assert.AreEqual failed. Expected:<Null>. Actual:<False>`.
+
+- [ ] **Step 3: Widen the record**
+
+In `src/Brmble.Server/Events/ISessionMappingService.cs`, change the record and the mutation signature:
+
+```csharp
+public record SessionMapping(string MatrixUserId, string MumbleName, long UserId, string CompanionId, bool? IsBrmbleClient = null, string? CertHash = null);
+```
+
+and in the interface:
+
+```csharp
+    bool TryUpdateBrmbleStatus(int sessionId, bool? isBrmbleClient);
+```
+
+Update the implementation signature in `SessionMappingService.cs` to match (`bool? isBrmbleClient`). The CAS body from Task 1 needs no other change.
+
+- [ ] **Step 4: Publish unknown instead of false**
+
+In `src/Brmble.Server/Events/SessionMappingHandler.cs`, replace line 38:
+
+```csharp
+        // A registered WebSocket proves true. Nothing proves false here: after a restart
+        // _activeSessions is empty, so "not active" only means "not known yet". Publishing
+        // false would assert something we cannot know, and clients would believe it.
+        bool? isBrmbleClient = _activeSessions.IsBrmbleClient(user.CertHash) ? true : null;
+```
+
+The rest of the method needs no change: `TryUpdateBrmbleStatus` now takes `bool?`, and the anonymous payload picks up `isBrmbleClient` as `bool?`, which `System.Text.Json` serialises as `null`.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~SessionMappingHandlerTests"`
+
+Expected: PASS.
+
+- [ ] **Step 6: Fix the fallout and run everything**
+
+Run: `dotnet build`
+
+`BrmbleWebSocketHandler.CreateUserMappingAddedPayload` hardcodes `isBrmbleClient = true`, which stays correct — that path runs only when a socket has registered. Any test asserting `isBrmbleClient = false` in a `userMappingAdded` payload must be updated to expect `null`; that is the intended behaviour change.
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Server/ tests/Brmble.Server.Tests/
+git commit -m "fix: publish unknown brmble status instead of asserting false"
+```
+
+---
+
+## Task 3: Ordered mutate-then-broadcast publisher
+
+**Files:**
+- Create: `src/Brmble.Server/Events/MappingEnvelope.cs`
+- Create: `src/Brmble.Server/Events/IMappingEventPublisher.cs`
+- Create: `src/Brmble.Server/Events/MappingEventPublisher.cs`
+- Modify: `src/Brmble.Server/Mumble/MumbleExtensions.cs`
+- Test: `tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs` (create)
+
+**Why:** Revision order must match delivery order, or a client will discard a newer payload as a duplicate. Mutations and broadcasts currently happen as two separate statements in five different files, so two threads can interleave them. `BroadcastCoreAsync` enqueues synchronously and does no socket I/O, so holding a short lock across the call is safe and sufficient.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs`:
+
+```csharp
+using System.Text.Json;
+using Brmble.Server.Events;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.Events;
+
+[TestClass]
+public class MappingEventPublisherTests
+{
+    private SessionMappingService _mappings = null!;
+    private RecordingEventBus _bus = null!;
+    private MappingEventPublisher _publisher = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mappings = new SessionMappingService();
+        _bus = new RecordingEventBus();
+        _publisher = new MappingEventPublisher(_mappings, _bus);
+        _mappings.TryAddMatrixUser(1, "@alice:test", "Alice", 1L, "floppy");
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_StampsPayloadWithInstanceIdAndPostMutationRevision()
+    {
+        await _publisher.PublishAsync(
+            () => _mappings.TryUpdateCompanionId(1, "retro"),
+            envelope => new { type = "companionChanged", instanceId = envelope.InstanceId, revision = envelope.Revision });
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(_bus.Broadcasts.Single()));
+        Assert.AreEqual(_mappings.InstanceId, doc.RootElement.GetProperty("instanceId").GetString());
+        Assert.AreEqual(_mappings.Revision, doc.RootElement.GetProperty("revision").GetInt64());
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_DoesNotBroadcastWhenMutationReportsNoChange()
+    {
+        await _publisher.PublishAsync(
+            () => _mappings.TryUpdateCompanionId(999, "retro"),
+            envelope => new { type = "companionChanged", instanceId = envelope.InstanceId, revision = envelope.Revision });
+
+        Assert.AreEqual(0, _bus.Broadcasts.Count);
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_DeliversInRevisionOrderUnderConcurrency()
+    {
+        await Task.WhenAll(Enumerable.Range(0, 100).Select(i => Task.Run(() =>
+            _publisher.PublishAsync(
+                () => _mappings.TryUpdateCompanionId(1, $"c{i}"),
+                envelope => new { type = "companionChanged", instanceId = envelope.InstanceId, revision = envelope.Revision }))));
+
+        var revisions = _bus.Broadcasts
+            .Select(p => JsonDocument.Parse(JsonSerializer.Serialize(p))
+                .RootElement.GetProperty("revision").GetInt64())
+            .ToList();
+
+        Assert.AreEqual(100, revisions.Count);
+        CollectionAssert.AreEqual(revisions.OrderBy(r => r).ToList(), revisions,
+            "enqueue order must match revision order, or clients discard newer payloads as duplicates");
+    }
+
+    private sealed class RecordingEventBus : IBrmbleEventBus
+    {
+        private readonly object _gate = new();
+        public List<object> Broadcasts { get; } = new();
+
+        public Task BroadcastAsync(object message)
+        {
+            // Mirrors BrmbleEventBus: admission happens synchronously on the calling thread.
+            lock (_gate) Broadcasts.Add(message);
+            return Task.CompletedTask;
+        }
+
+        public Task BroadcastToChannelAsync(int channelId, object message) => BroadcastAsync(message);
+        public Task BroadcastExceptAsync(System.Net.WebSockets.WebSocket excluded, object message) => BroadcastAsync(message);
+        public Task AddClientAsync(System.Net.WebSockets.WebSocket socket, long userId, Func<Task<IReadOnlyList<object>>> initialPayloads) => Task.CompletedTask;
+        public void RemoveClient(System.Net.WebSockets.WebSocket socket) { }
+        public bool HasConnectedClient(long userId) => false;
+    }
+}
+```
+
+`RecordingEventBus` must implement every member of `IBrmbleEventBus`. Open `src/Brmble.Server/Events/IBrmbleEventBus.cs` and add stubs for any member not listed above.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~MappingEventPublisherTests"`
+
+Expected: FAIL — compile error, `The type or namespace name 'MappingEventPublisher' could not be found`.
+
+- [ ] **Step 3: Create the envelope**
+
+Create `src/Brmble.Server/Events/MappingEnvelope.cs`:
+
+```csharp
+namespace Brmble.Server.Events;
+
+/// <summary>
+/// Stamped on every session-mapping payload so a client can tell a restart from a gap.
+/// </summary>
+/// <param name="InstanceId">Identifies the server's mapping table; changes on restart.</param>
+/// <param name="Revision">The table revision produced by the mutation being announced.</param>
+public readonly record struct MappingEnvelope(string InstanceId, long Revision);
+```
+
+- [ ] **Step 4: Create the interface**
+
+Create `src/Brmble.Server/Events/IMappingEventPublisher.cs`:
+
+```csharp
+namespace Brmble.Server.Events;
+
+public interface IMappingEventPublisher
+{
+    /// <summary>
+    /// Runs <paramref name="mutate"/> and, only if it reports a change, broadcasts the payload
+    /// built from the resulting envelope. Mutation and broadcast admission happen under one
+    /// lock, so revision order always matches delivery order.
+    /// </summary>
+    /// <param name="mutate">Performs the mutation; returns false if nothing changed.</param>
+    /// <param name="payload">Builds the payload from the post-mutation envelope.</param>
+    Task PublishAsync(Func<bool> mutate, Func<MappingEnvelope, object> payload);
+}
+```
+
+- [ ] **Step 5: Create the implementation**
+
+Create `src/Brmble.Server/Events/MappingEventPublisher.cs`:
+
+```csharp
+namespace Brmble.Server.Events;
+
+public sealed class MappingEventPublisher(
+    ISessionMappingService mappings,
+    IBrmbleEventBus eventBus) : IMappingEventPublisher
+{
+    private readonly object _gate = new();
+
+    public Task PublishAsync(Func<bool> mutate, Func<MappingEnvelope, object> payload)
+    {
+        Task send;
+        lock (_gate)
+        {
+            if (!mutate()) return Task.CompletedTask;
+
+            var envelope = new MappingEnvelope(mappings.InstanceId, mappings.Revision);
+
+            // Safe under the lock: BrmbleEventBus.BroadcastCoreAsync is deliberately not async
+            // and enqueues to every per-socket queue before returning, so no socket I/O happens
+            // here. Awaiting inside the lock would be wrong; capturing the task is not.
+            send = eventBus.BroadcastAsync(payload(envelope));
+        }
+
+        return send;
+    }
+}
+```
+
+- [ ] **Step 6: Register it**
+
+In `src/Brmble.Server/Mumble/MumbleExtensions.cs`, beside the existing `IChannelMembershipService` registration:
+
+```csharp
+        services.AddSingleton<IMappingEventPublisher, MappingEventPublisher>();
+```
+
+Add `using Brmble.Server.Events;` if it is not already present.
+
+- [ ] **Step 7: Run to verify it passes**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~MappingEventPublisherTests"`
+
+Expected: PASS, three tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Server/Events/ src/Brmble.Server/Mumble/MumbleExtensions.cs tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
+git commit -m "feat: add ordered mutate-then-broadcast publisher for session mappings"
+```
+
+---
+
+## Task 4: Route every mapping broadcast through the publisher
+
+**Files:**
+- Modify: `src/Brmble.Server/Events/SessionMappingHandler.cs`
+- Modify: `src/Brmble.Server/Auth/AuthService.cs:259-268` and `:282-290`
+- Modify: `src/Brmble.Server/Auth/AuthEndpoints.cs` (`PersistCompanionSelectionAsync`)
+- Modify: `src/Brmble.Server/Companions/CustomCompanionEndpoints.cs:68-82`
+- Modify: `src/Brmble.Server/Mumble/MumbleServerCallback.cs:197` (`userMappingRemoved`)
+- Test: `tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs` (create)
+
+**Why:** A client applies `revision == last + 1` and treats anything higher as a gap. If even one producer omits the envelope, every client resyncs on it forever.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs`:
+
+```csharp
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.Events;
+
+/// <summary>
+/// Every session-mapping payload must carry the envelope. A producer that forgets it makes
+/// every connected client detect a permanent gap and resync in a loop.
+/// </summary>
+[TestClass]
+public class MappingPayloadEnvelopeTests
+{
+    private static readonly string[] MappingEventTypes =
+    {
+        "userMappingAdded",
+        "userMappingRemoved",
+        "brmbleClientActivated",
+        "brmbleClientDeactivated",
+        "companionChanged",
+        "sessionMappingSnapshot"
+    };
+
+    [TestMethod]
+    public void EveryMappingEventTypeIsCoveredByAnEnvelopeAssertion()
+    {
+        // Guards against a new mapping event being added without an envelope test.
+        // Update this list and add a matching assertion in the suites listed in the plan.
+        Assert.AreEqual(6, MappingEventTypes.Length);
+    }
+
+    internal static void AssertHasEnvelope(object payload, string expectedType)
+    {
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
+        Assert.AreEqual(expectedType, doc.RootElement.GetProperty("type").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("instanceId", out var instanceId),
+            $"{expectedType} is missing instanceId");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(instanceId.GetString()),
+            $"{expectedType} has a blank instanceId");
+        Assert.IsTrue(doc.RootElement.TryGetProperty("revision", out var revision),
+            $"{expectedType} is missing revision");
+        Assert.IsTrue(revision.GetInt64() > 0,
+            $"{expectedType} must carry the post-mutation revision");
+    }
+}
+```
+
+Then add an envelope assertion to each existing suite that already captures a broadcast:
+
+- In `SessionMappingHandlerTests`, in the `userMappingAdded` test from Task 2, add:
+  `MappingPayloadEnvelopeTests.AssertHasEnvelope(payload, "userMappingAdded");`
+- In `AuthEndpointsCompanionTests.PostAuthCompanion_PersistsAndBroadcastsToAllClients`, capture the broadcast argument and assert the same for `"companionChanged"`.
+- In `CustomCompanionDeletionTests.Delete_ActiveRecordBroadcastsFloppyChangeToAllClients`, likewise.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~MappingPayloadEnvelopeTests|FullyQualifiedName~SessionMappingHandlerTests"`
+
+Expected: FAIL — `userMappingAdded is missing instanceId`.
+
+- [ ] **Step 3: Convert SessionMappingHandler**
+
+Inject `IMappingEventPublisher publisher` into the constructor and store it as `_publisher`. Then replace the broadcast block in `OnUserConnected` (currently lines 47-67) with:
+
+```csharp
+        var wire = CompanionWireSelection.FromPersisted(companionId);
+        await _publisher.PublishAsync(
+            // The mapping mutations above already happened; this announcement is unconditional.
+            () => true,
+            envelope => new
+            {
+                type = "userMappingAdded",
+                instanceId = envelope.InstanceId,
+                revision = envelope.Revision,
+                sessionId = user.SessionId,
+                matrixUserId = dbUser.MatrixUserId,
+                mumbleName = user.Name,
+                companionId = wire.CompanionId,
+                customCompanionId = wire.CustomCompanionId,
+                certHash = user.CertHash,
+                isBrmbleClient
+            });
+
+        if (!mappingAdded && isBrmbleClient == true)
+        {
+            await _publisher.PublishAsync(
+                () => true,
+                envelope => new
+                {
+                    type = "brmbleClientActivated",
+                    instanceId = envelope.InstanceId,
+                    revision = envelope.Revision,
+                    sessionId = user.SessionId
+                });
+        }
+```
+
+- [ ] **Step 4: Convert the other four producers**
+
+Apply the same shape in each place. The `mutate` lambda is the existing mutation call, so the broadcast is skipped when nothing changed:
+
+`AuthService.cs:260-268` becomes:
+
+```csharp
+        _ = _publisher.PublishAsync(
+            () => _sessionMapping.TryGetSessionByUserId(user!.Id, out activatedSessionId)
+                  && _sessionMapping.TryUpdateBrmbleStatus(activatedSessionId, true),
+            envelope => new
+            {
+                type = "brmbleClientActivated",
+                instanceId = envelope.InstanceId,
+                revision = envelope.Revision,
+                sessionId = activatedSessionId
+            });
+```
+
+Declare `var activatedSessionId = 0;` above the call, since it is now assigned inside the lambda.
+
+`AuthService.cs:282-290` becomes the same shape with `TryGetSessionId(name, out deactivatedSessionId)`, `TryUpdateBrmbleStatus(deactivatedSessionId, false)` — note `false` here is *knowledge*, not a default — and `type = "brmbleClientDeactivated"`.
+
+`AuthEndpoints.PersistCompanionSelectionAsync` becomes:
+
+```csharp
+        var sessionId = 0;
+        await publisher.PublishAsync(
+            () => sessionMapping.TryGetMappingByUserId(user.Id, out sessionId, out _)
+                  && sessionMapping.TryUpdateCompanionId(sessionId, companionId),
+            envelope =>
+            {
+                var wire = CompanionWireSelection.FromPersisted(companionId);
+                return new
+                {
+                    type = "companionChanged",
+                    instanceId = envelope.InstanceId,
+                    revision = envelope.Revision,
+                    sessionId,
+                    matrixUserId = user.MatrixUserId,
+                    companionId = wire.CompanionId,
+                    customCompanionId = wire.CustomCompanionId
+                };
+            });
+```
+
+Add `IMappingEventPublisher publisher` to the `/auth/companion` endpoint's DI parameters and to `PersistCompanionSelectionAsync`'s signature, replacing `IBrmbleEventBus eventBus` if it becomes unused.
+
+`CustomCompanionEndpoints.cs:71-83` becomes:
+
+```csharp
+                    await publisher.PublishAsync(
+                        () => sessionMapping.TryUpdateCompanionIdIfCurrent(
+                            sessionId, deletedCompanionId, "floppy"),
+                        envelope => new
+                        {
+                            type = "companionChanged",
+                            instanceId = envelope.InstanceId,
+                            revision = envelope.Revision,
+                            sessionId,
+                            matrixUserId = mapping.MatrixUserId,
+                            companionId = "floppy",
+                            customCompanionId = (string?)null
+                        });
+```
+
+`MumbleServerCallback.cs:197` becomes:
+
+```csharp
+        await _publisher.PublishAsync(
+            () => true,   // RemoveSession already ran and bumped the revision
+            envelope => new
+            {
+                type = "userMappingRemoved",
+                instanceId = envelope.InstanceId,
+                revision = envelope.Revision,
+                sessionId = user.SessionId
+            });
+```
+
+Inject `IMappingEventPublisher` into `MumbleServerCallback`'s constructor as `_publisher`, following the existing `_eventBus` field pattern.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj`
+
+Expected: PASS. Tests that assert an exact serialised payload string will fail on the two new properties — update those expected strings to include `instanceId` and `revision`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Server/ tests/Brmble.Server.Tests/
+git commit -m "feat: stamp every session mapping event with instance id and revision"
+```
+
+---
+
+## Task 5: Stamp snapshots and handle requestSnapshot
+
+**Files:**
+- Modify: `src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs`
+- Modify: `src/Brmble.Server/Auth/AuthEndpoints.cs:203-215`
+- Test: `tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs`
+
+**Why:** A snapshot is what repairs a client after a gap, so it must carry the envelope it is repairing *to*. And the read loop currently discards everything that is not a Close frame, using a 1024-byte buffer and ignoring `EndOfMessage`, so a client has no way to ask.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs`:
+
+```csharp
+    [TestMethod]
+    public async Task BuildInitialPayloadsAsync_StampsSnapshotWithEnvelope()
+    {
+        var mappings = new SessionMappingService();
+        mappings.TryAddMatrixUser(42, "@alice:test", "Alice", 1L, "floppy");
+
+        var payloads = await BrmbleWebSocketHandler.BuildInitialPayloadsAsync(
+            new StubDuelSnapshotProvider(), 0, mappings.GetSnapshot(),
+            new MappingEnvelope(mappings.InstanceId, mappings.Revision));
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payloads[0]));
+        Assert.AreEqual("sessionMappingSnapshot", doc.RootElement.GetProperty("type").GetString());
+        Assert.AreEqual(mappings.InstanceId, doc.RootElement.GetProperty("instanceId").GetString());
+        Assert.AreEqual(mappings.Revision, doc.RootElement.GetProperty("revision").GetInt64());
+    }
+
+    [TestMethod]
+    public void TryParseClientMessage_RecognisesRequestSnapshot()
+    {
+        Assert.IsTrue(BrmbleWebSocketHandler.TryParseClientMessage(
+            "{\"type\":\"requestSnapshot\"}", out var type));
+        Assert.AreEqual("requestSnapshot", type);
+    }
+
+    [TestMethod]
+    public void TryParseClientMessage_RejectsGarbageWithoutThrowing()
+    {
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("not json", out _));
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("{}", out _));
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("", out _));
+    }
+```
+
+Reuse whatever duel-snapshot stub the file already defines; if there is none, add a minimal `StubDuelSnapshotProvider` implementing `IDuelSnapshotProvider`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~BrmbleWebSocketHandlerTests"`
+
+Expected: FAIL — compile error, no overload of `BuildInitialPayloadsAsync` takes 4 arguments.
+
+- [ ] **Step 3: Stamp the snapshot**
+
+In `BrmbleWebSocketHandler.cs`, change `BuildInitialPayloadsAsync` to accept the envelope and include it:
+
+```csharp
+    internal static async Task<IReadOnlyList<object>> BuildInitialPayloadsAsync(
+        IDuelSnapshotProvider snapshots,
+        long sessionId,
+        IReadOnlyDictionary<int, SessionMapping> mappings,
+        MappingEnvelope envelope)
+    {
+        var snapshot = mappings.ToDictionary(
+            kvp => kvp.Key.ToString(),
+            kvp =>
+            {
+                var wire = CompanionWireSelection.FromPersisted(kvp.Value.CompanionId);
+                return new
+                {
+                    matrixUserId = kvp.Value.MatrixUserId,
+                    mumbleName = kvp.Value.MumbleName,
+                    companionId = wire.CompanionId,
+                    customCompanionId = wire.CustomCompanionId,
+                    certHash = kvp.Value.CertHash,
+                    isBrmbleClient = kvp.Value.IsBrmbleClient,
+                };
+            });
+        var initial = new List<object>
+        {
+            new
+            {
+                type = "sessionMappingSnapshot",
+                instanceId = envelope.InstanceId,
+                revision = envelope.Revision,
+                mappings = snapshot
+            }
+        };
+        if (sessionId != 0)
+            initial.Add(DuelWire.ToEvent(await snapshots.GetSnapshotForSessionAsync(sessionId)));
+        return initial;
+    }
+```
+
+Update the call in `InitializeAcceptedClientAsync` to pass
+`new MappingEnvelope(sessionMapping.InstanceId, sessionMapping.Revision)`.
+
+Apply the same two properties to the `/auth/token` response in `AuthEndpoints.cs:203-215`, adding `instanceId` and `revision` beside `sessionMappings`, read from the injected `ISessionMappingService`.
+
+- [ ] **Step 4: Add the message parser**
+
+Add to `BrmbleWebSocketHandler`:
+
+```csharp
+    /// <summary>
+    /// Parses a client-to-server frame. Returns false for anything unparseable rather than
+    /// throwing: a malformed frame must never take the socket down.
+    /// </summary>
+    internal static bool TryParseClientMessage(string json, out string type)
+    {
+        type = string.Empty;
+        if (string.IsNullOrWhiteSpace(json)) return false;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return false;
+            if (!doc.RootElement.TryGetProperty("type", out var typeProperty)) return false;
+            if (typeProperty.ValueKind != JsonValueKind.String) return false;
+            type = typeProperty.GetString() ?? string.Empty;
+            return type.Length > 0;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+```
+
+Add `using System.Text.Json;` at the top.
+
+- [ ] **Step 5: Fix the read loop and serve the request**
+
+Replace the read loop (lines 46-56) with one that reassembles multi-frame messages and caps their size:
+
+```csharp
+            // Read loop until close. Messages are reassembled across frames; anything larger
+            // than the cap is discarded rather than buffered, so a client cannot exhaust memory.
+            const int MaxClientMessageBytes = 8 * 1024;
+            var buffer = new byte[1024];
+            var accumulated = new MemoryStream();
+            while (ws.State == WebSocketState.Open)
+            {
+                var result = await ws.ReceiveAsync(buffer, context.RequestAborted);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
+                    break;
+                }
+
+                if (accumulated.Length + result.Count <= MaxClientMessageBytes)
+                    accumulated.Write(buffer, 0, result.Count);
+
+                if (!result.EndOfMessage) continue;
+
+                var json = System.Text.Encoding.UTF8.GetString(accumulated.ToArray());
+                accumulated.SetLength(0);
+
+                if (!TryParseClientMessage(json, out var messageType)) continue;
+                if (messageType != "requestSnapshot") continue;
+
+                sessionMapping.TryGetSessionByUserId(user.Id, out var resyncSessionId);
+                var payloads = await BuildInitialPayloadsAsync(
+                    context.RequestServices.GetRequiredService<IDuelSnapshotProvider>(),
+                    resyncSessionId,
+                    sessionMapping.GetSnapshot(),
+                    new MappingEnvelope(sessionMapping.InstanceId, sessionMapping.Revision));
+
+                foreach (var payload in payloads)
+                    await eventBus.SendToClientAsync(ws, payload);
+            }
+```
+
+`IBrmbleEventBus` has no public single-client send. Add one, mirroring the existing private `SendToClient`:
+
+```csharp
+    // IBrmbleEventBus.cs
+    Task SendToClientAsync(System.Net.WebSockets.WebSocket socket, object message);
+```
+
+```csharp
+    // BrmbleEventBus.cs — beside BroadcastAsync
+    public Task SendToClientAsync(WebSocket socket, object message) =>
+        SendToClient(socket, Serialize(message), default);
+```
+
+Add the stub to `RecordingEventBus` in `MappingEventPublisherTests` and to any other hand-written `IBrmbleEventBus` double.
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~BrmbleWebSocketHandlerTests"`
+
+Expected: PASS.
+
+- [ ] **Step 7: Full verification**
+
+```bash
+dotnet build
+dotnet test
+```
+
+Expected: build clean with 0 warnings; all four test projects pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Server/ tests/Brmble.Server.Tests/
+git commit -m "feat: stamp mapping snapshots and serve client resync requests"
+```
+
+---
+
+## Done when
+
+- [ ] `dotnet build` is clean with 0 warnings
+- [ ] `dotnet test` passes in all four projects
+- [ ] Every one of the six mapping payload types carries `instanceId` and `revision`
+- [ ] `userMappingAdded` carries `isBrmbleClient: null` when no socket has registered
+- [ ] A `{"type":"requestSnapshot"}` frame returns a stamped `sessionMappingSnapshot`
+- [ ] An existing client build still connects and behaves normally — every change is additive, and the client ignores unknown fields
+
+## Manual smoke test
+
+```bash
+cd src/Brmble.Web; npm run build; cd ../..
+docker compose -f docker-local/docker-compose.yml up -d --build brmble
+dotnet run --project src/Brmble.Client
+```
+
+Connect, confirm the user list and companions render as before, then restart only the Brmble container and confirm the client reconnects:
+
+```bash
+docker compose -f docker-local/docker-compose.yml restart brmble
+```
+
+Phase 1 alone does **not** fix the badge/skin reversion on restart — the client still ignores the new fields. It should, however, be no worse than before. The fix lands in Phase 3.
+
+---
+
+## Next
+
+Phase 2 (`UserProjectionStore`, pure client-side, no wiring) and Phase 3 (`MumbleAdapter` and `App.tsx`) are separate plans, written after this one lands.

--- a/docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md
+++ b/docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md
@@ -750,7 +750,7 @@ Add `IMappingEventPublisher publisher` to the `/auth/companion` endpoint's DI pa
 
 `CustomCompanionEndpoints` deletion. `cd7b48fa` restructured this into "mutate inside the coordinator lock, collect, broadcast after". Preserve that shape — but note the publisher must do the *mutation* too, since it is the mutation that assigns the revision. Collect the returned tasks and await them after the lock releases.
 
-Replace the `resetSessions` list and the loop that follows it with:
+Replace the `resetSessions` declaration (`CustomCompanionEndpoints.cs:41`), the `resetSessions.Add(...)` call at `:75`, and the broadcast loop at `:83-95` with:
 
 ```csharp
             var sends = new List<Task>();

--- a/docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md
+++ b/docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md
@@ -1,0 +1,1505 @@
+# User Projection — Phase 2: `UserProjectionStore` (client) + `baseRevision` (server)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the single authoritative client-side projection — a pure, dependency-free `UserProjectionStore` that merges Mumble presence and Brmble identity under two rules (ownership, and null-means-unknown) — and add the `baseRevision` field the server needs for that store to detect gaps correctly.
+
+**Architecture:** The store owns a `Dictionary<uint, UserProjection>` and exposes four `Apply*` methods, one per input source. Each returns a `ChangeSet` describing what moved. It has no Mumble, no HTTP and no JSON dependency: callers translate wire shapes into plain input records first, so the store unit-tests without a protocol stack. Phase 2 builds and tests the store in isolation — **nothing calls it yet**. Wiring is Phase 3.
+
+**Tech Stack:** C# / .NET 10, MSTest. `InternalsVisibleTo` for `Brmble.Client.Tests` is already configured (`src/Brmble.Client/Brmble.Client.csproj:19-21`), so `internal` types are directly testable.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-user-projection-design.md` §3.1, §3.2, §4.2, §4.3, §6.6, §8.
+
+**Depends on:** Phase 1 (`feature/user-projection-phase-1`, HEAD `1f5aa25e`). Confirm before starting:
+
+```powershell
+git log --oneline -1                    # expect 1f5aa25e
+Select-String -Path src/Brmble.Server/Events/MappingEventPublisher.cs -Pattern PublishExceptAsync
+```
+
+Baseline: `dotnet build` clean with 0 warnings, `dotnet test` 1250 passing (Server 777, Client 301, MumbleVoiceEngine 99, Audio 73). Confirm this so you can tell your own failures from pre-existing ones.
+
+---
+
+## Background you need
+
+### Why `baseRevision` exists (Task 1)
+
+Spec §4.2 gives the client these rules: apply when `revision == ours + 1`, treat `revision > ours + 1` as a gap, ignore `revision <= ours`. **Those rules cannot be implemented against Phase 1 as shipped.** One logical operation bumps the counter several times but is announced once — `SessionMappingHandler.OnUserConnected` calls `TryAddMatrixUser`, `TryUpdateCertHash` and `TryUpdateBrmbleStatus` inside a single `PublishAsync`, so a first registration moves the revision `0 → 3` and announces `3`. A client following §4.2 literally would read every normal registration as a gap and resync forever.
+
+Rather than force every operation down to exactly one bump (an invasive server refactor), each event now carries **both** ends of the range it spans:
+
+- `baseRevision` — the table revision *before* this operation's mutations.
+- `revision` — the revision *after* them.
+
+The client rule becomes "apply when `baseRevision == ours`", which is insensitive to how many bumps an operation makes:
+
+| Condition | Meaning | Action |
+|---|---|---|
+| `instanceId` differs | server restarted | drop server-owned fields, request snapshot |
+| `baseRevision == ours` | contiguous | apply, set `ours = revision` |
+| `baseRevision < ours` | already applied — duplicate or reorder | ignore |
+| `baseRevision > ours` | genuine gap | apply nothing, request snapshot |
+
+This also makes the deliberate duplicate in `SessionMappingHandler` correct by construction. The `brmbleClientActivated` there restates a fact the preceding `userMappingAdded` already carries and performs no mutation of its own, so it reuses that payload's captured envelope. Its `baseRevision` is therefore below `ours` by the time it arrives, and the rule above ignores it — which is exactly right, since applying it would be a no-op.
+
+Snapshots do **not** carry `baseRevision`. A snapshot is absolute, not a delta: it sets `ours = revision` outright.
+
+### Two rules the store exists to enforce (Tasks 3-5)
+
+**Ownership (spec §3.2 rule 1).** A Mumble input may only write Mumble-owned fields; a server input only server-owned ones. This is enforced by the *shape of the input types* — `MumbleUserInput` has no `MatrixUserId` field to write, and `ServerMappingEntry` has no `Name` — so a cross-write is a compile error, not a code-review catch.
+
+**Null means unknown (spec §3.2 rule 2).** On a server input, a `null` field leaves the existing value untouched. This is why `isBrmbleClient` can never silently become `false` and a companion can never silently become floppy. Clearing happens only through snapshot reconciliation or an explicit removal. Note the asymmetry: Mumble-owned fields are *not* subject to this rule — Mumble sends complete `UserState` every time, so its values are authoritative including when empty.
+
+### Threading (spec §6.6)
+
+Inputs arrive on three threads: the Mumble protocol thread, the WebSocket read loop, and an HTTP continuation. Every `Apply*` takes one lock, mutates, computes the `ChangeSet`, and releases before returning. The store never invokes a callback or bridge under its lock — it returns data and lets the caller emit. Phase 3 relies on this.
+
+### `certHash` has two sources
+
+Mumble supplies `CertificateHash` on `UserState`; the server supplies `certHash` in mappings. The current code prefers Mumble's (`MumbleAdapter.cs:4190`: `u.CertificateHash ?? sm!.CertHash`). The projection keeps both in separate fields, each written only by its owner, and exposes a computed `CertHash` preserving that precedence. This is what lets a server restart clear its own copy without touching Mumble's.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/Brmble.Server/Events/MappingEnvelope.cs` | *Modify* — gains `BaseRevision` plus a `Snapshot` factory |
+| `src/Brmble.Server/Events/MappingEventPublisher.cs` | *Modify* — captures the revision before and after the mutation |
+| `src/Brmble.Server/Events/SessionMappingHandler.cs` | *Modify* — stamp `baseRevision` |
+| `src/Brmble.Server/Auth/AuthService.cs` | *Modify* — stamp `baseRevision` (2 sites) |
+| `src/Brmble.Server/Auth/AuthEndpoints.cs` | *Modify* — stamp `baseRevision` (2 sites); snapshot factory for `/auth/token` |
+| `src/Brmble.Server/Companions/CustomCompanionEndpoints.cs` | *Modify* — stamp `baseRevision` |
+| `src/Brmble.Server/Mumble/MumbleServerCallback.cs` | *Modify* — stamp `baseRevision` |
+| `src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs` | *Modify* — stamp `baseRevision` on `userMappingAdded`; snapshot factory |
+| `src/Brmble.Client/Services/Voice/UserProjection/UserProjection.cs` | *Create* — the row record |
+| `src/Brmble.Client/Services/Voice/UserProjection/ProjectionInputs.cs` | *Create* — dependency-free input records |
+| `src/Brmble.Client/Services/Voice/UserProjection/ChangeSet.cs` | *Create* — the output of every `Apply*` |
+| `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs` | *Create* — the store itself |
+
+---
+
+## Task 1: `baseRevision` on the wire
+
+**Files:**
+- Modify: `src/Brmble.Server/Events/MappingEnvelope.cs`
+- Modify: `src/Brmble.Server/Events/MappingEventPublisher.cs`
+- Modify: all seven producers (listed in each step below)
+- Test: `tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs`, `tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs`, inside the existing class:
+
+```csharp
+    [TestMethod]
+    public async Task PublishAsync_StampsTheRevisionRangeTheMutationSpanned()
+    {
+        // One logical operation may bump several times. baseRevision is the revision before
+        // the mutation, revision the one after, so a client can apply on "baseRevision ==
+        // ours" without caring how many bumps happened in between.
+        var before = _mappings.Revision;
+
+        await _publisher.PublishAsync(
+            () =>
+            {
+                _mappings.TryUpdateCompanionId(1, "retro");
+                _mappings.TryUpdateCertHash(1, "abc");
+                return true;
+            },
+            envelope => new
+            {
+                type = "companionChanged",
+                instanceId = envelope.InstanceId,
+                baseRevision = envelope.BaseRevision,
+                revision = envelope.Revision
+            });
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(_bus.Broadcasts.Single()));
+        Assert.AreEqual(before, doc.RootElement.GetProperty("baseRevision").GetInt64());
+        Assert.AreEqual(before + 2, doc.RootElement.GetProperty("revision").GetInt64());
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_RangesAreContiguousUnderConcurrency()
+    {
+        // Each event's baseRevision must equal the previous event's revision, or a client
+        // applying on "baseRevision == ours" stalls and resyncs forever.
+        await Task.WhenAll(Enumerable.Range(0, 100).Select(i => Task.Run(() =>
+            _publisher.PublishAsync(
+                () => _mappings.TryUpdateCompanionId(1, $"c{i}"),
+                envelope => new
+                {
+                    type = "companionChanged",
+                    instanceId = envelope.InstanceId,
+                    baseRevision = envelope.BaseRevision,
+                    revision = envelope.Revision
+                }))));
+
+        var ranges = _bus.Broadcasts
+            .Select(p => JsonDocument.Parse(JsonSerializer.Serialize(p)).RootElement)
+            .Select(e => (Base: e.GetProperty("baseRevision").GetInt64(),
+                          Rev: e.GetProperty("revision").GetInt64()))
+            .ToList();
+
+        Assert.AreEqual(100, ranges.Count);
+        for (var i = 1; i < ranges.Count; i++)
+            Assert.AreEqual(ranges[i - 1].Rev, ranges[i].Base,
+                $"event {i} does not start where event {i - 1} ended");
+    }
+```
+
+Then tighten the shared assertion in `tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs`. Replace `AssertHasEnvelope` with two methods — snapshots are absolute and carry no `baseRevision`:
+
+```csharp
+    internal static void AssertHasEnvelope(object payload, string expectedType)
+    {
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
+        Assert.AreEqual(expectedType, doc.RootElement.GetProperty("type").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("instanceId", out var instanceId),
+            $"{expectedType} is missing instanceId");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(instanceId.GetString()),
+            $"{expectedType} has a blank instanceId");
+        Assert.IsTrue(doc.RootElement.TryGetProperty("revision", out var revision),
+            $"{expectedType} is missing revision");
+        Assert.IsTrue(revision.GetInt64() > 0,
+            $"{expectedType} must carry the post-mutation revision");
+        Assert.IsTrue(doc.RootElement.TryGetProperty("baseRevision", out var baseRevision),
+            $"{expectedType} is missing baseRevision, so a client cannot tell a gap from a jump");
+        Assert.IsTrue(baseRevision.GetInt64() < revision.GetInt64()
+                      || baseRevision.GetInt64() == revision.GetInt64(),
+            $"{expectedType} has baseRevision above revision");
+    }
+
+    /// <summary>
+    /// Snapshots are absolute rather than deltas: they set the client's cursor outright, so
+    /// they carry no baseRevision.
+    /// </summary>
+    internal static void AssertHasSnapshotEnvelope(object payload, string expectedType)
+    {
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
+        Assert.AreEqual(expectedType, doc.RootElement.GetProperty("type").GetString());
+        Assert.IsFalse(string.IsNullOrWhiteSpace(
+            doc.RootElement.GetProperty("instanceId").GetString()));
+        Assert.IsTrue(doc.RootElement.TryGetProperty("revision", out _));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~MappingEventPublisherTests"`
+
+Expected: FAIL — compile error, `'MappingEnvelope' does not contain a definition for 'BaseRevision'`.
+
+- [ ] **Step 3: Widen the envelope**
+
+Replace the body of `src/Brmble.Server/Events/MappingEnvelope.cs`:
+
+```csharp
+namespace Brmble.Server.Events;
+
+/// <summary>
+/// Stamped on every session-mapping payload so a client can tell a restart from a gap.
+/// </summary>
+/// <param name="InstanceId">Identifies the server's mapping table; changes on restart.</param>
+/// <param name="Revision">The table revision after the mutation being announced.</param>
+/// <param name="BaseRevision">
+/// The table revision before it. One logical operation may bump the counter several times, so a
+/// client applies on <c>BaseRevision == ours</c> rather than on <c>Revision == ours + 1</c>.
+/// </param>
+public readonly record struct MappingEnvelope(string InstanceId, long Revision, long BaseRevision)
+{
+    /// <summary>
+    /// A snapshot is absolute rather than a delta — it sets the client's cursor outright — so it
+    /// is its own base.
+    /// </summary>
+    public static MappingEnvelope Snapshot(string instanceId, long revision) =>
+        new(instanceId, revision, revision);
+}
+```
+
+- [ ] **Step 4: Capture the range in the publisher**
+
+In `src/Brmble.Server/Events/MappingEventPublisher.cs`, replace the `PublishCore` body:
+
+```csharp
+    private Task PublishCore(
+        Func<bool> mutate,
+        Func<MappingEnvelope, object> payload,
+        Func<IBrmbleEventBus, object, Task> send,
+        IBrmbleEventBus bus)
+    {
+        Task pending;
+        lock (_gate)
+        {
+            // Read before, mutate, read after — all inside the lock, so the range provably
+            // belongs to this mutation and cannot straddle a concurrent one.
+            var baseRevision = mappings.Revision;
+            if (!mutate()) return Task.CompletedTask;
+
+            var envelope = new MappingEnvelope(mappings.InstanceId, mappings.Revision, baseRevision);
+
+            // Safe under the lock: BrmbleEventBus's broadcast paths are deliberately not async
+            // and enqueue to every per-socket queue before returning, so no socket I/O happens
+            // here. Awaiting inside the lock would be wrong; capturing the task is not.
+            pending = send(bus, payload(envelope));
+        }
+
+        return pending;
+    }
+```
+
+- [ ] **Step 5: Run the publisher tests to verify they pass**
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~MappingEventPublisherTests"`
+
+Expected: PASS, five tests.
+
+- [ ] **Step 6: Stamp `baseRevision` on all six event producers**
+
+Each producer already emits `instanceId` and `revision`. Add `baseRevision = envelope.BaseRevision` immediately after `instanceId` in every event payload. The six sites:
+
+1. `src/Brmble.Server/Events/SessionMappingHandler.cs` — the `userMappingAdded` dictionary. Add between `["instanceId"]` and `["revision"]`:
+
+```csharp
+                    ["baseRevision"] = envelope.BaseRevision,
+```
+
+2. `src/Brmble.Server/Events/SessionMappingHandler.cs` — the `brmbleClientActivated` restatement. It reuses the captured `announced` envelope, so add:
+
+```csharp
+                    baseRevision = announced.BaseRevision,
+```
+
+3. `src/Brmble.Server/Auth/AuthService.cs` — both `brmbleClientActivated` and `brmbleClientDeactivated`:
+
+```csharp
+                baseRevision = envelope.BaseRevision,
+```
+
+4. `src/Brmble.Server/Auth/AuthEndpoints.cs` — both branches of the `/auth/token` publish (`userMappingAdded` and `brmbleClientActivated`), and the `companionChanged` in `PersistCompanionSelectionAsync`:
+
+```csharp
+                                baseRevision = envelope.BaseRevision,
+```
+
+5. `src/Brmble.Server/Companions/CustomCompanionEndpoints.cs` — the `companionChanged` in the deletion loop:
+
+```csharp
+                            baseRevision = envelope.BaseRevision,
+```
+
+6. `src/Brmble.Server/Mumble/MumbleServerCallback.cs` — `userMappingRemoved`:
+
+```csharp
+                baseRevision = envelope.BaseRevision,
+```
+
+7. `src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs` — `CreateUserMappingAddedPayload`, between `instanceId` and `revision`:
+
+```csharp
+            baseRevision = envelope.BaseRevision,
+```
+
+- [ ] **Step 7: Switch the two snapshot sites to the factory**
+
+Snapshots must *not* gain `baseRevision`. Change their construction to the explicit factory so the intent is visible.
+
+In `src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs`, both envelope constructions for `BuildInitialPayloadsAsync` (the resync path and the bootstrap path) become:
+
+```csharp
+                var resyncEnvelope = MappingEnvelope.Snapshot(
+                    sessionMapping.InstanceId, sessionMapping.Revision);
+```
+
+```csharp
+            var bootstrapEnvelope = MappingEnvelope.Snapshot(
+                sessionMapping.InstanceId, sessionMapping.Revision);
+```
+
+Keep the existing comments about reading the revision before the snapshot — that ordering still matters and is unrelated to this change.
+
+`/auth/token` in `AuthEndpoints.cs` reads `sessionMapping.InstanceId` / `.Revision` directly into the response object rather than building an envelope; leave it as is. It already emits no `baseRevision`, which is correct.
+
+- [ ] **Step 8: Fix the fallout and run everything**
+
+Run: `dotnet build`
+
+Any remaining two-argument `new MappingEnvelope(...)` in tests will fail to compile. In `tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs` there are several `new MappingEnvelope("inst", 9L)` and `new MappingEnvelope(mappings.InstanceId, mappings.Revision)` calls — give each an explicit third argument (`new MappingEnvelope("inst", 9L, 8L)`) or switch snapshot-shaped ones to `MappingEnvelope.Snapshot(...)`.
+
+Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj`
+
+Expected: PASS. If a suite asserts on `sessionMappingSnapshot`, point it at `AssertHasSnapshotEnvelope`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Brmble.Server/ tests/Brmble.Server.Tests/
+git commit -m "feat: stamp baseRevision so clients can apply across multi-bump operations"
+```
+
+---
+
+## Task 2: Projection row, inputs and change set
+
+**Files:**
+- Create: `src/Brmble.Client/Services/Voice/UserProjection/UserProjection.cs`
+- Create: `src/Brmble.Client/Services/Voice/UserProjection/ProjectionInputs.cs`
+- Create: `src/Brmble.Client/Services/Voice/UserProjection/ChangeSet.cs`
+- Test: `tests/Brmble.Client.Tests/Services/UserProjectionTests.cs` (create)
+
+**Why:** Ownership is enforced by the shape of these types. `MumbleUserInput` has no server-owned field to write and `ServerMappingEntry` has no Mumble-owned one, so a cross-write cannot compile. Getting these right is what makes the store's logic small.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Brmble.Client.Tests/Services/UserProjectionTests.cs`:
+
+```csharp
+using Brmble.Client.Services.Voice.UserProjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class UserProjectionTests
+{
+    [TestMethod]
+    public void CertHash_PrefersMumbleOverServer()
+    {
+        // Mumble observes the certificate on the live connection; the server's copy is a
+        // record of one. When both exist the live one wins, matching today's behaviour.
+        var row = new UserProjection
+        {
+            SessionId = 1,
+            MumbleCertHash = "from-mumble",
+            ServerCertHash = "from-server"
+        };
+
+        Assert.AreEqual("from-mumble", row.CertHash);
+    }
+
+    [TestMethod]
+    public void CertHash_FallsBackToServerWhenMumbleHasNone()
+    {
+        var row = new UserProjection { SessionId = 1, ServerCertHash = "from-server" };
+
+        Assert.AreEqual("from-server", row.CertHash);
+    }
+
+    [TestMethod]
+    public void CertHash_IsNullWhenNeitherSourceKnows()
+    {
+        Assert.IsNull(new UserProjection { SessionId = 1 }.CertHash);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~UserProjectionTests"`
+
+Expected: FAIL — compile error, `The type or namespace name 'UserProjection' could not be found`.
+
+- [ ] **Step 3: Create the row record**
+
+Create `src/Brmble.Client/Services/Voice/UserProjection/UserProjection.cs`:
+
+```csharp
+namespace Brmble.Client.Services.Voice.UserProjection;
+
+/// <summary>
+/// One row of the authoritative user projection: Mumble-native presence merged with
+/// Brmble-owned identity.
+/// </summary>
+/// <remarks>
+/// Fields are grouped by owner and never cross. A Mumble input may write only the first group,
+/// a server input only the second. In the server group, <c>null</c> means "not known" rather
+/// than "empty" — see <see cref="UserProjectionStore"/> for the rule that preserves it.
+/// </remarks>
+internal sealed record UserProjection
+{
+    public required uint SessionId { get; init; }
+
+    // ---- Mumble-owned. Authoritative, including when empty: UserState is complete every time.
+    public string? Name { get; init; }
+    public uint ChannelId { get; init; }
+    public bool Muted { get; init; }
+    public bool Deafened { get; init; }
+    public string? Comment { get; init; }
+    public string? MumbleCertHash { get; init; }
+    public bool IsSelf { get; init; }
+
+    // ---- Server-owned. null means unknown, never "cleared".
+    public string? MatrixUserId { get; init; }
+    public string? CompanionId { get; init; }
+    public bool? IsBrmbleClient { get; init; }
+    public string? ServerCertHash { get; init; }
+
+    /// <summary>
+    /// The live connection's certificate wins over the server's recorded copy, so a server
+    /// restart clearing its own copy cannot blank a hash Mumble can still see.
+    /// </summary>
+    public string? CertHash => MumbleCertHash ?? ServerCertHash;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~UserProjectionTests"`
+
+Expected: PASS, three tests.
+
+- [ ] **Step 5: Create the input records**
+
+Create `src/Brmble.Client/Services/Voice/UserProjection/ProjectionInputs.cs`. These deliberately reference no Mumble, HTTP or JSON type — the caller translates before handing them over, which is what keeps the store unit-testable:
+
+```csharp
+namespace Brmble.Client.Services.Voice.UserProjection;
+
+/// <summary>
+/// A Mumble <c>UserState</c>, reduced to the fields Mumble owns. Complete every time: Mumble
+/// resends the full state on every change, so these values are authoritative even when empty.
+/// </summary>
+internal sealed record MumbleUserInput(
+    uint SessionId,
+    string? Name,
+    uint ChannelId,
+    bool Muted,
+    bool Deafened,
+    string? Comment,
+    string? CertHash,
+    bool IsSelf);
+
+/// <summary>
+/// The server-owned half of one session. Every field is nullable and <c>null</c> means "not
+/// known", never "cleared".
+/// </summary>
+internal sealed record ServerMappingEntry(
+    string? MatrixUserId,
+    string? CompanionId,
+    bool? IsBrmbleClient,
+    string? CertHash);
+
+/// <summary>
+/// A complete statement of every session the server knows about, from <c>/auth/token</c> or a
+/// WebSocket <c>sessionMappingSnapshot</c>. Authoritative for membership: a session absent from
+/// it has its server-owned fields reset to unknown (spec §4.3).
+/// </summary>
+internal sealed record ServerSnapshot(
+    string InstanceId,
+    long Revision,
+    IReadOnlyDictionary<uint, ServerMappingEntry> Mappings);
+
+internal enum ServerEventKind
+{
+    MappingAdded,
+    MappingRemoved,
+    CompanionChanged,
+    BrmbleActivated,
+    BrmbleDeactivated
+}
+
+/// <summary>
+/// One incremental server event.
+/// </summary>
+/// <param name="BaseRevision">
+/// The revision this event applies on top of. The client applies when this equals its own
+/// cursor — see the table in the Phase 2 plan. Not <c>Revision - 1</c>: one operation may bump
+/// the server's counter several times.
+/// </param>
+internal sealed record ServerEvent(
+    ServerEventKind Kind,
+    string InstanceId,
+    long BaseRevision,
+    long Revision,
+    uint SessionId,
+    ServerMappingEntry? Entry = null);
+```
+
+- [ ] **Step 6: Create the change set**
+
+Create `src/Brmble.Client/Services/Voice/UserProjection/ChangeSet.cs`:
+
+```csharp
+namespace Brmble.Client.Services.Voice.UserProjection;
+
+/// <summary>
+/// What one <c>Apply</c> changed. Rows in <see cref="Changed"/> are always complete — every
+/// field present — so a consumer replaces by session id and never merges field-by-field.
+/// </summary>
+/// <param name="IsReset">
+/// The caller should replace its whole list rather than patch it. Set by a Mumble reset and by
+/// a snapshot that changed membership.
+/// </param>
+/// <param name="NeedsSnapshot">
+/// The store detected a gap or a restart and cannot proceed from incremental events. The caller
+/// should request a snapshot. Nothing in the projection was changed by the event that set this.
+/// </param>
+internal sealed record ChangeSet(
+    IReadOnlyList<UserProjection> Changed,
+    IReadOnlyList<uint> Removed,
+    bool IsReset = false,
+    bool NeedsSnapshot = false)
+{
+    public static readonly ChangeSet Empty = new([], []);
+
+    public bool IsEmpty => Changed.Count == 0 && Removed.Count == 0 && !IsReset && !NeedsSnapshot;
+}
+```
+
+- [ ] **Step 7: Build and commit**
+
+Run: `dotnet build`
+
+Expected: clean, 0 warnings.
+
+```bash
+git add src/Brmble.Client/Services/Voice/UserProjection/ tests/Brmble.Client.Tests/Services/UserProjectionTests.cs
+git commit -m "feat: add user projection row, inputs and change set types"
+```
+
+---
+
+## Task 3: The store and its Mumble inputs
+
+**Files:**
+- Create: `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs`
+- Test: `tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs` (create)
+
+**Why:** Mumble alone owns session existence (spec §3.3). If the Brmble server is down, rows still appear, move channel and mute — they just carry stale enrichment. That property comes from this task.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs`:
+
+```csharp
+using Brmble.Client.Services.Voice.UserProjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class UserProjectionStoreMumbleTests
+{
+    private UserProjectionStore _store = null!;
+
+    [TestInitialize]
+    public void Setup() => _store = new UserProjectionStore();
+
+    private static MumbleUserInput User(uint session, string name = "Alice", uint channel = 0) =>
+        new(session, name, channel, false, false, null, null, false);
+
+    [TestMethod]
+    public void ApplyMumbleUserState_AddsARowAndReportsIt()
+    {
+        var change = _store.ApplyMumbleUserState(User(1));
+
+        Assert.AreEqual(1, change.Changed.Count);
+        Assert.AreEqual(1u, change.Changed[0].SessionId);
+        Assert.AreEqual("Alice", change.Changed[0].Name);
+        Assert.AreEqual(1, _store.Snapshot().Count);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleUserState_IsIdempotentForAnUnchangedState()
+    {
+        _store.ApplyMumbleUserState(User(1));
+
+        var change = _store.ApplyMumbleUserState(User(1));
+
+        Assert.IsTrue(change.IsEmpty, "an identical UserState must not churn the UI");
+    }
+
+    [TestMethod]
+    public void ApplyMumbleUserState_UpdatesMumbleFieldsWithoutTouchingServerFields()
+    {
+        _store.ApplyMumbleUserState(User(1));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst", 5, new Dictionary<uint, ServerMappingEntry>
+        {
+            [1] = new("@alice:test", "retro", true, "cert-server")
+        }));
+
+        var change = _store.ApplyMumbleUserState(User(1, "Alice", channel: 7));
+
+        var row = change.Changed.Single();
+        Assert.AreEqual(7u, row.ChannelId);
+        Assert.AreEqual("@alice:test", row.MatrixUserId, "a Mumble input must not clear identity");
+        Assert.AreEqual("retro", row.CompanionId);
+        Assert.AreEqual(true, row.IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleUserRemove_DeletesTheRowEntirely()
+    {
+        _store.ApplyMumbleUserState(User(1));
+
+        var change = _store.ApplyMumbleUserRemove(1);
+
+        CollectionAssert.AreEqual(new[] { 1u }, change.Removed.ToArray());
+        Assert.AreEqual(0, _store.Snapshot().Count);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleUserRemove_IsSilentForAnUnknownSession()
+    {
+        Assert.IsTrue(_store.ApplyMumbleUserRemove(99).IsEmpty);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleReset_ReplacesMembershipAndFlagsAReset()
+    {
+        _store.ApplyMumbleUserState(User(1));
+        _store.ApplyMumbleUserState(User(2, "Bob"));
+
+        var change = _store.ApplyMumbleReset([User(2, "Bob"), User(3, "Carol")]);
+
+        Assert.IsTrue(change.IsReset);
+        CollectionAssert.AreEquivalent(new[] { 2u, 3u }, _store.Snapshot().Keys.ToArray());
+    }
+
+    [TestMethod]
+    public void ApplyMumbleReset_KeepsServerFieldsForSessionsThatSurvive()
+    {
+        // A voice reconnect must not cost us identity we already know.
+        _store.ApplyMumbleUserState(User(1));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst", 5, new Dictionary<uint, ServerMappingEntry>
+        {
+            [1] = new("@alice:test", "retro", true, null)
+        }));
+
+        _store.ApplyMumbleReset([User(1)]);
+
+        Assert.AreEqual("@alice:test", _store.Snapshot()[1].MatrixUserId);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~UserProjectionStoreMumbleTests"`
+
+Expected: FAIL — compile error, `The type or namespace name 'UserProjectionStore' could not be found`.
+
+- [ ] **Step 3: Create the store with its Mumble inputs**
+
+Create `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs`. `ApplyServerSnapshot` and `ApplyServerEvent` are stubbed here and implemented in Tasks 4 and 5 — the tests above need `ApplyServerSnapshot` to work, so it gets a minimal real body now and its reconciliation rules in Task 4:
+
+```csharp
+namespace Brmble.Client.Services.Voice.UserProjection;
+
+/// <summary>
+/// The single authoritative user projection. Merges Mumble presence and Brmble identity under
+/// two rules: each input writes only the fields it owns, and a null server field means "not
+/// known" rather than "cleared".
+/// </summary>
+/// <remarks>
+/// Every Apply takes one lock, mutates, computes the change set and releases. No callback runs
+/// under the lock — the caller emits from the returned value (spec §6.6). Inputs arrive on the
+/// Mumble protocol thread, the WebSocket read loop and an HTTP continuation.
+/// </remarks>
+internal sealed class UserProjectionStore
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<uint, UserProjection> _rows = [];
+
+    private string? _instanceId;
+    private long _revision;
+
+    /// <summary>A copy of the current projection, for tests and for building a full reset.</summary>
+    public IReadOnlyDictionary<uint, UserProjection> Snapshot()
+    {
+        lock (_gate) return new Dictionary<uint, UserProjection>(_rows);
+    }
+
+    public ChangeSet ApplyMumbleUserState(MumbleUserInput input)
+    {
+        lock (_gate)
+        {
+            _rows.TryGetValue(input.SessionId, out var existing);
+            var updated = WithMumbleFields(existing, input);
+            if (existing == updated) return ChangeSet.Empty;
+
+            _rows[input.SessionId] = updated;
+            return new ChangeSet([updated], []);
+        }
+    }
+
+    public ChangeSet ApplyMumbleUserRemove(uint sessionId)
+    {
+        lock (_gate)
+        {
+            // Mumble alone owns existence, so this is the only path that deletes a row.
+            return _rows.Remove(sessionId)
+                ? new ChangeSet([], [sessionId])
+                : ChangeSet.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Replaces membership wholesale on voice connect or reconnect. Server-owned fields survive
+    /// for sessions present in both the old and new list.
+    /// </summary>
+    public ChangeSet ApplyMumbleReset(IReadOnlyList<MumbleUserInput> users)
+    {
+        lock (_gate)
+        {
+            var rebuilt = new Dictionary<uint, UserProjection>(users.Count);
+            foreach (var input in users)
+            {
+                _rows.TryGetValue(input.SessionId, out var existing);
+                rebuilt[input.SessionId] = WithMumbleFields(existing, input);
+            }
+
+            _rows.Clear();
+            foreach (var (sessionId, row) in rebuilt) _rows[sessionId] = row;
+
+            return new ChangeSet([.. rebuilt.Values], [], IsReset: true);
+        }
+    }
+
+    /// <summary>
+    /// Writes only Mumble-owned fields. Server-owned fields are carried across untouched, which
+    /// is why a channel move cannot blank a badge.
+    /// </summary>
+    private static UserProjection WithMumbleFields(UserProjection? existing, MumbleUserInput input)
+    {
+        var row = existing ?? new UserProjection { SessionId = input.SessionId };
+        return row with
+        {
+            Name = input.Name,
+            ChannelId = input.ChannelId,
+            Muted = input.Muted,
+            Deafened = input.Deafened,
+            Comment = input.Comment,
+            MumbleCertHash = input.CertHash,
+            IsSelf = input.IsSelf
+        };
+    }
+
+    public ChangeSet ApplyServerSnapshot(ServerSnapshot snapshot)
+    {
+        lock (_gate)
+        {
+            _instanceId = snapshot.InstanceId;
+            _revision = snapshot.Revision;
+
+            var changed = new List<UserProjection>();
+            foreach (var (sessionId, entry) in snapshot.Mappings)
+            {
+                if (!_rows.TryGetValue(sessionId, out var existing)) continue;
+                var updated = WithServerFields(existing, entry);
+                if (existing == updated) continue;
+                _rows[sessionId] = updated;
+                changed.Add(updated);
+            }
+
+            return changed.Count == 0 ? ChangeSet.Empty : new ChangeSet(changed, []);
+        }
+    }
+
+    /// <summary>
+    /// Writes only server-owned fields, and only those the input actually knows: a null leaves
+    /// the current value alone. This is the rule that stops a missing field becoming a wrong one.
+    /// </summary>
+    private static UserProjection WithServerFields(UserProjection row, ServerMappingEntry entry) =>
+        row with
+        {
+            MatrixUserId = entry.MatrixUserId ?? row.MatrixUserId,
+            CompanionId = entry.CompanionId ?? row.CompanionId,
+            IsBrmbleClient = entry.IsBrmbleClient ?? row.IsBrmbleClient,
+            ServerCertHash = entry.CertHash ?? row.ServerCertHash
+        };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~UserProjectionStoreMumbleTests"`
+
+Expected: PASS, seven tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs
+git commit -m "feat: add user projection store with Mumble-owned inputs"
+```
+
+---
+
+## Task 4: Snapshot reconciliation
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs`
+- Test: `tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs` (create)
+
+**Why:** Spec §4.3 changes what a snapshot *means*. Today it only patches rows that already exist and never clears, so a session that vanished during an outage keeps stale enrichment forever. A snapshot is now the complete set of server-known sessions: anything absent has its server-owned fields reset to unknown. It still cannot delete a row — only Mumble owns existence.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs`:
+
+```csharp
+using Brmble.Client.Services.Voice.UserProjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class UserProjectionStoreSnapshotTests
+{
+    private UserProjectionStore _store = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _store = new UserProjectionStore();
+        _store.ApplyMumbleUserState(new MumbleUserInput(1, "Alice", 0, false, false, null, null, false));
+        _store.ApplyMumbleUserState(new MumbleUserInput(2, "Bob", 0, false, false, null, null, false));
+    }
+
+    private static ServerSnapshot Snapshot(long revision, params (uint Session, ServerMappingEntry Entry)[] entries) =>
+        new("inst-a", revision, entries.ToDictionary(e => e.Session, e => e.Entry));
+
+    [TestMethod]
+    public void ApplyServerSnapshot_FillsServerFieldsForKnownSessions()
+    {
+        var change = _store.ApplyServerSnapshot(
+            Snapshot(5, (1, new ServerMappingEntry("@alice:test", "retro", true, "cert-a"))));
+
+        Assert.AreEqual("@alice:test", _store.Snapshot()[1].MatrixUserId);
+        Assert.AreEqual(1, change.Changed.Count);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_ResetsServerFieldsForSessionsItOmits()
+    {
+        // Session 2 was known to the server, then vanished during an outage. The snapshot is
+        // authoritative for membership, so its enrichment goes back to unknown rather than
+        // lingering as a confident wrong answer.
+        _store.ApplyServerSnapshot(Snapshot(5,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, null)),
+            (2, new ServerMappingEntry("@bob:test", "bee", true, null))));
+
+        _store.ApplyServerSnapshot(Snapshot(6,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+
+        var bob = _store.Snapshot()[2];
+        Assert.IsNull(bob.MatrixUserId);
+        Assert.IsNull(bob.CompanionId);
+        Assert.IsNull(bob.IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_DoesNotDeleteRowsMumbleStillShows()
+    {
+        _store.ApplyServerSnapshot(Snapshot(5, (1, new ServerMappingEntry("@alice:test", null, null, null))));
+
+        Assert.IsTrue(_store.Snapshot().ContainsKey(2), "only Mumble may remove a row");
+        Assert.AreEqual("Bob", _store.Snapshot()[2].Name);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_KeepsMumbleFieldsIntact()
+    {
+        _store.ApplyServerSnapshot(Snapshot(5, (1, new ServerMappingEntry("@alice:test", null, null, null))));
+
+        Assert.AreEqual("Alice", _store.Snapshot()[1].Name);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_ForAnEntryWithNoMumbleRowIsIgnored()
+    {
+        // The server knows a session Mumble has not shown us. Existence is Mumble's to grant,
+        // so nothing is created; the next UserState will pick the enrichment up via the
+        // snapshot that follows it.
+        _store.ApplyServerSnapshot(Snapshot(5, (99, new ServerMappingEntry("@ghost:test", null, null, null))));
+
+        Assert.IsFalse(_store.Snapshot().ContainsKey(99));
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_FlagsAResetWhenMembershipChanged()
+    {
+        _store.ApplyServerSnapshot(Snapshot(5,
+            (1, new ServerMappingEntry("@alice:test", null, null, null)),
+            (2, new ServerMappingEntry("@bob:test", null, null, null))));
+
+        var change = _store.ApplyServerSnapshot(Snapshot(6,
+            (1, new ServerMappingEntry("@alice:test", null, null, null))));
+
+        Assert.IsTrue(change.Changed.Any(r => r.SessionId == 2),
+            "the reset row must be reported so the UI drops the badge");
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_FromANewInstanceReplacesEverything()
+    {
+        _store.ApplyServerSnapshot(Snapshot(90, (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst-b", 2,
+            new Dictionary<uint, ServerMappingEntry>
+            {
+                [1] = new("@alice:test", "bee", null, null)
+            }));
+
+        var alice = _store.Snapshot()[1];
+        Assert.AreEqual("bee", alice.CompanionId);
+        Assert.IsNull(alice.IsBrmbleClient, "a restart invalidates what the old instance told us");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~UserProjectionStoreSnapshotTests"`
+
+Expected: FAIL — `ApplyServerSnapshot_ResetsServerFieldsForSessionsItOmits` fails because Bob keeps `@bob:test`.
+
+- [ ] **Step 3: Implement reconciliation**
+
+In `UserProjectionStore.cs`, replace `ApplyServerSnapshot` entirely:
+
+```csharp
+    /// <summary>
+    /// Applies a complete statement of server-known sessions. Sessions the snapshot omits have
+    /// their server-owned fields reset to unknown — stale enrichment is worse than none — but
+    /// their rows survive, because only Mumble owns existence.
+    /// </summary>
+    public ChangeSet ApplyServerSnapshot(ServerSnapshot snapshot)
+    {
+        lock (_gate)
+        {
+            // A different instance means the old revision line is meaningless. Nothing special
+            // is needed beyond taking this snapshot as truth, which the reset below does.
+            _instanceId = snapshot.InstanceId;
+            _revision = snapshot.Revision;
+
+            var changed = new List<UserProjection>();
+
+            foreach (var sessionId in _rows.Keys.ToArray())
+            {
+                var existing = _rows[sessionId];
+
+                var updated = snapshot.Mappings.TryGetValue(sessionId, out var entry)
+                    // Present: overwrite the server half outright. A snapshot states every
+                    // server-owned field, so null here is knowledge, not absence — this is the
+                    // one place the null-means-unknown rule does not apply.
+                    ? existing with
+                    {
+                        MatrixUserId = entry.MatrixUserId,
+                        CompanionId = entry.CompanionId,
+                        IsBrmbleClient = entry.IsBrmbleClient,
+                        ServerCertHash = entry.CertHash
+                    }
+                    // Absent: the server does not know this session. Back to unknown.
+                    : existing with
+                    {
+                        MatrixUserId = null,
+                        CompanionId = null,
+                        IsBrmbleClient = null,
+                        ServerCertHash = null
+                    };
+
+                if (existing == updated) continue;
+                _rows[sessionId] = updated;
+                changed.Add(updated);
+            }
+
+            return changed.Count == 0 ? ChangeSet.Empty : new ChangeSet(changed, []);
+        }
+    }
+```
+
+`WithServerFields` is now used only by `ApplyServerEvent` in Task 5. Leave it in place.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~UserProjectionStore"`
+
+Expected: PASS — the seven Mumble tests and the seven snapshot tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
+git commit -m "feat: make snapshots authoritative for server-owned membership"
+```
+
+---
+
+## Task 5: Incremental events and sequencing
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs`
+- Test: `tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs` (create)
+
+**Why:** This is where a lost or reordered event stops producing a confidently wrong value. The four sequencing branches from the Background table live here.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs`:
+
+```csharp
+using Brmble.Client.Services.Voice.UserProjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class UserProjectionStoreEventTests
+{
+    private UserProjectionStore _store = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _store = new UserProjectionStore();
+        _store.ApplyMumbleUserState(new MumbleUserInput(1, "Alice", 0, false, false, null, null, false));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst-a", 10,
+            new Dictionary<uint, ServerMappingEntry>
+            {
+                [1] = new("@alice:test", "retro", true, "cert-a")
+            }));
+    }
+
+    private static ServerEvent Companion(long baseRevision, long revision, string? companionId) =>
+        new(ServerEventKind.CompanionChanged, "inst-a", baseRevision, revision, 1,
+            new ServerMappingEntry(null, companionId, null, null));
+
+    [TestMethod]
+    public void ApplyServerEvent_AppliesWhenBaseRevisionMatchesTheCursor()
+    {
+        var change = _store.ApplyServerEvent(Companion(10, 13, "bee"));
+
+        Assert.AreEqual("bee", _store.Snapshot()[1].CompanionId);
+        Assert.AreEqual(1, change.Changed.Count);
+        Assert.IsFalse(change.NeedsSnapshot);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_AcceptsAMultiBumpRange()
+    {
+        // One server operation can bump the counter several times; the client must not read
+        // that as a gap.
+        var change = _store.ApplyServerEvent(Companion(10, 40, "bee"));
+
+        Assert.AreEqual("bee", _store.Snapshot()[1].CompanionId);
+        Assert.IsFalse(change.NeedsSnapshot);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_IgnoresAnAlreadyAppliedEvent()
+    {
+        _store.ApplyServerEvent(Companion(10, 13, "bee"));
+
+        var change = _store.ApplyServerEvent(Companion(10, 13, "bee"));
+
+        Assert.IsTrue(change.IsEmpty, "a duplicate must not re-emit");
+        Assert.AreEqual("bee", _store.Snapshot()[1].CompanionId);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_IgnoresAReorderedOlderEvent()
+    {
+        _store.ApplyServerEvent(Companion(10, 20, "bee"));
+
+        var change = _store.ApplyServerEvent(Companion(12, 15, "stale"));
+
+        Assert.AreEqual("bee", _store.Snapshot()[1].CompanionId);
+        Assert.IsTrue(change.IsEmpty);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_RequestsASnapshotOnAGapAndChangesNothing()
+    {
+        var change = _store.ApplyServerEvent(Companion(30, 33, "bee"));
+
+        Assert.IsTrue(change.NeedsSnapshot);
+        Assert.AreEqual(0, change.Changed.Count);
+        Assert.AreEqual("retro", _store.Snapshot()[1].CompanionId, "a gap must apply nothing");
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_RequestsASnapshotWhenTheInstanceChanged()
+    {
+        var change = _store.ApplyServerEvent(
+            new ServerEvent(ServerEventKind.CompanionChanged, "inst-b", 0, 1, 1,
+                new ServerMappingEntry(null, "bee", null, null)));
+
+        Assert.IsTrue(change.NeedsSnapshot);
+        Assert.AreEqual("retro", _store.Snapshot()[1].CompanionId);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_BeforeAnySnapshotRequestsOne()
+    {
+        var fresh = new UserProjectionStore();
+        fresh.ApplyMumbleUserState(new MumbleUserInput(1, "Alice", 0, false, false, null, null, false));
+
+        var change = fresh.ApplyServerEvent(Companion(0, 1, "bee"));
+
+        Assert.IsTrue(change.NeedsSnapshot, "without a cursor there is nothing to sequence against");
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_NullFieldsLeaveKnownValuesAlone()
+    {
+        // The rule that makes a lost field harmless: unknown never overwrites known.
+        var change = _store.ApplyServerEvent(Companion(10, 11, null));
+
+        Assert.AreEqual("retro", _store.Snapshot()[1].CompanionId);
+        Assert.IsTrue(change.IsEmpty);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_BrmbleDeactivatedIsKnowledgeAndClearsTheBadge()
+    {
+        var change = _store.ApplyServerEvent(
+            new ServerEvent(ServerEventKind.BrmbleDeactivated, "inst-a", 10, 11, 1));
+
+        Assert.AreEqual(false, _store.Snapshot()[1].IsBrmbleClient);
+        Assert.AreEqual(1, change.Changed.Count);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_BrmbleActivatedSetsTheBadge()
+    {
+        _store.ApplyServerEvent(new ServerEvent(ServerEventKind.BrmbleDeactivated, "inst-a", 10, 11, 1));
+
+        _store.ApplyServerEvent(new ServerEvent(ServerEventKind.BrmbleActivated, "inst-a", 11, 12, 1));
+
+        Assert.AreEqual(true, _store.Snapshot()[1].IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_MappingRemovedClearsServerFieldsButKeepsTheRow()
+    {
+        var change = _store.ApplyServerEvent(
+            new ServerEvent(ServerEventKind.MappingRemoved, "inst-a", 10, 11, 1));
+
+        Assert.IsTrue(_store.Snapshot().ContainsKey(1), "only Mumble removes rows");
+        Assert.IsNull(_store.Snapshot()[1].MatrixUserId);
+        Assert.IsNull(_store.Snapshot()[1].IsBrmbleClient);
+        Assert.AreEqual(0, change.Removed.Count);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_ForASessionMumbleHasNotShownIsIgnoredButAdvancesTheCursor()
+    {
+        // The row does not exist yet, so there is nothing to enrich — but the event was still
+        // observed, and treating it as a gap would resync on every unrelated user's join.
+        var change = _store.ApplyServerEvent(
+            new ServerEvent(ServerEventKind.CompanionChanged, "inst-a", 10, 11, 77,
+                new ServerMappingEntry(null, "bee", null, null)));
+
+        Assert.IsFalse(change.NeedsSnapshot);
+        Assert.IsFalse(_store.Snapshot().ContainsKey(77));
+
+        var next = _store.ApplyServerEvent(Companion(11, 12, "pip"));
+        Assert.AreEqual("pip", _store.Snapshot()[1].CompanionId);
+        Assert.IsFalse(next.NeedsSnapshot);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~UserProjectionStoreEventTests"`
+
+Expected: FAIL — compile error, `'UserProjectionStore' does not contain a definition for 'ApplyServerEvent'`.
+
+- [ ] **Step 3: Implement `ApplyServerEvent`**
+
+Add to `UserProjectionStore.cs`:
+
+```csharp
+    /// <summary>
+    /// Applies one incremental server event, or reports that a snapshot is needed.
+    /// </summary>
+    /// <remarks>
+    /// Sequencing uses <c>BaseRevision</c>, not <c>Revision - 1</c>: a single server operation
+    /// may bump the counter several times, so only the range's start tells us whether we are
+    /// contiguous. An event that cannot be applied changes nothing at all — a partially applied
+    /// gap is what produces a confidently wrong row.
+    /// </remarks>
+    public ChangeSet ApplyServerEvent(ServerEvent evt)
+    {
+        lock (_gate)
+        {
+            // No cursor yet: nothing to sequence against, so ask for the snapshot that
+            // establishes one.
+            if (_instanceId is null)
+                return new ChangeSet([], [], NeedsSnapshot: true);
+
+            // The server restarted. Everything it told us belongs to a table that no longer
+            // exists, so take nothing from this event and resync.
+            if (!string.Equals(evt.InstanceId, _instanceId, StringComparison.Ordinal))
+                return new ChangeSet([], [], NeedsSnapshot: true);
+
+            // Already reflected — a duplicate or a reorder. Silently correct.
+            if (evt.BaseRevision < _revision) return ChangeSet.Empty;
+
+            // A genuine gap: we missed something in between and cannot infer it.
+            if (evt.BaseRevision > _revision)
+                return new ChangeSet([], [], NeedsSnapshot: true);
+
+            // Contiguous. Advance the cursor even if the event turns out not to touch a row we
+            // hold, or the next event would look like a gap.
+            _revision = evt.Revision;
+
+            if (!_rows.TryGetValue(evt.SessionId, out var existing))
+                return ChangeSet.Empty;
+
+            var updated = evt.Kind switch
+            {
+                ServerEventKind.MappingRemoved => existing with
+                {
+                    MatrixUserId = null,
+                    CompanionId = null,
+                    IsBrmbleClient = null,
+                    ServerCertHash = null
+                },
+                // Activation and deactivation are both knowledge, so they write a real bool.
+                ServerEventKind.BrmbleActivated => existing with { IsBrmbleClient = true },
+                ServerEventKind.BrmbleDeactivated => existing with { IsBrmbleClient = false },
+                // Everything else carries a partial entry: null means unknown, so leave it.
+                _ => evt.Entry is null ? existing : WithServerFields(existing, evt.Entry)
+            };
+
+            if (existing == updated) return ChangeSet.Empty;
+
+            _rows[evt.SessionId] = updated;
+            return new ChangeSet([updated], []);
+        }
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~UserProjectionStoreEventTests"`
+
+Expected: PASS, twelve tests.
+
+- [ ] **Step 5: Run the whole client suite**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs
+git commit -m "feat: apply server events with base-revision sequencing"
+```
+
+---
+
+## Task 6: Convergence property test
+
+**Files:**
+- Test: `tests/Brmble.Client.Tests/Services/UserProjectionConvergenceTests.cs` (create)
+
+**Why:** Spec §8 calls this "the whole design in one assertion". Every individual rule exists to serve one property: **however events are reordered or dropped, a final snapshot always produces the same projection.** If this holds, the failure modes in spec §7 cannot occur.
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/Brmble.Client.Tests/Services/UserProjectionConvergenceTests.cs`:
+
+```csharp
+using Brmble.Client.Services.Voice.UserProjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+/// <summary>
+/// The design's central property: given the same starting point and the same final snapshot,
+/// any permutation of the intervening events — with any subset dropped — converges on the same
+/// projection. Ordering and delivery become irrelevant to correctness.
+/// </summary>
+[TestClass]
+public class UserProjectionConvergenceTests
+{
+    private static readonly MumbleUserInput[] Users =
+    [
+        new(1, "Alice", 0, false, false, null, null, false),
+        new(2, "Bob", 0, false, false, null, null, false),
+        new(3, "Carol", 0, false, false, null, null, false)
+    ];
+
+    private static readonly ServerSnapshot Final = new("inst-a", 100,
+        new Dictionary<uint, ServerMappingEntry>
+        {
+            [1] = new("@alice:test", "retro", true, "cert-a"),
+            // Session 2 is deliberately absent. Events below enrich it, so a patch-only
+            // reconciliation would leave it enriched in some trials and not others — this is
+            // what makes the property test able to catch a §4.3 regression rather than passing
+            // trivially because the final snapshot overwrites everything.
+            [3] = new("@carol:test", "pip", null, null)
+        });
+
+    private static ServerEvent[] BuildEvents() =>
+    [
+        new(ServerEventKind.CompanionChanged, "inst-a", 10, 11, 1, new ServerMappingEntry(null, "bee", null, null)),
+        new(ServerEventKind.BrmbleActivated, "inst-a", 11, 12, 2),
+        new(ServerEventKind.CompanionChanged, "inst-a", 12, 20, 3, new ServerMappingEntry(null, "floppy", null, null)),
+        new(ServerEventKind.BrmbleDeactivated, "inst-a", 20, 21, 1),
+        new(ServerEventKind.MappingRemoved, "inst-a", 21, 25, 2),
+        new(ServerEventKind.CompanionChanged, "inst-a", 25, 26, 1, new ServerMappingEntry(null, "pip", null, null))
+    ];
+
+    private static UserProjectionStore Seeded()
+    {
+        var store = new UserProjectionStore();
+        foreach (var user in Users) store.ApplyMumbleUserState(user);
+        store.ApplyServerSnapshot(new ServerSnapshot("inst-a", 10,
+            new Dictionary<uint, ServerMappingEntry>
+            {
+                [1] = new("@alice:test", "retro", null, null),
+                [2] = new("@bob:test", "bee", null, null),
+                [3] = new("@carol:test", "pip", null, null)
+            }));
+        return store;
+    }
+
+    private static string Describe(IReadOnlyDictionary<uint, UserProjection> rows) =>
+        string.Join("|", rows.OrderBy(r => r.Key).Select(r =>
+            $"{r.Key}:{r.Value.Name}:{r.Value.MatrixUserId}:{r.Value.CompanionId}:" +
+            $"{r.Value.IsBrmbleClient?.ToString() ?? "unknown"}:{r.Value.CertHash ?? "none"}"));
+
+    [TestMethod]
+    public void AnyPermutationWithAnyDropsConvergesOnTheSameProjection()
+    {
+        var reference = Seeded();
+        foreach (var evt in BuildEvents()) reference.ApplyServerEvent(evt);
+        reference.ApplyServerSnapshot(Final);
+        var expected = Describe(reference.Snapshot());
+
+        var random = new Random(20260801);
+
+        for (var trial = 0; trial < 500; trial++)
+        {
+            var events = BuildEvents().ToList();
+
+            // Shuffle.
+            for (var i = events.Count - 1; i > 0; i--)
+            {
+                var j = random.Next(i + 1);
+                (events[i], events[j]) = (events[j], events[i]);
+            }
+
+            // Drop an arbitrary subset.
+            events = events.Where(_ => random.Next(4) != 0).ToList();
+
+            var store = Seeded();
+            foreach (var evt in events) store.ApplyServerEvent(evt);
+            store.ApplyServerSnapshot(Final);
+
+            Assert.AreEqual(expected, Describe(store.Snapshot()),
+                $"trial {trial} diverged with {events.Count} of 6 events");
+        }
+    }
+
+    [TestMethod]
+    public void ASessionTheFinalSnapshotOmitsEndsUnknownRegardlessOfWhatEventsSaid()
+    {
+        // Guards the guard: this is the case that makes the permutation test load-bearing. If
+        // snapshot reconciliation regressed to patch-only, session 2 would keep whatever the
+        // events happened to set and the permutations would diverge.
+        var withEvent = Seeded();
+        withEvent.ApplyServerEvent(new ServerEvent(ServerEventKind.BrmbleActivated, "inst-a", 10, 12, 2));
+        withEvent.ApplyServerSnapshot(Final);
+
+        var withoutEvent = Seeded();
+        withoutEvent.ApplyServerSnapshot(Final);
+
+        Assert.IsNull(withEvent.Snapshot()[2].IsBrmbleClient);
+        Assert.IsNull(withEvent.Snapshot()[2].MatrixUserId);
+        Assert.AreEqual(Describe(withoutEvent.Snapshot()), Describe(withEvent.Snapshot()));
+    }
+
+    [TestMethod]
+    public void ADroppedEventNeverProducesAConfidentlyWrongValue()
+    {
+        // The failure this design exists to remove: a lost event must leave a field unknown or
+        // stale-but-true, never asserted wrong.
+        var store = Seeded();
+
+        // Alice's deactivation is dropped; her later companion change still arrives.
+        store.ApplyServerEvent(new ServerEvent(
+            ServerEventKind.CompanionChanged, "inst-a", 20, 26, 1,
+            new ServerMappingEntry(null, "pip", null, null)));
+
+        var alice = store.Snapshot()[1];
+        Assert.AreEqual("retro", alice.CompanionId, "the gapped event must not be applied");
+        Assert.IsNull(alice.IsBrmbleClient, "and must not invent a badge state");
+    }
+
+    [TestMethod]
+    public void AGapIsAlwaysReportedSoTheCallerCanRepairIt()
+    {
+        var store = Seeded();
+
+        var change = store.ApplyServerEvent(new ServerEvent(
+            ServerEventKind.CompanionChanged, "inst-a", 50, 51, 1,
+            new ServerMappingEntry(null, "pip", null, null)));
+
+        Assert.IsTrue(change.NeedsSnapshot);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~UserProjectionConvergenceTests"`
+
+Expected: PASS, four tests. If the permutation test fails, **do not weaken it** — it is the design's core property, and a failure means one of Tasks 3-5 has a real bug. The assertion message names the trial and how many events survived; reproduce it by seeding `Random` with that trial number.
+
+- [ ] **Step 3: Full verification**
+
+```bash
+dotnet build
+dotnet test
+```
+
+Expected: build clean with 0 warnings; all four test projects pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/Brmble.Client.Tests/Services/UserProjectionConvergenceTests.cs
+git commit -m "test: prove the projection converges under reordering and loss"
+```
+
+---
+
+## Done when
+
+- [ ] `dotnet build` is clean with 0 warnings
+- [ ] `dotnet test` passes in all four projects, with more tests than the 1250 baseline
+- [ ] Every mapping **event** carries `baseRevision`; every **snapshot** carries `instanceId` and `revision` and no `baseRevision`
+- [ ] Consecutive events from one publisher are contiguous: each event's `baseRevision` equals the previous event's `revision`
+- [ ] `UserProjectionStore` references no Mumble, HTTP or JSON type. Verify: `Select-String -Path src/Brmble.Client/Services/Voice/UserProjection/*.cs -Pattern "MumbleSharp|HttpClient|JsonElement|System.Text.Json"` returns nothing
+- [ ] A server input can only reach server-owned fields and a Mumble input only Mumble-owned ones — enforced by the input types, not by a guard
+- [ ] The convergence test passes with 500 trials
+- [ ] **Nothing calls the store yet.** `MumbleAdapter.cs` and `App.tsx` are untouched by this phase. Verify: `git diff --stat main -- src/Brmble.Client/Services/Voice/MumbleAdapter.cs src/Brmble.Web/src/App.tsx` shows no changes
+
+## Manual smoke test
+
+There is nothing to see: Phase 2 adds no behaviour. The only user-visible surface is Task 1, which is additive on the wire. Confirm it is harmless:
+
+```bash
+cd src/Brmble.Web; npm run build; cd ../..
+docker compose -f docker-local/docker-compose.yml up -d --build brmble
+dotnet run --project src/Brmble.Client
+```
+
+Connect and confirm the user list, badges and companions render exactly as before — the client ignores `baseRevision`. The restart symptoms are still present; they are fixed in Phase 3.
+
+---
+
+## Next
+
+**Phase 3** wires the store in and is where the user-visible fixes land: delete `_sessionMappings`, translate wire payloads into the input records from Task 2, collapse the 17 `setUsers` sites to 2, move avatars into their own state keyed by `matrixUserId`, and add client version negotiation via a `pv` query parameter so the server can send a single truthful `companionId` (spec §4.4) instead of the legacy `companionId`/`customCompanionId` split. It touches the two most actively edited files in the repo, so it is planned against shipped code after Phase 2 lands.

--- a/docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md
+++ b/docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md
@@ -73,10 +73,12 @@ Mumble supplies `CertificateHash` on `UserState`; the server supplies `certHash`
 | `src/Brmble.Server/Companions/CustomCompanionEndpoints.cs` | *Modify* — stamp `baseRevision` |
 | `src/Brmble.Server/Mumble/MumbleServerCallback.cs` | *Modify* — stamp `baseRevision` |
 | `src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs` | *Modify* — stamp `baseRevision` on `userMappingAdded`; snapshot factory |
-| `src/Brmble.Client/Services/Voice/UserProjection/UserProjection.cs` | *Create* — the row record |
-| `src/Brmble.Client/Services/Voice/UserProjection/ProjectionInputs.cs` | *Create* — dependency-free input records |
-| `src/Brmble.Client/Services/Voice/UserProjection/ChangeSet.cs` | *Create* — the output of every `Apply*` |
-| `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs` | *Create* — the store itself |
+| `src/Brmble.Client/Services/Voice/Projection/UserProjection.cs` | *Create* — the row record |
+| `src/Brmble.Client/Services/Voice/Projection/ProjectionInputs.cs` | *Create* — dependency-free input records |
+| `src/Brmble.Client/Services/Voice/Projection/ChangeSet.cs` | *Create* — the output of every `Apply*` |
+| `src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs` | *Create* — the store itself |
+
+The namespace is `Brmble.Client.Services.Voice.Projection`, deliberately **not** `...Voice.UserProjection`. A namespace whose last segment matches a type it contains (`UserProjection`) trips CA1724 and can produce a `CS0118 'namespace used like a type'` when the type is referenced from inside that namespace. Do not "tidy" the folder name to match the type.
 
 ---
 
@@ -344,9 +346,9 @@ git commit -m "feat: stamp baseRevision so clients can apply across multi-bump o
 ## Task 2: Projection row, inputs and change set
 
 **Files:**
-- Create: `src/Brmble.Client/Services/Voice/UserProjection/UserProjection.cs`
-- Create: `src/Brmble.Client/Services/Voice/UserProjection/ProjectionInputs.cs`
-- Create: `src/Brmble.Client/Services/Voice/UserProjection/ChangeSet.cs`
+- Create: `src/Brmble.Client/Services/Voice/Projection/UserProjection.cs`
+- Create: `src/Brmble.Client/Services/Voice/Projection/ProjectionInputs.cs`
+- Create: `src/Brmble.Client/Services/Voice/Projection/ChangeSet.cs`
 - Test: `tests/Brmble.Client.Tests/Services/UserProjectionTests.cs` (create)
 
 **Why:** Ownership is enforced by the shape of these types. `MumbleUserInput` has no server-owned field to write and `ServerMappingEntry` has no Mumble-owned one, so a cross-write cannot compile. Getting these right is what makes the store's logic small.
@@ -356,7 +358,7 @@ git commit -m "feat: stamp baseRevision so clients can apply across multi-bump o
 Create `tests/Brmble.Client.Tests/Services/UserProjectionTests.cs`:
 
 ```csharp
-using Brmble.Client.Services.Voice.UserProjection;
+using Brmble.Client.Services.Voice.Projection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Brmble.Client.Tests.Services;
@@ -403,10 +405,10 @@ Expected: FAIL — compile error, `The type or namespace name 'UserProjection' c
 
 - [ ] **Step 3: Create the row record**
 
-Create `src/Brmble.Client/Services/Voice/UserProjection/UserProjection.cs`:
+Create `src/Brmble.Client/Services/Voice/Projection/UserProjection.cs`:
 
 ```csharp
-namespace Brmble.Client.Services.Voice.UserProjection;
+namespace Brmble.Client.Services.Voice.Projection;
 
 /// <summary>
 /// One row of the authoritative user projection: Mumble-native presence merged with
@@ -452,10 +454,10 @@ Expected: PASS, three tests.
 
 - [ ] **Step 5: Create the input records**
 
-Create `src/Brmble.Client/Services/Voice/UserProjection/ProjectionInputs.cs`. These deliberately reference no Mumble, HTTP or JSON type — the caller translates before handing them over, which is what keeps the store unit-testable:
+Create `src/Brmble.Client/Services/Voice/Projection/ProjectionInputs.cs`. These deliberately reference no Mumble, HTTP or JSON type — the caller translates before handing them over, which is what keeps the store unit-testable:
 
 ```csharp
-namespace Brmble.Client.Services.Voice.UserProjection;
+namespace Brmble.Client.Services.Voice.Projection;
 
 /// <summary>
 /// A Mumble <c>UserState</c>, reduced to the fields Mumble owns. Complete every time: Mumble
@@ -519,10 +521,10 @@ internal sealed record ServerEvent(
 
 - [ ] **Step 6: Create the change set**
 
-Create `src/Brmble.Client/Services/Voice/UserProjection/ChangeSet.cs`:
+Create `src/Brmble.Client/Services/Voice/Projection/ChangeSet.cs`:
 
 ```csharp
-namespace Brmble.Client.Services.Voice.UserProjection;
+namespace Brmble.Client.Services.Voice.Projection;
 
 /// <summary>
 /// What one <c>Apply</c> changed. Rows in <see cref="Changed"/> are always complete — every
@@ -555,7 +557,7 @@ Run: `dotnet build`
 Expected: clean, 0 warnings.
 
 ```bash
-git add src/Brmble.Client/Services/Voice/UserProjection/ tests/Brmble.Client.Tests/Services/UserProjectionTests.cs
+git add src/Brmble.Client/Services/Voice/Projection/ tests/Brmble.Client.Tests/Services/UserProjectionTests.cs
 git commit -m "feat: add user projection row, inputs and change set types"
 ```
 
@@ -564,7 +566,7 @@ git commit -m "feat: add user projection row, inputs and change set types"
 ## Task 3: The store and its Mumble inputs
 
 **Files:**
-- Create: `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs`
+- Create: `src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs`
 - Test: `tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs` (create)
 
 **Why:** Mumble alone owns session existence (spec §3.3). If the Brmble server is down, rows still appear, move channel and mute — they just carry stale enrichment. That property comes from this task.
@@ -574,7 +576,7 @@ git commit -m "feat: add user projection row, inputs and change set types"
 Create `tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs`:
 
 ```csharp
-using Brmble.Client.Services.Voice.UserProjection;
+using Brmble.Client.Services.Voice.Projection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Brmble.Client.Tests.Services;
@@ -683,10 +685,10 @@ Expected: FAIL — compile error, `The type or namespace name 'UserProjectionSto
 
 - [ ] **Step 3: Create the store with its Mumble inputs**
 
-Create `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs`. `ApplyServerSnapshot` and `ApplyServerEvent` are stubbed here and implemented in Tasks 4 and 5 — the tests above need `ApplyServerSnapshot` to work, so it gets a minimal real body now and its reconciliation rules in Task 4:
+Create `src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs`. `ApplyServerSnapshot` and `ApplyServerEvent` are stubbed here and implemented in Tasks 4 and 5 — the tests above need `ApplyServerSnapshot` to work, so it gets a minimal real body now and its reconciliation rules in Task 4:
 
 ```csharp
-namespace Brmble.Client.Services.Voice.UserProjection;
+namespace Brmble.Client.Services.Voice.Projection;
 
 /// <summary>
 /// The single authoritative user projection. Merges Mumble presence and Brmble identity under
@@ -822,7 +824,7 @@ Expected: PASS, seven tests.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs
+git add src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs
 git commit -m "feat: add user projection store with Mumble-owned inputs"
 ```
 
@@ -831,7 +833,7 @@ git commit -m "feat: add user projection store with Mumble-owned inputs"
 ## Task 4: Snapshot reconciliation
 
 **Files:**
-- Modify: `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs`
+- Modify: `src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs`
 - Test: `tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs` (create)
 
 **Why:** Spec §4.3 changes what a snapshot *means*. Today it only patches rows that already exist and never clears, so a session that vanished during an outage keeps stale enrichment forever. A snapshot is now the complete set of server-known sessions: anything absent has its server-owned fields reset to unknown. It still cannot delete a row — only Mumble owns existence.
@@ -841,7 +843,7 @@ git commit -m "feat: add user projection store with Mumble-owned inputs"
 Create `tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs`:
 
 ```csharp
-using Brmble.Client.Services.Voice.UserProjection;
+using Brmble.Client.Services.Voice.Projection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Brmble.Client.Tests.Services;
@@ -1023,7 +1025,7 @@ Expected: PASS — the seven Mumble tests and the seven snapshot tests.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
+git add src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
 git commit -m "feat: make snapshots authoritative for server-owned membership"
 ```
 
@@ -1032,7 +1034,7 @@ git commit -m "feat: make snapshots authoritative for server-owned membership"
 ## Task 5: Incremental events and sequencing
 
 **Files:**
-- Modify: `src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs`
+- Modify: `src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs`
 - Test: `tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs` (create)
 
 **Why:** This is where a lost or reordered event stops producing a confidently wrong value. The four sequencing branches from the Background table live here.
@@ -1042,7 +1044,7 @@ git commit -m "feat: make snapshots authoritative for server-owned membership"
 Create `tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs`:
 
 ```csharp
-using Brmble.Client.Services.Voice.UserProjection;
+using Brmble.Client.Services.Voice.Projection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Brmble.Client.Tests.Services;
@@ -1291,7 +1293,7 @@ Expected: PASS.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/Brmble.Client/Services/Voice/UserProjection/UserProjectionStore.cs tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs
+git add src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs
 git commit -m "feat: apply server events with base-revision sequencing"
 ```
 
@@ -1309,7 +1311,7 @@ git commit -m "feat: apply server events with base-revision sequencing"
 Create `tests/Brmble.Client.Tests/Services/UserProjectionConvergenceTests.cs`:
 
 ```csharp
-using Brmble.Client.Services.Voice.UserProjection;
+using Brmble.Client.Services.Voice.Projection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Brmble.Client.Tests.Services;
@@ -1481,7 +1483,7 @@ git commit -m "test: prove the projection converges under reordering and loss"
 - [ ] `dotnet test` passes in all four projects, with more tests than the 1250 baseline
 - [ ] Every mapping **event** carries `baseRevision`; every **snapshot** carries `instanceId` and `revision` and no `baseRevision`
 - [ ] Consecutive events from one publisher are contiguous: each event's `baseRevision` equals the previous event's `revision`
-- [ ] `UserProjectionStore` references no Mumble, HTTP or JSON type. Verify: `Select-String -Path src/Brmble.Client/Services/Voice/UserProjection/*.cs -Pattern "MumbleSharp|HttpClient|JsonElement|System.Text.Json"` returns nothing
+- [ ] `UserProjectionStore` references no Mumble, HTTP or JSON type. Verify: `Select-String -Path src/Brmble.Client/Services/Voice/Projection/*.cs -Pattern "MumbleSharp|HttpClient|JsonElement|System.Text.Json"` returns nothing
 - [ ] A server input can only reach server-owned fields and a Mumble input only Mumble-owned ones — enforced by the input types, not by a guard
 - [ ] The convergence test passes with 500 trials
 - [ ] **Nothing calls the store yet.** `MumbleAdapter.cs` and `App.tsx` are untouched by this phase. Verify: `git diff --stat main -- src/Brmble.Client/Services/Voice/MumbleAdapter.cs src/Brmble.Web/src/App.tsx` shows no changes
@@ -1503,3 +1505,4 @@ Connect and confirm the user list, badges and companions render exactly as befor
 ## Next
 
 **Phase 3** wires the store in and is where the user-visible fixes land: delete `_sessionMappings`, translate wire payloads into the input records from Task 2, collapse the 17 `setUsers` sites to 2, move avatars into their own state keyed by `matrixUserId`, and add client version negotiation via a `pv` query parameter so the server can send a single truthful `companionId` (spec §4.4) instead of the legacy `companionId`/`customCompanionId` split. It touches the two most actively edited files in the repo, so it is planned against shipped code after Phase 2 lands.
+

--- a/docs/superpowers/plans/README-user-projection.md
+++ b/docs/superpowers/plans/README-user-projection.md
@@ -1,0 +1,117 @@
+# User Projection — session handoff
+
+Sequence, current state, and a ready-to-paste prompt for whichever phase comes next.
+
+**Design spec:** [`../specs/2026-07-31-user-projection-design.md`](../specs/2026-07-31-user-projection-design.md)
+**Superseded problem statement:** [`../specs/2026-07-31-user-data-propagation-problem.md`](../specs/2026-07-31-user-data-propagation-problem.md)
+
+---
+
+## Phases
+
+| Phase | Scope | Plan | Status |
+|---|---|---|---|
+| 1 | Server wire contract — `instanceId`, `revision`, tri-state `isBrmbleClient`, `requestSnapshot` | [`2026-07-31-user-projection-phase-1-server.md`](2026-07-31-user-projection-phase-1-server.md) | Planned, not built |
+| 2 | `UserProjectionStore` — pure, dependency-free C# in `Brmble.Client` | Not written | Blocked on Phase 1 landing |
+| 3 | Rewire `MumbleAdapter` + `App.tsx`; companion collapse; `pv` negotiation | Not written | Blocked on Phase 2 landing |
+
+**Phases 2 and 3 are deliberately unplanned.** They touch `MumbleAdapter.cs` (~4,700 lines) and
+`App.tsx` (~5,600 lines), the most actively edited files in the repo, and plans written against
+them go stale fast — that has already happened twice during this work, once from the
+`custom-companion` merge and once from the companion-race fix. Plan one phase at a time, against
+code that exists.
+
+---
+
+## Prompt: build Phase 1
+
+Paste everything between the rules into a fresh session.
+
+---
+
+Implement Phase 1 of the Brmble user projection work.
+
+### Start here
+
+Repo: `C:\Projects\brmble`
+Branch: `docs/user-projection-design` (HEAD should be `2661adca`)
+
+Read these two files first, in this order:
+
+1. `docs/superpowers/specs/2026-07-31-user-projection-design.md` — the approved design. Read §1–§4 and §11 for context; skim the rest.
+2. `docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md` — the plan you are executing. Read it in full, including "Background you need", before writing any code.
+
+The plan is self-contained: 5 tasks, 42 checkbox steps, with complete code and exact commands. Follow it in order.
+
+### Before you write code — sanity check you're on the right branch
+
+Both of this plan's dependencies are **already satisfied** on this branch. These commands just confirm you haven't landed somewhere unexpected:
+
+```powershell
+git rev-parse --abbrev-ref HEAD          # expect: docs/user-projection-design
+git log --oneline origin/main | Select-String "broadcast companion changes"
+Select-String -Path src/Brmble.Server/Events/ISessionMappingService.cs -Pattern TryUpdateCompanionIdIfOwnedBy
+```
+
+All three must return something. The companion-race fix (`cd7b48fa`) is the base commit of this branch, so `TryUpdateCompanionIdIfOwnedBy` is present at `ISessionMappingService.cs:16` and in use at `AuthEndpoints.cs:334`. If it's missing, you're on the wrong branch — stop and ask.
+
+Baseline before starting: `dotnet build` (0 warnings) and `dotnet test` (1230 passing — Server 758, Client 300, MumbleVoiceEngine 99, Audio 73). Confirm this so you can tell your own failures from pre-existing ones.
+
+### How to work
+
+- Create a new branch off the current one: `git checkout -b feature/user-projection-phase-1`. Never commit to main.
+- Use the **test-driven-development** skill. The plan is written red-green-refactor and every task starts with a failing test. Actually run each test and watch it fail for the expected reason before implementing — the plan states the expected failure message.
+- Use the **verification-before-completion** skill before claiming anything works. Run the command, read the output, then make the claim.
+- Commit after each task, using the commit message given in that task's final step.
+- Do not push or open a PR without asking first.
+
+### Two things the plan warns about — do not get these wrong
+
+1. **JSON naming.** Always write `instanceId = envelope.InstanceId`, never the `envelope.InstanceId` property shorthand. The event bus serialises with a camelCase policy but the tests use default options, so the shorthand emits `InstanceId` and every assertion fails.
+
+2. **Locks and broadcasts.** Calling `BroadcastAsync` only enqueues; *awaiting* it waits for the fan-out. `MappingEventPublisher` enqueues under its lock and returns, and callers await outside. This is deliberate and is what keeps commit `cd7b48fa`'s concurrency fix intact. Do not "simplify" it by awaiting inside the lock.
+
+### Ignore the LSP noise
+
+The language server in this repo reports unresolved `Moq`, `TestClass`, `Microsoft.Extensions` and `Ice` references in files you have not touched. These are false — `dotnet build` is clean. Trust the build, not the diagnostics.
+
+### Done when
+
+The plan's "Done when" checklist passes, including the invariant that **every revision bump is announced** — cross-check each `Bump()` call site against a producer that broadcasts a stamped payload. An unannounced bump manufactures a phantom gap in every connected client.
+
+Report back with: what you built, test counts before and after, and anything in the plan that turned out to be wrong.
+
+### What happens after this (context, not your task)
+
+Phase 1 is the server wire contract. It is additive — older clients ignore the new fields — so it ships alone and fixes nothing user-visible on its own. The restart symptoms (badge loss, companion reverting to floppy) are fixed in Phase 3.
+
+- **Phase 2** builds `UserProjectionStore` in `Brmble.Client`: ownership-scoped inputs, unknown-never-overwrites-known, unit-testable without a protocol stack.
+- **Phase 3** rewires `MumbleAdapter` and `App.tsx`: deletes `_sessionMappings`, collapses 17 `setUsers` sites to 2, moves avatars into their own state, and adds companion version negotiation via a `pv` query parameter on the `/ws` URL.
+
+Do not start Phase 2. When Phase 1 is committed and green, stop and report.
+
+---
+
+## Prompt: plan Phase 2 (after Phase 1 lands)
+
+---
+
+Write the Phase 2 implementation plan for the Brmble user projection.
+
+Read `docs/superpowers/specs/2026-07-31-user-projection-design.md` (§3, §5, §6.5, §8) and the Phase 1 plan and code as they were actually built — not as Phase 1 was planned, since the two may differ.
+
+Phase 2 is `UserProjectionStore` in `src/Brmble.Client/Services/Voice/UserProjection/`: a pure type with no Mumble or network dependency, four apply methods, and the two rules from §3.2. No wiring into `MumbleAdapter` — that is Phase 3.
+
+Use the **writing-plans** skill. Save to `docs/superpowers/plans/YYYY-MM-DD-user-projection-phase-2-store.md`.
+
+Resolve spec §11 question 2 (how long to buffer an event naming an unknown session) as part of this plan, now that it can be measured against a real store.
+
+---
+
+## Decisions worth not relitigating
+
+- **Mumble owns session existence.** If the Brmble container is down, rows still appear and voice keeps working. Rejected: the server assembling and pushing the whole list.
+- **The projection carries identifiers, never resolved assets.** `avatarUrl` and `atlasCacheKey` stay outside it. See spec §3.4.
+- **Every revision bump is announced.** An unannounced bump is worse than no bump. See spec §11.3.
+- **`/auth/token` cannot be dropped** — the client needs credentials before the WebSocket is up. See spec §2.1.
+- **Moderator redactions already reach every client** via Matrix sync, independently of the WebSocket. An earlier reading claimed otherwise and was wrong; see spec §5.1 before re-investigating.

--- a/docs/superpowers/plans/phase-1-review-findings.md
+++ b/docs/superpowers/plans/phase-1-review-findings.md
@@ -1,0 +1,113 @@
+# Phase 1 review findings — fix prompt
+
+Paste the block below into a fresh session to fix the two defects found reviewing Phase 1.
+
+---
+
+Fix two defects found reviewing Phase 1 of the Brmble user projection.
+
+## Context
+
+Repo: `C:\Projects\brmble`
+Branch: `feature/user-projection-phase-1` (HEAD `804230fe`)
+
+Phase 1 is built and green — `dotnet build` clean, `dotnet test` 1246 passing (Server 774, Client 300, MumbleVoiceEngine 99, Audio 73). Confirm that baseline before you start.
+
+Read `docs/superpowers/specs/2026-07-31-user-projection-design.md` §3.2, §4.1 and §4.2 for the rules these defects violate. The Phase 1 plan is at `docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md`.
+
+Both defects originate in the plan, not in the implementation — it followed the plan faithfully. Fix the code; do not treat this as a rework of someone's mistake.
+
+Use the **test-driven-development** skill: failing test first, watched to fail for the right reason, then the fix. Commit each defect separately.
+
+---
+
+## Defect 1 — tri-state null breaks the currently shipped client (ship blocker)
+
+The server now emits `isBrmbleClient: null` for any session whose owner has not registered a WebSocket. The shipped client parses it like this, in two places:
+
+- `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:130` (`ParseSessionMappings`)
+- `src/Brmble.Client/Services/Voice/MumbleAdapter.cs:2650` (`userMappingAdded` handler)
+
+```csharp
+var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b) && b.GetBoolean();
+```
+
+`TryGetProperty` returns **true** for an explicit JSON null, and `JsonElement.GetBoolean()` **throws** `InvalidOperationException` when the value kind is Null. Line 130 runs while handling the `/auth/token` response, so an updated server would throw inside credential handling for every existing client, for every unregistered user in the snapshot.
+
+**Fix, server-side: omit the property when unknown instead of writing null.**
+
+An absent property makes old clients evaluate `TryGetProperty` to false and fall back to `false` — exactly today's behaviour. New clients treat absent and null identically as "unknown" (spec §3.2 rule 2), so nothing is lost. `false` must still be written explicitly, because an observed deactivation is knowledge, not an absence.
+
+**Do not** set a global `DefaultIgnoreCondition = WhenWritingNull` on `BrmbleEventBus`'s `JsonOptions`. `customCompanionId = (string?)null` is deliberately meaningful on the wire and omitting it would change companion parsing. Make the omission specific to `isBrmbleClient`.
+
+Sites that serialise it: `BrmbleWebSocketHandler.BuildInitialPayloadsAsync`, `BrmbleWebSocketHandler.CreateUserMappingAddedPayload`, `SessionMappingHandler.OnUserConnected`, and the `/auth/token` response in `AuthEndpoints`.
+
+Tests to add:
+- A payload for an unregistered session has **no** `isBrmbleClient` property at all (assert `TryGetProperty` is false), for both the snapshot and `userMappingAdded`.
+- A payload for a deactivated session still carries `isBrmbleClient: false` explicitly.
+- A regression test that the shipped client parser survives it: call `MumbleAdapter.ParseSessionMappings` (internal, `InternalsVisibleTo` is configured for `Brmble.Client.Tests`) with a snapshot containing an omitted `isBrmbleClient`, and assert it does not throw and yields `IsBrmbleClient == false`. Add the same for a payload containing an explicit `null`, so the client is hardened even if a null ever reaches it.
+
+---
+
+## Defect 2 — revision stamped outside the ordering lock
+
+`MappingEventPublisher` exists so that revision order matches delivery order: it mutates, reads the revision and enqueues the broadcast under one lock. Five sites bypass that, mutating first and reading `sessionMapping.Revision` afterwards, unsynchronised:
+
+| Site | Problem |
+|---|---|
+| `src/Brmble.Server/Auth/AuthEndpoints.cs:93-115` | 3 mutations, then raw `eventBus.BroadcastAsync` reading `.Revision` |
+| `src/Brmble.Server/Auth/AuthEndpoints.cs:123-133` | 2 mutations, then raw `eventBus.BroadcastAsync` reading `.Revision` |
+| `src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs:131-139` | 2 mutations, then raw `BroadcastExceptAsync` reading `.Revision` |
+| `src/Brmble.Server/Events/SessionMappingHandler.cs:43-45` | uses the publisher, but with `() => true` — mutations already happened outside the lock |
+| `src/Brmble.Server/Mumble/MumbleServerCallback.cs:187,200` | `RemoveSession` at :187, publisher with `() => true` at :200 |
+
+The race, with two users registering simultaneously:
+
+```
+Thread A: mutates            -> revision becomes 5
+Thread B: publisher mutates  -> revision becomes 6, enqueues payload(6)
+Thread A: reads .Revision    -> gets 6, enqueues payload(6)   <- wrong revision
+```
+
+Two payloads claim revision 6. A client applies one and discards the other as a duplicate — silent data loss, which is the exact failure this phase exists to prevent. It triggers under concurrent registration, which is the spec's §8 acceptance test.
+
+`() => true` fails for the same underlying reason: the mutation happened before the lock, so the revision read inside it is not provably the one that mutation produced.
+
+**Fix: move the mutations inside the publisher's `mutate` callback**, so mutation, revision read and enqueue are one atomic unit:
+
+```csharp
+await publisher.PublishAsync(
+    () =>
+    {
+        sessionMapping.TryUpdateCertHash(sid, certHash);
+        sessionMapping.TryUpdateBrmbleStatus(sid, true);
+        return true;
+    },
+    envelope => new
+    {
+        type = "brmbleClientActivated",
+        instanceId = envelope.InstanceId,
+        revision = envelope.Revision,
+        sessionId = sid
+    });
+```
+
+Notes per site:
+- `SessionMappingHandler` needs `TryAddMatrixUser`'s result after the fact to decide whether to send `brmbleClientActivated`. Capture it into a local from inside the callback.
+- `BrmbleWebSocketHandler` excludes the registering socket, so add a `PublishExceptAsync(WebSocket excluded, ...)` overload to `IMappingEventPublisher` that calls `BroadcastExceptAsync` under the same lock.
+- `MumbleServerCallback` must keep `RemoveSession` ordered against the LiveKit and channel-membership cleanup around it. Move only `RemoveSession` into the callback; the surrounding work stays where it is.
+
+Test to add: a concurrency test that fires many simultaneous publishes and asserts **no two broadcast payloads carry the same revision**, and that revisions arrive in ascending order. Model it on the existing `PublishAsync_DeliversInRevisionOrderUnderConcurrency` in `tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs`, but drive it through the real endpoints rather than the publisher directly, so it actually covers the five sites above.
+
+---
+
+## Done when
+
+- `dotnet build` clean, 0 warnings
+- `dotnet test` green, with more tests than the 1246 baseline
+- No payload carries `isBrmbleClient` when the value is unknown; `false` is still explicit
+- `ParseSessionMappings` survives both an omitted and an explicit-null `isBrmbleClient`
+- Every mapping mutation reaches the wire through `MappingEventPublisher`, with no `() => true` left where a real mutation should be
+- Grep confirms no remaining `eventBus.BroadcastAsync` for a mapping payload outside the publisher
+
+Do not push or open a PR. Report what you changed and the test counts.

--- a/docs/superpowers/plans/phase-2-handoff.md
+++ b/docs/superpowers/plans/phase-2-handoff.md
@@ -1,0 +1,103 @@
+# Phase 2 handoff — start prompt
+
+Paste the block below into a fresh session to execute Phase 2.
+
+---
+
+Implement Phase 2 of the Brmble user projection.
+
+## Start here
+
+Repo: `C:\Projects\brmble`
+Branch: `feature/user-projection-phase-1` (HEAD should be `fced11b1`)
+
+Read these, in this order:
+
+1. `docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md` — the plan you are executing. Read it in full, including "Background you need", before writing any code.
+2. `docs/superpowers/specs/2026-07-31-user-projection-design.md` — the approved design. §3.1, §3.2, §4.2, §4.3, §6.6 and §8 are the sections Phase 2 implements. Skim the rest.
+
+The plan is self-contained: 6 tasks with complete code, exact commands and expected failure messages. Follow it in order.
+
+## Sanity check you're in the right place
+
+```powershell
+git rev-parse --abbrev-ref HEAD        # feature/user-projection-phase-1
+git log --oneline -1                   # fced11b1
+Select-String -Path src/Brmble.Server/Events/MappingEventPublisher.cs -Pattern PublishExceptAsync
+```
+
+Baseline before you start — confirm both, so you can tell your own failures from pre-existing ones:
+
+```powershell
+dotnet build     # 0 warnings, 0 errors
+dotnet test      # 1250 passing: Server 777, Client 301, MumbleVoiceEngine 99, Audio 73
+```
+
+If the baseline doesn't match, stop and ask rather than guessing which failures are yours.
+
+## Context you need that isn't in the plan
+
+**Phase 1 is open as PR #619** (`https://github.com/brmble/brmble/pull/619`), 18 commits, not yet merged. Phase 2 lands on the *same branch* — the PR picks up new commits automatically. Do not open a second PR.
+
+**The branch is not based on `main`.** It diverges from `origin/main` at `a4c993fa` and carries an unmerged prior fix (`cd7b48fa`). `git diff main` is misleading; use `git diff origin/main...HEAD` if you need it.
+
+**Task 1 touches files that are under review in #619.** If review comments land on `MappingEventPublisher.cs`, `SessionMappingHandler.cs`, `AuthEndpoints.cs`, `AuthService.cs`, `CustomCompanionEndpoints.cs`, `MumbleServerCallback.cs` or `BrmbleWebSocketHandler.cs` while you work, rebase before continuing. Tasks 2-6 touch only new files and cannot conflict.
+
+## Environment traps that cost time in Phase 1
+
+**1. The language server lies.** It reports unresolved `Moq`, `TestClass`, `Microsoft.Extensions`, `Ice`, `ProtoBuf`, `WebApplicationFactory` and similar in files you have not touched. These are false. `dotnet build` is the source of truth — trust it, not the inline diagnostics. Do not "fix" imports that are already correct.
+
+**2. Moq mocks silently return defaults for new interface members.** When Phase 1 added `InstanceId` and `Revision` to `ISessionMappingService`, every `Mock<ISessionMappingService>` returned `null` and `0`, so payloads went out with blank envelopes and tests failed with confusing assertions rather than compile errors. Task 1 does not add interface members, so this specific trap should not recur — but if an envelope assertion fails with a blank or zero value, check the mock setup before suspecting the production code. The stubs live in:
+   - `tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs` (delegates to a real `SessionMappingService`)
+   - `tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs` (`CompanionAuthFactory` hides the base mock with a bare one)
+   - `tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs`
+
+**3. Hand-written test doubles break on interface changes.** `tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs` implements `ISessionMappingService` by hand, and `MappingEventPublisherTests` / `BrmbleWebSocketHandlerTests` implement `IBrmbleEventBus` by hand. Task 1 changes neither interface, but if you widen one you must update these.
+
+**4. Adding a wire field breaks exact-string payload assertions.** Task 1 adds `baseRevision` to every event payload. At least one test previously asserted a full serialised JSON string; it was converted to a structural assertion in Phase 1, but check for others if a test fails on an unexpected substring. Prefer structural assertions — `instanceId` is a per-process GUID and can never be matched exactly.
+
+**5. `dotnet test --no-build` after an edit runs stale binaries.** Only use `--no-build` immediately after a successful `dotnet build`.
+
+**6. Git prints CRLF warnings on nearly every commit.** Cosmetic, ignore them.
+
+## How to work
+
+- Stay on `feature/user-projection-phase-1`. Do not create a new branch, and never commit to `main`.
+- Use the **test-driven-development** skill. Every task starts with a failing test, and the plan states the expected failure message. Actually run it and watch it fail for that reason before implementing.
+- Use the **verification-before-completion** skill before claiming anything works. Run the command, read the output, then make the claim.
+- Commit after each task with the message given in that task's final step.
+- Do not push or comment on the PR without asking first.
+
+## Things the plan warns about — do not get these wrong
+
+**1. The namespace is `Brmble.Client.Services.Voice.Projection`, not `...Voice.UserProjection`.** A namespace ending in the name of a type it contains trips CA1724 and can produce `CS0118 'namespace used like a type'`. Do not rename the folder to match the type.
+
+**2. Snapshots and events treat `null` differently, on purpose.** On an *event*, a null server field means "not telling you" and must leave the existing value alone. On a *snapshot*, null means "there is no value" and must overwrite. Task 4's implementation overwrites; Task 5's preserves. Both have comments explaining why. Getting these the same way round is the single most likely way to break the design.
+
+**3. A gap must apply nothing at all.** When `baseRevision > ours`, return `NeedsSnapshot` and change no row. Partially applying a gapped event is precisely what produces the confidently-wrong values this design exists to eliminate.
+
+**4. Advance the cursor even when the event touches no row you hold.** An event for a session Mumble has not shown you is still an observed event. If you skip the cursor update, the next event looks like a gap and the client resyncs on every unrelated user's join. There is a test for this.
+
+**5. Do not weaken the convergence test.** It is the design's core property in one assertion. If it fails, one of Tasks 3-5 has a real bug. Its final snapshot deliberately omits a session the events enrich — that omission is what makes it able to catch a snapshot-reconciliation regression instead of passing trivially. Do not "simplify" it by making the final snapshot complete.
+
+**6. Phase 2 ships no behaviour.** Nothing calls the store. `MumbleAdapter.cs` and `App.tsx` must be untouched — that is an explicit "Done when" item. If you find yourself editing either, you have drifted into Phase 3.
+
+## Done when
+
+The plan's "Done when" checklist passes, including:
+
+- `dotnet build` clean, 0 warnings
+- `dotnet test` green with more than the 1250 baseline
+- Every mapping **event** carries `baseRevision`; every **snapshot** carries `instanceId` and `revision` and no `baseRevision`
+- Consecutive events from one publisher are contiguous — each event's `baseRevision` equals the previous event's `revision`
+- The store has no Mumble, HTTP or JSON dependency:
+  `Select-String -Path src/Brmble.Client/Services/Voice/Projection/*.cs -Pattern "MumbleSharp|HttpClient|JsonElement|System.Text.Json"` returns nothing
+- `git diff origin/main...HEAD -- src/Brmble.Client/Services/Voice/MumbleAdapter.cs src/Brmble.Web/src/App.tsx` shows no changes
+
+Report back with: what you built, test counts before and after, and anything in the plan that turned out to be wrong. The last two phases each found real defects in their own plan — say so plainly if you find one rather than working around it silently.
+
+## What happens after this (context, not your task)
+
+**Phase 3** wires the store in and is where the user-visible fixes land: delete `_sessionMappings`, translate wire payloads into the Task 2 input records, collapse 17 `setUsers` sites in `App.tsx` to 2, move avatars into their own state keyed by `matrixUserId`, and add client version negotiation via a `pv` query parameter so the server can send one truthful `companionId` instead of the legacy `companionId`/`customCompanionId` split.
+
+Phase 3 is **not planned yet, deliberately** — it touches the repo's two most actively edited files, and plans against them go stale fast. It gets planned after Phase 2 lands, against shipped code. Do not start it.

--- a/docs/superpowers/specs/2026-07-31-user-data-propagation-problem.md
+++ b/docs/superpowers/specs/2026-07-31-user-data-propagation-problem.md
@@ -1,5 +1,18 @@
 # User data reaches clients by four different routes
 
+> **Status: SUPERSEDED — historical record, do not work from this document.**
+>
+> The design that answers this is
+> [`2026-07-31-user-projection-design.md`](2026-07-31-user-projection-design.md). All four open
+> questions below are decided there, and its §2.1 carries forward the constraints.
+>
+> Kept because it holds the original evidence and debugging history. **Its line references are
+> stale** — they predate the `custom-companion` merge (`31353ec5`) and no longer resolve. Use the
+> design document for current anchors.
+>
+> One claim made during the follow-up investigation — that moderator redactions failed to reach
+> out-of-channel clients — was later disproved. See §5.1 of the design.
+
 **Status:** problem statement only. No solution chosen — this is input for a brainstorm.
 
 **Written:** 2026-07-31, from the investigation behind `29ac2c8c`, `621ce204` and `659797c4`.
@@ -77,14 +90,18 @@ Consequences:
 
 ## Open design questions for the brainstorm
 
+*(All four are answered in the design document — pointers added retrospectively.)*
+
 1. Should server-owned user data become self-correcting like `UserState`, by periodic or
    change-driven re-assertion — or should the client resync when it sees an event for a
-   session it cannot place?
+   session it cannot place? → **Resync on gap, driven by a revision counter** (design §4.2).
 2. Can routes two and three collapse into one? They carry identical data for different
-   reasons.
+   reasons. → **No — two transports, one code path** (design §3.1, §2.1 constraint 2).
 3. Should "absent" be representable at all on the wire, or should every payload be complete?
+   → **Yes, as tri-state; absent means unknown** (design §3.2, §4.1).
 4. Does the merge belong in one function in `App.tsx`, or should the adapter own a single
-   authoritative user projection and the UI stop merging entirely?
+   authoritative user projection and the UI stop merging entirely? → **The adapter owns it; the
+   UI stops merging** (design §3.1, §6.2).
 
 ## What is deliberately not decided here
 

--- a/docs/superpowers/specs/2026-07-31-user-projection-design.md
+++ b/docs/superpowers/specs/2026-07-31-user-projection-design.md
@@ -53,6 +53,23 @@ resolution, but they do not live in it.
 **Also out of scope:** replacing the Mumble protocol (not ours), and unifying the Matrix media
 layer (see §9).
 
+### 2.1 Inherited constraints
+
+Carried forward from the problem statement, which this document supersedes:
+
+1. **The Mumble protocol is not ours to change.** Mumble-owned fields keep arriving as `UserState`
+   and keep repeating on every change. The design leans on that rather than replacing it.
+2. **`/auth/token` cannot be dropped.** It exists because the client needs credentials *before*
+   the WebSocket is up, so it is not redundant with `sessionMappingSnapshot` even though they
+   carry identical data. §3.1 keeps them as two transports sharing one code path rather than
+   collapsing them — a future "simplification" that deletes the HTTP route would break bootstrap.
+3. **The projection is not the only consumer.** Client-side, companions read it (§6.5). The
+   *server's* `ISessionMappingService` is a different thing and additionally feeds duels, paint,
+   screen share and channel routing — it is not in scope here.
+4. **It has to survive concurrent joins.** Simultaneous registration is what exposed this bug
+   class in the first place, via a deadlock that starved clients of `sessionMappingSnapshot`
+   entirely (fixed in `29ac2c8c`). See the concurrency acceptance test in §8.
+
 ---
 
 ## 3. Architecture
@@ -370,6 +387,12 @@ currently fails on all four counts.
 **Moderation.** A moderator redacts a skin while a client sits in a different channel with that
 atlas cached. That client loses it from memory and disk without changing channels or reconnecting.
 (Expected to pass already via Matrix sync — this pins it against regression.)
+
+**Concurrency.** Several clients register their WebSockets simultaneously. Every one of them
+receives a complete `sessionMappingSnapshot`, and every one converges on the same projection.
+Simultaneous registration is what exposed this bug class originally — a deadlock left clients with
+no snapshot at all (`29ac2c8c`) — so it is a standing acceptance criterion, not a one-off
+regression test.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-31-user-projection-design.md
+++ b/docs/superpowers/specs/2026-07-31-user-projection-design.md
@@ -434,9 +434,41 @@ pipeline; there is no useful half-state, and Velopack delivers it in one update.
 
 ---
 
-## 11. Open questions for the implementation plan
+## 11. Resolved design questions
 
-1. Projection version negotiation (§4.4): announced in the WS registration handshake, or derived
-   from a `requestSnapshot` field? The former is cleaner but touches the handshake.
-2. How long is "buffer briefly" for an event naming an unknown session, before resync?
-3. Does `userMappingRemoved` still earn its place once snapshots reconcile membership?
+**1. Where does projection version negotiation live? → A `pv` query parameter on the `/ws` URL.**
+
+The client already builds the WebSocket path by hand (`MumbleAdapter.cs:2283`) and constructs the
+HTTP upgrade over BouncyCastle TLS, so appending `?pv=1` is trivial. `app.Map("/ws", HandleAsync)`
+(`Program.cs:137`) lets `HandleAsync` read `context.Request.Query["pv"]` *before*
+`AcceptWebSocketAsync()`, so the version is known before initial payloads are built.
+
+An in-band handshake message was rejected: it would force the server to wait for a client frame
+before sending initial payloads, which fights `AddClientAsync`, where payloads are produced by a
+callback during registration.
+
+Absent `pv` means version 0, which gets the legacy `companionId` / `customCompanionId` split.
+Implemented in **Phase 3**, alongside the companion field collapse it exists to serve — reading a
+query parameter is purely additive, so no earlier phase needs to reserve anything for it.
+
+**2. How long is "buffer briefly" for an event naming an unknown session? → Deferred to Phase 2.**
+
+Purely client-side, with no effect on the wire contract. Decide it against the real store, where
+the trade-off between a redundant resync and a delayed row can actually be measured.
+
+**3. Does `userMappingRemoved` still earn its place? → Yes.**
+
+`MumbleServerCallback.cs:184` calls `RemoveSession` and `:197` announces it; they are paired 1:1
+and it is the only place either happens. Since `RemoveSession` bumps the revision, dropping the
+announcement would leave a bump nobody hears — the next event would arrive at N+2 against a client
+holding N, triggering a resync for nothing. Dropping the event would therefore mean dropping the
+bump too, and then two snapshots either side of a removal would carry the same revision, which is
+ambiguous.
+
+This generalises to an invariant every producer must respect:
+
+> **Every revision bump is announced.** A mutation that bumps the counter without broadcasting a
+> stamped payload manufactures a phantom gap in every connected client.
+
+The snapshot's membership reconciliation (§4.3) is a *repair* mechanism, not a substitute for the
+event.

--- a/docs/superpowers/specs/2026-07-31-user-projection-design.md
+++ b/docs/superpowers/specs/2026-07-31-user-projection-design.md
@@ -1,0 +1,419 @@
+# A single authoritative user projection
+
+**Status:** design, approved in brainstorm. Not yet planned or implemented.
+
+**Written:** 2026-07-31
+
+**Supersedes the open questions in:** `docs/superpowers/specs/2026-07-31-user-data-propagation-problem.md`
+
+**Precondition:** assumes `custom-companion` (PR #616) is merged, which it is as of `31353ec5`.
+
+---
+
+## 1. The problem, in one sentence
+
+Server-owned user data reaches the client over three fire-once transports, is cached, and is then
+re-asserted to the UI on every Mumble `UserState` — so a lost or out-of-order event does not
+produce a *missing* value, it produces a **confidently wrong** value, rebroadcast indefinitely by
+an unrelated event.
+
+The prior document records the evidence. This document decides what to do.
+
+### Why now
+
+Connect, disconnect and reconnect are constant in normal operation. Every one of them is a chance
+for the current design to settle on a wrong answer, and there is no mechanism that ever corrects
+it short of a full reconnect.
+
+Two concrete instances, both live on `main` at the time of writing:
+
+- **`isBrmbleClient` after a Brmble restart.** `SessionMappingHandler.cs:38` derives the flag from
+  `AuthService._activeSessions`, which is in-memory and wiped by the restart. The Ice snapshot
+  (`MumbleIceService.cs:78`) then re-publishes every user as `isBrmbleClient = false` — not
+  "unknown", but a positive assertion of the wrong value — until each user's own WebSocket
+  re-registers.
+- **Stale index producing a confident broadcast.** `PersistCompanionSelectionAsync` resolved a
+  session through an index that can disagree with the mapping table, then announced a change that
+  may never have happened. Fixed in `fix/companion-broadcast-scope` (PR #617) by routing through
+  the validated `TryGetMappingByUserId`. That fix is a point repair of the same class this design
+  removes structurally.
+
+---
+
+## 2. Scope
+
+**In scope:** the fields that compose a sidebar row — server-owned identity (`matrixUserId`,
+`companionId`, `isBrmbleClient`, `certHash`) and Mumble-native presence (`name`, `channelId`,
+`muted`, `deafened`, `comment`).
+
+**Out of scope, deliberately:** screen shares, LiveKit participants, duel/queue state, paint
+sessions. These remain feature-owned. They may consume the projection for session → user
+resolution, but they do not live in it.
+
+**Also out of scope:** replacing the Mumble protocol (not ours), and unifying the Matrix media
+layer (see §9).
+
+---
+
+## 3. Architecture
+
+### 3.1 One projection, three inputs, one output
+
+A new `UserProjectionStore` in `Brmble.Client` owns the single authoritative
+`Dictionary<uint, UserProjection>`.
+
+| Input | Source | Owns exclusively |
+|---|---|---|
+| `ApplyMumbleUserState` / `ApplyMumbleUserRemove` | Mumble `UserState` / `UserRemove` | session existence, `name`, `channelId`, `muted`, `deafened`, `comment`, Mumble `certHash` |
+| `ApplyServerSnapshot` | `/auth/token` + WS `sessionMappingSnapshot` | `matrixUserId`, `companionId`, `isBrmbleClient`, server `certHash`, and membership reconciliation |
+| `ApplyServerEvent` | WS `userMappingAdded/Removed`, `brmbleClient*`, `companionChanged` | the same server-owned set, incrementally |
+
+### 3.2 The two rules that do all the work
+
+1. **Ownership.** A Mumble input can only write Mumble-owned fields; a server input only
+   server-owned ones. Cross-writes are impossible by construction — not by convention, and not by
+   a guard that a future contributor might forget.
+
+2. **Null means unknown.** On any server input, a `null` field leaves the existing value
+   untouched. Clearing is never implicit: it happens only through snapshot reconciliation or an
+   explicit `userMappingRemoved`.
+
+Rule 2 is why `companionId: null` can never become floppy and `isBrmbleClient: null` can never
+become `false`. Today those defaults are applied in four separate places: `MumbleAdapter.cs:139`
+(`ParseWireCompanionId`), `:2110` (`GetSelfCompanionOrDefault`), `:2656` (`userMappingAdded`), and
+the `IsBrmbleClient = false` default on the `SessionMappingEntry` record at `:110`.
+
+### 3.3 Degraded mode
+
+Session existence is owned by Mumble alone. If the Brmble container is down, rows still appear,
+move channels, mute and unmute. They carry stale-but-last-known enrichment. Voice is unaffected.
+
+This is a deliberate rejection of "the Brmble server assembles and pushes the whole list": it
+would be a simpler merge, but a Brmble outage would empty the user list while audio kept flowing.
+
+### 3.4 The invariant
+
+> **The projection carries identifiers, never resolved assets.**
+> If a value can be re-derived from an identifier, it does not belong in the projection.
+
+`matrixUserId` and `companionId` are in. `avatarUrl` and `atlasCacheKey` are out.
+
+This is not a style preference. There are two layers with opposite characteristics, and mixing
+them is what lets a lost event corrupt a cache:
+
+| Layer | Nature | Failure of a lost update |
+|---|---|---|
+| Identity (this design) | pushed, fire-once, order-sensitive | permanent wrongness |
+| Asset (avatar, companion atlas) | pulled, derived, retried, cached | self-heals on next derive |
+
+The avatar pipeline was the one thing that already worked in the original problem statement
+precisely because it was accidentally obeying this rule. The rule makes that deliberate and
+answers "where does the next field go?" without re-litigating it each time.
+
+---
+
+## 4. Wire contract
+
+Five changes on the Brmble side. The Mumble protocol is untouched. All are additive in the sense
+that an older client ignores the new fields — but §4.3 changes the *meaning* of an existing
+payload, so it is the one that needs care.
+
+### 4.1 Tri-state `isBrmbleClient`
+
+`SessionMapping` (`ISessionMappingService.cs:3`) gains `bool? IsBrmbleClient`, serialised as
+`true` / `false` / `null`.
+
+The restart bug then fixes itself: `SessionMappingHandler.cs:38` publishes `null` — *unknown* —
+instead of `false`, and rule 2 preserves the badge until the client's own socket asserts `true`.
+
+`companionId` gets the same treatment. `ParseSessionMappings` (`MumbleAdapter.cs:117`) currently
+defaults an absent companion to `"floppy"`, which is exactly how a missing field became a wrong
+value. Absent becomes `null`; `"floppy"` becomes a **render-time** fallback only, in
+`resolveCompanionDisplay`.
+
+### 4.2 `instanceId` + `revision`
+
+- **`instanceId`** — a GUID generated once at Brmble server startup. `SessionMappingService` is
+  purely in-memory (`SessionMappingService.cs:7-10`), so a restart resets everything. A changed
+  `instanceId` tells the client "discard all server-owned fields and take the new snapshot as
+  truth" without inference.
+- **`revision`** — a monotonic `long` on the mapping table, incremented on every mutation and
+  stamped on every snapshot and event.
+
+Client rules:
+
+| Condition | Action |
+|---|---|
+| `instanceId` differs | Discard server-owned fields, request snapshot |
+| `revision <= ours` | Ignore — duplicate or reorder, already applied |
+| `revision == ours + 1` | Apply |
+| `revision > ours + 1` | Gap — apply nothing, request snapshot |
+| Event for a session Mumble has not shown us | Buffer briefly, then request snapshot |
+
+**This requires all projection events to be broadcast server-wide.** Channel-scoped delivery would
+make out-of-channel clients observe phantom gaps and resync continuously. PR #617 already made
+`companionChanged` global for both the selection and moderator-deletion paths, which is the
+prerequisite. No privacy boundary is crossed: every client already receives the full mapping table
+in its snapshot.
+
+### 4.3 Snapshots are authoritative for membership
+
+Today `voice.sessionMappingSnapshot` only patches rows that already exist and never removes
+(`App.tsx:3079`), so a session that vanished during an outage lingers forever.
+
+A snapshot now means "this is the complete set of server-known sessions": any session absent from
+it has its server-owned fields reset to unknown. It still cannot delete a row — only Mumble owns
+existence.
+
+### 4.4 Companion becomes one field
+
+`custom-companion` introduced `CompanionWireSelection.FromPersisted`, which for a custom skin
+sends `companionId: "floppy"` plus the truth in `customCompanionId`. That is a legacy-safe shim
+for clients predating the feature, and it works — but it transmits a default as though it were a
+fact, which §3.2 rule 2 exists to prevent.
+
+Resolution: `UserProjection` carries a single `CompanionSelection` (a built-in id or
+`custom:$eventId`), with `null` meaning unknown. The client announces a projection version at
+WebSocket registration; the server sends the single truthful field to clients that support it and
+the legacy split to those that do not. The compatibility lie lives at the compatibility boundary
+rather than in the core protocol, and `ParseWireCompanionId`'s `"floppy"` defaults collapse to one
+render-time fallback.
+
+`TryUpdateCompanionIdIfCurrent` (the per-field CAS added by `custom-companion`) is retired: a
+mutation carrying a stale revision is rejected wholesale.
+
+### 4.5 Client → server resync request
+
+The WebSocket is receive-only today, and the server's read loop reads into a 1024-byte buffer and
+discards everything that is not a Close frame, ignoring `EndOfMessage`
+(`BrmbleWebSocketHandler.cs:46-55`). This design fixes that loop properly and adds one message:
+
+```json
+{ "type": "requestSnapshot", "instanceId": "...", "haveRevision": 42 }
+```
+
+The server replies by reusing `BuildInitialPayloadsAsync`, which already builds exactly this
+payload. The client already has a correct masked-frame writer (`SendWebSocketFrame`,
+`MumbleAdapter.cs`); it needs the stream hoisted out of the retry loop into a field, plus a send
+lock, since pongs share the socket.
+
+Resync is rate-limited: one in flight, minimum 1s spacing, exponential backoff to 30s if gaps
+persist. If the socket is down it is a no-op — reconnection delivers a snapshot anyway. The worst
+case is a redundant snapshot, never a loop.
+
+**Rejected alternative:** dropping and re-establishing the WebSocket to trigger a snapshot. It
+costs a TLS handshake and makes the server broadcast `userMappingAdded` to everyone, so the
+recovery path itself generates churn. The read loop needs fixing regardless.
+
+---
+
+## 5. Asset invalidation
+
+A second event class, distinct from identity change, which the first draft of this design missed.
+
+| | Identity change | Asset invalidation |
+|---|---|---|
+| Means | this session's identifier changed | the asset behind an identifier changed or was revoked |
+| Cardinality | one session | one-to-many sessions |
+| Examples | user picks a new companion | moderator redacts a skin; user changes avatar |
+
+A moderator redaction is a single revision bump that changes N sessions atomically — which is
+precisely the case a per-field CAS handles badly and a table-level revision handles naturally.
+
+Invalidation events carry a revision like any other mutation, so a missed one is caught by gap
+detection and repaired by the next snapshot.
+
+Client-side an invalidation is two steps: the projection resets the affected sessions'
+`companionId`, and the asset layer purges its cache entry. The projection emits the change; the
+existing `cleanupEntry` / `deleteAtlas` machinery does the purge. No new caching code.
+
+### 5.1 Correction to an earlier reading
+
+An earlier analysis in this workstream claimed that a moderator deletion failed to reach
+out-of-channel clients, leaving redacted skins rendering from IndexedDB. **That was wrong**, and
+is recorded here so it is not rediscovered as a bug:
+
+- Every Brmble client is force-joined to the gallery room on every `/auth`
+  (`AuthEndpoints.cs:147-160` → `EnsureUserInRoom`).
+- `useCustomCompanionGallery` listens on `RoomStateEvent.Events`, `RoomEvent.Timeline` and
+  `ClientEvent.Sync`, so a redaction propagates via Matrix sync independently of the WebSocket and
+  of voice channel.
+- `applyRedaction` → `cleanupEntry` revokes the object URLs and calls `deleteAtlas`, a real
+  IndexedDB delete. `resolveCompanionDisplay` falls back to floppy as soon as the entry is gone.
+
+The moderation path is sound. The WebSocket `companionChanged` is only the selection reset.
+
+---
+
+## 6. Client structure
+
+### 6.1 Output: two bridge events replace eight
+
+`ApplyX` returns a `ChangeSet`, which becomes:
+
+- `voice.usersReset { users: [...] }` — the complete list. Voice connect, disconnect (empty),
+  reconnect.
+- `voice.usersChanged { users: [...], removed: [sessions] }` — full rows for changed sessions.
+
+`voice.connected` survives, but stops carrying `users`: it keeps the channel list and connection
+metadata, and the user list arrives as the first `voice.usersReset`. This removes the only
+wholesale user-list assignment outside the projection (`App.tsx:2176`).
+
+Rows are always **complete** — every field present, nulls explicit. React therefore has nothing to
+merge and no absent-vs-null ambiguity. There is exactly one row serializer, replacing the six
+duplicated shapes in `MumbleAdapter.cs` (`2626`, `2660`, `2670`, `2685`, `4168` via
+`SendVoiceConnected`, `4299`).
+
+### 6.2 `App.tsx`: 17 `setUsers` sites become 2
+
+```
+voice.usersReset   → setUsers(d.users)
+voice.usersChanged → setUsers(prev => applyChangeSet(prev, d))
+```
+
+`applyChangeSet` does index-by-session replace and remove, with **no field logic** — no `||`, no
+`??`, no `!== undefined`. Adding a field to the projection requires no `App.tsx` change at all.
+
+The 17 current sites decompose as:
+
+| Group | Lines | Becomes |
+|---|---|---|
+| Avatar writes (5) | `1434`, `1562`, `1615`, `1630`, `1910` | writes to the avatar map (§6.3) |
+| Bridge-event reducers (9) | `2176`, `2552`, `2765`, `2892`, `3058`, `3079`, `3104`, `3135`, `3144` | `voice.usersChanged` |
+| Clear-to-empty (3) | `2273`, `3043`, `3718` | `voice.usersReset` with an empty list |
+
+Deleted: `onVoiceUserJoined`, `onVoiceUserLeft`, `onVoiceUserCommentChanged`,
+`onUserMappingUpdated`, `onSessionMappingSnapshot`, `onVoiceCompanionChanged`,
+`onBrmbleClientActivated`, `onBrmbleClientDeactivated` (registered at `App.tsx:3211`, `3214`,
+`3223`, `3266`, `3267`, `3268`, `3270`, `3271`) — along with the three-guard-style merge in
+`onVoiceUserJoined` and the patch-only snapshot handler at `:3076-3082`.
+
+### 6.3 Avatars move out of `users`
+
+`avatarUrl` becomes its own React state keyed by **asset identity** (`matrixUserId`), joined onto
+projection rows in a selector. The derive-and-retry effect (`App.tsx:1585-1592`, backed by
+`fetchAvatarForUser` at `:1898` and the helpers in `utils/avatarFetch.ts`) is unchanged in
+behaviour — it just reads from the projection and writes to the avatar map instead of round-tripping
+through `users`.
+
+This is what allows `users` to be overwritten wholesale without losing avatars. Keying by asset
+identity rather than session also means a future shared media layer (§9) is a substitution rather
+than a rewrite.
+
+### 6.4 Targeted structural cleanup
+
+In scope because the work lands here; not a general refactor:
+
+- `MumbleAdapter.cs` is 4,698 lines and not `partial`. `UserProjectionStore` and `UserProjection`
+  become standalone types in `Services/Voice/UserProjection/` with no Mumble dependency, so they
+  unit-test without a protocol stack.
+- `App.tsx` is 5,623 lines. User and avatar state move into a `useUserDirectory` hook alongside the
+  existing 20 hooks, exposing `users` (joined), `usersRef` and the avatar map. Consumers keep the
+  same row shape and do not change.
+- The two divergent `User` types — `types/index.ts:22` (no `companionId`) and `App.tsx:651` (has
+  it) — collapse to one, generated to match the C# record field-for-field, with `types/index.ts`
+  re-exporting.
+
+### 6.5 Other consumers
+
+`_sessionMappings` is deleted. `GetSelfCompanionOrDefault` / `UpdateSelfCompanionMapping`
+(`MumbleAdapter.cs:2104-2118`) read the projection instead. Duels are unaffected — they read the
+*server's* `ISessionMappingService`, not this client cache.
+
+### 6.6 Threading
+
+Inputs arrive on three threads: Mumble protocol, WebSocket read loop, HTTP continuation. The store
+takes a single lock for the apply, computes the `ChangeSet`, releases, and *then* emits to the
+bridge. No bridge call happens under the lock.
+
+---
+
+## 7. Failure modes
+
+| Failure | Before | After |
+|---|---|---|
+| Lost `brmbleClientActivated` | Badge reverts, rebroadcast forever | Stays unknown, kept; next snapshot corrects |
+| Event missing `companionId` | Becomes floppy permanently | Ignored as unknown; skin preserved |
+| Brmble restart | Everyone flagged non-Brmble, skins revert | `instanceId` change → full resync |
+| Reordered events | Last writer wins | Lower revision ignored |
+| Session leaves during outage | Ghost row forever | Snapshot reconciliation clears server fields |
+| Moderator redaction missed | — | Gap detected, snapshot repairs |
+| Brmble down entirely | — | Rows persist with stale enrichment; voice unaffected |
+
+---
+
+## 8. Testing
+
+**1. `UserProjectionStore` unit tests** (`tests/Brmble.Client.Tests`, MSTest; `InternalsVisibleTo`
+is already configured). No Mumble or network dependency, so these are fast and exhaustive:
+ownership violations, unknown-never-overwrites, every sequencing branch, snapshot reconciliation.
+
+Plus a **convergence test**: given a random permutation of a fixed event set with arbitrary drops,
+applying them and then a final snapshot always yields the same projection. That property is the
+whole design in one assertion.
+
+**2. Server tests** (`tests/Brmble.Server.Tests`): revision monotonicity, `instanceId` stability
+within a process, tri-state serialisation, and `requestSnapshot` handling — including a
+multi-frame message, since the current read loop uses a 1024-byte buffer and ignores
+`EndOfMessage`.
+
+**3. Vitest** for `applyChangeSet` and the avatar join selector. Small, because little logic
+remains.
+
+### Acceptance tests
+
+**Restart.** Against `docker-local`: two clients connected, one plain Mumble and one Brmble with a
+custom companion. Restart only the `brmble` container. Assert no user-list flicker, the Brmble
+badge never disappears, the custom skin never reverts to floppy, and voice is uninterrupted. This
+currently fails on all four counts.
+
+**Moderation.** A moderator redacts a skin while a client sits in a different channel with that
+atlas cached. That client loses it from memory and disk without changing channels or reconnecting.
+(Expected to pass already via Matrix sync — this pins it against regression.)
+
+---
+
+## 9. Not doing
+
+Recorded so the next reader does not have to rediscover the reasoning.
+
+**A unified Matrix media layer.** Avatar and custom-companion assets both resolve from Matrix and
+share real primitives — mxc→http construction (four ad-hoc call sites with different arities),
+bounded authenticated fetch, object-URL lifetime, in-flight dedupe, server-side image validation.
+But they solve different problems: profile pull vs room-state subscription, unauthenticated
+`<img src>` vs authenticated size-capped fetch, no cache vs IndexedDB LRU. The companion
+implementation is more advanced but has no production usage yet; unifying today means rewriting
+working avatar code against an unproven design. §3.4 and §6.3 keep the door open.
+
+**Avatar authenticated-media migration.** Avatars resolve via the unauthenticated media endpoint
+(`useMatrixClient.ts`, 4-arg `mxcUrlToHttp`), while the companion loader uses
+`useAuthentication=true`. Matrix is moving to authenticated media, so this is a deprecation track
+with its own risk profile. Separate work.
+
+**IndexedDB keyspace reconciliation.** Nothing enumerates cached atlases and deletes keys absent
+from the gallery, so an orphaned blob can survive to LRU eviction (100MB budget). It never renders,
+because rendering requires a live gallery entry. Minor; belongs with the media layer.
+
+**Persisting server session state.** Rebuilding from Ice `getUsers()` + SQLite is adequate once
+`isBrmbleClient` stops asserting a false value. Persistence would be a larger change with its own
+consistency questions.
+
+**Ice connect retry.** `MumbleIceService` swallows a startup Ice failure with a warning and no
+retry, leaving mappings empty until the next restart. Real, but independent of this design.
+
+---
+
+## 10. Rollout
+
+Server changes are additive — `instanceId`, `revision`, tri-state, `requestSnapshot` — and ignored
+by older clients, so the server ships first. The client change is a single atomic swap of the user
+pipeline; there is no useful half-state, and Velopack delivers it in one update.
+
+---
+
+## 11. Open questions for the implementation plan
+
+1. Projection version negotiation (§4.4): announced in the WS registration handshake, or derived
+   from a `requestSnapshot` field? The former is cleaner but touches the handshake.
+2. How long is "buffer briefly" for an event naming an unknown session, before resync?
+3. Does `userMappingRemoved` still earn its place once snapshots reconcile membership?

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -127,7 +127,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 var certHash = prop.Value.TryGetProperty("certHash", out var h) ? h.GetString() : null;
                 if (matrixId is not null && name is not null && companionId is not null)
                 {
-                    var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b) && b.GetBoolean();
+                    // Only an explicit `true` counts. A JSON null means "unknown" and
+                    // TryGetProperty reports it as present, so GetBoolean() would throw.
+                    var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b)
+                        && b.ValueKind == System.Text.Json.JsonValueKind.True;
                     result[sid] = new SessionMappingEntry(matrixId, name, companionId, isBrmble, certHash);
                 }
             }
@@ -2647,7 +2650,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                     // known companion is kept rather than replaced with the default.
                     var announcedCompanionId = ParseWireCompanionIdOrNull(root);
                     var addCertHash = root.TryGetProperty("certHash", out var certProp) ? certProp.GetString() : null;
-                    var addIsBrmble = root.TryGetProperty("isBrmbleClient", out var brmbleProp) && brmbleProp.GetBoolean();
+                    // As in ParseSessionMappings: null means unknown, not false, and
+                    // GetBoolean() would throw on it.
+                    var addIsBrmble = root.TryGetProperty("isBrmbleClient", out var brmbleProp)
+                        && brmbleProp.ValueKind == System.Text.Json.JsonValueKind.True;
                     if (addSid > 0 && addMatrixId is not null && addName is not null)
                     {
                         var knownCompanionId = _sessionMappings.TryGetValue(addSid, out var priorMapping)

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -267,7 +267,7 @@ public static class AuthEndpoints
             CustomCompanionEventCoordinator customCompanionEventCoordinator,
             CustomCompanionRepository customCompanionRepository,
             ISessionMappingService sessionMapping,
-            IBrmbleEventBus eventBus,
+            IMappingEventPublisher publisher,
             ILogger<AuthService> logger) =>
         {
             var certHash = certHashExtractor.GetCertHash(httpContext);
@@ -298,7 +298,7 @@ public static class AuthEndpoints
 
                     return await PersistCompanionSelectionAsync(
                         user, companionId!, userRepository, sessionMapping,
-                        eventBus, logger);
+                        publisher, logger);
                 }
             }
 
@@ -307,7 +307,7 @@ public static class AuthEndpoints
 
             return await PersistCompanionSelectionAsync(
                 user, normalized, userRepository, sessionMapping,
-                eventBus, logger);
+                publisher, logger);
         });
 
         return app;
@@ -318,7 +318,7 @@ public static class AuthEndpoints
         string companionId,
         UserRepository userRepository,
         ISessionMappingService sessionMapping,
-        IBrmbleEventBus eventBus,
+        IMappingEventPublisher publisher,
         ILogger<AuthService> logger)
     {
         await userRepository.SetCompanionId(user.Id, companionId);
@@ -330,22 +330,27 @@ public static class AuthEndpoints
         // did not happen — or attribute it to somebody else. The update is then done with a
         // CAS on the owning userId, so a recycle racing between the lookup and the write
         // cannot land on the new owner's mapping either.
-        if (sessionMapping.TryGetMappingByUserId(user.Id, out var sessionId, out _)
-            && sessionMapping.TryUpdateCompanionIdIfOwnedBy(sessionId, user.Id, companionId))
-        {
-            var wire = CompanionWireSelection.FromPersisted(companionId);
-            // Broadcast server-wide: clients keep a server-wide user list, and channel-scoped
-            // delivery left everyone outside the user's channel with a stale selection until
-            // their next reconnect (nothing re-delivers it on channel move).
-            await eventBus.BroadcastAsync(new
+        var sessionId = 0;
+        // Broadcast server-wide: clients keep a server-wide user list, and channel-scoped
+        // delivery left everyone outside the user's channel with a stale selection until
+        // their next reconnect (nothing re-delivers it on channel move).
+        await publisher.PublishAsync(
+            () => sessionMapping.TryGetMappingByUserId(user.Id, out sessionId, out _)
+                  && sessionMapping.TryUpdateCompanionIdIfOwnedBy(sessionId, user.Id, companionId),
+            envelope =>
             {
-                type = "companionChanged",
-                sessionId,
-                matrixUserId = user.MatrixUserId,
-                companionId = wire.CompanionId,
-                customCompanionId = wire.CustomCompanionId
+                var wire = CompanionWireSelection.FromPersisted(companionId);
+                return new
+                {
+                    type = "companionChanged",
+                    instanceId = envelope.InstanceId,
+                    revision = envelope.Revision,
+                    sessionId,
+                    matrixUserId = user.MatrixUserId,
+                    companionId = wire.CompanionId,
+                    customCompanionId = wire.CustomCompanionId
+                };
             });
-        }
 
         logger.LogInformation(
             "Companion updated: UserId={UserId}, CompanionId={CompanionId}",

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -200,6 +200,10 @@ public static class AuthEndpoints
             {
                 matrix = matrixPayload,
                 userMappings,
+                // Same envelope the WebSocket snapshot carries: this is the bootstrap
+                // transport for the identical data, so it must be orderable too.
+                instanceId = sessionMapping.InstanceId,
+                revision = sessionMapping.Revision,
                 sessionMappings = sessionMapping.GetSnapshot()
                     .ToDictionary(
                         kvp => kvp.Key.ToString(),

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -220,19 +220,7 @@ public static class AuthEndpoints
                 sessionMappings = sessionMapping.GetSnapshot()
                     .ToDictionary(
                         kvp => kvp.Key.ToString(),
-                        kvp =>
-                        {
-                            var wire = CompanionWireSelection.FromPersisted(kvp.Value.CompanionId);
-                            return new
-                            {
-                            matrixUserId = kvp.Value.MatrixUserId,
-                            mumbleName = kvp.Value.MumbleName,
-                            companionId = wire.CompanionId,
-                            customCompanionId = wire.CustomCompanionId,
-                            certHash = kvp.Value.CertHash,
-                            isBrmbleClient = kvp.Value.IsBrmbleClient
-                            };
-                        }),
+                        kvp => SessionMappingWire.From(kvp.Value)),
                 registered = result.IsRegistered,
                 registeredName = result.DisplayName,
                 passwordProtectedChannelIds,

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -100,13 +100,18 @@ public static class AuthEndpoints
                     {
                         mappingAdded = sessionMapping.TryAddMatrixUser(
                             sid, result.MatrixUserId, resolvedName, result.UserId, companionId);
-                        sessionMapping.TryUpdateCertHash(sid, certHash);
+
                         // This user just authenticated via Brmble, so mark them as a Brmble
                         // client immediately. Authenticate() may have failed to update the
                         // mapping if TryAddMatrixUser hadn't been called yet (race with
                         // SessionMappingHandler).
-                        sessionMapping.TryUpdateBrmbleStatus(sid, true);
-                        return true;
+                        //
+                        // Ownership-constrained: `sid` came from a name lookup made outside this
+                        // lock, so the session may since have been recycled to a different user.
+                        // Updating by raw session id would write this user's certificate and
+                        // status into that user's mapping and then announce it as their own.
+                        return sessionMapping.TryClaimBrmbleSession(
+                            sid, result.UserId, certHash, out _);
                     },
                     envelope =>
                     {

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -25,7 +25,7 @@ public static class AuthEndpoints
             CustomCompanionGalleryService customCompanionGalleryService,
             IAclAuthorizationService aclAuthorization,
             ISessionMappingService sessionMapping,
-            IBrmbleEventBus eventBus,
+            IMappingEventPublisher publisher,
             ILogger<AuthService> logger) =>
         {
             var certHash = certHashExtractor.GetCertHash(httpContext);
@@ -90,48 +90,52 @@ public static class AuthEndpoints
                 sessionMapping.TryGetSessionId(resolvedName, out var sid))
             {
                 var companionId = await userRepository.GetCompanionId(result.UserId);
-                if (sessionMapping.TryAddMatrixUser(sid, result.MatrixUserId, resolvedName, result.UserId, companionId))
-                {
-                    sessionMapping.TryUpdateCertHash(sid, certHash);
-                    // This user just authenticated via Brmble, so mark them as a Brmble client
-                    // immediately. Authenticate() may have failed to update the mapping if
-                    // TryAddMatrixUser hadn't been called yet (race with SessionMappingHandler).
-                    sessionMapping.TryUpdateBrmbleStatus(sid, true);
-                    var wire = CompanionWireSelection.FromPersisted(companionId);
-                    await eventBus.BroadcastAsync(new
+                var mappingAdded = false;
+                // Mutations run inside the publisher's lock so the stamped revision is provably
+                // the one they produced. Reading .Revision after mutating unsynchronised lets a
+                // concurrent registration bump in between, and two payloads then claim one
+                // revision — a client applies the first and discards the second as a duplicate.
+                await publisher.PublishAsync(
+                    () =>
                     {
-                        type = "userMappingAdded",
-                        // Stamped after the three mutations above, so their bumps are
-                        // announced rather than silent.
-                        instanceId = sessionMapping.InstanceId,
-                        revision = sessionMapping.Revision,
-                        sessionId = sid,
-                        matrixUserId = result.MatrixUserId,
-                        mumbleName = resolvedName,
-                        companionId = wire.CompanionId,
-                        customCompanionId = wire.CustomCompanionId,
-                        certHash,
-                        isBrmbleClient = true
-                    });
-                }
-                else
-                {
-                    // Mapping already existed (created by SessionMappingHandler.OnUserConnected).
-                    // Ensure Brmble status is up to date — Authenticate() sets _activeSessions
-                    // but TryUpdateBrmbleStatus may not have been called if the mapping
-                    // was created before auth completed.
-                    sessionMapping.TryUpdateCertHash(sid, certHash);
-                    sessionMapping.TryUpdateBrmbleStatus(sid, true);
-                    // Both mutations bump the revision. Announcing is not optional: an
-                    // unannounced bump leaves every client with a permanent phantom gap.
-                    await eventBus.BroadcastAsync(new
+                        mappingAdded = sessionMapping.TryAddMatrixUser(
+                            sid, result.MatrixUserId, resolvedName, result.UserId, companionId);
+                        sessionMapping.TryUpdateCertHash(sid, certHash);
+                        // This user just authenticated via Brmble, so mark them as a Brmble
+                        // client immediately. Authenticate() may have failed to update the
+                        // mapping if TryAddMatrixUser hadn't been called yet (race with
+                        // SessionMappingHandler).
+                        sessionMapping.TryUpdateBrmbleStatus(sid, true);
+                        return true;
+                    },
+                    envelope =>
                     {
-                        type = "brmbleClientActivated",
-                        instanceId = sessionMapping.InstanceId,
-                        revision = sessionMapping.Revision,
-                        sessionId = sid
+                        var wire = CompanionWireSelection.FromPersisted(companionId);
+                        // A new mapping is announced as userMappingAdded; an existing one only
+                        // changed its Brmble status, so it is announced as an activation.
+                        // Either way the bumps above are announced rather than silent.
+                        return mappingAdded
+                            ? new
+                            {
+                                type = "userMappingAdded",
+                                instanceId = envelope.InstanceId,
+                                revision = envelope.Revision,
+                                sessionId = sid,
+                                matrixUserId = result.MatrixUserId,
+                                mumbleName = resolvedName,
+                                companionId = wire.CompanionId,
+                                customCompanionId = wire.CustomCompanionId,
+                                certHash,
+                                isBrmbleClient = true
+                            }
+                            : (object)new
+                            {
+                                type = "brmbleClientActivated",
+                                instanceId = envelope.InstanceId,
+                                revision = envelope.Revision,
+                                sessionId = sid
+                            };
                     });
-                }
             }
 
             logger.LogInformation(
@@ -215,6 +219,8 @@ public static class AuthEndpoints
                 userMappings,
                 // Same envelope the WebSocket snapshot carries: this is the bootstrap
                 // transport for the identical data, so it must be orderable too.
+                // Keep revision above sessionMappings — initialisers evaluate in source order,
+                // and a snapshot must never claim a revision newer than the data it holds.
                 instanceId = sessionMapping.InstanceId,
                 revision = sessionMapping.Revision,
                 sessionMappings = sessionMapping.GetSnapshot()

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -327,9 +327,11 @@ public static class AuthEndpoints
         // userId→session index can outlive or disagree with the session→mapping table, so a
         // bare session lookup can point at a session with no mapping, or one that has since
         // been recycled to a different user. Announcing either would publish a change that
-        // did not happen — or attribute it to somebody else.
+        // did not happen — or attribute it to somebody else. The update is then done with a
+        // CAS on the owning userId, so a recycle racing between the lookup and the write
+        // cannot land on the new owner's mapping either.
         if (sessionMapping.TryGetMappingByUserId(user.Id, out var sessionId, out _)
-            && sessionMapping.TryUpdateCompanionId(sessionId, companionId))
+            && sessionMapping.TryUpdateCompanionIdIfOwnedBy(sessionId, user.Id, companionId))
         {
             var wire = CompanionWireSelection.FromPersisted(companionId);
             // Broadcast server-wide: clients keep a server-wide user list, and channel-scoped

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -101,6 +101,10 @@ public static class AuthEndpoints
                     await eventBus.BroadcastAsync(new
                     {
                         type = "userMappingAdded",
+                        // Stamped after the three mutations above, so their bumps are
+                        // announced rather than silent.
+                        instanceId = sessionMapping.InstanceId,
+                        revision = sessionMapping.Revision,
                         sessionId = sid,
                         matrixUserId = result.MatrixUserId,
                         mumbleName = resolvedName,
@@ -118,6 +122,15 @@ public static class AuthEndpoints
                     // was created before auth completed.
                     sessionMapping.TryUpdateCertHash(sid, certHash);
                     sessionMapping.TryUpdateBrmbleStatus(sid, true);
+                    // Both mutations bump the revision. Announcing is not optional: an
+                    // unannounced bump leaves every client with a permanent phantom gap.
+                    await eventBus.BroadcastAsync(new
+                    {
+                        type = "brmbleClientActivated",
+                        instanceId = sessionMapping.InstanceId,
+                        revision = sessionMapping.Revision,
+                        sessionId = sid
+                    });
                 }
             }
 

--- a/src/Brmble.Server/Auth/AuthService.cs
+++ b/src/Brmble.Server/Auth/AuthService.cs
@@ -269,7 +269,7 @@ public class AuthService : IActiveBrmbleSessions
                 sessionId = activatedSessionId
             });
 
-        return new AuthResult(user.Id, user.MatrixUserId, user.MatrixAccessToken!, user.DisplayName, isRegistered);
+        return new AuthResult(user!.Id, user.MatrixUserId, user.MatrixAccessToken!, user.DisplayName, isRegistered);
     }
 
     public void Deactivate(string certHash)

--- a/src/Brmble.Server/Auth/AuthService.cs
+++ b/src/Brmble.Server/Auth/AuthService.cs
@@ -38,7 +38,7 @@ public class AuthService : IActiveBrmbleSessions
     private readonly ILogger<AuthService> _logger;
     private readonly IMumbleRegistrationService _mumbleRegistration;
     private readonly ISessionMappingService _sessionMapping;
-    private readonly IBrmbleEventBus _eventBus;
+    private readonly IMappingEventPublisher _publisher;
     private readonly HashSet<string> _activeSessions = [];
     private readonly HashSet<string> _activeNames = [];
     private readonly Dictionary<string, string> _certToName = [];
@@ -53,14 +53,14 @@ public class AuthService : IActiveBrmbleSessions
         ILogger<AuthService> logger,
         IMumbleRegistrationService mumbleRegistration,
         ISessionMappingService sessionMapping,
-        IBrmbleEventBus eventBus)
+        IMappingEventPublisher publisher)
     {
         _userRepository = userRepository;
         _matrixAppService = matrixAppService;
         _logger = logger;
         _mumbleRegistration = mumbleRegistration;
         _sessionMapping = sessionMapping;
-        _eventBus = eventBus;
+        _publisher = publisher;
     }
 
     public bool IsBrmbleClient(string certHash)
@@ -257,15 +257,17 @@ public class AuthService : IActiveBrmbleSessions
         }
 
         // Broadcast Brmble client activation
-        if (_sessionMapping.TryGetSessionByUserId(user!.Id, out var activatedSessionId))
-        {
-            _sessionMapping.TryUpdateBrmbleStatus(activatedSessionId, true);
-            _ = _eventBus.BroadcastAsync(new
+        var activatedSessionId = 0;
+        _ = _publisher.PublishAsync(
+            () => _sessionMapping.TryGetSessionByUserId(user!.Id, out activatedSessionId)
+                  && _sessionMapping.TryUpdateBrmbleStatus(activatedSessionId, true),
+            envelope => new
             {
                 type = "brmbleClientActivated",
+                instanceId = envelope.InstanceId,
+                revision = envelope.Revision,
                 sessionId = activatedSessionId
             });
-        }
 
         return new AuthResult(user.Id, user.MatrixUserId, user.MatrixAccessToken!, user.DisplayName, isRegistered);
     }
@@ -279,15 +281,18 @@ public class AuthService : IActiveBrmbleSessions
             {
                 _activeNames.Remove(name);
                 // Broadcast Brmble client deactivation
-                if (_sessionMapping.TryGetSessionId(name, out var deactivatedSessionId))
-                {
-                    _sessionMapping.TryUpdateBrmbleStatus(deactivatedSessionId, false);
-                    _ = _eventBus.BroadcastAsync(new
+                var deactivatedSessionId = 0;
+                _ = _publisher.PublishAsync(
+                    () => _sessionMapping.TryGetSessionId(name, out deactivatedSessionId)
+                          // false here is knowledge — we observed the socket go away.
+                          && _sessionMapping.TryUpdateBrmbleStatus(deactivatedSessionId, false),
+                    envelope => new
                     {
                         type = "brmbleClientDeactivated",
+                        instanceId = envelope.InstanceId,
+                        revision = envelope.Revision,
                         sessionId = deactivatedSessionId
                     });
-                }
             }
         }
     }

--- a/src/Brmble.Server/Companions/CustomCompanionEndpoints.cs
+++ b/src/Brmble.Server/Companions/CustomCompanionEndpoints.cs
@@ -27,7 +27,7 @@ public static class CustomCompanionEndpoints
             CustomCompanionRepository repository,
             IMatrixAppService matrixAppService,
             ISessionMappingService sessionMapping,
-            IBrmbleEventBus eventBus,
+            IMappingEventPublisher publisher,
             ILogger<CustomCompanionGalleryService> logger) =>
         {
             var certHash = certHashExtractor.GetCertHash(httpContext);
@@ -38,7 +38,7 @@ public static class CustomCompanionEndpoints
             if (!await aclAuthorization.CanModerateServerAsync(user.Id))
                 return Results.StatusCode(StatusCodes.Status403Forbidden);
 
-            var resetSessions = new List<(int SessionId, string MatrixUserId)>();
+            var sends = new List<Task>();
 
             using (await eventCoordinator.AcquireAsync(eventId, httpContext.RequestAborted))
             {
@@ -69,30 +69,32 @@ public static class CustomCompanionEndpoints
                         continue;
                     }
 
-                    if (sessionMapping.TryUpdateCompanionIdIfCurrent(
-                            sessionId, deletedCompanionId, "floppy"))
-                    {
-                        resetSessions.Add((sessionId, mapping.MatrixUserId));
-                    }
+                    // PublishAsync returns as soon as the payload is enqueued, so the
+                    // coordinator lock is not held across the fan-out. Awaiting these here
+                    // would reintroduce exactly what cd7b48fa removed.
+                    //
+                    // Broadcast server-wide: a channel lookup failure previously swallowed
+                    // the event, and out-of-channel clients were never told at all.
+                    sends.Add(publisher.PublishAsync(
+                        () => sessionMapping.TryUpdateCompanionIdIfCurrent(
+                            sessionId, deletedCompanionId, "floppy"),
+                        envelope => new
+                        {
+                            type = "companionChanged",
+                            instanceId = envelope.InstanceId,
+                            revision = envelope.Revision,
+                            sessionId,
+                            matrixUserId = mapping.MatrixUserId,
+                            companionId = "floppy",
+                            customCompanionId = (string?)null
+                        }));
                 }
             }
 
-            // Broadcast outside the coordinator lock: each announcement is a full-server
+            // Awaited outside the coordinator lock: each announcement is a full-server
             // fan-out and one deletion can affect every user wearing the skin, so holding the
             // lock across that socket I/O would serialise unrelated deletions behind it.
-            foreach (var (sessionId, matrixUserId) in resetSessions)
-            {
-                // Broadcast server-wide: a channel lookup failure previously swallowed
-                // the event, and out-of-channel clients were never told at all.
-                await eventBus.BroadcastAsync(new
-                {
-                    type = "companionChanged",
-                    sessionId,
-                    matrixUserId,
-                    companionId = "floppy",
-                    customCompanionId = (string?)null
-                });
-            }
+            await Task.WhenAll(sends);
 
             return Results.NoContent();
         });

--- a/src/Brmble.Server/Companions/CustomCompanionEndpoints.cs
+++ b/src/Brmble.Server/Companions/CustomCompanionEndpoints.cs
@@ -38,6 +38,8 @@ public static class CustomCompanionEndpoints
             if (!await aclAuthorization.CanModerateServerAsync(user.Id))
                 return Results.StatusCode(StatusCodes.Status403Forbidden);
 
+            var resetSessions = new List<(int SessionId, string MatrixUserId)>();
+
             using (await eventCoordinator.AcquireAsync(eventId, httpContext.RequestAborted))
             {
                 var record = await repository.GetActiveByEventIdAsync(eventId);
@@ -70,21 +72,29 @@ public static class CustomCompanionEndpoints
                     if (sessionMapping.TryUpdateCompanionIdIfCurrent(
                             sessionId, deletedCompanionId, "floppy"))
                     {
-                        // Broadcast server-wide: a channel lookup failure previously swallowed
-                        // the event, and out-of-channel clients were never told at all.
-                        await eventBus.BroadcastAsync(new
-                        {
-                            type = "companionChanged",
-                            sessionId,
-                            matrixUserId = mapping.MatrixUserId,
-                            companionId = "floppy",
-                            customCompanionId = (string?)null
-                        });
+                        resetSessions.Add((sessionId, mapping.MatrixUserId));
                     }
                 }
-
-                return Results.NoContent();
             }
+
+            // Broadcast outside the coordinator lock: each announcement is a full-server
+            // fan-out and one deletion can affect every user wearing the skin, so holding the
+            // lock across that socket I/O would serialise unrelated deletions behind it.
+            foreach (var (sessionId, matrixUserId) in resetSessions)
+            {
+                // Broadcast server-wide: a channel lookup failure previously swallowed
+                // the event, and out-of-channel clients were never told at all.
+                await eventBus.BroadcastAsync(new
+                {
+                    type = "companionChanged",
+                    sessionId,
+                    matrixUserId,
+                    companionId = "floppy",
+                    customCompanionId = (string?)null
+                });
+            }
+
+            return Results.NoContent();
         });
 
         return app;

--- a/src/Brmble.Server/Events/BrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/BrmbleEventBus.cs
@@ -245,6 +245,13 @@ public class BrmbleEventBus : IBrmbleEventBus
     private static ArraySegment<byte> Serialize(object message) =>
         new(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(message, JsonOptions)));
 
+    /// <summary>
+    /// Sends one payload to a single already-registered socket. Used to serve a client's
+    /// resync request without disturbing anyone else.
+    /// </summary>
+    public Task SendToClientAsync(WebSocket socket, object message) =>
+        SendToClient(socket, Serialize(message), default);
+
     public Task BroadcastToChannelAsync(int channelId, object message)
     {
         var sessions = _channelMembership.GetSessionsInChannel(channelId);

--- a/src/Brmble.Server/Events/IBrmbleEventBus.cs
+++ b/src/Brmble.Server/Events/IBrmbleEventBus.cs
@@ -9,6 +9,7 @@ public interface IBrmbleEventBus
     void RemoveClient(WebSocket ws);
     bool HasConnectedClient(long userId);
     Task BroadcastAsync(object message);
+    Task SendToClientAsync(WebSocket socket, object message);
     Task BroadcastExceptAsync(WebSocket excluded, object message);
     Task BroadcastToChannelAsync(int channelId, object message);
     Task<IReadOnlySet<long>> GetConnectedUserIdsAsync();

--- a/src/Brmble.Server/Events/IMappingEventPublisher.cs
+++ b/src/Brmble.Server/Events/IMappingEventPublisher.cs
@@ -10,4 +10,14 @@ public interface IMappingEventPublisher
     /// <param name="mutate">Performs the mutation; returns false if nothing changed.</param>
     /// <param name="payload">Builds the payload from the post-mutation envelope.</param>
     Task PublishAsync(Func<bool> mutate, Func<MappingEnvelope, object> payload);
+
+    /// <summary>
+    /// As <see cref="PublishAsync"/>, but the payload is not delivered to
+    /// <paramref name="excluded"/>. Used by the registration path, where the joining socket's
+    /// own snapshot already carries the mapping being announced.
+    /// </summary>
+    Task PublishExceptAsync(
+        System.Net.WebSockets.WebSocket excluded,
+        Func<bool> mutate,
+        Func<MappingEnvelope, object> payload);
 }

--- a/src/Brmble.Server/Events/IMappingEventPublisher.cs
+++ b/src/Brmble.Server/Events/IMappingEventPublisher.cs
@@ -1,0 +1,13 @@
+namespace Brmble.Server.Events;
+
+public interface IMappingEventPublisher
+{
+    /// <summary>
+    /// Runs <paramref name="mutate"/> and, only if it reports a change, broadcasts the payload
+    /// built from the resulting envelope. Mutation and broadcast admission happen under one
+    /// lock, so revision order always matches delivery order.
+    /// </summary>
+    /// <param name="mutate">Performs the mutation; returns false if nothing changed.</param>
+    /// <param name="payload">Builds the payload from the post-mutation envelope.</param>
+    Task PublishAsync(Func<bool> mutate, Func<MappingEnvelope, object> payload);
+}

--- a/src/Brmble.Server/Events/IMappingEventPublisher.cs
+++ b/src/Brmble.Server/Events/IMappingEventPublisher.cs
@@ -20,4 +20,19 @@ public interface IMappingEventPublisher
         System.Net.WebSockets.WebSocket excluded,
         Func<bool> mutate,
         Func<MappingEnvelope, object> payload);
+
+    /// <summary>
+    /// Captures the mapping table and its revision, and enqueues a snapshot built from them to a
+    /// single socket — all under the same ordering gate mutations use.
+    /// </summary>
+    /// <remarks>
+    /// The capture and the enqueue must not be separated. Reading the revision and the mappings,
+    /// then awaiting anything before enqueuing, lets an event at a later revision reach the
+    /// socket ahead of the snapshot. A client then either discards that event while waiting for
+    /// the repair it already had, or applies it and is rolled back by the older snapshot — and
+    /// nothing replays it afterwards.
+    /// </remarks>
+    Task PublishSnapshotAsync(
+        System.Net.WebSockets.WebSocket target,
+        Func<MappingEnvelope, IReadOnlyDictionary<int, SessionMapping>, object> payload);
 }

--- a/src/Brmble.Server/Events/ISessionMappingService.cs
+++ b/src/Brmble.Server/Events/ISessionMappingService.cs
@@ -36,5 +36,21 @@ public interface ISessionMappingService
     bool TryUpdateCompanionIdIfOwnedBy(int sessionId, long userId, string companionId);
     bool TryUpdateBrmbleStatus(int sessionId, bool? isBrmbleClient);
     bool TryUpdateCertHash(int sessionId, string certHash);
+
+    /// <summary>
+    /// Marks a session as an active Brmble client and records its certificate hash, but only if
+    /// the session still belongs to <paramref name="userId"/>.
+    /// </summary>
+    /// <remarks>
+    /// Atomic and ownership-constrained on purpose. Doing this as separate
+    /// <see cref="TryUpdateBrmbleStatus"/> and <see cref="TryUpdateCertHash"/> calls guarded by a
+    /// later ownership check writes one user's certificate and status into another user's
+    /// mapping whenever a session is recycled in between, and then suppresses the announcement —
+    /// corrupting the projection and leaving unannounced revision bumps behind. It is also one
+    /// bump rather than two, so the announced range covers exactly this change.
+    /// </remarks>
+    /// <param name="mapping">The post-claim mapping to announce, or null if the claim was refused.</param>
+    bool TryClaimBrmbleSession(int sessionId, long userId, string certHash, out SessionMapping? mapping);
+
     IReadOnlyDictionary<int, SessionMapping> GetSnapshot();
 }

--- a/src/Brmble.Server/Events/ISessionMappingService.cs
+++ b/src/Brmble.Server/Events/ISessionMappingService.cs
@@ -13,8 +13,15 @@ public interface ISessionMappingService
 
     /// <summary>
     /// Monotonic counter, incremented once per successful mutation. Stamped on every payload so
-    /// a client can detect a gap (revision > last + 1) and request a snapshot.
+    /// a client can order and deduplicate events.
     /// </summary>
+    /// <remarks>
+    /// One logical operation may increment this several times — a first registration does add,
+    /// certHash and brmbleStatus under a single announcement, moving it by three — so
+    /// <c>revision == last + 1</c> is <b>not</b> a valid gap test. Phase 2 stamps the range's
+    /// start alongside it (<c>baseRevision</c>) precisely so a client can distinguish a
+    /// multi-bump operation from a genuine gap.
+    /// </remarks>
     long Revision { get; }
 
     void SetNameForSession(string name, int sessionId);

--- a/src/Brmble.Server/Events/ISessionMappingService.cs
+++ b/src/Brmble.Server/Events/ISessionMappingService.cs
@@ -4,6 +4,19 @@ public record SessionMapping(string MatrixUserId, string MumbleName, long UserId
 
 public interface ISessionMappingService
 {
+    /// <summary>
+    /// Identifies this process's mapping table. Regenerated on every start, so a client that
+    /// sees a different value knows the server restarted and its cached server-owned fields
+    /// are worthless.
+    /// </summary>
+    string InstanceId { get; }
+
+    /// <summary>
+    /// Monotonic counter, incremented once per successful mutation. Stamped on every payload so
+    /// a client can detect a gap (revision > last + 1) and request a snapshot.
+    /// </summary>
+    long Revision { get; }
+
     void SetNameForSession(string name, int sessionId);
     bool TryAddMatrixUser(int sessionId, string matrixUserId, string mumbleName, long userId, string companionId);
     void RemoveSession(int sessionId);

--- a/src/Brmble.Server/Events/ISessionMappingService.cs
+++ b/src/Brmble.Server/Events/ISessionMappingService.cs
@@ -13,6 +13,7 @@ public interface ISessionMappingService
     bool TryGetMappingByUserId(long userId, out int sessionId, out SessionMapping? mapping);
     bool TryUpdateCompanionId(int sessionId, string companionId);
     bool TryUpdateCompanionIdIfCurrent(int sessionId, string expectedCompanionId, string companionId);
+    bool TryUpdateCompanionIdIfOwnedBy(int sessionId, long userId, string companionId);
     bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient);
     bool TryUpdateCertHash(int sessionId, string certHash);
     IReadOnlyDictionary<int, SessionMapping> GetSnapshot();

--- a/src/Brmble.Server/Events/ISessionMappingService.cs
+++ b/src/Brmble.Server/Events/ISessionMappingService.cs
@@ -1,6 +1,6 @@
 namespace Brmble.Server.Events;
 
-public record SessionMapping(string MatrixUserId, string MumbleName, long UserId, string CompanionId, bool IsBrmbleClient = false, string? CertHash = null);
+public record SessionMapping(string MatrixUserId, string MumbleName, long UserId, string CompanionId, bool? IsBrmbleClient = null, string? CertHash = null);
 
 public interface ISessionMappingService
 {
@@ -27,7 +27,7 @@ public interface ISessionMappingService
     bool TryUpdateCompanionId(int sessionId, string companionId);
     bool TryUpdateCompanionIdIfCurrent(int sessionId, string expectedCompanionId, string companionId);
     bool TryUpdateCompanionIdIfOwnedBy(int sessionId, long userId, string companionId);
-    bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient);
+    bool TryUpdateBrmbleStatus(int sessionId, bool? isBrmbleClient);
     bool TryUpdateCertHash(int sessionId, string certHash);
     IReadOnlyDictionary<int, SessionMapping> GetSnapshot();
 }

--- a/src/Brmble.Server/Events/MappingEnvelope.cs
+++ b/src/Brmble.Server/Events/MappingEnvelope.cs
@@ -1,0 +1,8 @@
+namespace Brmble.Server.Events;
+
+/// <summary>
+/// Stamped on every session-mapping payload so a client can tell a restart from a gap.
+/// </summary>
+/// <param name="InstanceId">Identifies the server's mapping table; changes on restart.</param>
+/// <param name="Revision">The table revision produced by the mutation being announced.</param>
+public readonly record struct MappingEnvelope(string InstanceId, long Revision);

--- a/src/Brmble.Server/Events/MappingEventPublisher.cs
+++ b/src/Brmble.Server/Events/MappingEventPublisher.cs
@@ -15,6 +15,25 @@ public sealed class MappingEventPublisher(
         Func<MappingEnvelope, object> payload) =>
         PublishCore(mutate, payload, (bus, message) => bus.BroadcastExceptAsync(excluded, message), eventBus);
 
+    public Task PublishSnapshotAsync(
+        System.Net.WebSockets.WebSocket target,
+        Func<MappingEnvelope, IReadOnlyDictionary<int, SessionMapping>, object> payload)
+    {
+        Task pending;
+        lock (_gate)
+        {
+            // Revision, mappings and enqueue all happen inside the gate. A mutation racing this
+            // is therefore either fully reflected in the capture and at or below the stamped
+            // revision, or enqueued after the snapshot and so applies on top of it. Splitting
+            // these — capturing here and enqueuing after an await — lets a later event overtake
+            // the snapshot it was supposed to be repaired by.
+            var envelope = new MappingEnvelope(mappings.InstanceId, mappings.Revision);
+            pending = eventBus.SendToClientAsync(target, payload(envelope, mappings.GetSnapshot()));
+        }
+
+        return pending;
+    }
+
     private Task PublishCore(
         Func<bool> mutate,
         Func<MappingEnvelope, object> payload,

--- a/src/Brmble.Server/Events/MappingEventPublisher.cs
+++ b/src/Brmble.Server/Events/MappingEventPublisher.cs
@@ -1,0 +1,26 @@
+namespace Brmble.Server.Events;
+
+public sealed class MappingEventPublisher(
+    ISessionMappingService mappings,
+    IBrmbleEventBus eventBus) : IMappingEventPublisher
+{
+    private readonly object _gate = new();
+
+    public Task PublishAsync(Func<bool> mutate, Func<MappingEnvelope, object> payload)
+    {
+        Task send;
+        lock (_gate)
+        {
+            if (!mutate()) return Task.CompletedTask;
+
+            var envelope = new MappingEnvelope(mappings.InstanceId, mappings.Revision);
+
+            // Safe under the lock: BrmbleEventBus.BroadcastCoreAsync is deliberately not async
+            // and enqueues to every per-socket queue before returning, so no socket I/O happens
+            // here. Awaiting inside the lock would be wrong; capturing the task is not.
+            send = eventBus.BroadcastAsync(payload(envelope));
+        }
+
+        return send;
+    }
+}

--- a/src/Brmble.Server/Events/MappingEventPublisher.cs
+++ b/src/Brmble.Server/Events/MappingEventPublisher.cs
@@ -6,21 +6,34 @@ public sealed class MappingEventPublisher(
 {
     private readonly object _gate = new();
 
-    public Task PublishAsync(Func<bool> mutate, Func<MappingEnvelope, object> payload)
+    public Task PublishAsync(Func<bool> mutate, Func<MappingEnvelope, object> payload) =>
+        PublishCore(mutate, payload, static (bus, message) => bus.BroadcastAsync(message), eventBus);
+
+    public Task PublishExceptAsync(
+        System.Net.WebSockets.WebSocket excluded,
+        Func<bool> mutate,
+        Func<MappingEnvelope, object> payload) =>
+        PublishCore(mutate, payload, (bus, message) => bus.BroadcastExceptAsync(excluded, message), eventBus);
+
+    private Task PublishCore(
+        Func<bool> mutate,
+        Func<MappingEnvelope, object> payload,
+        Func<IBrmbleEventBus, object, Task> send,
+        IBrmbleEventBus bus)
     {
-        Task send;
+        Task pending;
         lock (_gate)
         {
             if (!mutate()) return Task.CompletedTask;
 
             var envelope = new MappingEnvelope(mappings.InstanceId, mappings.Revision);
 
-            // Safe under the lock: BrmbleEventBus.BroadcastCoreAsync is deliberately not async
-            // and enqueues to every per-socket queue before returning, so no socket I/O happens
+            // Safe under the lock: BrmbleEventBus's broadcast paths are deliberately not async
+            // and enqueue to every per-socket queue before returning, so no socket I/O happens
             // here. Awaiting inside the lock would be wrong; capturing the task is not.
-            send = eventBus.BroadcastAsync(payload(envelope));
+            pending = send(bus, payload(envelope));
         }
 
-        return send;
+        return pending;
     }
 }

--- a/src/Brmble.Server/Events/SessionMappingHandler.cs
+++ b/src/Brmble.Server/Events/SessionMappingHandler.cs
@@ -40,19 +40,24 @@ public class SessionMappingHandler : IMumbleEventHandler
         // false would assert something we cannot know, and clients would believe it.
         bool? isBrmbleClient = _activeSessions.IsBrmbleClient(user.CertHash) ? true : null;
 
-        var mappingAdded = _sessionMapping.TryAddMatrixUser(user.SessionId, dbUser.MatrixUserId, user.Name, dbUser.Id, companionId);
-        _sessionMapping.TryUpdateCertHash(user.SessionId, user.CertHash);
-        _sessionMapping.TryUpdateBrmbleStatus(user.SessionId, isBrmbleClient);
-
-        _logger.LogInformation(
-            "Mapped session {Session} ({Name}) to {MatrixUserId} via cert (brmbleClient={IsBrmble}, added={Added})",
-            user.SessionId, user.Name, dbUser.MatrixUserId, isBrmbleClient, mappingAdded);
         var wire = CompanionWireSelection.FromPersisted(companionId);
+        var mappingAdded = false;
+        var announced = default(MappingEnvelope);
         await _publisher.PublishAsync(
-            // The mapping mutations above already happened; this announcement is unconditional.
-            () => true,
+            // The mutations run inside the lock so the revision stamped below is provably the
+            // one they produced. Doing them outside lets a concurrent registration bump the
+            // counter in between, and two payloads then claim the same revision.
+            () =>
+            {
+                mappingAdded = _sessionMapping.TryAddMatrixUser(
+                    user.SessionId, dbUser.MatrixUserId, user.Name, dbUser.Id, companionId);
+                _sessionMapping.TryUpdateCertHash(user.SessionId, user.CertHash);
+                _sessionMapping.TryUpdateBrmbleStatus(user.SessionId, isBrmbleClient);
+                return true;
+            },
             envelope =>
             {
+                announced = envelope;
                 // A dictionary rather than an anonymous type so isBrmbleClient can be omitted
                 // when unknown: an explicit null throws in the shipped client's parser.
                 // Keys are written in camelCase and pass through both serialiser configs
@@ -74,15 +79,23 @@ public class SessionMappingHandler : IMumbleEventHandler
                 return payload;
             });
 
+        _logger.LogInformation(
+            "Mapped session {Session} ({Name}) to {MatrixUserId} via cert (brmbleClient={IsBrmble}, added={Added})",
+            user.SessionId, user.Name, dbUser.MatrixUserId, isBrmbleClient, mappingAdded);
+
         if (!mappingAdded && isBrmbleClient == true)
         {
+            // A legacy-compatibility restatement of a fact the userMappingAdded above already
+            // carries; it performs no mutation of its own. It therefore reuses that payload's
+            // envelope rather than reading the counter again — a fresh read could pick up an
+            // unrelated concurrent bump and claim another event's revision.
             await _publisher.PublishAsync(
                 () => true,
-                envelope => new
+                _ => new
                 {
                     type = "brmbleClientActivated",
-                    instanceId = envelope.InstanceId,
-                    revision = envelope.Revision,
+                    instanceId = announced.InstanceId,
+                    revision = announced.Revision,
                     sessionId = user.SessionId
                 });
         }

--- a/src/Brmble.Server/Events/SessionMappingHandler.cs
+++ b/src/Brmble.Server/Events/SessionMappingHandler.cs
@@ -7,20 +7,20 @@ namespace Brmble.Server.Events;
 public class SessionMappingHandler : IMumbleEventHandler
 {
     private readonly ISessionMappingService _sessionMapping;
-    private readonly IBrmbleEventBus _eventBus;
+    private readonly IMappingEventPublisher _publisher;
     private readonly UserRepository _userRepository;
     private readonly IActiveBrmbleSessions _activeSessions;
     private readonly ILogger<SessionMappingHandler> _logger;
 
     public SessionMappingHandler(
         ISessionMappingService sessionMapping,
-        IBrmbleEventBus eventBus,
+        IMappingEventPublisher publisher,
         UserRepository userRepository,
         IActiveBrmbleSessions activeSessions,
         ILogger<SessionMappingHandler> logger)
     {
         _sessionMapping = sessionMapping;
-        _eventBus = eventBus;
+        _publisher = publisher;
         _userRepository = userRepository;
         _activeSessions = activeSessions;
         _logger = logger;
@@ -48,25 +48,34 @@ public class SessionMappingHandler : IMumbleEventHandler
             "Mapped session {Session} ({Name}) to {MatrixUserId} via cert (brmbleClient={IsBrmble}, added={Added})",
             user.SessionId, user.Name, dbUser.MatrixUserId, isBrmbleClient, mappingAdded);
         var wire = CompanionWireSelection.FromPersisted(companionId);
-        await _eventBus.BroadcastAsync(new
-        {
-            type = "userMappingAdded",
-            sessionId = user.SessionId,
-            matrixUserId = dbUser.MatrixUserId,
-            mumbleName = user.Name,
-            companionId = wire.CompanionId,
-            customCompanionId = wire.CustomCompanionId,
-            certHash = user.CertHash,
-            isBrmbleClient
-        });
+        await _publisher.PublishAsync(
+            // The mapping mutations above already happened; this announcement is unconditional.
+            () => true,
+            envelope => new
+            {
+                type = "userMappingAdded",
+                instanceId = envelope.InstanceId,
+                revision = envelope.Revision,
+                sessionId = user.SessionId,
+                matrixUserId = dbUser.MatrixUserId,
+                mumbleName = user.Name,
+                companionId = wire.CompanionId,
+                customCompanionId = wire.CustomCompanionId,
+                certHash = user.CertHash,
+                isBrmbleClient
+            });
 
         if (!mappingAdded && isBrmbleClient == true)
         {
-            await _eventBus.BroadcastAsync(new
-            {
-                type = "brmbleClientActivated",
-                sessionId = user.SessionId
-            });
+            await _publisher.PublishAsync(
+                () => true,
+                envelope => new
+                {
+                    type = "brmbleClientActivated",
+                    instanceId = envelope.InstanceId,
+                    revision = envelope.Revision,
+                    sessionId = user.SessionId
+                });
         }
     }
 

--- a/src/Brmble.Server/Events/SessionMappingHandler.cs
+++ b/src/Brmble.Server/Events/SessionMappingHandler.cs
@@ -35,7 +35,10 @@ public class SessionMappingHandler : IMumbleEventHandler
         var companionId = await _userRepository.GetCompanionId(dbUser.Id);
 
         _activeSessions.TrackMumbleName(user.Name, user.CertHash);
-        var isBrmbleClient = _activeSessions.IsBrmbleClient(user.CertHash);
+        // A registered WebSocket proves true. Nothing proves false here: after a restart
+        // _activeSessions is empty, so "not active" only means "not known yet". Publishing
+        // false would assert something we cannot know, and clients would believe it.
+        bool? isBrmbleClient = _activeSessions.IsBrmbleClient(user.CertHash) ? true : null;
 
         var mappingAdded = _sessionMapping.TryAddMatrixUser(user.SessionId, dbUser.MatrixUserId, user.Name, dbUser.Id, companionId);
         _sessionMapping.TryUpdateCertHash(user.SessionId, user.CertHash);
@@ -57,7 +60,7 @@ public class SessionMappingHandler : IMumbleEventHandler
             isBrmbleClient
         });
 
-        if (!mappingAdded && isBrmbleClient)
+        if (!mappingAdded && isBrmbleClient == true)
         {
             await _eventBus.BroadcastAsync(new
             {

--- a/src/Brmble.Server/Events/SessionMappingHandler.cs
+++ b/src/Brmble.Server/Events/SessionMappingHandler.cs
@@ -51,18 +51,27 @@ public class SessionMappingHandler : IMumbleEventHandler
         await _publisher.PublishAsync(
             // The mapping mutations above already happened; this announcement is unconditional.
             () => true,
-            envelope => new
+            envelope =>
             {
-                type = "userMappingAdded",
-                instanceId = envelope.InstanceId,
-                revision = envelope.Revision,
-                sessionId = user.SessionId,
-                matrixUserId = dbUser.MatrixUserId,
-                mumbleName = user.Name,
-                companionId = wire.CompanionId,
-                customCompanionId = wire.CustomCompanionId,
-                certHash = user.CertHash,
-                isBrmbleClient
+                // A dictionary rather than an anonymous type so isBrmbleClient can be omitted
+                // when unknown: an explicit null throws in the shipped client's parser.
+                // Keys are written in camelCase and pass through both serialiser configs
+                // unchanged, since DictionaryKeyPolicy is not set on the event bus.
+                var payload = new Dictionary<string, object?>
+                {
+                    ["type"] = "userMappingAdded",
+                    ["instanceId"] = envelope.InstanceId,
+                    ["revision"] = envelope.Revision,
+                    ["sessionId"] = user.SessionId,
+                    ["matrixUserId"] = dbUser.MatrixUserId,
+                    ["mumbleName"] = user.Name,
+                    ["companionId"] = wire.CompanionId,
+                    ["customCompanionId"] = wire.CustomCompanionId,
+                    ["certHash"] = user.CertHash
+                };
+                if (isBrmbleClient.HasValue)
+                    payload["isBrmbleClient"] = isBrmbleClient.Value;
+                return payload;
             });
 
         if (!mappingAdded && isBrmbleClient == true)

--- a/src/Brmble.Server/Events/SessionMappingService.cs
+++ b/src/Brmble.Server/Events/SessionMappingService.cs
@@ -92,7 +92,7 @@ public class SessionMappingService : ISessionMappingService
         return false;
     }
 
-    public bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient)
+    public bool TryUpdateBrmbleStatus(int sessionId, bool? isBrmbleClient)
     {
         while (_sessionToMapping.TryGetValue(sessionId, out var existing))
         {

--- a/src/Brmble.Server/Events/SessionMappingService.cs
+++ b/src/Brmble.Server/Events/SessionMappingService.cs
@@ -33,7 +33,38 @@ public class SessionMappingService : ISessionMappingService
             return true;
         }
 
-        _userIdToSession[userId] = sessionId;
+        // The session already has a mapping. Only refresh the index when that mapping is this
+        // user's own: pointing a user at a session somebody else owns makes every later by-user
+        // lookup resolve to — and mutate — the wrong projection.
+        if (_sessionToMapping.TryGetValue(sessionId, out var existing) && existing.UserId == userId)
+            _userIdToSession[userId] = sessionId;
+
+        return false;
+    }
+
+    public bool TryClaimBrmbleSession(int sessionId, long userId, string certHash, out SessionMapping? mapping)
+    {
+        while (_sessionToMapping.TryGetValue(sessionId, out var existing))
+        {
+            // Ownership is checked inside the CAS, not before it, so a recycle racing this call
+            // loses rather than being overwritten.
+            if (existing.UserId != userId)
+            {
+                mapping = null;
+                return false;
+            }
+
+            var updated = existing with { IsBrmbleClient = true, CertHash = certHash };
+            if (_sessionToMapping.TryUpdate(sessionId, updated, existing))
+            {
+                _userIdToSession[userId] = sessionId;
+                Bump();
+                mapping = updated;
+                return true;
+            }
+        }
+
+        mapping = null;
         return false;
     }
 

--- a/src/Brmble.Server/Events/SessionMappingService.cs
+++ b/src/Brmble.Server/Events/SessionMappingService.cs
@@ -115,6 +115,24 @@ public class SessionMappingService : ISessionMappingService
         return false;
     }
 
+    public bool TryUpdateCompanionIdIfOwnedBy(int sessionId, long userId, string companionId)
+    {
+        while (_sessionToMapping.TryGetValue(sessionId, out var existing))
+        {
+            // Compare-and-swap on the mapping we read: a session removed and recycled to a
+            // different user between the read and the write would otherwise have its owner's
+            // companion overwritten, and the change announced under the wrong identity.
+            if (existing.UserId != userId)
+                return false;
+
+            var updated = existing with { CompanionId = companionId };
+            if (_sessionToMapping.TryUpdate(sessionId, updated, existing))
+                return true;
+        }
+
+        return false;
+    }
+
     public bool TryUpdateCertHash(int sessionId, string certHash)
     {
         if (_sessionToMapping.TryGetValue(sessionId, out var existing))

--- a/src/Brmble.Server/Events/SessionMappingService.cs
+++ b/src/Brmble.Server/Events/SessionMappingService.cs
@@ -9,6 +9,15 @@ public class SessionMappingService : ISessionMappingService
     private readonly ConcurrentDictionary<int, string> _sessionToName = new();
     private readonly ConcurrentDictionary<long, int> _userIdToSession = new();
 
+    private readonly string _instanceId = Guid.NewGuid().ToString("N");
+    private long _revision;
+
+    public string InstanceId => _instanceId;
+
+    public long Revision => Interlocked.Read(ref _revision);
+
+    private void Bump() => Interlocked.Increment(ref _revision);
+
     public void SetNameForSession(string name, int sessionId)
     {
         _nameToSession[name] = sessionId;
@@ -20,6 +29,7 @@ public class SessionMappingService : ISessionMappingService
         if (_sessionToMapping.TryAdd(sessionId, new SessionMapping(matrixUserId, mumbleName, userId, companionId)))
         {
             _userIdToSession[userId] = sessionId;
+            Bump();
             return true;
         }
 
@@ -29,11 +39,13 @@ public class SessionMappingService : ISessionMappingService
 
     public void RemoveSession(int sessionId)
     {
+        var changed = false;
         if (_sessionToMapping.TryRemove(sessionId, out var mapping))
         {
             // Only remove userId→session if it still points to this session
             ((ICollection<KeyValuePair<long, int>>)_userIdToSession)
                 .Remove(new KeyValuePair<long, int>(mapping.UserId, sessionId));
+            changed = true;
         }
         if (_sessionToName.TryRemove(sessionId, out var name))
         {
@@ -42,6 +54,7 @@ public class SessionMappingService : ISessionMappingService
             ((ICollection<KeyValuePair<string, int>>)_nameToSession)
                 .Remove(new KeyValuePair<string, int>(name, sessionId));
         }
+        if (changed) Bump();
     }
 
     public bool TryGetMatrixUserId(int sessionId, out string? matrixUserId)
@@ -81,20 +94,29 @@ public class SessionMappingService : ISessionMappingService
 
     public bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient)
     {
-        if (_sessionToMapping.TryGetValue(sessionId, out var existing))
+        while (_sessionToMapping.TryGetValue(sessionId, out var existing))
         {
-            _sessionToMapping[sessionId] = existing with { IsBrmbleClient = isBrmbleClient };
-            return true;
+            var updated = existing with { IsBrmbleClient = isBrmbleClient };
+            if (_sessionToMapping.TryUpdate(sessionId, updated, existing))
+            {
+                Bump();
+                return true;
+            }
         }
+
         return false;
     }
 
     public bool TryUpdateCompanionId(int sessionId, string companionId)
     {
-        if (_sessionToMapping.TryGetValue(sessionId, out var existing))
+        while (_sessionToMapping.TryGetValue(sessionId, out var existing))
         {
-            _sessionToMapping[sessionId] = existing with { CompanionId = companionId };
-            return true;
+            var updated = existing with { CompanionId = companionId };
+            if (_sessionToMapping.TryUpdate(sessionId, updated, existing))
+            {
+                Bump();
+                return true;
+            }
         }
 
         return false;
@@ -109,7 +131,10 @@ public class SessionMappingService : ISessionMappingService
 
             var updated = existing with { CompanionId = companionId };
             if (_sessionToMapping.TryUpdate(sessionId, updated, existing))
+            {
+                Bump();
                 return true;
+            }
         }
 
         return false;
@@ -127,7 +152,10 @@ public class SessionMappingService : ISessionMappingService
 
             var updated = existing with { CompanionId = companionId };
             if (_sessionToMapping.TryUpdate(sessionId, updated, existing))
+            {
+                Bump();
                 return true;
+            }
         }
 
         return false;
@@ -135,10 +163,14 @@ public class SessionMappingService : ISessionMappingService
 
     public bool TryUpdateCertHash(int sessionId, string certHash)
     {
-        if (_sessionToMapping.TryGetValue(sessionId, out var existing))
+        while (_sessionToMapping.TryGetValue(sessionId, out var existing))
         {
-            _sessionToMapping[sessionId] = existing with { CertHash = certHash };
-            return true;
+            var updated = existing with { CertHash = certHash };
+            if (_sessionToMapping.TryUpdate(sessionId, updated, existing))
+            {
+                Bump();
+                return true;
+            }
         }
 
         return false;

--- a/src/Brmble.Server/Events/SessionMappingWire.cs
+++ b/src/Brmble.Server/Events/SessionMappingWire.cs
@@ -1,0 +1,64 @@
+using System.Text.Json.Serialization;
+
+namespace Brmble.Server.Events;
+
+/// <summary>
+/// Wire shape for one session-mapping entry in a snapshot.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>isBrmbleClient</c> is omitted entirely when unknown rather than written as an explicit
+/// null. Shipped clients parse it with
+/// <c>TryGetProperty("isBrmbleClient", out var b) &amp;&amp; b.GetBoolean()</c>, and
+/// <see cref="System.Text.Json.JsonElement.GetBoolean"/> throws on a Null value kind while
+/// <c>TryGetProperty</c> reports the property as present. Since this runs while handling the
+/// <c>/auth/token</c> response, a null would throw inside credential handling on every
+/// already-installed client. An absent property makes an old client fall back to <c>false</c>
+/// — today's behaviour — and means "unknown" to a projection-aware client (spec §3.2 rule 2).
+/// </para>
+/// <para>
+/// <c>false</c> is still written explicitly: an observed deactivation is knowledge, not an
+/// absence. <c>customCompanionId</c> is likewise never omitted — a null there is meaningful to
+/// companion parsing, which is why the omission is per-property and not a global
+/// <c>DefaultIgnoreCondition</c>.
+/// </para>
+/// <para>
+/// Property names are pinned with <see cref="JsonPropertyNameAttribute"/> so the shape is
+/// identical under the event bus's camelCase policy and under default serialiser options.
+/// </para>
+/// </remarks>
+public sealed record SessionMappingWire
+{
+    [JsonPropertyName("matrixUserId")]
+    public required string MatrixUserId { get; init; }
+
+    [JsonPropertyName("mumbleName")]
+    public required string MumbleName { get; init; }
+
+    [JsonPropertyName("companionId")]
+    public required string CompanionId { get; init; }
+
+    [JsonPropertyName("customCompanionId")]
+    public string? CustomCompanionId { get; init; }
+
+    [JsonPropertyName("certHash")]
+    public string? CertHash { get; init; }
+
+    [JsonPropertyName("isBrmbleClient")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? IsBrmbleClient { get; init; }
+
+    public static SessionMappingWire From(SessionMapping mapping)
+    {
+        var wire = Companions.CompanionWireSelection.FromPersisted(mapping.CompanionId);
+        return new SessionMappingWire
+        {
+            MatrixUserId = mapping.MatrixUserId,
+            MumbleName = mapping.MumbleName,
+            CompanionId = wire.CompanionId,
+            CustomCompanionId = wire.CustomCompanionId,
+            CertHash = mapping.CertHash,
+            IsBrmbleClient = mapping.IsBrmbleClient
+        };
+    }
+}

--- a/src/Brmble.Server/Games/SessionMappingGamePresence.cs
+++ b/src/Brmble.Server/Games/SessionMappingGamePresence.cs
@@ -23,7 +23,7 @@ public sealed class SessionMappingGamePresence : IGamePresence
         userId = 0;
         if (!_sessions.GetSnapshot().TryGetValue((int)sessionId, out var mapping) || mapping is null)
             return false;
-        isBrmble = mapping.IsBrmbleClient;
+        isBrmble = mapping.IsBrmbleClient == true;
         userId = mapping.UserId;
         return _membership.TryGetChannel((int)sessionId, out channelId);
     }

--- a/src/Brmble.Server/Mumble/MumbleExtensions.cs
+++ b/src/Brmble.Server/Mumble/MumbleExtensions.cs
@@ -11,6 +11,7 @@ public static class MumbleExtensions
             .BindConfiguration("Ice");
         services.AddSingleton<ISessionMappingService, SessionMappingService>();
         services.AddSingleton<IChannelMembershipService, ChannelMembershipService>();
+        services.AddSingleton<IMappingEventPublisher, MappingEventPublisher>();
         services.AddOptions<EventBusSettings>()
             .BindConfiguration("EventBus");
         services.AddSingleton<IBrmbleEventBus, BrmbleEventBus>();

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -12,6 +12,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
     private readonly IEnumerable<IMumbleEventHandler> _handlers;
     private readonly ISessionMappingService _sessionMapping;
     private readonly IBrmbleEventBus _eventBus;
+    private readonly IMappingEventPublisher _publisher;
     private readonly IChannelMembershipService _channelMembership;
     private readonly ScreenShareTracker _screenShareTracker;
     private readonly ILiveKitParticipantRevocationScheduler _liveKitRevocationScheduler;
@@ -25,6 +26,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
         IEnumerable<IMumbleEventHandler> handlers,
         ISessionMappingService sessionMapping,
         IBrmbleEventBus eventBus,
+        IMappingEventPublisher publisher,
         IChannelMembershipService channelMembership,
         ScreenShareTracker screenShareTracker,
         ILiveKitParticipantRevocationScheduler liveKitRevocationScheduler,
@@ -36,6 +38,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
         _handlers = handlers;
         _sessionMapping = sessionMapping;
         _eventBus = eventBus;
+        _publisher = publisher;
         _channelMembership = channelMembership;
         _screenShareTracker = screenShareTracker;
         _liveKitRevocationScheduler = liveKitRevocationScheduler;
@@ -194,7 +197,15 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
 
         await _liveKitRevocationScheduler.RevokeParticipants(revokedRecords);
 
-        await _eventBus.BroadcastAsync(new { type = "userMappingRemoved", sessionId = user.SessionId });
+        await _publisher.PublishAsync(
+            () => true,   // RemoveSession already ran and bumped the revision
+            envelope => new
+            {
+                type = "userMappingRemoved",
+                instanceId = envelope.InstanceId,
+                revision = envelope.Revision,
+                sessionId = user.SessionId
+            });
         await Task.WhenAll(_handlers.Select(h => h.OnUserDisconnected(user)));
     }
 

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -184,7 +184,23 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
 
         _liveKitParticipantTracker.MarkSessionRevoking(user.SessionId);
         var revokedRecords = _liveKitParticipantTracker.RemoveBySession(user.SessionId);
-        _sessionMapping.RemoveSession(user.SessionId);
+        // RemoveSession stays in place, ordered against the LiveKit and channel-membership
+        // cleanup around it. The publish is hoisted here so the mutation and the revision read
+        // are one atomic unit; PublishAsync only enqueues, so the fan-out is still awaited
+        // below, in the position the broadcast previously occupied.
+        var removalSend = _publisher.PublishAsync(
+            () =>
+            {
+                _sessionMapping.RemoveSession(user.SessionId);
+                return true;
+            },
+            envelope => new
+            {
+                type = "userMappingRemoved",
+                instanceId = envelope.InstanceId,
+                revision = envelope.Revision,
+                sessionId = user.SessionId
+            });
         _channelMembership.Remove(user.SessionId);
 
         if (snapshot.TryGetValue(user.SessionId, out mapping))
@@ -197,15 +213,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
 
         await _liveKitRevocationScheduler.RevokeParticipants(revokedRecords);
 
-        await _publisher.PublishAsync(
-            () => true,   // RemoveSession already ran and bumped the revision
-            envelope => new
-            {
-                type = "userMappingRemoved",
-                instanceId = envelope.InstanceId,
-                revision = envelope.Revision,
-                sessionId = user.SessionId
-            });
+        await removalSend;
         await Task.WhenAll(_handlers.Select(h => h.OnUserDisconnected(user)));
     }
 

--- a/src/Brmble.Server/Paint/IPaintPresence.cs
+++ b/src/Brmble.Server/Paint/IPaintPresence.cs
@@ -17,7 +17,7 @@ public sealed class SessionMappingPaintPresence(ISessionMappingService sessions,
     {
         participant = null!;
         if (!sessions.TryGetMappingByUserId(userId, out var sessionId, out var mapping) || mapping is null ||
-            !mapping.IsBrmbleClient || !membership.TryGetChannel(sessionId, out var channelId))
+            mapping.IsBrmbleClient != true || !membership.TryGetChannel(sessionId, out var channelId))
             return false;
         participant = new PaintPresenceParticipant(userId, channelId, sessionId, mapping.MatrixUserId);
         return true;
@@ -27,7 +27,7 @@ public sealed class SessionMappingPaintPresence(ISessionMappingService sessions,
     {
         var snapshot = sessions.GetSnapshot();
         return membership.GetSessionsInChannel(channelId)
-            .Where(sessionId => snapshot.TryGetValue(sessionId, out var mapping) && mapping.IsBrmbleClient)
+            .Where(sessionId => snapshot.TryGetValue(sessionId, out var mapping) && mapping.IsBrmbleClient == true)
             .Select(sessionId =>
             {
                 var mapping = snapshot[sessionId];
@@ -41,7 +41,7 @@ public sealed class SessionMappingPaintPresence(ISessionMappingService sessions,
         participant = null!;
         var snapshot = sessions.GetSnapshot();
         if (!snapshot.TryGetValue(mumbleSessionId, out var mapping)
-            || !mapping.IsBrmbleClient
+            || mapping.IsBrmbleClient != true
             || !membership.TryGetChannel(mumbleSessionId, out var channelId))
             return false;
 

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -41,7 +41,9 @@ public static class BrmbleWebSocketHandler
         try
         {
             await InitializeAcceptedClientAsync(
-                ws, user.Id, hash, sessionMapping, eventBus, activeSessions,
+                ws, user.Id, hash, sessionMapping, eventBus,
+                context.RequestServices.GetRequiredService<IMappingEventPublisher>(),
+                activeSessions,
                 context.RequestServices.GetRequiredService<IDuelSnapshotProvider>());
 
             // Read loop until close. Messages are reassembled across frames; anything larger
@@ -70,11 +72,17 @@ public static class BrmbleWebSocketHandler
                 if (messageType != "requestSnapshot") continue;
 
                 sessionMapping.TryGetSessionByUserId(user.Id, out var resyncSessionId);
+                // Read the revision before the snapshot, never after. If a mutation lands in
+                // between, the snapshot then under-claims: the client re-applies an event it
+                // already reflects, which is idempotent. Reading it after would over-claim, and
+                // the client would discard the intervening events as duplicates forever.
+                var resyncEnvelope = new MappingEnvelope(
+                    sessionMapping.InstanceId, sessionMapping.Revision);
                 var payloads = await BuildInitialPayloadsAsync(
                     context.RequestServices.GetRequiredService<IDuelSnapshotProvider>(),
                     resyncSessionId,
                     sessionMapping.GetSnapshot(),
-                    new MappingEnvelope(sessionMapping.InstanceId, sessionMapping.Revision));
+                    resyncEnvelope);
 
                 foreach (var payload in payloads)
                     await eventBus.SendToClientAsync(ws, payload);
@@ -121,6 +129,7 @@ public static class BrmbleWebSocketHandler
         string certHash,
         ISessionMappingService sessionMapping,
         IBrmbleEventBus eventBus,
+        IMappingEventPublisher publisher,
         IActiveBrmbleSessions activeSessions,
         IDuelSnapshotProvider snapshots) =>
         eventBus.AddClientAsync(socket, userId, async () =>
@@ -128,21 +137,27 @@ public static class BrmbleWebSocketHandler
             if (sessionMapping.TryGetMappingByUserId(userId, out var sessionId, out var mapping))
             {
                 activeSessions.TrackMumbleName(mapping!.MumbleName, certHash, active: true);
-                sessionMapping.TryUpdateBrmbleStatus(sessionId, true);
-                sessionMapping.TryUpdateCertHash(sessionId, certHash);
-                await eventBus.BroadcastExceptAsync(
+                // Mutations run inside the publisher's lock so the stamped revision is provably
+                // the one they produced; a concurrent registration would otherwise let two
+                // payloads claim the same revision.
+                await publisher.PublishExceptAsync(
                     socket,
-                    CreateUserMappingAddedPayload(
-                        sessionId, mapping, certHash,
-                        // Stamped after the two mutations above, so their bumps are announced
-                        // rather than silent.
-                        new MappingEnvelope(sessionMapping.InstanceId, sessionMapping.Revision)));
+                    () =>
+                    {
+                        sessionMapping.TryUpdateBrmbleStatus(sessionId, true);
+                        sessionMapping.TryUpdateCertHash(sessionId, certHash);
+                        return true;
+                    },
+                    envelope => CreateUserMappingAddedPayload(sessionId, mapping, certHash, envelope));
             }
 
             sessionMapping.TryGetSessionByUserId(userId, out var queueSessionId);
+            // Revision before snapshot: see the note on the resync path. Under-claiming is
+            // self-correcting, over-claiming silently drops the intervening events.
+            var bootstrapEnvelope = new MappingEnvelope(
+                sessionMapping.InstanceId, sessionMapping.Revision);
             return await BuildInitialPayloadsAsync(
-                snapshots, queueSessionId, sessionMapping.GetSnapshot(),
-                new MappingEnvelope(sessionMapping.InstanceId, sessionMapping.Revision));
+                snapshots, queueSessionId, sessionMapping.GetSnapshot(), bootstrapEnvelope);
         });
 
     /// <summary>

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -158,19 +158,7 @@ public static class BrmbleWebSocketHandler
     {
         var snapshot = mappings.ToDictionary(
             kvp => kvp.Key.ToString(),
-            kvp =>
-            {
-                var wire = CompanionWireSelection.FromPersisted(kvp.Value.CompanionId);
-                return new
-                {
-                    matrixUserId = kvp.Value.MatrixUserId,
-                    mumbleName = kvp.Value.MumbleName,
-                    companionId = wire.CompanionId,
-                    customCompanionId = wire.CustomCompanionId,
-                    certHash = kvp.Value.CertHash,
-                    isBrmbleClient = kvp.Value.IsBrmbleClient,
-                };
-            });
+            kvp => SessionMappingWire.From(kvp.Value));
         var initial = new List<object>
         {
             new

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -1,4 +1,5 @@
 using System.Net.WebSockets;
+using System.Text.Json;
 using Brmble.Server.Auth;
 using Brmble.Server.Companions;
 using Brmble.Server.Events;
@@ -43,8 +44,11 @@ public static class BrmbleWebSocketHandler
                 ws, user.Id, hash, sessionMapping, eventBus, activeSessions,
                 context.RequestServices.GetRequiredService<IDuelSnapshotProvider>());
 
-            // Read loop until close
+            // Read loop until close. Messages are reassembled across frames; anything larger
+            // than the cap is discarded rather than buffered, so a client cannot exhaust memory.
+            const int MaxClientMessageBytes = 8 * 1024;
             var buffer = new byte[1024];
+            var accumulated = new MemoryStream();
             while (ws.State == WebSocketState.Open)
             {
                 var result = await ws.ReceiveAsync(buffer, context.RequestAborted);
@@ -53,6 +57,27 @@ public static class BrmbleWebSocketHandler
                     await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
                     break;
                 }
+
+                if (accumulated.Length + result.Count <= MaxClientMessageBytes)
+                    accumulated.Write(buffer, 0, result.Count);
+
+                if (!result.EndOfMessage) continue;
+
+                var json = System.Text.Encoding.UTF8.GetString(accumulated.ToArray());
+                accumulated.SetLength(0);
+
+                if (!TryParseClientMessage(json, out var messageType)) continue;
+                if (messageType != "requestSnapshot") continue;
+
+                sessionMapping.TryGetSessionByUserId(user.Id, out var resyncSessionId);
+                var payloads = await BuildInitialPayloadsAsync(
+                    context.RequestServices.GetRequiredService<IDuelSnapshotProvider>(),
+                    resyncSessionId,
+                    sessionMapping.GetSnapshot(),
+                    new MappingEnvelope(sessionMapping.InstanceId, sessionMapping.Revision));
+
+                foreach (var payload in payloads)
+                    await eventBus.SendToClientAsync(ws, payload);
             }
         }
         catch (WebSocketException) { /* client disconnected */ }
@@ -107,7 +132,9 @@ public static class BrmbleWebSocketHandler
             }
 
             sessionMapping.TryGetSessionByUserId(userId, out var queueSessionId);
-            return await BuildInitialPayloadsAsync(snapshots, queueSessionId, sessionMapping.GetSnapshot());
+            return await BuildInitialPayloadsAsync(
+                snapshots, queueSessionId, sessionMapping.GetSnapshot(),
+                new MappingEnvelope(sessionMapping.InstanceId, sessionMapping.Revision));
         });
 
     /// <summary>
@@ -118,7 +145,8 @@ public static class BrmbleWebSocketHandler
     internal static async Task<IReadOnlyList<object>> BuildInitialPayloadsAsync(
         IDuelSnapshotProvider snapshots,
         long sessionId,
-        IReadOnlyDictionary<int, SessionMapping> mappings)
+        IReadOnlyDictionary<int, SessionMapping> mappings,
+        MappingEnvelope envelope)
     {
         var snapshot = mappings.ToDictionary(
             kvp => kvp.Key.ToString(),
@@ -135,9 +163,41 @@ public static class BrmbleWebSocketHandler
                     isBrmbleClient = kvp.Value.IsBrmbleClient,
                 };
             });
-        var initial = new List<object> { new { type = "sessionMappingSnapshot", mappings = snapshot } };
+        var initial = new List<object>
+        {
+            new
+            {
+                type = "sessionMappingSnapshot",
+                instanceId = envelope.InstanceId,
+                revision = envelope.Revision,
+                mappings = snapshot
+            }
+        };
         if (sessionId != 0)
             initial.Add(DuelWire.ToEvent(await snapshots.GetSnapshotForSessionAsync(sessionId)));
         return initial;
+    }
+
+    /// <summary>
+    /// Parses a client-to-server frame. Returns false for anything unparseable rather than
+    /// throwing: a malformed frame must never take the socket down.
+    /// </summary>
+    internal static bool TryParseClientMessage(string json, out string type)
+    {
+        type = string.Empty;
+        if (string.IsNullOrWhiteSpace(json)) return false;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return false;
+            if (!doc.RootElement.TryGetProperty("type", out var typeProperty)) return false;
+            if (typeProperty.ValueKind != JsonValueKind.String) return false;
+            type = typeProperty.GetString() ?? string.Empty;
+            return type.Length > 0;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 }

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -90,12 +90,15 @@ public static class BrmbleWebSocketHandler
         }
     }
 
-    internal static object CreateUserMappingAddedPayload(int sessionId, SessionMapping mapping, string certHash)
+    internal static object CreateUserMappingAddedPayload(
+        int sessionId, SessionMapping mapping, string certHash, MappingEnvelope envelope)
     {
         var wire = CompanionWireSelection.FromPersisted(mapping.CompanionId);
         return new
         {
             type = "userMappingAdded",
+            instanceId = envelope.InstanceId,
+            revision = envelope.Revision,
             sessionId,
             matrixUserId = mapping.MatrixUserId,
             mumbleName = mapping.MumbleName,
@@ -128,7 +131,12 @@ public static class BrmbleWebSocketHandler
                 sessionMapping.TryUpdateBrmbleStatus(sessionId, true);
                 sessionMapping.TryUpdateCertHash(sessionId, certHash);
                 await eventBus.BroadcastExceptAsync(
-                    socket, CreateUserMappingAddedPayload(sessionId, mapping, certHash));
+                    socket,
+                    CreateUserMappingAddedPayload(
+                        sessionId, mapping, certHash,
+                        // Stamped after the two mutations above, so their bumps are announced
+                        // rather than silent.
+                        new MappingEnvelope(sessionMapping.InstanceId, sessionMapping.Revision)));
             }
 
             sessionMapping.TryGetSessionByUserId(userId, out var queueSessionId);

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -36,21 +36,29 @@ public static class BrmbleWebSocketHandler
         var sessionMapping = context.RequestServices.GetRequiredService<ISessionMappingService>();
         var eventBus = context.RequestServices.GetRequiredService<IBrmbleEventBus>();
         var activeSessions = context.RequestServices.GetRequiredService<IActiveBrmbleSessions>();
+        var publisher = context.RequestServices.GetRequiredService<IMappingEventPublisher>();
 
         using var ws = await context.WebSockets.AcceptWebSocketAsync();
         try
         {
             await InitializeAcceptedClientAsync(
-                ws, user.Id, hash, sessionMapping, eventBus,
-                context.RequestServices.GetRequiredService<IMappingEventPublisher>(),
-                activeSessions,
+                ws, user.Id, hash, sessionMapping, eventBus, publisher, activeSessions,
                 context.RequestServices.GetRequiredService<IDuelSnapshotProvider>());
 
-            // Read loop until close. Messages are reassembled across frames; anything larger
-            // than the cap is discarded rather than buffered, so a client cannot exhaust memory.
+            // Read loop until close. Messages are reassembled across frames. A message that
+            // exceeds the cap is discarded in full rather than truncated: truncating would let a
+            // client send a valid short prefix followed by megabytes of padding and still have
+            // the prefix honoured, which is an amplification vector rather than a limit.
             const int MaxClientMessageBytes = 8 * 1024;
+            // Rebuilding a snapshot is server-wide work, so an authenticated client cannot be
+            // allowed to drive it in a loop. The read loop is sequential per socket, so one
+            // request is in flight at a time; this bounds the rate as well. A client refused
+            // here simply asks again after its next gap detection.
+            var snapshotCooldown = TimeSpan.FromSeconds(1);
+            var lastSnapshot = DateTimeOffset.MinValue;
             var buffer = new byte[1024];
             var accumulated = new MemoryStream();
+            var oversized = false;
             while (ws.State == WebSocketState.Open)
             {
                 var result = await ws.ReceiveAsync(buffer, context.RequestAborted);
@@ -60,32 +68,49 @@ public static class BrmbleWebSocketHandler
                     break;
                 }
 
-                if (accumulated.Length + result.Count <= MaxClientMessageBytes)
+                // Only text frames carry client messages. A binary frame is not something this
+                // protocol defines, so it is dropped rather than UTF8-decoded and guessed at.
+                if (result.MessageType != WebSocketMessageType.Text)
+                {
+                    if (result.EndOfMessage) { accumulated.SetLength(0); oversized = false; }
+                    continue;
+                }
+
+                if (accumulated.Length + result.Count > MaxClientMessageBytes)
+                    oversized = true;
+                else
                     accumulated.Write(buffer, 0, result.Count);
 
                 if (!result.EndOfMessage) continue;
 
-                var json = System.Text.Encoding.UTF8.GetString(accumulated.ToArray());
+                var json = oversized ? null : System.Text.Encoding.UTF8.GetString(accumulated.ToArray());
                 accumulated.SetLength(0);
+                oversized = false;
 
+                if (json is null) continue;
                 if (!TryParseClientMessage(json, out var messageType)) continue;
                 if (messageType != "requestSnapshot") continue;
 
-                sessionMapping.TryGetSessionByUserId(user.Id, out var resyncSessionId);
-                // Read the revision before the snapshot, never after. If a mutation lands in
-                // between, the snapshot then under-claims: the client re-applies an event it
-                // already reflects, which is idempotent. Reading it after would over-claim, and
-                // the client would discard the intervening events as duplicates forever.
-                var resyncEnvelope = new MappingEnvelope(
-                    sessionMapping.InstanceId, sessionMapping.Revision);
-                var payloads = await BuildInitialPayloadsAsync(
-                    context.RequestServices.GetRequiredService<IDuelSnapshotProvider>(),
-                    resyncSessionId,
-                    sessionMapping.GetSnapshot(),
-                    resyncEnvelope);
+                var now = DateTimeOffset.UtcNow;
+                if (now - lastSnapshot < snapshotCooldown) continue;
+                lastSnapshot = now;
 
-                foreach (var payload in payloads)
-                    await eventBus.SendToClientAsync(ws, payload);
+                // The mapping snapshot is captured and enqueued under the publisher's ordering
+                // gate, before anything is awaited. Building it alongside the duel payload would
+                // leave a window in which an event at a later revision reaches this socket first,
+                // and the client would either discard the repair it was waiting for or apply the
+                // event and be rolled back by the older snapshot.
+                await publisher.PublishSnapshotAsync(ws, (envelope, snapshot) =>
+                    CreateSessionMappingSnapshotPayload(snapshot, envelope));
+
+                // Unrelated to mapping ordering, so it can safely follow an await.
+                sessionMapping.TryGetSessionByUserId(user.Id, out var resyncSessionId);
+                if (resyncSessionId != 0)
+                {
+                    var duels = context.RequestServices.GetRequiredService<IDuelSnapshotProvider>();
+                    await eventBus.SendToClientAsync(
+                        ws, DuelWire.ToEvent(await duels.GetSnapshotForSessionAsync(resyncSessionId)));
+                }
             }
         }
         catch (WebSocketException) { /* client disconnected */ }
@@ -139,33 +164,20 @@ public static class BrmbleWebSocketHandler
                 activeSessions.TrackMumbleName(mapping!.MumbleName, certHash, active: true);
 
                 SessionMapping? announced = null;
-                // Mutations run inside the publisher's lock so the stamped revision is provably
-                // the one they produced; a concurrent registration would otherwise let two
-                // payloads claim the same revision.
+                // One atomic, ownership-constrained claim rather than two blind updates followed
+                // by an ownership check. Checking afterwards is too late: if the session was
+                // recycled between the read above and this lock, the blind updates would already
+                // have written this user's certificate and Brmble status into somebody else's
+                // mapping, and the failed check would then suppress the announcement — corrupting
+                // the projection and leaving two unannounced revision bumps behind.
+                //
+                // The claim also returns the post-mutation mapping, so the payload cannot carry
+                // the value captured outside the lock: a companionChanged landing in between
+                // would otherwise ship an older companionId under a newer revision, and every
+                // client would overwrite the newer value with the stale one.
                 await publisher.PublishExceptAsync(
                     socket,
-                    () =>
-                    {
-                        var changed = sessionMapping.TryUpdateBrmbleStatus(sessionId, true);
-                        changed |= sessionMapping.TryUpdateCertHash(sessionId, certHash);
-
-                        // Nothing moved, so the mapping was removed between the read above and
-                        // this lock. Announcing anyway would emit a userMappingAdded for a
-                        // mapping that no longer exists, stamped with a revision this operation
-                        // did not produce and which another payload already owns.
-                        if (!changed) return false;
-
-                        // Re-read under the lock rather than announcing the value captured
-                        // above. A companionChanged landing in between would otherwise be
-                        // undone: the payload would carry the older companionId under this
-                        // operation's newer revision, so every client would overwrite the newer
-                        // value with the stale one. Requiring the same session id also rejects
-                        // a mapping recycled to a different user mid-flight.
-                        return sessionMapping.TryGetMappingByUserId(
-                                   userId, out var currentSessionId, out announced)
-                               && currentSessionId == sessionId
-                               && announced is not null;
-                    },
+                    () => sessionMapping.TryClaimBrmbleSession(sessionId, userId, certHash, out announced),
                     envelope => CreateUserMappingAddedPayload(sessionId, announced!, certHash, envelope));
             }
 
@@ -189,23 +201,27 @@ public static class BrmbleWebSocketHandler
         IReadOnlyDictionary<int, SessionMapping> mappings,
         MappingEnvelope envelope)
     {
-        var snapshot = mappings.ToDictionary(
-            kvp => kvp.Key.ToString(),
-            kvp => SessionMappingWire.From(kvp.Value));
-        var initial = new List<object>
-        {
-            new
-            {
-                type = "sessionMappingSnapshot",
-                instanceId = envelope.InstanceId,
-                revision = envelope.Revision,
-                mappings = snapshot
-            }
-        };
+        var initial = new List<object> { CreateSessionMappingSnapshotPayload(mappings, envelope) };
         if (sessionId != 0)
             initial.Add(DuelWire.ToEvent(await snapshots.GetSnapshotForSessionAsync(sessionId)));
         return initial;
     }
+
+    /// <summary>
+    /// The complete statement of every session the server knows about. Shared by the bootstrap
+    /// and resync paths so both describe membership identically.
+    /// </summary>
+    internal static object CreateSessionMappingSnapshotPayload(
+        IReadOnlyDictionary<int, SessionMapping> mappings, MappingEnvelope envelope) =>
+        new
+        {
+            type = "sessionMappingSnapshot",
+            instanceId = envelope.InstanceId,
+            revision = envelope.Revision,
+            mappings = mappings.ToDictionary(
+                kvp => kvp.Key.ToString(),
+                kvp => SessionMappingWire.From(kvp.Value))
+        };
 
     /// <summary>
     /// Parses a client-to-server frame. Returns false for anything unparseable rather than

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -137,6 +137,8 @@ public static class BrmbleWebSocketHandler
             if (sessionMapping.TryGetMappingByUserId(userId, out var sessionId, out var mapping))
             {
                 activeSessions.TrackMumbleName(mapping!.MumbleName, certHash, active: true);
+
+                SessionMapping? announced = null;
                 // Mutations run inside the publisher's lock so the stamped revision is provably
                 // the one they produced; a concurrent registration would otherwise let two
                 // payloads claim the same revision.
@@ -144,11 +146,27 @@ public static class BrmbleWebSocketHandler
                     socket,
                     () =>
                     {
-                        sessionMapping.TryUpdateBrmbleStatus(sessionId, true);
-                        sessionMapping.TryUpdateCertHash(sessionId, certHash);
-                        return true;
+                        var changed = sessionMapping.TryUpdateBrmbleStatus(sessionId, true);
+                        changed |= sessionMapping.TryUpdateCertHash(sessionId, certHash);
+
+                        // Nothing moved, so the mapping was removed between the read above and
+                        // this lock. Announcing anyway would emit a userMappingAdded for a
+                        // mapping that no longer exists, stamped with a revision this operation
+                        // did not produce and which another payload already owns.
+                        if (!changed) return false;
+
+                        // Re-read under the lock rather than announcing the value captured
+                        // above. A companionChanged landing in between would otherwise be
+                        // undone: the payload would carry the older companionId under this
+                        // operation's newer revision, so every client would overwrite the newer
+                        // value with the stale one. Requiring the same session id also rejects
+                        // a mapping recycled to a different user mid-flight.
+                        return sessionMapping.TryGetMappingByUserId(
+                                   userId, out var currentSessionId, out announced)
+                               && currentSessionId == sessionId
+                               && announced is not null;
                     },
-                    envelope => CreateUserMappingAddedPayload(sessionId, mapping, certHash, envelope));
+                    envelope => CreateUserMappingAddedPayload(sessionId, announced!, certHash, envelope));
             }
 
             sessionMapping.TryGetSessionByUserId(userId, out var queueSessionId);

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -1061,6 +1061,24 @@ public class MumbleAdapterParseTests
     }
 
     [TestMethod]
+    public void ParseSessionMappings_ExplicitNullIsBrmbleClient_DoesNotThrow()
+    {
+        // TryGetProperty returns true for an explicit JSON null and GetBoolean() throws on it.
+        // This runs inside /auth/token credential handling, so a null would take the client
+        // down on connect. Absent and null must both mean "unknown", rendering as false today.
+        var json = JsonDocument.Parse("""
+        {
+            "5": { "matrixUserId": "@user:localhost", "mumbleName": "User", "isBrmbleClient": null }
+        }
+        """);
+
+        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.IsFalse(result[5].IsBrmbleClient);
+    }
+
+    [TestMethod]
     public void ParseSessionMappings_SkipsEntriesWithMissingRequiredFields()
     {
         var json = JsonDocument.Parse("""

--- a/tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs
@@ -58,6 +58,11 @@ public class AuthEndpointsCompanionTests : IDisposable
         _factory.SessionMappingMock.Verify(m => m.TryUpdateCompanionIdIfOwnedBy(42, 1, "floppy"), Times.Once);
         _factory.EventBusMock.Verify(b => b.BroadcastAsync(It.Is<object>(payload =>
             JsonSerializer.Serialize(payload).Contains("\"type\":\"companionChanged\""))), Times.Once);
+        var companionPayload = _factory.EventBusMock.Invocations
+            .Where(i => i.Method.Name == nameof(IBrmbleEventBus.BroadcastAsync))
+            .Select(i => i.Arguments[0])
+            .Single(p => JsonSerializer.Serialize(p).Contains("\"type\":\"companionChanged\""));
+        Events.MappingPayloadEnvelopeTests.AssertHasEnvelope(companionPayload, "companionChanged");
         _factory.EventBusMock.Verify(
             b => b.BroadcastToChannelAsync(It.IsAny<int>(), It.IsAny<object>()), Times.Never);
     }
@@ -259,6 +264,9 @@ public class AuthEndpointsCompanionTests : IDisposable
                 if (eventBusDescriptor is not null) services.Remove(eventBusDescriptor);
 
                 SessionMappingMock.Setup(m => m.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>());
+                // The bare mock still has to look like a live table to the publisher.
+                SessionMappingMock.SetupGet(m => m.InstanceId).Returns("test-instance");
+                SessionMappingMock.SetupGet(m => m.Revision).Returns(1L);
                 SessionMappingMock.Setup(m => m.TryGetSessionId(It.IsAny<string>(), out It.Ref<int>.IsAny)).Returns(false);
                 SessionMappingMock.Setup(m => m.TryAddMatrixUser(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<string>())).Returns(false);
                 SessionMappingMock.Setup(m => m.TryUpdateBrmbleStatus(It.IsAny<int>(), It.IsAny<bool>())).Returns(true);

--- a/tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs
@@ -47,7 +47,7 @@ public class AuthEndpointsCompanionTests : IDisposable
                 return true;
             });
         _factory.SessionMappingMock
-            .Setup(m => m.TryUpdateCompanionId(42, "floppy"))
+            .Setup(m => m.TryUpdateCompanionIdIfOwnedBy(42, 1, "floppy"))
             .Returns(true);
 
         var response = await _client.PostAsync(
@@ -55,7 +55,7 @@ public class AuthEndpointsCompanionTests : IDisposable
             new StringContent(JsonSerializer.Serialize(new { companionId = "floppy" }), Encoding.UTF8, "application/json"));
 
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-        _factory.SessionMappingMock.Verify(m => m.TryUpdateCompanionId(42, "floppy"), Times.Once);
+        _factory.SessionMappingMock.Verify(m => m.TryUpdateCompanionIdIfOwnedBy(42, 1, "floppy"), Times.Once);
         _factory.EventBusMock.Verify(b => b.BroadcastAsync(It.Is<object>(payload =>
             JsonSerializer.Serialize(payload).Contains("\"type\":\"companionChanged\""))), Times.Once);
         _factory.EventBusMock.Verify(
@@ -80,7 +80,7 @@ public class AuthEndpointsCompanionTests : IDisposable
                 return true;
             });
         _factory.SessionMappingMock
-            .Setup(m => m.TryUpdateCompanionId(99, "retro"))
+            .Setup(m => m.TryUpdateCompanionIdIfOwnedBy(99, 1, "retro"))
             .Returns(true);
 
         var response = await _client.PostAsync(
@@ -127,7 +127,40 @@ public class AuthEndpointsCompanionTests : IDisposable
             .GetRequiredService<Brmble.Server.Auth.UserRepository>().GetCompanionId(1));
         _factory.EventBusMock.Verify(b => b.BroadcastAsync(It.IsAny<object>()), Times.Never);
         _factory.SessionMappingMock.Verify(
-            m => m.TryUpdateCompanionId(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+            m => m.TryUpdateCompanionIdIfOwnedBy(It.IsAny<int>(), It.IsAny<long>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [TestMethod]
+    public async Task PostAuthCompanion_DoesNotBroadcastWhenSessionIsRecycledDuringUpdate()
+    {
+        var tokenResponse = await _client.PostAsync("/auth/token", null);
+        tokenResponse.EnsureSuccessStatusCode();
+
+        // The mapping lookup validates ownership, but the session can still be removed and
+        // recycled to a different user before the write lands. The CAS on userId rejects it,
+        // so nothing is announced under the new owner's session.
+        _factory.SessionMappingMock
+            .Setup(m => m.TryGetMappingByUserId(
+                It.IsAny<long>(), out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
+            .Returns((long userId, out int sid, out SessionMapping? mapping) =>
+            {
+                sid = 42;
+                mapping = new SessionMapping("@alice:test", "Alice", userId, "floppy");
+                return true;
+            });
+        _factory.SessionMappingMock
+            .Setup(m => m.TryUpdateCompanionIdIfOwnedBy(42, It.IsAny<long>(), It.IsAny<string>()))
+            .Returns(false);
+
+        var response = await _client.PostAsync(
+            "/auth/companion",
+            new StringContent(JsonSerializer.Serialize(new { companionId = "bee" }), Encoding.UTF8, "application/json"));
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual("bee", await _factory.Services
+            .GetRequiredService<Brmble.Server.Auth.UserRepository>().GetCompanionId(1));
+        _factory.EventBusMock.Verify(b => b.BroadcastAsync(It.IsAny<object>()), Times.Never);
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Auth/AuthServiceRegistrationTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthServiceRegistrationTests.cs
@@ -38,7 +38,8 @@ public class AuthServiceRegistrationTests
         var mockEventBus = new Mock<IBrmbleEventBus>();
         mockEventBus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
         _authService = new AuthService(repo, mockMatrix.Object, NullLogger<AuthService>.Instance,
-            _mockReg.Object, _mockSession.Object, mockEventBus.Object);
+            _mockReg.Object, _mockSession.Object,
+            new MappingEventPublisher(_mockSession.Object, mockEventBus.Object));
     }
 
     [TestCleanup]

--- a/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthServiceTests.cs
@@ -46,7 +46,8 @@ public class AuthServiceTests
         var mockEventBus = new Mock<IBrmbleEventBus>();
         mockEventBus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
         _svc = new AuthService(repo, _mockMatrix.Object, NullLogger<AuthService>.Instance,
-            _mockMumbleReg.Object, _mockSessionMapping.Object, mockEventBus.Object);
+            _mockMumbleReg.Object, _mockSessionMapping.Object,
+            new MappingEventPublisher(_mockSessionMapping.Object, mockEventBus.Object));
     }
 
     [TestCleanup]

--- a/tests/Brmble.Server.Tests/Companions/CustomCompanionDeletionTests.cs
+++ b/tests/Brmble.Server.Tests/Companions/CustomCompanionDeletionTests.cs
@@ -71,9 +71,21 @@ public sealed class CustomCompanionDeletionTests : IDisposable
         var response = await _client.DeleteAsync("/companions/%24sprite%3Atest");
 
         Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
-        _factory.EventBusMock.Verify(bus => bus.BroadcastAsync(It.Is<object>(payload =>
-            JsonSerializer.Serialize(payload) ==
-            "{\"type\":\"companionChanged\",\"sessionId\":42,\"matrixUserId\":\"@alice:test\",\"companionId\":\"floppy\",\"customCompanionId\":null}")), Times.Once);
+        // instanceId is a per-process GUID, so this asserts structurally rather than on an
+        // exact serialised string.
+        var companionPayload = _factory.EventBusMock.Invocations
+            .Where(i => i.Method.Name == nameof(IBrmbleEventBus.BroadcastAsync))
+            .Select(i => i.Arguments[0])
+            .Single(p => JsonSerializer.Serialize(p).Contains("\"type\":\"companionChanged\""));
+        Events.MappingPayloadEnvelopeTests.AssertHasEnvelope(companionPayload, "companionChanged");
+        using (var doc = JsonDocument.Parse(JsonSerializer.Serialize(companionPayload)))
+        {
+            Assert.AreEqual(42, doc.RootElement.GetProperty("sessionId").GetInt32());
+            Assert.AreEqual("@alice:test", doc.RootElement.GetProperty("matrixUserId").GetString());
+            Assert.AreEqual("floppy", doc.RootElement.GetProperty("companionId").GetString());
+            Assert.AreEqual(JsonValueKind.Null,
+                doc.RootElement.GetProperty("customCompanionId").ValueKind);
+        }
         _factory.EventBusMock.Verify(
             bus => bus.BroadcastToChannelAsync(It.IsAny<int>(), It.IsAny<object>()), Times.Never);
     }

--- a/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
+++ b/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
@@ -83,4 +83,73 @@ public class MappingEventPublisherTests
         public Task BroadcastToUsersAsync(IReadOnlySet<long> userIds, object message, EventDeliveryOptions options = default) =>
             BroadcastAsync(message);
     }
+
+    [TestMethod]
+    public void PublishSnapshotAsync_CapturesRevisionAndMappingsAndEnqueuesUnderOneGate()
+    {
+        // The capture and the enqueue must not be separable. If a mutation could land between
+        // them, an event at a later revision could reach the socket ahead of the snapshot it was
+        // supposed to be repaired by.
+        _mappings.TryUpdateCompanionId(1, "retro");
+        var socket = new Moq.Mock<System.Net.WebSockets.WebSocket>().Object;
+
+        _publisher.PublishSnapshotAsync(socket, (envelope, snapshot) => new
+        {
+            type = "sessionMappingSnapshot",
+            instanceId = envelope.InstanceId,
+            revision = envelope.Revision,
+            count = snapshot.Count,
+            companion = snapshot[1].CompanionId
+        });
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(_bus.Broadcasts.Single()));
+        Assert.AreEqual(_mappings.Revision, doc.RootElement.GetProperty("revision").GetInt64());
+        Assert.AreEqual(_mappings.InstanceId, doc.RootElement.GetProperty("instanceId").GetString());
+        Assert.AreEqual("retro", doc.RootElement.GetProperty("companion").GetString(),
+            "the snapshot must reflect the state at the revision it claims");
+    }
+
+    [TestMethod]
+    public async Task PublishSnapshotAsync_NoEventCanBeEnqueuedBetweenTheCaptureAndTheSnapshot()
+    {
+        // Hammer both paths concurrently. Every snapshot's claimed revision must match the
+        // mapping state it carries, and never trail an event that was already delivered.
+        var socket = new Moq.Mock<System.Net.WebSockets.WebSocket>().Object;
+
+        await Task.WhenAll(
+            Task.Run(() =>
+            {
+                for (var i = 0; i < 200; i++)
+                    _publisher.PublishAsync(
+                        () => _mappings.TryUpdateCompanionId(1, $"c{i}"),
+                        envelope => new
+                        {
+                            type = "companionChanged",
+                            revision = envelope.Revision,
+                            companion = _mappings.GetSnapshot()[1].CompanionId
+                        });
+            }),
+            Task.Run(() =>
+            {
+                for (var i = 0; i < 200; i++)
+                    _publisher.PublishSnapshotAsync(socket, (envelope, snapshot) => new
+                    {
+                        type = "sessionMappingSnapshot",
+                        revision = envelope.Revision,
+                        companion = snapshot[1].CompanionId
+                    });
+            }));
+
+        // Enqueue order is delivery order, so revisions must never go backwards across the
+        // combined stream of events and snapshots.
+        var revisions = _bus.Broadcasts
+            .Select(p => JsonDocument.Parse(JsonSerializer.Serialize(p))
+                .RootElement.GetProperty("revision").GetInt64())
+            .ToList();
+
+        Assert.AreEqual(400, revisions.Count);
+        CollectionAssert.AreEqual(revisions.OrderBy(r => r).ToList(), revisions,
+            "a snapshot delivered after a newer event rolls the client back and is never replayed");
+    }
 }
+

--- a/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
+++ b/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
@@ -73,6 +73,7 @@ public class MappingEventPublisherTests
         }
 
         public Task BroadcastToChannelAsync(int channelId, object message) => BroadcastAsync(message);
+        public Task SendToClientAsync(System.Net.WebSockets.WebSocket socket, object message) => BroadcastAsync(message);
         public Task BroadcastExceptAsync(System.Net.WebSockets.WebSocket excluded, object message) => BroadcastAsync(message);
         public Task AddClientAsync(System.Net.WebSockets.WebSocket ws, long userId, Func<Task<IReadOnlyList<object>>>? initialMessages = null) => Task.CompletedTask;
         public void RemoveClient(System.Net.WebSockets.WebSocket ws) { }

--- a/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
+++ b/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using Brmble.Server.Events;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.Events;
+
+[TestClass]
+public class MappingEventPublisherTests
+{
+    private SessionMappingService _mappings = null!;
+    private RecordingEventBus _bus = null!;
+    private MappingEventPublisher _publisher = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mappings = new SessionMappingService();
+        _bus = new RecordingEventBus();
+        _publisher = new MappingEventPublisher(_mappings, _bus);
+        _mappings.TryAddMatrixUser(1, "@alice:test", "Alice", 1L, "floppy");
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_StampsPayloadWithInstanceIdAndPostMutationRevision()
+    {
+        await _publisher.PublishAsync(
+            () => _mappings.TryUpdateCompanionId(1, "retro"),
+            envelope => new { type = "companionChanged", instanceId = envelope.InstanceId, revision = envelope.Revision });
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(_bus.Broadcasts.Single()));
+        Assert.AreEqual(_mappings.InstanceId, doc.RootElement.GetProperty("instanceId").GetString());
+        Assert.AreEqual(_mappings.Revision, doc.RootElement.GetProperty("revision").GetInt64());
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_DoesNotBroadcastWhenMutationReportsNoChange()
+    {
+        await _publisher.PublishAsync(
+            () => _mappings.TryUpdateCompanionId(999, "retro"),
+            envelope => new { type = "companionChanged", instanceId = envelope.InstanceId, revision = envelope.Revision });
+
+        Assert.AreEqual(0, _bus.Broadcasts.Count);
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_DeliversInRevisionOrderUnderConcurrency()
+    {
+        await Task.WhenAll(Enumerable.Range(0, 100).Select(i => Task.Run(() =>
+            _publisher.PublishAsync(
+                () => _mappings.TryUpdateCompanionId(1, $"c{i}"),
+                envelope => new { type = "companionChanged", instanceId = envelope.InstanceId, revision = envelope.Revision }))));
+
+        var revisions = _bus.Broadcasts
+            .Select(p => JsonDocument.Parse(JsonSerializer.Serialize(p))
+                .RootElement.GetProperty("revision").GetInt64())
+            .ToList();
+
+        Assert.AreEqual(100, revisions.Count);
+        CollectionAssert.AreEqual(revisions.OrderBy(r => r).ToList(), revisions,
+            "enqueue order must match revision order, or clients discard newer payloads as duplicates");
+    }
+
+    private sealed class RecordingEventBus : IBrmbleEventBus
+    {
+        private readonly object _gate = new();
+        public List<object> Broadcasts { get; } = new();
+
+        public Task BroadcastAsync(object message)
+        {
+            // Mirrors BrmbleEventBus: admission happens synchronously on the calling thread.
+            lock (_gate) Broadcasts.Add(message);
+            return Task.CompletedTask;
+        }
+
+        public Task BroadcastToChannelAsync(int channelId, object message) => BroadcastAsync(message);
+        public Task BroadcastExceptAsync(System.Net.WebSockets.WebSocket excluded, object message) => BroadcastAsync(message);
+        public Task AddClientAsync(System.Net.WebSockets.WebSocket ws, long userId, Func<Task<IReadOnlyList<object>>>? initialMessages = null) => Task.CompletedTask;
+        public void RemoveClient(System.Net.WebSockets.WebSocket ws) { }
+        public bool HasConnectedClient(long userId) => false;
+        public Task<IReadOnlySet<long>> GetConnectedUserIdsAsync() =>
+            Task.FromResult<IReadOnlySet<long>>(new HashSet<long>());
+        public Task BroadcastToUsersAsync(IReadOnlySet<long> userIds, object message, EventDeliveryOptions options = default) =>
+            BroadcastAsync(message);
+    }
+}

--- a/tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs
+++ b/tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs
@@ -16,29 +16,56 @@ public class MappingPayloadEnvelopeTests
         "userMappingRemoved",
         "brmbleClientActivated",
         "brmbleClientDeactivated",
-        "companionChanged",
+        "companionChanged"
+    };
+
+    private static readonly string[] MappingSnapshotTypes =
+    {
         "sessionMappingSnapshot"
     };
 
     [TestMethod]
-    public void EveryMappingEventTypeIsCoveredByAnEnvelopeAssertion()
+    public void EveryMappingPayloadTypeIsCoveredByAnEnvelopeAssertion()
     {
-        // Guards against a new mapping event being added without an envelope test.
-        // Update this list and add a matching assertion in the suites listed in the plan.
-        Assert.AreEqual(6, MappingEventTypes.Length);
+        // Guards against a new mapping payload being added without an envelope test.
+        // Update these lists and add a matching assertion in the suites listed in the plan.
+        Assert.AreEqual(5, MappingEventTypes.Length);
+        Assert.AreEqual(1, MappingSnapshotTypes.Length);
     }
 
+    /// <summary>
+    /// For incremental events. An event always follows at least one successful mutation, so its
+    /// revision is necessarily above zero.
+    /// </summary>
     internal static void AssertHasEnvelope(object payload, string expectedType)
     {
-        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
-        Assert.AreEqual(expectedType, doc.RootElement.GetProperty("type").GetString());
-        Assert.IsTrue(doc.RootElement.TryGetProperty("instanceId", out var instanceId),
+        var root = AssertHasEnvelopeCore(payload, expectedType);
+        Assert.IsTrue(root.GetProperty("revision").GetInt64() > 0,
+            $"{expectedType} must carry the post-mutation revision");
+    }
+
+    /// <summary>
+    /// For snapshots, which are absolute rather than deltas. A snapshot taken from a freshly
+    /// started server that has not yet mutated legitimately carries revision 0, so this does not
+    /// require a positive value.
+    /// </summary>
+    internal static void AssertHasSnapshotEnvelope(object payload, string expectedType)
+    {
+        var root = AssertHasEnvelopeCore(payload, expectedType);
+        Assert.IsTrue(root.GetProperty("revision").GetInt64() >= 0,
+            $"{expectedType} must carry a revision");
+    }
+
+    private static JsonElement AssertHasEnvelopeCore(object payload, string expectedType)
+    {
+        var root = JsonDocument.Parse(JsonSerializer.Serialize(payload)).RootElement;
+        Assert.AreEqual(expectedType, root.GetProperty("type").GetString());
+        Assert.IsTrue(root.TryGetProperty("instanceId", out var instanceId),
             $"{expectedType} is missing instanceId");
         Assert.IsFalse(string.IsNullOrWhiteSpace(instanceId.GetString()),
             $"{expectedType} has a blank instanceId");
-        Assert.IsTrue(doc.RootElement.TryGetProperty("revision", out var revision),
+        Assert.IsTrue(root.TryGetProperty("revision", out _),
             $"{expectedType} is missing revision");
-        Assert.IsTrue(revision.GetInt64() > 0,
-            $"{expectedType} must carry the post-mutation revision");
+        return root;
     }
 }

--- a/tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs
+++ b/tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.Events;
+
+/// <summary>
+/// Every session-mapping payload must carry the envelope. A producer that forgets it makes
+/// every connected client detect a permanent gap and resync in a loop.
+/// </summary>
+[TestClass]
+public class MappingPayloadEnvelopeTests
+{
+    private static readonly string[] MappingEventTypes =
+    {
+        "userMappingAdded",
+        "userMappingRemoved",
+        "brmbleClientActivated",
+        "brmbleClientDeactivated",
+        "companionChanged",
+        "sessionMappingSnapshot"
+    };
+
+    [TestMethod]
+    public void EveryMappingEventTypeIsCoveredByAnEnvelopeAssertion()
+    {
+        // Guards against a new mapping event being added without an envelope test.
+        // Update this list and add a matching assertion in the suites listed in the plan.
+        Assert.AreEqual(6, MappingEventTypes.Length);
+    }
+
+    internal static void AssertHasEnvelope(object payload, string expectedType)
+    {
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
+        Assert.AreEqual(expectedType, doc.RootElement.GetProperty("type").GetString());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("instanceId", out var instanceId),
+            $"{expectedType} is missing instanceId");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(instanceId.GetString()),
+            $"{expectedType} has a blank instanceId");
+        Assert.IsTrue(doc.RootElement.TryGetProperty("revision", out var revision),
+            $"{expectedType} is missing revision");
+        Assert.IsTrue(revision.GetInt64() > 0,
+            $"{expectedType} must carry the post-mutation revision");
+    }
+}

--- a/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
@@ -35,10 +35,13 @@ public class SessionMappingHandlerTests
         db.Initialize();
         _repo = new UserRepository(db, Options.Create(new MatrixSettings { ServerDomain = "test.local" }));
         _mapping = new Mock<ISessionMappingService>();
+        // The publisher stamps payloads from these, so they must look like a live table.
+        _mapping.SetupGet(m => m.InstanceId).Returns("test-instance");
+        _mapping.SetupGet(m => m.Revision).Returns(7L);
         _bus = new Mock<IBrmbleEventBus>();
         _bus.Setup(b => b.BroadcastAsync(It.IsAny<object>())).Returns(Task.CompletedTask);
         _activeSessions = new Mock<IActiveBrmbleSessions>();
-        _handler = new SessionMappingHandler(_mapping.Object, _bus.Object, _repo, _activeSessions.Object, NullLogger<SessionMappingHandler>.Instance);
+        _handler = new SessionMappingHandler(_mapping.Object, new MappingEventPublisher(_mapping.Object, _bus.Object), _repo, _activeSessions.Object, NullLogger<SessionMappingHandler>.Instance);
     }
 
     [TestCleanup]
@@ -84,7 +87,7 @@ public class SessionMappingHandlerTests
         var user = await _repo.Insert("abc123", "Alice");
         var mapping = new SessionMappingService();
         _activeSessions.Setup(s => s.IsBrmbleClient("abc123")).Returns(true);
-        var handler = new SessionMappingHandler(mapping, _bus.Object, _repo, _activeSessions.Object, NullLogger<SessionMappingHandler>.Instance);
+        var handler = new SessionMappingHandler(mapping, new MappingEventPublisher(mapping, _bus.Object), _repo, _activeSessions.Object, NullLogger<SessionMappingHandler>.Instance);
 
         await handler.OnUserConnected(new MumbleUser("Alice", "abc123", 1));
 
@@ -198,6 +201,7 @@ public class SessionMappingHandlerTests
 
         Assert.AreEqual(JsonValueKind.Null,
             doc.RootElement.GetProperty("isBrmbleClient").ValueKind);
+        MappingPayloadEnvelopeTests.AssertHasEnvelope(payload, "userMappingAdded");
     }
 
     [TestMethod]

--- a/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
@@ -126,10 +126,11 @@ public class SessionMappingHandlerTests
         // No socket has registered, so the status is unknown rather than a positive false.
         _mapping.Verify(m => m.TryUpdateBrmbleStatus(1, (bool?)null), Times.Once);
         _bus.Verify(b => b.BroadcastAsync(It.Is<object>(message =>
-            message.GetType().GetProperty("type")!.GetValue(message)!.Equals("userMappingAdded") &&
-            message.GetType().GetProperty("sessionId")!.GetValue(message)!.Equals(1) &&
-            message.GetType().GetProperty("certHash")!.GetValue(message)!.Equals("abc123") &&
-            message.GetType().GetProperty("isBrmbleClient")!.GetValue(message) == null)), Times.Once);
+            JsonSerializer.Serialize(message).Contains("\"type\":\"userMappingAdded\"") &&
+            JsonSerializer.Serialize(message).Contains("\"sessionId\":1") &&
+            JsonSerializer.Serialize(message).Contains("\"certHash\":\"abc123\"") &&
+            // Unknown is an absent property, never an explicit null.
+            !JsonSerializer.Serialize(message).Contains("isBrmbleClient"))), Times.Once);
     }
 
     [TestMethod]
@@ -144,8 +145,8 @@ public class SessionMappingHandlerTests
 
         _mapping.Verify(m => m.TryUpdateBrmbleStatus(1, true), Times.Once);
         _bus.Verify(b => b.BroadcastAsync(It.Is<object>(message =>
-            message.GetType().GetProperty("type")!.GetValue(message)!.Equals("brmbleClientActivated") &&
-            message.GetType().GetProperty("sessionId")!.GetValue(message)!.Equals(1))), Times.Once);
+            JsonSerializer.Serialize(message).Contains("\"type\":\"brmbleClientActivated\"") &&
+            JsonSerializer.Serialize(message).Contains("\"sessionId\":1"))), Times.Once);
     }
 
     [TestMethod]
@@ -199,11 +200,10 @@ public class SessionMappingHandlerTests
             JsonSerializer.Serialize(p).Contains("\"type\":\"userMappingAdded\""));
         using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
 
-        Assert.AreEqual(JsonValueKind.Null,
-            doc.RootElement.GetProperty("isBrmbleClient").ValueKind);
+        Assert.IsFalse(doc.RootElement.TryGetProperty("isBrmbleClient", out _),
+            "unknown must be an absent property: an explicit null throws in the shipped client");
         MappingPayloadEnvelopeTests.AssertHasEnvelope(payload, "userMappingAdded");
     }
-
     [TestMethod]
     public async Task OnUserConnected_PublishesTrueWhenSessionIsKnownActive()
     {

--- a/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
@@ -222,4 +222,37 @@ public class SessionMappingHandlerTests
 
         Assert.IsTrue(doc.RootElement.GetProperty("isBrmbleClient").GetBoolean());
     }
+
+    [TestMethod]
+    public async Task OnUserConnected_ConcurrentRegistrations_NeverReuseARevision()
+    {
+        // Mutating outside the publisher's lock and reading .Revision afterwards lets two
+        // threads observe the same value, so two payloads claim one revision and a client
+        // discards the second as a duplicate. Simultaneous registration is spec §8.
+        const int users = 40;
+        var mappings = new SessionMappingService();
+        var broadcasts = new List<object>();
+        var bus = new Mock<IBrmbleEventBus>();
+        bus.Setup(b => b.BroadcastAsync(It.IsAny<object>()))
+            .Callback<object>(m => { lock (broadcasts) broadcasts.Add(m); })
+            .Returns(Task.CompletedTask);
+        var handler = new SessionMappingHandler(
+            mappings, new MappingEventPublisher(mappings, bus.Object), _repo,
+            _activeSessions.Object, NullLogger<SessionMappingHandler>.Instance);
+
+        for (var i = 0; i < users; i++)
+            await _repo.Insert($"cert-{i}", $"User{i}");
+
+        await Task.WhenAll(Enumerable.Range(0, users).Select(i =>
+            Task.Run(() => handler.OnUserConnected(new MumbleUser($"User{i}", $"cert-{i}", i + 1)))));
+
+        var revisions = broadcasts
+            .Select(p => JsonDocument.Parse(JsonSerializer.Serialize(p))
+                .RootElement.GetProperty("revision").GetInt64())
+            .ToList();
+
+        Assert.AreEqual(users, revisions.Count);
+        CollectionAssert.AllItemsAreUnique(revisions,
+            "two payloads claiming one revision means a client silently drops one");
+    }
 }

--- a/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs
@@ -114,18 +114,19 @@ public class SessionMappingHandlerTests
     {
         var user = await _repo.Insert("abc123", "Alice");
         _mapping.Setup(m => m.TryAddMatrixUser(1, user.MatrixUserId, "Alice", user.Id, "floppy")).Returns(false);
-        _mapping.Setup(m => m.TryUpdateBrmbleStatus(1, false)).Returns(true);
+        _mapping.Setup(m => m.TryUpdateBrmbleStatus(1, (bool?)null)).Returns(true);
         _mapping.Setup(m => m.TryUpdateCertHash(1, "abc123")).Returns(true);
 
         await _handler.OnUserConnected(new MumbleUser("Alice", "abc123", 1));
 
         _mapping.Verify(m => m.TryAddMatrixUser(1, user.MatrixUserId, "Alice", user.Id, "floppy"), Times.Once);
-        _mapping.Verify(m => m.TryUpdateBrmbleStatus(1, false), Times.Once);
+        // No socket has registered, so the status is unknown rather than a positive false.
+        _mapping.Verify(m => m.TryUpdateBrmbleStatus(1, (bool?)null), Times.Once);
         _bus.Verify(b => b.BroadcastAsync(It.Is<object>(message =>
             message.GetType().GetProperty("type")!.GetValue(message)!.Equals("userMappingAdded") &&
             message.GetType().GetProperty("sessionId")!.GetValue(message)!.Equals(1) &&
             message.GetType().GetProperty("certHash")!.GetValue(message)!.Equals("abc123") &&
-            message.GetType().GetProperty("isBrmbleClient")!.GetValue(message)!.Equals(false))), Times.Once);
+            message.GetType().GetProperty("isBrmbleClient")!.GetValue(message) == null)), Times.Once);
     }
 
     [TestMethod]
@@ -176,5 +177,45 @@ public class SessionMappingHandlerTests
         _bus.Verify(b => b.BroadcastAsync(It.Is<object>(payload =>
             JsonSerializer.Serialize(payload).Contains("\"companionId\":\"floppy\"") &&
             JsonSerializer.Serialize(payload).Contains("\"customCompanionId\":\"custom:$sprite:test\""))), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task OnUserConnected_PublishesUnknownBrmbleStatusWhenNoActiveSession()
+    {
+        // No WebSocket has registered for this cert, so IActiveBrmbleSessions returns false.
+        // That is absence of evidence, not evidence of absence: it must go out as null.
+        await _repo.Insert("cert-alice", "Alice");
+        var broadcasts = new List<object>();
+        _bus.Setup(b => b.BroadcastAsync(It.IsAny<object>()))
+            .Callback<object>(broadcasts.Add)
+            .Returns(Task.CompletedTask);
+
+        await _handler.OnUserConnected(new MumbleUser("Alice", "cert-alice", 42));
+
+        var payload = broadcasts.Single(p =>
+            JsonSerializer.Serialize(p).Contains("\"type\":\"userMappingAdded\""));
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
+
+        Assert.AreEqual(JsonValueKind.Null,
+            doc.RootElement.GetProperty("isBrmbleClient").ValueKind);
+    }
+
+    [TestMethod]
+    public async Task OnUserConnected_PublishesTrueWhenSessionIsKnownActive()
+    {
+        await _repo.Insert("cert-alice", "Alice");
+        _activeSessions.Setup(s => s.IsBrmbleClient("cert-alice")).Returns(true);
+        var broadcasts = new List<object>();
+        _bus.Setup(b => b.BroadcastAsync(It.IsAny<object>()))
+            .Callback<object>(broadcasts.Add)
+            .Returns(Task.CompletedTask);
+
+        await _handler.OnUserConnected(new MumbleUser("Alice", "cert-alice", 42));
+
+        var payload = broadcasts.Single(p =>
+            JsonSerializer.Serialize(p).Contains("\"type\":\"userMappingAdded\""));
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
+
+        Assert.IsTrue(doc.RootElement.GetProperty("isBrmbleClient").GetBoolean());
     }
 }

--- a/tests/Brmble.Server.Tests/Events/SessionMappingServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingServiceTests.cs
@@ -99,11 +99,14 @@ public class SessionMappingServiceTests
     [TestMethod]
     public void TryAddMatrixUser_ExistingSession_RefreshesUserIdIndex()
     {
+        // Re-adding a mapping the same user already owns is a no-op that still leaves the index
+        // pointing at it. The cross-user case is deliberately *not* refreshed — see
+        // TryAddMatrixUser_FailedAdd_DoesNotRepointTheIndexAtAnotherUsersSession.
         Assert.IsTrue(_svc.TryAddMatrixUser(1, "@old:server", "Alice", 10L, "bee"));
 
-        Assert.IsFalse(_svc.TryAddMatrixUser(1, "@new:server", "Alice", 42L, "bee"));
+        Assert.IsFalse(_svc.TryAddMatrixUser(1, "@new:server", "Alice", 10L, "bee"));
 
-        Assert.IsTrue(_svc.TryGetSessionByUserId(42L, out var sessionId));
+        Assert.IsTrue(_svc.TryGetSessionByUserId(10L, out var sessionId));
         Assert.AreEqual(1, sessionId);
     }
 
@@ -265,5 +268,66 @@ public class SessionMappingServiceTests
 
         // 200 adds + 200 updates, none of them lost to a read-modify-write race.
         Assert.AreEqual(400L, _svc.Revision);
+    }
+
+    [TestMethod]
+    public void TryAddMatrixUser_FailedAdd_DoesNotRepointTheIndexAtAnotherUsersSession()
+    {
+        // Session 1 belongs to Alice. Bob authenticating against a recycled session id must not
+        // leave his userId pointing at her mapping - every later by-user lookup would resolve to
+        // her session and mutate her projection.
+        _svc.TryAddMatrixUser(1, "@alice:server", "Alice", 100L, "bee");
+
+        var added = _svc.TryAddMatrixUser(1, "@bob:server", "Bob", 200L, "retro");
+
+        Assert.IsFalse(added);
+        Assert.IsFalse(_svc.TryGetSessionByUserId(200L, out _),
+            "a failed add must not create an index entry pointing at somebody else's session");
+        Assert.IsTrue(_svc.TryGetSessionByUserId(100L, out var aliceSession));
+        Assert.AreEqual(1, aliceSession);
+    }
+
+    [TestMethod]
+    public void TryClaimBrmbleSession_SetsBothFieldsAtomicallyAndReturnsThePostState()
+    {
+        _svc.TryAddMatrixUser(1, "@alice:server", "Alice", 100L, "bee");
+        var before = _svc.Revision;
+
+        var claimed = _svc.TryClaimBrmbleSession(1, 100L, "cert-alice", out var mapping);
+
+        Assert.IsTrue(claimed);
+        Assert.IsNotNull(mapping);
+        Assert.AreEqual(true, mapping!.IsBrmbleClient);
+        Assert.AreEqual("cert-alice", mapping.CertHash);
+        Assert.AreEqual("bee", mapping.CompanionId, "the claim must not disturb other fields");
+        Assert.AreEqual(before + 1, _svc.Revision, "one logical claim is one bump");
+    }
+
+    [TestMethod]
+    public void TryClaimBrmbleSession_RefusesASessionOwnedBySomebodyElseAndMutatesNothing()
+    {
+        // The blocker: writing Bob's certificate and Brmble status into Alice's mapping, then
+        // suppressing the announcement because the ownership check failed afterwards.
+        _svc.TryAddMatrixUser(1, "@alice:server", "Alice", 100L, "bee");
+        var before = _svc.Revision;
+
+        var claimed = _svc.TryClaimBrmbleSession(1, 200L, "cert-bob", out var mapping);
+
+        Assert.IsFalse(claimed);
+        Assert.IsNull(mapping);
+        var alice = _svc.GetSnapshot()[1];
+        Assert.IsNull(alice.IsBrmbleClient, "another user's status must not be written");
+        Assert.IsNull(alice.CertHash, "another user's certificate must not be written");
+        Assert.AreEqual(before, _svc.Revision, "a refused claim must not bump the revision");
+    }
+
+    [TestMethod]
+    public void TryClaimBrmbleSession_RefusesAnUnknownSession()
+    {
+        var before = _svc.Revision;
+
+        Assert.IsFalse(_svc.TryClaimBrmbleSession(99, 100L, "cert", out var mapping));
+        Assert.IsNull(mapping);
+        Assert.AreEqual(before, _svc.Revision);
     }
 }

--- a/tests/Brmble.Server.Tests/Events/SessionMappingServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingServiceTests.cs
@@ -195,4 +195,75 @@ public class SessionMappingServiceTests
         Assert.IsTrue(updated);
         Assert.AreEqual("cert-alice", _svc.GetSnapshot()[42].CertHash);
     }
+
+    [TestMethod]
+    public void Revision_StartsAtZeroAndIncrementsOnEverySuccessfulMutation()
+    {
+        Assert.AreEqual(0L, _svc.Revision);
+
+        _svc.TryAddMatrixUser(1, "@1:server", "Alice", 1L, "bee");
+        Assert.AreEqual(1L, _svc.Revision);
+
+        _svc.TryUpdateCompanionId(1, "retro");
+        Assert.AreEqual(2L, _svc.Revision);
+
+        _svc.TryUpdateBrmbleStatus(1, true);
+        Assert.AreEqual(3L, _svc.Revision);
+
+        _svc.TryUpdateCertHash(1, "abc");
+        Assert.AreEqual(4L, _svc.Revision);
+
+        _svc.TryUpdateCompanionIdIfOwnedBy(1, 1L, "pip");
+        Assert.AreEqual(5L, _svc.Revision);
+
+        _svc.RemoveSession(1);
+        Assert.AreEqual(6L, _svc.Revision);
+    }
+
+    [TestMethod]
+    public void Revision_DoesNotIncrementWhenMutationDoesNotApply()
+    {
+        _svc.TryAddMatrixUser(1, "@1:server", "Alice", 1L, "bee");
+        var before = _svc.Revision;
+
+        // Session 99 has no mapping, so none of these change anything.
+        Assert.IsFalse(_svc.TryUpdateCompanionId(99, "retro"));
+        Assert.IsFalse(_svc.TryUpdateBrmbleStatus(99, true));
+        Assert.IsFalse(_svc.TryUpdateCertHash(99, "abc"));
+        _svc.RemoveSession(99);
+
+        // A CAS whose expected value does not match must not bump either.
+        Assert.IsFalse(_svc.TryUpdateCompanionIdIfCurrent(1, "notthecurrentone", "pip"));
+
+        // Nor one whose owning userId does not match.
+        Assert.IsFalse(_svc.TryUpdateCompanionIdIfOwnedBy(1, 999L, "pip"));
+
+        Assert.AreEqual(before, _svc.Revision);
+    }
+
+    [TestMethod]
+    public void InstanceId_IsStableWithinAnInstanceAndDiffersAcrossInstances()
+    {
+        var first = _svc.InstanceId;
+
+        _svc.TryAddMatrixUser(1, "@1:server", "Alice", 1L, "bee");
+        Assert.AreEqual(first, _svc.InstanceId, "InstanceId must not change while the process lives");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(first));
+
+        var replacement = new SessionMappingService();
+        Assert.AreNotEqual(first, replacement.InstanceId, "a restart must be observable");
+        Assert.AreEqual(0L, replacement.Revision);
+    }
+
+    [TestMethod]
+    public void Revision_IsMonotonicUnderConcurrentMutations()
+    {
+        for (var i = 0; i < 200; i++)
+            _svc.TryAddMatrixUser(i, $"@{i}:server", $"U{i}", i, "bee");
+
+        Parallel.For(0, 200, i => _svc.TryUpdateCompanionId(i, "retro"));
+
+        // 200 adds + 200 updates, none of them lost to a read-modify-write race.
+        Assert.AreEqual(400L, _svc.Revision);
+    }
 }

--- a/tests/Brmble.Server.Tests/Events/SessionMappingServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Events/SessionMappingServiceTests.cs
@@ -156,6 +156,36 @@ public class SessionMappingServiceTests
     }
 
     [TestMethod]
+    public void TryUpdateCompanionIdIfOwnedBy_UpdatesWhenSessionStillOwnedByUser()
+    {
+        _svc.TryAddMatrixUser(42, "@alice:test", "Alice", 100L, "bee");
+
+        var updated = _svc.TryUpdateCompanionIdIfOwnedBy(42, 100L, "floppy");
+
+        Assert.IsTrue(updated);
+        Assert.AreEqual("floppy", _svc.GetSnapshot()[42].CompanionId);
+    }
+
+    [TestMethod]
+    public void TryUpdateCompanionIdIfOwnedBy_RejectsRecycledSession()
+    {
+        // Session 42 was released by user 100 and reclaimed by user 200 — a write carrying
+        // the old owner's userId must not land on the new owner's mapping.
+        _svc.TryAddMatrixUser(42, "@bob:test", "Bob", 200L, "bee");
+
+        var updated = _svc.TryUpdateCompanionIdIfOwnedBy(42, 100L, "floppy");
+
+        Assert.IsFalse(updated);
+        Assert.AreEqual("bee", _svc.GetSnapshot()[42].CompanionId);
+    }
+
+    [TestMethod]
+    public void TryUpdateCompanionIdIfOwnedBy_ReturnsFalseWhenMappingIsMissing()
+    {
+        Assert.IsFalse(_svc.TryUpdateCompanionIdIfOwnedBy(42, 100L, "floppy"));
+    }
+
+    [TestMethod]
     public void TryUpdateCertHash_UpdatesExistingMapping()
     {
         _svc.TryAddMatrixUser(42, "@alice:test", "Alice", 100L, "bee");

--- a/tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs
+++ b/tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs
@@ -28,7 +28,7 @@ file sealed class FakeSessionMapping : ISessionMappingService
     public bool TryUpdateCompanionId(int sessionId, string companionId) => throw new NotImplementedException();
     public bool TryUpdateCompanionIdIfCurrent(int sessionId, string expectedCompanionId, string companionId) => throw new NotImplementedException();
     public bool TryUpdateCompanionIdIfOwnedBy(int sessionId, long userId, string companionId) => throw new NotImplementedException();
-    public bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient) => throw new NotImplementedException();
+    public bool TryUpdateBrmbleStatus(int sessionId, bool? isBrmbleClient) => throw new NotImplementedException();
     public bool TryUpdateCertHash(int sessionId, string certHash) => throw new NotImplementedException();
 }
 

--- a/tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs
+++ b/tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs
@@ -29,6 +29,7 @@ file sealed class FakeSessionMapping : ISessionMappingService
     public bool TryUpdateCompanionIdIfCurrent(int sessionId, string expectedCompanionId, string companionId) => throw new NotImplementedException();
     public bool TryUpdateCompanionIdIfOwnedBy(int sessionId, long userId, string companionId) => throw new NotImplementedException();
     public bool TryUpdateBrmbleStatus(int sessionId, bool? isBrmbleClient) => throw new NotImplementedException();
+    public bool TryClaimBrmbleSession(int sessionId, long userId, string certHash, out SessionMapping? mapping) => throw new NotImplementedException();
     public bool TryUpdateCertHash(int sessionId, string certHash) => throw new NotImplementedException();
 }
 

--- a/tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs
+++ b/tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs
@@ -15,6 +15,9 @@ file sealed class FakeSessionMapping : ISessionMappingService
     public FakeSessionMapping(Dictionary<int, SessionMapping> snapshot) => _snapshot = snapshot;
     public IReadOnlyDictionary<int, SessionMapping> GetSnapshot() => _snapshot;
 
+    public string InstanceId => "test";
+    public long Revision => 0;
+
     public void SetNameForSession(string name, int sessionId) => throw new NotImplementedException();
     public bool TryAddMatrixUser(int sessionId, string matrixUserId, string mumbleName, long userId, string companionId) => throw new NotImplementedException();
     public void RemoveSession(int sessionId) => throw new NotImplementedException();

--- a/tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs
+++ b/tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs
@@ -24,6 +24,7 @@ file sealed class FakeSessionMapping : ISessionMappingService
     public bool TryGetMappingByUserId(long userId, out int sessionId, out SessionMapping? mapping) => throw new NotImplementedException();
     public bool TryUpdateCompanionId(int sessionId, string companionId) => throw new NotImplementedException();
     public bool TryUpdateCompanionIdIfCurrent(int sessionId, string expectedCompanionId, string companionId) => throw new NotImplementedException();
+    public bool TryUpdateCompanionIdIfOwnedBy(int sessionId, long userId, string companionId) => throw new NotImplementedException();
     public bool TryUpdateBrmbleStatus(int sessionId, bool isBrmbleClient) => throw new NotImplementedException();
     public bool TryUpdateCertHash(int sessionId, string certHash) => throw new NotImplementedException();
 }

--- a/tests/Brmble.Server.Tests/Integration/AuthTokenTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/AuthTokenTests.cs
@@ -185,6 +185,63 @@ public class AuthTokenTests : IDisposable
     }
 
     [TestMethod]
+    public async Task PostAuthToken_StampsResponseWithEnvelope()
+    {
+        using var factory = new BrmbleServerFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsync("/auth/token", null);
+        response.EnsureSuccessStatusCode();
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.IsTrue(doc.RootElement.TryGetProperty("instanceId", out var instanceId),
+            "/auth/token is the bootstrap snapshot transport and must be orderable");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(instanceId.GetString()));
+        Assert.IsTrue(doc.RootElement.TryGetProperty("revision", out _));
+    }
+
+    [TestMethod]
+    public async Task PostAuthToken_NewMappingBroadcastsStampedUserMappingAdded()
+    {
+        // The endpoint bumps the revision three times (add, certHash, brmbleStatus) before
+        // announcing. An unstamped announcement makes all three bumps silent.
+        using var factory = new RecordingBusFactory();
+        using var client = factory.CreateClient();
+        factory.Services.GetRequiredService<ISessionMappingService>()
+            .SetNameForSession("Alice", 1);
+
+        var body = new StringContent(
+            JsonSerializer.Serialize(new { mumbleUsername = "Alice" }),
+            Encoding.UTF8, "application/json");
+        (await client.PostAsync("/auth/token", body)).EnsureSuccessStatusCode();
+
+        var payload = factory.Broadcasts
+            .Single(p => JsonSerializer.Serialize(p).Contains("\"type\":\"userMappingAdded\""));
+        Events.MappingPayloadEnvelopeTests.AssertHasEnvelope(payload, "userMappingAdded");
+    }
+
+    /// <summary>Swaps the real event bus for one that records broadcasts.</summary>
+    private sealed class RecordingBusFactory : BrmbleServerFactory
+    {
+        public List<object> Broadcasts { get; } = new();
+
+        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+            builder.ConfigureServices(services =>
+            {
+                var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IBrmbleEventBus));
+                if (existing is not null) services.Remove(existing);
+                var bus = new Moq.Mock<IBrmbleEventBus>();
+                bus.Setup(b => b.BroadcastAsync(Moq.It.IsAny<object>()))
+                    .Callback<object>(m => { lock (Broadcasts) Broadcasts.Add(m); })
+                    .Returns(Task.CompletedTask);
+                services.AddSingleton(bus.Object);
+            });
+        }
+    }
+
+    [TestMethod]
     public async Task PostAuthToken_IncludesPasswordProtectedChannelIdsWithoutTokenPlaintext()
     {
         var snapshots = _factory.Services.GetRequiredService<IAclSnapshotRepository>();

--- a/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
+++ b/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
@@ -55,6 +55,9 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
             .Setup(service => service.CreateChannelAsync(It.IsAny<string>()))
             .ReturnsAsync((string name) => new CreatedMumbleChannel(42, name));
         var defaultSessionMapping = new SessionMappingService();
+        // Delegate the envelope source too, so payloads carry a real monotonic revision.
+        SessionMappingMock.SetupGet(s => s.InstanceId).Returns(() => defaultSessionMapping.InstanceId);
+        SessionMappingMock.SetupGet(s => s.Revision).Returns(() => defaultSessionMapping.Revision);
         SessionMappingMock.Setup(s => s.SetNameForSession(It.IsAny<string>(), It.IsAny<int>()))
             .Callback<string, int>(defaultSessionMapping.SetNameForSession);
         SessionMappingMock.Setup(s => s.RemoveSession(It.IsAny<int>()))
@@ -62,8 +65,8 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
         SessionMappingMock.Setup(s => s.TryAddMatrixUser(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<string>()))
             .Returns((int sessionId, string matrixUserId, string mumbleName, long userId, string companionId) =>
                 defaultSessionMapping.TryAddMatrixUser(sessionId, matrixUserId, mumbleName, userId, companionId));
-        SessionMappingMock.Setup(s => s.TryUpdateBrmbleStatus(It.IsAny<int>(), It.IsAny<bool>()))
-            .Returns((int sessionId, bool isBrmbleClient) => defaultSessionMapping.TryUpdateBrmbleStatus(sessionId, isBrmbleClient));
+        SessionMappingMock.Setup(s => s.TryUpdateBrmbleStatus(It.IsAny<int>(), It.IsAny<bool?>()))
+            .Returns((int sessionId, bool? isBrmbleClient) => defaultSessionMapping.TryUpdateBrmbleStatus(sessionId, isBrmbleClient));
         SessionMappingMock.Setup(s => s.TryUpdateCompanionId(It.IsAny<int>(), It.IsAny<string>()))
             .Returns((int sessionId, string companionId) => defaultSessionMapping.TryUpdateCompanionId(sessionId, companionId));
         SessionMappingMock.Setup(s => s.TryUpdateCompanionIdIfCurrent(

--- a/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
+++ b/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
@@ -67,6 +67,10 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
                 defaultSessionMapping.TryAddMatrixUser(sessionId, matrixUserId, mumbleName, userId, companionId));
         SessionMappingMock.Setup(s => s.TryUpdateBrmbleStatus(It.IsAny<int>(), It.IsAny<bool?>()))
             .Returns((int sessionId, bool? isBrmbleClient) => defaultSessionMapping.TryUpdateBrmbleStatus(sessionId, isBrmbleClient));
+        SessionMappingMock.Setup(s => s.TryClaimBrmbleSession(
+                It.IsAny<int>(), It.IsAny<long>(), It.IsAny<string>(), out It.Ref<SessionMapping?>.IsAny))
+            .Returns((int sessionId, long userId, string certHash, out SessionMapping? mapping) =>
+                defaultSessionMapping.TryClaimBrmbleSession(sessionId, userId, certHash, out mapping));
         SessionMappingMock.Setup(s => s.TryUpdateCompanionId(It.IsAny<int>(), It.IsAny<string>()))
             .Returns((int sessionId, string companionId) => defaultSessionMapping.TryUpdateCompanionId(sessionId, companionId));
         SessionMappingMock.Setup(s => s.TryUpdateCompanionIdIfCurrent(

--- a/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
+++ b/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
@@ -70,6 +70,10 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
                 It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>()))
             .Returns((int sessionId, string expectedCompanionId, string companionId) =>
                 defaultSessionMapping.TryUpdateCompanionIdIfCurrent(sessionId, expectedCompanionId, companionId));
+        SessionMappingMock.Setup(s => s.TryUpdateCompanionIdIfOwnedBy(
+                It.IsAny<int>(), It.IsAny<long>(), It.IsAny<string>()))
+            .Returns((int sessionId, long userId, string companionId) =>
+                defaultSessionMapping.TryUpdateCompanionIdIfOwnedBy(sessionId, userId, companionId));
         SessionMappingMock.Setup(s => s.TryUpdateCertHash(It.IsAny<int>(), It.IsAny<string>()))
             .Returns((int sessionId, string certHash) => defaultSessionMapping.TryUpdateCertHash(sessionId, certHash));
         SessionMappingMock.Setup(s => s.TryGetSessionId(It.IsAny<string>(), out It.Ref<int>.IsAny))

--- a/tests/Brmble.Server.Tests/Mumble/MumbleIceServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleIceServiceTests.cs
@@ -30,6 +30,7 @@ public class MumbleIceServiceTests
             Enumerable.Empty<IMumbleEventHandler>(),
             new Mock<ISessionMappingService>().Object,
             new Mock<IBrmbleEventBus>().Object,
+            new Mock<IMappingEventPublisher>().Object,
             new Mock<IChannelMembershipService>().Object,
             new ScreenShareTracker(),
             revocationScheduler,

--- a/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
@@ -53,10 +53,12 @@ public class MumbleServerCallbackTests
             NullLogger<LiveKitParticipantRevocationScheduler>.Instance,
             liveKitRevocationRetryDelays ?? []);
 
+        var effectiveBus = bus ?? new Mock<IBrmbleEventBus>().Object;
         return new MumbleServerCallback(
             handlers,
             mapping,
-            bus ?? new Mock<IBrmbleEventBus>().Object,
+            effectiveBus,
+            new MappingEventPublisher(mapping, effectiveBus),
             channelMembership ?? new Mock<IChannelMembershipService>().Object,
             screenShareTracker ?? new ScreenShareTracker(),
             revocationScheduler,

--- a/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
@@ -173,6 +173,10 @@ public class BrmbleWebSocketHandlerTests
         mappings.Setup(x => x.TryGetSessionByUserId(42, out It.Ref<int>.IsAny))
             .Returns((long _, out int sessionId) => { sessionId = 7; return true; });
         mappings.Setup(x => x.GetSnapshot()).Returns(new Dictionary<int, SessionMapping> { [7] = mapping });
+        // Registration only announces when a mutation actually reported a change, so these must
+        // return true or no userMappingAdded is broadcast and this test waits forever.
+        mappings.Setup(x => x.TryUpdateBrmbleStatus(7, It.IsAny<bool?>())).Returns(true);
+        mappings.Setup(x => x.TryUpdateCertHash(7, It.IsAny<string>())).Returns(true);
         var realBus = CreateBus(mappings.Object);
         var bus = new BlockingMappingBroadcastBus(realBus);
         var snapshots = new Mock<IDuelSnapshotProvider>();
@@ -285,6 +289,118 @@ public class BrmbleWebSocketHandlerTests
     }
 
     [TestMethod]
+    public async Task InitializeAcceptedClientAsync_DoesNotAnnounceWhenTheMappingVanishedBeforeTheLock()
+    {
+        // The mapping is read outside the publisher's lock. If it is removed before the lock is
+        // taken, both mutations fail and no revision is produced — announcing anyway would emit
+        // a userMappingAdded for a mapping that no longer exists, stamped with a revision that
+        // another payload already owns.
+        var mapping = new SessionMapping("@alice:test", "Alice", 42, "bee");
+        var mappings = new Mock<ISessionMappingService>();
+        mappings.SetupGet(x => x.InstanceId).Returns("inst");
+        mappings.SetupGet(x => x.Revision).Returns(5L);
+        mappings.Setup(x => x.TryGetMappingByUserId(42, out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
+            .Returns((long _, out int sessionId, out SessionMapping? value) =>
+            {
+                sessionId = 7;
+                value = mapping;
+                return true;
+            });
+        // No duel queue session: keeps this test off the duel snapshot path entirely.
+        mappings.Setup(x => x.TryGetSessionByUserId(42, out It.Ref<int>.IsAny))
+            .Returns((long _, out int sessionId) => { sessionId = 0; return false; });
+        mappings.Setup(x => x.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>());
+        // The session is gone: every mutation reports no change.
+        mappings.Setup(x => x.TryUpdateBrmbleStatus(7, It.IsAny<bool?>())).Returns(false);
+        mappings.Setup(x => x.TryUpdateCertHash(7, It.IsAny<string>())).Returns(false);
+
+        var broadcasts = new List<object>();
+        var bus = new Mock<IBrmbleEventBus>();
+        bus.Setup(b => b.BroadcastExceptAsync(It.IsAny<WebSocket>(), It.IsAny<object>()))
+            .Callback((WebSocket _, object m) => { lock (broadcasts) broadcasts.Add(m); })
+            .Returns(Task.CompletedTask);
+        bus.Setup(b => b.AddClientAsync(It.IsAny<WebSocket>(), It.IsAny<long>(),
+                It.IsAny<Func<Task<IReadOnlyList<object>>>>()))
+            .Returns((WebSocket _, long _, Func<Task<IReadOnlyList<object>>>? build) => build!());
+
+        var socket = new Mock<WebSocket>();
+        socket.Setup(x => x.State).Returns(WebSocketState.Open);
+
+        await BrmbleWebSocketHandler.InitializeAcceptedClientAsync(
+            socket.Object, 42, "cert", mappings.Object, bus.Object,
+            new MappingEventPublisher(mappings.Object, bus.Object),
+            Mock.Of<IActiveBrmbleSessions>(), new Mock<IDuelSnapshotProvider>().Object);
+
+        Assert.AreEqual(0, broadcasts.Count,
+            "a mutation that changed nothing must not produce an announcement");
+    }
+
+    [TestMethod]
+    public async Task InitializeAcceptedClientAsync_AnnouncesThePostMutationMappingNotTheCapturedOne()
+    {
+        // A companionChanged landing between the read and the lock must not be undone. If the
+        // payload carried the captured companionId under this operation's newer revision, every
+        // client would overwrite the newer value with the stale one.
+        var captured = new SessionMapping("@alice:test", "Alice", 42, "bee");
+        var current = new SessionMapping("@alice:test", "Alice", 42, "retro");
+        var mappings = new Mock<ISessionMappingService>();
+        mappings.SetupGet(x => x.InstanceId).Returns("inst");
+        mappings.SetupGet(x => x.Revision).Returns(9L);
+        var reads = 0;
+        mappings.Setup(x => x.TryGetMappingByUserId(42, out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
+            .Returns((long _, out int sessionId, out SessionMapping? value) =>
+            {
+                sessionId = 7;
+                // First read is the one outside the lock; the second is the re-read inside it,
+                // by which point a concurrent companionChanged has landed.
+                value = Interlocked.Increment(ref reads) == 1 ? captured : current;
+                return true;
+            });
+        // No duel queue session: keeps this test off the duel snapshot path entirely.
+        mappings.Setup(x => x.TryGetSessionByUserId(42, out It.Ref<int>.IsAny))
+            .Returns((long _, out int sessionId) => { sessionId = 0; return false; });
+        mappings.Setup(x => x.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>());
+        mappings.Setup(x => x.TryUpdateBrmbleStatus(7, It.IsAny<bool?>())).Returns(true);
+        mappings.Setup(x => x.TryUpdateCertHash(7, It.IsAny<string>())).Returns(true);
+
+        var broadcasts = new List<object>();
+        var bus = new Mock<IBrmbleEventBus>();
+        bus.Setup(b => b.BroadcastExceptAsync(It.IsAny<WebSocket>(), It.IsAny<object>()))
+            .Callback((WebSocket _, object m) => { lock (broadcasts) broadcasts.Add(m); })
+            .Returns(Task.CompletedTask);
+        bus.Setup(b => b.AddClientAsync(It.IsAny<WebSocket>(), It.IsAny<long>(),
+                It.IsAny<Func<Task<IReadOnlyList<object>>>>()))
+            .Returns((WebSocket _, long _, Func<Task<IReadOnlyList<object>>>? build) => build!());
+
+        var socket = new Mock<WebSocket>();
+        socket.Setup(x => x.State).Returns(WebSocketState.Open);
+
+        await BrmbleWebSocketHandler.InitializeAcceptedClientAsync(
+            socket.Object, 42, "cert", mappings.Object, bus.Object,
+            new MappingEventPublisher(mappings.Object, bus.Object),
+            Mock.Of<IActiveBrmbleSessions>(), new Mock<IDuelSnapshotProvider>().Object);
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(broadcasts.Single()));
+        Assert.AreEqual("retro", doc.RootElement.GetProperty("companionId").GetString());
+    }
+
+    [TestMethod]
+    public async Task BuildInitialPayloadsAsync_SnapshotFromAFreshServerCarriesRevisionZero()
+    {
+        // A server that has not yet mutated anything is at revision 0, and its snapshot says so.
+        // Envelope assertions for snapshots must not require a positive revision.
+        var mappings = new SessionMappingService();
+
+        var payloads = await BrmbleWebSocketHandler.BuildInitialPayloadsAsync(
+            new Mock<IDuelSnapshotProvider>().Object, 0, mappings.GetSnapshot(),
+            new MappingEnvelope(mappings.InstanceId, mappings.Revision));
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payloads[0]));
+        Assert.AreEqual(0L, doc.RootElement.GetProperty("revision").GetInt64());
+        Events.MappingPayloadEnvelopeTests.AssertHasSnapshotEnvelope(payloads[0], "sessionMappingSnapshot");
+    }
+
+    [TestMethod]
     public void CreateUserMappingAddedPayload_AssertsTrueBecauseASocketHasRegistered()
     {
         // This path runs only from InitializeAcceptedClientAsync, where registration itself
@@ -297,4 +413,6 @@ public class BrmbleWebSocketHandlerTests
         Assert.IsTrue(doc.RootElement.GetProperty("isBrmbleClient").GetBoolean());
     }
 }
+
+
 

--- a/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
@@ -173,10 +173,10 @@ public class BrmbleWebSocketHandlerTests
         mappings.Setup(x => x.TryGetSessionByUserId(42, out It.Ref<int>.IsAny))
             .Returns((long _, out int sessionId) => { sessionId = 7; return true; });
         mappings.Setup(x => x.GetSnapshot()).Returns(new Dictionary<int, SessionMapping> { [7] = mapping });
-        // Registration only announces when a mutation actually reported a change, so these must
-        // return true or no userMappingAdded is broadcast and this test waits forever.
-        mappings.Setup(x => x.TryUpdateBrmbleStatus(7, It.IsAny<bool?>())).Returns(true);
-        mappings.Setup(x => x.TryUpdateCertHash(7, It.IsAny<string>())).Returns(true);
+        // Registration announces only when the ownership-constrained claim succeeds, so this
+        // must be stubbed or no userMappingAdded is broadcast and this test waits forever.
+        mappings.Setup(x => x.TryClaimBrmbleSession(7, 42, It.IsAny<string>(), out It.Ref<SessionMapping?>.IsAny))
+            .Returns((int _, long _, string _, out SessionMapping? m) => { m = mapping; return true; });
         var realBus = CreateBus(mappings.Object);
         var bus = new BlockingMappingBroadcastBus(realBus);
         var snapshots = new Mock<IDuelSnapshotProvider>();
@@ -310,9 +310,10 @@ public class BrmbleWebSocketHandlerTests
         mappings.Setup(x => x.TryGetSessionByUserId(42, out It.Ref<int>.IsAny))
             .Returns((long _, out int sessionId) => { sessionId = 0; return false; });
         mappings.Setup(x => x.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>());
-        // The session is gone: every mutation reports no change.
-        mappings.Setup(x => x.TryUpdateBrmbleStatus(7, It.IsAny<bool?>())).Returns(false);
-        mappings.Setup(x => x.TryUpdateCertHash(7, It.IsAny<string>())).Returns(false);
+        // The session was recycled or removed, so the ownership-constrained claim refuses it and
+        // must leave the mapping table untouched rather than half-writing then suppressing.
+        mappings.Setup(x => x.TryClaimBrmbleSession(7, 42, It.IsAny<string>(), out It.Ref<SessionMapping?>.IsAny))
+            .Returns((int _, long _, string _, out SessionMapping? m) => { m = null; return false; });
 
         var broadcasts = new List<object>();
         var bus = new Mock<IBrmbleEventBus>();
@@ -340,28 +341,26 @@ public class BrmbleWebSocketHandlerTests
     {
         // A companionChanged landing between the read and the lock must not be undone. If the
         // payload carried the captured companionId under this operation's newer revision, every
-        // client would overwrite the newer value with the stale one.
+        // client would overwrite the newer value with the stale one. The claim returns the
+        // post-mutation mapping precisely so the payload cannot use the captured one.
         var captured = new SessionMapping("@alice:test", "Alice", 42, "bee");
         var current = new SessionMapping("@alice:test", "Alice", 42, "retro");
         var mappings = new Mock<ISessionMappingService>();
         mappings.SetupGet(x => x.InstanceId).Returns("inst");
         mappings.SetupGet(x => x.Revision).Returns(9L);
-        var reads = 0;
         mappings.Setup(x => x.TryGetMappingByUserId(42, out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
             .Returns((long _, out int sessionId, out SessionMapping? value) =>
             {
                 sessionId = 7;
-                // First read is the one outside the lock; the second is the re-read inside it,
-                // by which point a concurrent companionChanged has landed.
-                value = Interlocked.Increment(ref reads) == 1 ? captured : current;
+                value = captured;
                 return true;
             });
         // No duel queue session: keeps this test off the duel snapshot path entirely.
         mappings.Setup(x => x.TryGetSessionByUserId(42, out It.Ref<int>.IsAny))
             .Returns((long _, out int sessionId) => { sessionId = 0; return false; });
         mappings.Setup(x => x.GetSnapshot()).Returns(new Dictionary<int, SessionMapping>());
-        mappings.Setup(x => x.TryUpdateBrmbleStatus(7, It.IsAny<bool?>())).Returns(true);
-        mappings.Setup(x => x.TryUpdateCertHash(7, It.IsAny<string>())).Returns(true);
+        mappings.Setup(x => x.TryClaimBrmbleSession(7, 42, It.IsAny<string>(), out It.Ref<SessionMapping?>.IsAny))
+            .Returns((int _, long _, string _, out SessionMapping? m) => { m = current; return true; });
 
         var broadcasts = new List<object>();
         var bus = new Mock<IBrmbleEventBus>();
@@ -412,7 +411,26 @@ public class BrmbleWebSocketHandlerTests
         using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
         Assert.IsTrue(doc.RootElement.GetProperty("isBrmbleClient").GetBoolean());
     }
+
+    [TestMethod]
+    public void TryParseClientMessage_RejectsATruncatedOversizedMessage()
+    {
+        // The abuse shape: a valid short prefix followed by padding that pushes the message past
+        // the cap. Truncating and honouring the prefix turns a size limit into an amplifier, so
+        // the whole message has to be discarded. The read loop signals this by passing null,
+        // but the parser must also reject the fragment it would otherwise see.
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage(
+            "{\"type\":\"requestSnapshot\"", out _), "an unterminated fragment is not valid JSON");
+    }
+
+    [TestMethod]
+    public void TryParseClientMessage_RejectsNonObjectAndNonStringType()
+    {
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("[1,2,3]", out _));
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("\"requestSnapshot\"", out _));
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("{\"type\":42}", out _));
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("{\"type\":null}", out _));
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("{\"type\":\"\"}", out _));
+    }
 }
-
-
 

--- a/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
@@ -253,4 +253,43 @@ public class BrmbleWebSocketHandlerTests
 
         Events.MappingPayloadEnvelopeTests.AssertHasEnvelope(payload, "userMappingAdded");
     }
+
+    [TestMethod]
+    public async Task BuildInitialPayloadsAsync_OmitsIsBrmbleClientWhenUnknownButKeepsExplicitFalse()
+    {
+        // An explicit null throws in the shipped client's ParseSessionMappings. Absent means
+        // the same thing to a new client and reads as false on an old one.
+        var mappings = new SessionMappingService();
+        mappings.TryAddMatrixUser(1, "@unknown:test", "Unknown", 1L, "floppy");
+        mappings.TryAddMatrixUser(2, "@known:test", "Known", 2L, "floppy");
+        mappings.TryUpdateBrmbleStatus(2, false);
+        mappings.TryAddMatrixUser(3, "@active:test", "Active", 3L, "floppy");
+        mappings.TryUpdateBrmbleStatus(3, true);
+
+        var payloads = await BrmbleWebSocketHandler.BuildInitialPayloadsAsync(
+            new Mock<IDuelSnapshotProvider>().Object, 0, mappings.GetSnapshot(),
+            new MappingEnvelope(mappings.InstanceId, mappings.Revision));
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payloads[0]));
+        var entries = doc.RootElement.GetProperty("mappings");
+
+        Assert.IsFalse(entries.GetProperty("1").TryGetProperty("isBrmbleClient", out _),
+            "unknown must be omitted entirely");
+        Assert.IsFalse(entries.GetProperty("2").GetProperty("isBrmbleClient").GetBoolean(),
+            "an observed deactivation is knowledge and stays explicit");
+        Assert.IsTrue(entries.GetProperty("3").GetProperty("isBrmbleClient").GetBoolean());
+    }
+
+    [TestMethod]
+    public void CreateUserMappingAddedPayload_AssertsTrueBecauseASocketHasRegistered()
+    {
+        // This path runs only from InitializeAcceptedClientAsync, where registration itself
+        // is the proof. It is the one place true is knowledge rather than an assumption.
+        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(
+            42, new SessionMapping("@alice:test", "Alice", 1L, "floppy", IsBrmbleClient: null),
+            "cert", new MappingEnvelope("inst", 9L));
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
+        Assert.IsTrue(doc.RootElement.GetProperty("isBrmbleClient").GetBoolean());
+    }
 }

--- a/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
@@ -119,6 +119,7 @@ public class BrmbleWebSocketHandlerTests
 
         var initialization = BrmbleWebSocketHandler.InitializeAcceptedClientAsync(
             socket.Object, 42, "cert", mappings.Object, bus,
+            new MappingEventPublisher(mappings.Object, bus),
             Mock.Of<IActiveBrmbleSessions>(), provider.Object);
         await Task.Delay(50);
 
@@ -151,6 +152,7 @@ public class BrmbleWebSocketHandlerTests
         await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
             BrmbleWebSocketHandler.InitializeAcceptedClientAsync(
                 socket.Object, 42, "cert", mappings.Object, bus,
+                new MappingEventPublisher(mappings.Object, bus),
                 Mock.Of<IActiveBrmbleSessions>(), provider.Object));
 
         Assert.IsFalse(bus.HasConnectedClient(42));
@@ -193,7 +195,9 @@ public class BrmbleWebSocketHandlerTests
             .Returns(Task.CompletedTask);
 
         var accepted = BrmbleWebSocketHandler.InitializeAcceptedClientAsync(
-            socket.Object, 42, "cert", mappings.Object, bus, activeSessions.Object, snapshots.Object);
+            socket.Object, 42, "cert", mappings.Object, bus,
+            new MappingEventPublisher(mappings.Object, bus),
+            activeSessions.Object, snapshots.Object);
         await bus.MappingBroadcastEntered.Task;
         // The socket is already registered, so this queues behind the bootstrap rather than
         // being dropped. It cannot be awaited yet: it only completes once the drain reaches it.
@@ -293,3 +297,4 @@ public class BrmbleWebSocketHandlerTests
         Assert.IsTrue(doc.RootElement.GetProperty("isBrmbleClient").GetBoolean());
     }
 }
+

--- a/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
@@ -55,7 +55,7 @@ public class BrmbleWebSocketHandlerTests
             CertHash: null,
             IsBrmbleClient: false);
 
-        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash");
+        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash", new MappingEnvelope("inst", 1L));
 
         Assert.AreEqual("fresh-hash", payload.GetType().GetProperty("certHash")!.GetValue(payload));
     }
@@ -74,7 +74,7 @@ public class BrmbleWebSocketHandlerTests
     {
         var mapping = new SessionMapping("@alice:test", "Alice", 42, "custom:$sprite:test");
 
-        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash");
+        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash", new MappingEnvelope("inst", 1L));
 
         Assert.AreEqual("floppy", payload.GetType().GetProperty("companionId")!.GetValue(payload));
         Assert.AreEqual("custom:$sprite:test", payload.GetType().GetProperty("customCompanionId")!.GetValue(payload));
@@ -85,7 +85,7 @@ public class BrmbleWebSocketHandlerTests
     {
         var mapping = new SessionMapping("@alice:test", "Alice", 42, "floppy");
 
-        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash");
+        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash", new MappingEnvelope("inst", 1L));
 
         Assert.AreEqual("floppy", payload.GetType().GetProperty("companionId")!.GetValue(payload));
         Assert.IsNull(payload.GetType().GetProperty("customCompanionId")!.GetValue(payload));
@@ -240,5 +240,17 @@ public class BrmbleWebSocketHandlerTests
         Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("not json", out _));
         Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("{}", out _));
         Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("", out _));
+    }
+
+    [TestMethod]
+    public void CreateUserMappingAddedPayload_CarriesTheEnvelope()
+    {
+        // This payload is broadcast after TryUpdateBrmbleStatus/TryUpdateCertHash have already
+        // bumped the revision. Unstamped, those bumps are silent and every client sees a gap.
+        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(
+            42, new SessionMapping("@alice:test", "Alice", 1L, "floppy"), "cert",
+            new MappingEnvelope("inst", 9L));
+
+        Events.MappingPayloadEnvelopeTests.AssertHasEnvelope(payload, "userMappingAdded");
     }
 }

--- a/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
@@ -25,6 +25,7 @@ public class BrmbleWebSocketHandlerTests
         public void RemoveClient(WebSocket ws) => inner.RemoveClient(ws);
         public bool HasConnectedClient(long userId) => inner.HasConnectedClient(userId);
         public Task BroadcastAsync(object message) => inner.BroadcastAsync(message);
+        public Task SendToClientAsync(WebSocket socket, object message) => inner.SendToClientAsync(socket, message);
         public async Task BroadcastExceptAsync(WebSocket excluded, object message)
         {
             MappingBroadcastEntered.TrySetResult();
@@ -207,5 +208,37 @@ public class BrmbleWebSocketHandlerTests
             new[] { "sessionMappingSnapshot", "game.queueSnapshot", "privateEvent" }, sends);
         Assert.AreEqual(1, maxConcurrentSends);
         Assert.AreEqual(1, sends.Count(x => x == "sessionMappingSnapshot"));
+    }
+
+    [TestMethod]
+    public async Task BuildInitialPayloadsAsync_StampsSnapshotWithEnvelope()
+    {
+        var mappings = new SessionMappingService();
+        mappings.TryAddMatrixUser(42, "@alice:test", "Alice", 1L, "floppy");
+
+        var payloads = await BrmbleWebSocketHandler.BuildInitialPayloadsAsync(
+            new Mock<IDuelSnapshotProvider>().Object, 0, mappings.GetSnapshot(),
+            new MappingEnvelope(mappings.InstanceId, mappings.Revision));
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payloads[0]));
+        Assert.AreEqual("sessionMappingSnapshot", doc.RootElement.GetProperty("type").GetString());
+        Assert.AreEqual(mappings.InstanceId, doc.RootElement.GetProperty("instanceId").GetString());
+        Assert.AreEqual(mappings.Revision, doc.RootElement.GetProperty("revision").GetInt64());
+    }
+
+    [TestMethod]
+    public void TryParseClientMessage_RecognisesRequestSnapshot()
+    {
+        Assert.IsTrue(BrmbleWebSocketHandler.TryParseClientMessage(
+            "{\"type\":\"requestSnapshot\"}", out var type));
+        Assert.AreEqual("requestSnapshot", type);
+    }
+
+    [TestMethod]
+    public void TryParseClientMessage_RejectsGarbageWithoutThrowing()
+    {
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("not json", out _));
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("{}", out _));
+        Assert.IsFalse(BrmbleWebSocketHandler.TryParseClientMessage("", out _));
     }
 }


### PR DESCRIPTION
﻿## Summary

Establishes the server wire contract for the single authoritative user projection, plus the design and plans for the phases that follow.

This is **additive**: older clients ignore the new fields. It fixes nothing user-visible on its own — the restart symptoms (badge loss, companion reverting to floppy) are fixed in Phase 3.

Includes the unmerged companion-race fix `cd7b48fa` as its base, since this work builds directly on it. The branch diverges from `main` at `a4c993fa`.

## What Phase 1 adds

- **`instanceId`** — a per-process GUID identifying the mapping table, so a client can tell a restart from a gap.
- **`revision`** — a monotonic counter, incremented once per successful mutation and stamped on every mapping payload, so a client can order and deduplicate events.
- **Tri-state `isBrmbleClient`** — `true` / `false` / unknown, where unknown is an omitted property rather than a null. Absence of a registered WebSocket is not evidence of a non-Brmble client, and after a restart it never is.
- **`requestSnapshot`** — a client-initiated resync, served over the existing socket. The read loop now reassembles multi-frame messages with an 8 KiB cap.
- **`MappingEventPublisher`** — mutation, revision read and broadcast enqueue happen under one lock, so revision order always matches delivery order.

### What Phase 1 deliberately does not add: `baseRevision`

The design spec proposed the client rule `revision == ours + 1`. **That rule is not implementable against this PR**, and the gap is intentional rather than overlooked.

One logical operation bumps the counter several times but is announced once — `SessionMappingHandler.OnUserConnected` does add + certHash + brmbleStatus inside a single publish, moving the revision `0 -> 3` and announcing `3`. A client applying `== ours + 1` would read every normal registration as a gap and resync forever.

Phase 2 resolves this by stamping the range's start (`baseRevision`) alongside `revision`, so the client applies on `baseRevision == ours` — insensitive to how many bumps an operation makes. That work is specified in `docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md`, Task 1.

Until then `revision` is useful for ordering and deduplication but is **not** a gap oracle, and nothing in this PR treats it as one. No client consumes it yet.

## Two invariants that did real work

**Every revision bump is announced.** Cross-checking each `Bump()` against a producer caught `/auth/token` broadcasting unstamped after three mutations, and its already-mapped branch bumping twice while announcing nothing. Each unannounced bump manufactures a permanent phantom gap in every connected client.

**No two payloads share a revision.** Five sites mutated and then read `.Revision` unsynchronised, so concurrent registrations could both observe the same value — a client applies one payload and silently discards the other. Reproduced with 40 concurrent registrations before fixing.

## Review fixes included

Four defects found in review, each fixed with a reproducing test first.

**Ship blocker.** `isBrmbleClient: null` threw `InvalidOperationException` in the shipped client's `ParseSessionMappings` — `TryGetProperty` returns true for an explicit JSON null and `GetBoolean()` throws on it, inside `/auth/token` credential handling. The property is now omitted when unknown (`false` stays explicit, since an observed deactivation is knowledge). The client parser is hardened regardless.

**Revision stamped outside the ordering lock.** The race described above.

**Registration announced when nothing changed.** The mutate callback returned `true` unconditionally, so a mapping removed between the read and the lock still produced a `userMappingAdded` stamped with a revision the operation never produced.

**Registration announced a stale mapping.** The announced mapping was captured outside the lock, so a `companionChanged` landing in between was undone — the payload carried the older `companionId` under a newer revision, and every client overwrote the newer value with the stale one.

## Testing

`dotnet build` clean, 0 warnings. `dotnet test` 1253 passing, up from a 1246 baseline:

| Project | Before | After |
|---|---|---|
| Brmble.Server.Tests | 758 | 780 |
| Brmble.Client.Tests | 300 | 301 |
| MumbleVoiceEngine.Tests | 99 | 99 |
| Brmble.Audio.Tests | 73 | 73 |

Concurrency tests were run repeatedly to confirm they are not passing by luck.

## Also included

- `docs/superpowers/specs/2026-07-31-user-projection-design.md` — the approved design
- `docs/superpowers/plans/2026-07-31-user-projection-phase-1-server.md` — the plan this executed
- `docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md` — Phase 2, the pure client `UserProjectionStore`
- `docs/superpowers/plans/phase-2-handoff.md` — session handoff for executing Phase 2

## Not in this PR

Phase 2 (`UserProjectionStore` + `baseRevision`) and Phase 3 (`MumbleAdapter` / `App.tsx` rewiring). Phase 2 can land on this branch if preferred.
