### PR TITLE
Fix custom companion picker bug

### DIFF
--- a/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.css
+++ b/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.css
@@ -150,6 +150,7 @@
 .companion-picker-custom-sprite {
   width: var(--companion-picker-built-in-size);
   height: var(--companion-picker-built-in-size);
+  background-image: var(--companion-picker-custom-sprite-image);
   background-repeat: no-repeat;
   background-size: calc(100% * 8) calc(100% * 9);
   background-position: 0 0;

--- a/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.css
+++ b/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.css
@@ -147,10 +147,12 @@
   color: var(--text-muted);
 }
 
-.companion-picker-thumbnail img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
+.companion-picker-custom-sprite {
+  width: var(--companion-picker-built-in-size);
+  height: var(--companion-picker-built-in-size);
+  background-repeat: no-repeat;
+  background-size: calc(100% * 8) calc(100% * 9);
+  background-position: 0 0;
   image-rendering: pixelated;
 }
 

--- a/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.test.tsx
@@ -170,7 +170,8 @@ describe('CompanionPicker', () => {
     });
 
     const sprite = await waitFor(() => screen.getByTestId('companion-picker-custom-sprite'));
-    expect(sprite).toHaveStyle('background-image: url(blob:thumbnail)');
+    expect(sprite.style.getPropertyValue('--companion-picker-custom-sprite-image'))
+      .toBe('url(blob:thumbnail)');
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 });

--- a/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CustomCompanionEntry } from '../../../customCompanions/customCompanionTypes';
 import type { CustomCompanionGalleryController } from '../../../hooks/useCustomCompanionGallery';
 import { CompanionPicker } from './CompanionPicker';
@@ -58,6 +58,10 @@ describe('CompanionPicker', () => {
       unobserve() {}
       disconnect() {}
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('keeps built-ins visible while the custom section is loading', () => {

--- a/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CustomCompanionEntry } from '../../../customCompanions/customCompanionTypes';
@@ -45,8 +45,15 @@ function gallery(
 }
 
 describe('CompanionPicker', () => {
+  let intersectionCallback: IntersectionObserverCallback | undefined;
+
   beforeEach(() => {
+    intersectionCallback = undefined;
     vi.stubGlobal('IntersectionObserver', class {
+      constructor(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+      }
+
       observe() {}
       unobserve() {}
       disconnect() {}
@@ -139,5 +146,31 @@ describe('CompanionPicker', () => {
 
     expect(readyGallery.requestThumbnail).not.toHaveBeenCalled();
     expect(readyGallery.requestAtlas).not.toHaveBeenCalled();
+  });
+
+  it('renders a loaded custom thumbnail as a cropped sprite background', async () => {
+    const readyGallery = gallery('ready', [entry('$orbit:test', 'Alice', 1)]);
+
+    render(
+      <CompanionPicker
+        value="floppy"
+        gallery={readyGallery}
+        onChange={vi.fn()}
+        onUpload={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('companion-picker-custom-sprite')).not.toBeInTheDocument();
+
+    act(() => {
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    const sprite = await waitFor(() => screen.getByTestId('companion-picker-custom-sprite'));
+    expect(sprite).toHaveStyle('background-image: url(blob:thumbnail)');
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
   });
 });

--- a/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.tsx
@@ -53,7 +53,11 @@ function CustomCompanionRow({
     >
       <span className="companion-picker-thumbnail" aria-hidden="true">
         {thumbnailUrl ? (
-          <img src={thumbnailUrl} alt="" />
+          <span
+            className="companion-picker-custom-sprite"
+            style={{ backgroundImage: `url(${thumbnailUrl})` }}
+            data-testid="companion-picker-custom-sprite"
+          />
         ) : (
           <Icon name="palette" />
         )}

--- a/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/customCompanions/CompanionPicker.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useViewportThumbnail } from '../../../customCompanions/useViewportThumbnail';
 import type { CustomCompanionEntry } from '../../../customCompanions/customCompanionTypes';
 import type { CustomCompanionGalleryController } from '../../../hooks/useCustomCompanionGallery';
@@ -40,7 +41,17 @@ function CustomCompanionRow({
   onSelect: () => void;
 }) {
   const { ref, thumbnailUrl } = useViewportThumbnail(entry, gallery);
+  const customSpriteRef = useRef<HTMLSpanElement>(null);
   const accessibleName = `${entry.name}, uploaded by ${entry.uploaderDisplayName}`;
+
+  useEffect(() => {
+    if (thumbnailUrl) {
+      customSpriteRef.current?.style.setProperty(
+        '--companion-picker-custom-sprite-image',
+        `url(${thumbnailUrl})`,
+      );
+    }
+  }, [thumbnailUrl]);
 
   return (
     <button
@@ -54,8 +65,8 @@ function CustomCompanionRow({
       <span className="companion-picker-thumbnail" aria-hidden="true">
         {thumbnailUrl ? (
           <span
+            ref={customSpriteRef}
             className="companion-picker-custom-sprite"
-            style={{ backgroundImage: `url(${thumbnailUrl})` }}
             data-testid="companion-picker-custom-sprite"
           />
         ) : (


### PR DESCRIPTION
## Summary

Custom companion thumbnails now display only the top-left frame of the uploaded 8×9 sprite atlas, matching built-in companion previews.

## Changes

- Replaced the full-atlas `<img>` rendering with a cropped CSS sprite background.
- Added a square inner sprite element matching built-in preview dimensions.
- Added a regression test covering the loaded custom thumbnail behavior.
- Kept thumbnail loading, caching, and runtime rendering unchanged.

## Validation

- Focused picker tests pass: 7/7
- Type-check passes