### PR TITLE
feat: client user projection store and baseRevision wire field (Phase 2)

### DIFF
--- a/docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md
+++ b/docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md
@@ -518,8 +518,10 @@ namespace Brmble.Client.Services.Voice.Projection;
 /// field present — so a consumer replaces by session id and never merges field-by-field.
 /// </summary>
 /// <param name="IsReset">
-/// The caller should replace its whole list rather than patch it. Set by a Mumble reset and by
-/// a snapshot that changed membership.
+/// The caller should replace its whole list rather than patch it. Set by a Mumble reset only.
+/// A snapshot never sets it: <see cref="UserProjectionStore.ApplyServerSnapshot"/> can change
+/// what the server knows about a session, but it can neither add nor remove a row, because only
+/// Mumble owns existence (spec §4.3). Every row it resets is reported in <see cref="Changed"/>.
 /// </param>
 /// <param name="NeedsSnapshot">
 /// The store detected a gap or a restart and cannot proceed from incremental events. The caller
@@ -909,7 +911,7 @@ public class UserProjectionStoreSnapshotTests
     }
 
     [TestMethod]
-    public void ApplyServerSnapshot_FlagsAResetWhenMembershipChanged()
+    public void ApplyServerSnapshot_ReportsRowsItResets()
     {
         _store.ApplyServerSnapshot(Snapshot(5,
             (1, new ServerMappingEntry("@alice:test", null, null, null)),

--- a/docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md
+++ b/docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md
@@ -10,14 +10,15 @@
 
 **Spec:** `docs/superpowers/specs/2026-07-31-user-projection-design.md` §3.1, §3.2, §4.2, §4.3, §6.6, §8.
 
-**Depends on:** Phase 1 (`feature/user-projection-phase-1`, HEAD `1f5aa25e`). Confirm before starting:
+**Depends on:** Phase 1, merged into this branch. Work on `feature/user-projection-phase-2`, branched from `feature/user-projection-phase-1` at `50ee5f07`. Confirm before starting:
 
 ```powershell
-git log --oneline -1                    # expect 1f5aa25e
+git rev-parse --abbrev-ref HEAD        # feature/user-projection-phase-2
+git log --oneline -1                   # expect 50ee5f07 if no Phase 2 work has started
 Select-String -Path src/Brmble.Server/Events/MappingEventPublisher.cs -Pattern PublishExceptAsync
 ```
 
-Baseline: `dotnet build` clean with 0 warnings, `dotnet test` 1250 passing (Server 777, Client 301, MumbleVoiceEngine 99, Audio 73). Confirm this so you can tell your own failures from pre-existing ones.
+Baseline: `dotnet build` clean with 0 warnings, `dotnet test` 1253 passing (Server 780, Client 301, MumbleVoiceEngine 99, Audio 73). Confirm this so you can tell your own failures from pre-existing ones.
 
 ---
 
@@ -152,40 +153,24 @@ Add to `tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs`, inside 
     }
 ```
 
-Then tighten the shared assertion in `tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs`. Replace `AssertHasEnvelope` with two methods — snapshots are absolute and carry no `baseRevision`:
+Then tighten the event assertion in `tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs`.
+
+**Note:** the split into `AssertHasEnvelope` (events) and `AssertHasSnapshotEnvelope` (snapshots) **already exists** — it landed in `b632d0a3` from Phase 1 review feedback, along with the shared `AssertHasEnvelopeCore` helper. Do not recreate it. Only the `baseRevision` requirement is missing, and it belongs on the event helper alone: snapshots are absolute and must never carry one.
+
+Add to `AssertHasEnvelope`, after the existing `revision > 0` assertion:
 
 ```csharp
-    internal static void AssertHasEnvelope(object payload, string expectedType)
-    {
-        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
-        Assert.AreEqual(expectedType, doc.RootElement.GetProperty("type").GetString());
-        Assert.IsTrue(doc.RootElement.TryGetProperty("instanceId", out var instanceId),
-            $"{expectedType} is missing instanceId");
-        Assert.IsFalse(string.IsNullOrWhiteSpace(instanceId.GetString()),
-            $"{expectedType} has a blank instanceId");
-        Assert.IsTrue(doc.RootElement.TryGetProperty("revision", out var revision),
-            $"{expectedType} is missing revision");
-        Assert.IsTrue(revision.GetInt64() > 0,
-            $"{expectedType} must carry the post-mutation revision");
-        Assert.IsTrue(doc.RootElement.TryGetProperty("baseRevision", out var baseRevision),
+        Assert.IsTrue(root.TryGetProperty("baseRevision", out var baseRevision),
             $"{expectedType} is missing baseRevision, so a client cannot tell a gap from a jump");
-        Assert.IsTrue(baseRevision.GetInt64() < revision.GetInt64()
-                      || baseRevision.GetInt64() == revision.GetInt64(),
+        Assert.IsTrue(baseRevision.GetInt64() <= root.GetProperty("revision").GetInt64(),
             $"{expectedType} has baseRevision above revision");
-    }
+```
 
-    /// <summary>
-    /// Snapshots are absolute rather than deltas: they set the client's cursor outright, so
-    /// they carry no baseRevision.
-    /// </summary>
-    internal static void AssertHasSnapshotEnvelope(object payload, string expectedType)
-    {
-        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
-        Assert.AreEqual(expectedType, doc.RootElement.GetProperty("type").GetString());
-        Assert.IsFalse(string.IsNullOrWhiteSpace(
-            doc.RootElement.GetProperty("instanceId").GetString()));
-        Assert.IsTrue(doc.RootElement.TryGetProperty("revision", out _));
-    }
+Leave `AssertHasSnapshotEnvelope` untouched, and add one assertion to it proving the absence is deliberate rather than accidental:
+
+```csharp
+        Assert.IsFalse(root.TryGetProperty("baseRevision", out _),
+            $"{expectedType} is a snapshot and must not carry baseRevision");
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
@@ -328,7 +313,9 @@ Keep the existing comments about reading the revision before the snapshot — th
 
 Run: `dotnet build`
 
-Any remaining two-argument `new MappingEnvelope(...)` in tests will fail to compile. In `tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs` there are several `new MappingEnvelope("inst", 9L)` and `new MappingEnvelope(mappings.InstanceId, mappings.Revision)` calls — give each an explicit third argument (`new MappingEnvelope("inst", 9L, 8L)`) or switch snapshot-shaped ones to `MappingEnvelope.Snapshot(...)`.
+Any remaining two-argument `new MappingEnvelope(...)` will fail to compile. There are 11 construction sites — 3 in `src/` (`MappingEventPublisher.cs`, and two in `BrmbleWebSocketHandler.cs`) and 8 in `tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs`. Give each an explicit third argument (`new MappingEnvelope("inst", 9L, 8L)`), or switch snapshot-shaped ones to `MappingEnvelope.Snapshot(...)`.
+
+Two of the test sites assert snapshot behaviour specifically — `BuildInitialPayloadsAsync_StampsSnapshotWithEnvelope` and `BuildInitialPayloadsAsync_SnapshotFromAFreshServerCarriesRevisionZero` — and both should use `MappingEnvelope.Snapshot(...)`. The second exists because a freshly started server legitimately serves a snapshot at revision 0; do not "fix" it by seeding a mutation.
 
 Run: `dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj`
 
@@ -1480,7 +1467,7 @@ git commit -m "test: prove the projection converges under reordering and loss"
 ## Done when
 
 - [ ] `dotnet build` is clean with 0 warnings
-- [ ] `dotnet test` passes in all four projects, with more tests than the 1250 baseline
+- [ ] `dotnet test` passes in all four projects, with more tests than the 1253 baseline
 - [ ] Every mapping **event** carries `baseRevision`; every **snapshot** carries `instanceId` and `revision` and no `baseRevision`
 - [ ] Consecutive events from one publisher are contiguous: each event's `baseRevision` equals the previous event's `revision`
 - [ ] `UserProjectionStore` references no Mumble, HTTP or JSON type. Verify: `Select-String -Path src/Brmble.Client/Services/Voice/Projection/*.cs -Pattern "MumbleSharp|HttpClient|JsonElement|System.Text.Json"` returns nothing
@@ -1505,4 +1492,5 @@ Connect and confirm the user list, badges and companions render exactly as befor
 ## Next
 
 **Phase 3** wires the store in and is where the user-visible fixes land: delete `_sessionMappings`, translate wire payloads into the input records from Task 2, collapse the 17 `setUsers` sites to 2, move avatars into their own state keyed by `matrixUserId`, and add client version negotiation via a `pv` query parameter so the server can send a single truthful `companionId` (spec §4.4) instead of the legacy `companionId`/`customCompanionId` split. It touches the two most actively edited files in the repo, so it is planned against shipped code after Phase 2 lands.
+
 

--- a/docs/superpowers/plans/2026-08-01-user-projection-phase-3-wiring.md
+++ b/docs/superpowers/plans/2026-08-01-user-projection-phase-3-wiring.md
@@ -55,7 +55,7 @@ Both behaviours invert the design's rule 2. The translator written in Stage A re
 
 ### `voice.userJoined` is not a join event
 
-`:4303` emits `voice.userJoined` on **every** `UserState` — channel moves, mutes, comment changes. React's upsert at `App.tsx:2552` exists to cope with that. This is why item 3's "rows must be complete" matters: once the store owns merging, the C# side can emit a complete row on every change and React can replace by session id with no field logic at all.
+`:4305` emits `voice.userJoined` on **every** `UserState` — channel moves, mutes, comment changes. React's upsert at `App.tsx:2552` exists to cope with that. This is why item 3's "rows must be complete" matters: once the store owns merging, the C# side can emit a complete row on every change and React can replace by session id with no field logic at all.
 
 ### The WebSocket stream is a local variable
 

--- a/docs/superpowers/plans/2026-08-01-user-projection-phase-3-wiring.md
+++ b/docs/superpowers/plans/2026-08-01-user-projection-phase-3-wiring.md
@@ -17,7 +17,7 @@
 ```powershell
 git rev-parse --abbrev-ref HEAD     # feature/user-projection-phase-3
 dotnet build                        # 0 warnings, 0 errors
-dotnet test                         # 1299: Server 782, Client 345, MumbleVoiceEngine 99, Audio 73
+dotnet test                         # 1308: Server 791, Client 345, MumbleVoiceEngine 99, Audio 73
 cd src/Brmble.Web; npm run test -- --run; cd ../..
 ```
 
@@ -60,6 +60,18 @@ Both behaviours invert the design's rule 2. The translator written in Stage A re
 ### The WebSocket stream is a local variable
 
 `:2318` — `var stream = tlsProtocol.Stream;` — lives inside the reconnect loop in `StartWebSocketConnection`. `SendWebSocketFrame` (`:2536`) is `static` and is only ever called from inside `ReadWebSocketFrame` to answer a ping (`:2503`, `:2519`). There is no way to send an application message from outside the loop. Stage B hoists it.
+
+### What Phase 1's late review fixes changed under this plan
+
+`3c996dd1` landed on the Phase 1 branch after Phase 2 was written and was rebased in. It moves ground this plan stands on:
+
+- **`PublishSnapshotAsync`** (new on `IMappingEventPublisher`) captures the revision, the mappings, and the enqueue under one gate. Snapshots and events on a socket are now delivered in revision order. The client store already tolerates reordering, so this only *strengthens* its assumptions — no store change needed.
+- **Snapshot delivery is now two paths sharing one builder** (`CreateSessionMappingSnapshotPayload`). See Task C1 — the version has to reach both.
+- **`requestSnapshot` is rate-limited server-side** at 1/second per socket, silently. See Task B2.
+- **The read loop drops non-text frames** and discards oversized messages whole. The client must send opcode `0x1` (text); Task B2 does.
+- **`TryClaimBrmbleSession`** replaced the `TryUpdateBrmbleStatus` + `TryUpdateCertHash` pair in `InitializeAcceptedClientAsync` with one ownership-constrained CAS that bumps once.
+
+That last one does **not** weaken the case for `baseRevision`. Registration is now a single bump, but two multi-bump operations remain in one `PublishAsync` each — `SessionMappingHandler.OnUserConnected` (`TryAddMatrixUser` + `TryUpdateCertHash` + `TryUpdateBrmbleStatus`, three bumps) and `/auth/token` (`TryAddMatrixUser` + `TryClaimBrmbleSession`, two). A client applying on `revision == ours + 1` would still read both as gaps.
 
 ### Threading
 
@@ -810,6 +822,13 @@ git commit -m "refactor: hoist the websocket stream so the client can send"
 
 **Why:** item 7 — a persistent mismatch must never become a hot loop. Extract the throttle so it is testable without a socket.
 
+**The server already rate-limits this**, added in Phase 1's `3c996dd1`: `BrmbleWebSocketHandler.HandleAsync` holds a one-second per-socket cooldown and silently `continue`s past a request that arrives too soon. Two consequences for this task:
+
+- The client's `MinimumSpacing` must be **at least** one second. Below that, the extra requests are not merely wasteful — they are dropped with no reply at all, so the client would sit waiting for a snapshot the server already decided not to send.
+- A refused request produces **no response of any kind**. So `Complete()` must fire when the request is *sent*, not when a snapshot arrives, or one silent refusal wedges the throttle permanently at `_inFlight = true`. The implementation below does this correctly — do not "improve" it into completing on receipt.
+
+The server's cooldown is a floor that protects the server; the client's backoff is a ceiling that protects the client from a mismatch it cannot repair. Both are wanted.
+
 - [ ] **Step 1: Write the failing test**
 
 ```csharp
@@ -1110,7 +1129,17 @@ Call it in `HandleAsync` **before** `AcceptWebSocketAsync`, so the version is kn
         var projectionVersion = ParseProjectionVersion(context.Request.Query["pv"]);
 ```
 
-Thread it through `InitializeAcceptedClientAsync` and `BuildInitialPayloadsAsync` as a parameter.
+Thread it through **three** paths, not one. Phase 1's `3c996dd1` split snapshot delivery into a shared payload builder plus two callers:
+
+| Path | Entry point | Notes |
+|---|---|---|
+| Bootstrap | `InitializeAcceptedClientAsync` → `BuildInitialPayloadsAsync` | per-socket, version known |
+| Resync | the `requestSnapshot` branch → `publisher.PublishSnapshotAsync` | per-socket, version known — **easy to miss** |
+| Both | `CreateSessionMappingSnapshotPayload(mappings, envelope)` | the shared builder; gains a `projectionVersion` parameter |
+
+`CreateSessionMappingSnapshotPayload` is where `SessionMappingWire.From` is called, so the version has to reach it or a resyncing `pv=1` client silently gets the legacy split — the one case where a client that asked for the truthful field is told a floppy instead, and the hardest to notice because it only happens after a gap.
+
+**Watch the mocks when you change `InitializeAcceptedClientAsync`'s signature.** Its fixture stubs `TryClaimBrmbleSession` (also new in `3c996dd1`, replacing the old `TryUpdateBrmbleStatus`/`TryUpdateCertHash` pair). An unstubbed `Mock<ISessionMappingService>` returns `false` from it, no `userMappingAdded` is broadcast, and any test awaiting that broadcast **hangs forever** rather than failing.
 
 - [ ] **Step 4: Run, then commit**
 
@@ -1178,7 +1207,9 @@ Keep `FromPersisted` as the version-0 implementation so existing callers and tes
 
 - [ ] **Step 3: Thread the version through every mapping payload builder**
 
-`CreateUserMappingAddedPayload`, `SessionMappingWire.From`, `AuthEndpoints`' `/auth/token` and `PersistCompanionSelectionAsync`, `CustomCompanionEndpoints`, `SessionMappingHandler`. Broadcast events go to clients at mixed versions, so a broadcast **must** send the legacy split; only per-socket payloads (initial snapshot, and anything sent with `SendToClientAsync`) can use version 1.
+`CreateUserMappingAddedPayload`, `CreateSessionMappingSnapshotPayload`, `SessionMappingWire.From`, `AuthEndpoints`' `/auth/token` and `PersistCompanionSelectionAsync`, `CustomCompanionEndpoints`, `SessionMappingHandler`. Broadcast events go to clients at mixed versions, so a broadcast **must** send the legacy split; only per-socket payloads (bootstrap snapshot, resync snapshot, and anything sent with `SendToClientAsync`) can use version 1.
+
+Note `CreateUserMappingAddedPayload` is reached from **both** kinds of caller — `PublishExceptAsync` in `InitializeAcceptedClientAsync` (a broadcast, so version 0) and nothing else today. Keep it on the legacy shape and say so, rather than parameterising a builder whose only caller broadcasts.
 
 **Write this down in a comment at each broadcast site**, because it is the non-obvious constraint of this stage:
 
@@ -1550,7 +1581,7 @@ Recorded in spec §9 with reasoning; all are follow-ups:
 ## Done when
 
 - [ ] `dotnet build` clean, 0 warnings; `npx tsc --noEmit` clean
-- [ ] `dotnet test` green with more than the 1299 baseline; `npm run test -- --run` green
+- [ ] `dotnet test` green with more than the 1308 baseline; `npm run test -- --run` green
 - [ ] `Select-String -Path src/Brmble.Client/Services/Voice/MumbleAdapter.cs -Pattern "_sessionMappings|_pendingBrmbleStatus|_userMappings"` returns nothing
 - [ ] `Select-String -Path src/Brmble.Client/Services/Voice/Projection/*.cs -Pattern "MumbleSharp|HttpClient|JsonElement|System.Text.Json"` still returns nothing
 - [ ] `(Select-String -Path src/Brmble.Web/src/App.tsx -Pattern "setUsers\(").Count` is 0 — all writes go through `useUserDirectory`

--- a/docs/superpowers/plans/2026-08-01-user-projection-phase-3-wiring.md
+++ b/docs/superpowers/plans/2026-08-01-user-projection-phase-3-wiring.md
@@ -1,0 +1,1558 @@
+# User Projection — Phase 3: Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `UserProjectionStore` the client's only user state, so a Brmble server restart stops blanking badges, reverting companions and flickering the user list.
+
+**Architecture:** Four stages, each independently shippable and green. **A** teaches the client to read the `instanceId`/`revision`/`baseRevision` envelope and routes all three inputs through the store, still emitting today's eight bridge events so React is untouched. **B** adds the resync send path and fixes a socket teardown bug. **C** negotiates a projection version and collapses the two companion wire fields into one. **D** replaces the eight bridge events with two and collapses React's 17 `setUsers` sites to 2.
+
+**Tech Stack:** C# / .NET 10, MSTest, a hand-rolled RFC 6455 WebSocket client over BouncyCastle TLS, React 18 + TypeScript + Vite, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-user-projection-design.md` §3.4, §4.4, §5, §6, §8.
+
+**Branch:** `feature/user-projection-phase-3`, branched from `feature/user-projection-phase-2`.
+
+**Baseline — confirm before starting:**
+
+```powershell
+git rev-parse --abbrev-ref HEAD     # feature/user-projection-phase-3
+dotnet build                        # 0 warnings, 0 errors
+dotnet test                         # 1299: Server 782, Client 345, MumbleVoiceEngine 99, Audio 73
+cd src/Brmble.Web; npm run test -- --run; cd ../..
+```
+
+---
+
+## Background you need
+
+### The client cannot currently sequence anything
+
+Phase 1 put `instanceId` and `revision` on the wire and Phase 2 built a store that sequences on them. **Nothing on the client reads them.** `Select-String -Path src/Brmble.Client/Services/Voice/MumbleAdapter.cs -Pattern "instanceId|revision"` returns nothing.
+
+So Stage A is not merely "call the store instead of the dictionary". The envelope has to be parsed into `ServerSnapshot` and `ServerEvent` first, or `ApplyServerEvent` sees `instanceId: ""` on every event, mismatches its cursor, and returns `NeedsSnapshot` forever.
+
+### There are three user-state stores today, not one
+
+| Field | Line | Keyed by | Holds |
+|---|---|---|---|
+| `_sessionMappings` | `:66` | session id | matrixUserId, mumbleName, companionId, isBrmbleClient, certHash |
+| `_pendingBrmbleStatus` | `:68` | session id | a `bool` announced before its mapping arrived |
+| `_userMappings` | `:65` | **mumble name** | matrixUserId, from `/auth/token`'s `userMappings` |
+
+All three die in Stage A. `_userMappings` is easy to miss — it is read as a fallback at `:4191` and `:4315` (`_userMappings.GetValueOrDefault(u.Name)`) and is the reason a user can show a Matrix id with no mapping. The store's `MatrixUserId` replaces it. `_pendingBrmbleStatus` is replaced by the hold map added in Part A of the review fixes.
+
+### The parser drops mappings and invents companions
+
+`ParseSessionMappings` (`:117-139`):
+
+```csharp
+if (matrixId is not null && name is not null && companionId is not null)
+```
+
+`companionId` comes from `ParseWireCompanionId`, which falls back to `"floppy"` and therefore is *never* null — so that third clause is dead, and every entry silently gains a companion it may not have. Meanwhile a mapping with a null `mumbleName` is dropped entirely.
+
+Both behaviours invert the design's rule 2. The translator written in Stage A replaces this function; do not try to patch it.
+
+### `voice.userJoined` is not a join event
+
+`:4303` emits `voice.userJoined` on **every** `UserState` — channel moves, mutes, comment changes. React's upsert at `App.tsx:2552` exists to cope with that. This is why item 3's "rows must be complete" matters: once the store owns merging, the C# side can emit a complete row on every change and React can replace by session id with no field logic at all.
+
+### The WebSocket stream is a local variable
+
+`:2318` — `var stream = tlsProtocol.Stream;` — lives inside the reconnect loop in `StartWebSocketConnection`. `SendWebSocketFrame` (`:2536`) is `static` and is only ever called from inside `ReadWebSocketFrame` to answer a ping (`:2503`, `:2519`). There is no way to send an application message from outside the loop. Stage B hoists it.
+
+### Threading
+
+`UserProjectionStore` takes its own lock and returns data; it never invokes a callback under the lock. Inputs arrive on three threads — the Mumble protocol thread (`UserState`/`UserRemove`), the WebSocket read loop, and the HTTP continuation in `FetchAndSendCredentials`. Emit to the bridge **after** `Apply*` returns, never inside it. `_bridge?.Send` followed by `_bridge?.NotifyUiThread()` is the existing convention and is already thread-safe (`NativeBridge` marshals via `PostMessage`).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/Brmble.Client/Services/Voice/ProjectionWire.cs` | *Create* — JSON ⇄ projection input translation. Lives **outside** `Projection/` so the store keeps its no-JSON guarantee. |
+| `src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs` | *Modify* — Stage B adds a resync-request hook only |
+| `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` | *Modify* — all four stages |
+| `src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs` | *Modify* — Stage C reads `pv` |
+| `src/Brmble.Server/Auth/AuthEndpoints.cs` | *Modify* — Stage C |
+| `src/Brmble.Server/Mumble/CompanionWireSelection.cs` | *Modify* — Stage C gains a `pv>=1` shape |
+| `src/Brmble.Web/src/hooks/useUserDirectory.ts` | *Create* — Stage D |
+| `src/Brmble.Web/src/types/index.ts` | *Modify* — Stage D merges the two `User` types |
+| `src/Brmble.Web/src/App.tsx` | *Modify* — Stage D |
+
+---
+
+# STAGE A — Envelope parsing and store wiring
+
+**Outcome:** the store is the only user state in `MumbleAdapter`. The eight bridge events still fire, now derived from the store, so React is untouched and the app behaves identically. This stage alone fixes nothing user-visible; it makes Stage D small.
+
+## Task A1: The wire translator
+
+**Files:**
+- Create: `src/Brmble.Client/Services/Voice/ProjectionWire.cs`
+- Test: `tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs` (create)
+
+**Why:** the store must never see a `JsonElement` (Phase 2 "Done when" item). Translation is pure and therefore the cheapest thing in the system to test exhaustively — every wire quirk gets pinned here rather than discovered in the adapter.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs`:
+
+```csharp
+using System.Text.Json;
+using Brmble.Client.Services.Voice;
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class ProjectionWireTests
+{
+    private static JsonElement Json(string raw) => JsonDocument.Parse(raw).RootElement.Clone();
+
+    [TestMethod]
+    public void ReadSnapshot_ReadsTheEnvelopeAndEveryMapping()
+    {
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        {
+          "instanceId": "inst-a",
+          "revision": 7,
+          "mappings": {
+            "3": { "matrixUserId": "@alice:test", "mumbleName": "Alice",
+                   "companionId": "retro", "certHash": "abc", "isBrmbleClient": true }
+          }
+        }
+        """));
+
+        Assert.IsNotNull(snapshot);
+        Assert.AreEqual("inst-a", snapshot!.InstanceId);
+        Assert.AreEqual(7L, snapshot.Revision);
+        var entry = snapshot.Mappings[3];
+        Assert.AreEqual("@alice:test", entry.MatrixUserId);
+        Assert.AreEqual("retro", entry.CompanionId);
+        Assert.AreEqual(true, entry.IsBrmbleClient);
+        Assert.AreEqual("abc", entry.CertHash);
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_KeepsAMappingWithNoMumbleName()
+    {
+        // The old ParseSessionMappings dropped these outright, losing the identity entirely.
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "3": { "matrixUserId": "@alice:test" } } }
+        """));
+
+        Assert.AreEqual("@alice:test", snapshot!.Mappings[3].MatrixUserId);
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_AbsentCompanionIsUnknownNotFloppy()
+    {
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "3": { "matrixUserId": "@a:t" } } }
+        """));
+
+        Assert.IsNull(snapshot!.Mappings[3].CompanionId,
+            "a default must never be transmitted as though it were a fact");
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_NullIsBrmbleClientIsUnknownNotFalse()
+    {
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "3": { "matrixUserId": "@a:t", "isBrmbleClient": null } } }
+        """));
+
+        Assert.IsNull(snapshot!.Mappings[3].IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_PrefersACustomCompanionOverTheLegacyField()
+    {
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "3": { "companionId": "floppy",
+                               "customCompanionId": "custom:$abc" } } }
+        """));
+
+        Assert.AreEqual("custom:$abc", snapshot!.Mappings[3].CompanionId,
+            "the legacy split sends floppy alongside the truth; the truth wins");
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_ReturnsNullWhenTheEnvelopeIsMissing()
+    {
+        Assert.IsNull(ProjectionWire.ReadSnapshot(Json("""{ "mappings": {} }""")));
+    }
+
+    [TestMethod]
+    public void ReadEvent_ReadsAMappingAddedWithItsRange()
+    {
+        var evt = ProjectionWire.ReadEvent("userMappingAdded", Json("""
+        { "instanceId": "inst-a", "baseRevision": 4, "revision": 7, "sessionId": 3,
+          "matrixUserId": "@alice:test", "companionId": "retro", "isBrmbleClient": true }
+        """));
+
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(ServerEventKind.MappingAdded, evt!.Kind);
+        Assert.AreEqual(4L, evt.BaseRevision);
+        Assert.AreEqual(7L, evt.Revision);
+        Assert.AreEqual(3u, evt.SessionId);
+        Assert.AreEqual("retro", evt.Entry!.CompanionId);
+    }
+
+    [TestMethod]
+    public void ReadEvent_ActivationCarriesNoEntry()
+    {
+        var evt = ProjectionWire.ReadEvent("brmbleClientActivated", Json("""
+        { "instanceId": "i", "baseRevision": 1, "revision": 2, "sessionId": 3 }
+        """));
+
+        Assert.AreEqual(ServerEventKind.BrmbleActivated, evt!.Kind);
+        Assert.IsNull(evt.Entry);
+    }
+
+    [TestMethod]
+    public void ReadEvent_DefaultsAMissingBaseRevisionToOneBelowRevision()
+    {
+        // A server predating Phase 1 sends no baseRevision. Assuming a single bump is the
+        // only reading that lets an old server still drive a new client.
+        var evt = ProjectionWire.ReadEvent("companionChanged", Json("""
+        { "instanceId": "i", "revision": 9, "sessionId": 3, "companionId": "bee" }
+        """));
+
+        Assert.AreEqual(8L, evt!.BaseRevision);
+    }
+
+    [TestMethod]
+    public void ReadEvent_ReturnsNullForAnUnknownType()
+    {
+        Assert.IsNull(ProjectionWire.ReadEvent("screenShare.started", Json("{}")));
+    }
+
+    [TestMethod]
+    public void ReadEvent_ReturnsNullWithoutASessionId()
+    {
+        Assert.IsNull(ProjectionWire.ReadEvent("companionChanged",
+            Json("""{ "instanceId": "i", "revision": 2 }""")));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~ProjectionWireTests"`
+
+Expected: FAIL — compile error, `The name 'ProjectionWire' does not exist in the current context`.
+
+- [ ] **Step 3: Write the translator**
+
+Create `src/Brmble.Client/Services/Voice/ProjectionWire.cs`:
+
+```csharp
+using System.Text.Json;
+using Brmble.Client.Services.Voice.Projection;
+
+namespace Brmble.Client.Services.Voice;
+
+/// <summary>
+/// Translates Brmble wire payloads into <see cref="UserProjectionStore"/> inputs.
+/// </summary>
+/// <remarks>
+/// This is the only place that knows both JSON and the projection. Keeping it out of the
+/// <c>Projection</c> namespace is what lets the store be unit-tested without a protocol stack,
+/// and what stops wire quirks leaking into the merge rules.
+/// </remarks>
+internal static class ProjectionWire
+{
+    /// <summary>
+    /// Reads a <c>sessionMappingSnapshot</c> or an <c>/auth/token</c> body. Returns null when the
+    /// payload carries no envelope, because a snapshot without one cannot establish a cursor.
+    /// </summary>
+    internal static ServerSnapshot? ReadSnapshot(JsonElement root)
+    {
+        var instanceId = ReadString(root, "instanceId");
+        if (string.IsNullOrEmpty(instanceId)) return null;
+        if (!root.TryGetProperty("revision", out var revision) ||
+            revision.ValueKind != JsonValueKind.Number) return null;
+
+        var mappings = new Dictionary<uint, ServerMappingEntry>();
+        if (root.TryGetProperty("mappings", out var raw) && raw.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in raw.EnumerateObject())
+            {
+                if (!uint.TryParse(property.Name, out var sessionId)) continue;
+                mappings[sessionId] = ReadEntry(property.Value);
+            }
+        }
+
+        return new ServerSnapshot(instanceId, revision.GetInt64(), mappings);
+    }
+
+    /// <summary>
+    /// Reads one incremental mapping event. Returns null for any payload that is not one — the
+    /// caller dispatches every WebSocket message through here.
+    /// </summary>
+    internal static ServerEvent? ReadEvent(string? type, JsonElement root)
+    {
+        var kind = type switch
+        {
+            "userMappingAdded" => ServerEventKind.MappingAdded,
+            "userMappingRemoved" => ServerEventKind.MappingRemoved,
+            "companionChanged" => ServerEventKind.CompanionChanged,
+            "brmbleClientActivated" => ServerEventKind.BrmbleActivated,
+            "brmbleClientDeactivated" => ServerEventKind.BrmbleDeactivated,
+            _ => (ServerEventKind?)null
+        };
+        if (kind is null) return null;
+
+        var instanceId = ReadString(root, "instanceId");
+        if (string.IsNullOrEmpty(instanceId)) return null;
+
+        if (!root.TryGetProperty("sessionId", out var session) ||
+            session.ValueKind != JsonValueKind.Number) return null;
+        var sessionId = session.GetUInt32();
+        if (sessionId == 0) return null;
+
+        if (!root.TryGetProperty("revision", out var revisionProperty) ||
+            revisionProperty.ValueKind != JsonValueKind.Number) return null;
+        var revision = revisionProperty.GetInt64();
+
+        // A server predating Phase 1 sends no baseRevision. Assuming the operation bumped once
+        // is the only reading under which an old server can still drive a new client; a wrong
+        // guess costs one redundant snapshot, not a wrong value.
+        var baseRevision = root.TryGetProperty("baseRevision", out var b) &&
+                           b.ValueKind == JsonValueKind.Number
+            ? b.GetInt64()
+            : revision - 1;
+
+        // Removal and the two activation events assert their meaning through Kind alone; only
+        // the field-carrying events need an entry.
+        var entry = kind is ServerEventKind.MappingAdded or ServerEventKind.CompanionChanged
+            ? ReadEntry(root)
+            : null;
+
+        return new ServerEvent(kind.Value, instanceId, baseRevision, revision, sessionId, entry);
+    }
+
+    /// <summary>
+    /// Reads the server-owned half of one session. Every absent field becomes null, which the
+    /// store reads as "not known" — this is where the old parser's <c>"floppy"</c> default and
+    /// its <c>isBrmbleClient: false</c> default are removed.
+    /// </summary>
+    private static ServerMappingEntry ReadEntry(JsonElement element) =>
+        new(ReadString(element, "matrixUserId"),
+            ReadCompanionId(element),
+            ReadNullableBool(element, "isBrmbleClient"),
+            ReadString(element, "certHash"));
+
+    /// <summary>
+    /// Prefers the custom companion over the legacy field. The legacy split transmits
+    /// <c>companionId: "floppy"</c> alongside the real selection in <c>customCompanionId</c>,
+    /// so reading the legacy field first would turn every custom skin into a floppy.
+    /// </summary>
+    private static string? ReadCompanionId(JsonElement element)
+    {
+        if (ReadString(element, "customCompanionId") is { } custom &&
+            custom.StartsWith("custom:$", StringComparison.Ordinal))
+            return custom;
+
+        return ReadString(element, "companionId");
+    }
+
+    private static string? ReadString(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static bool? ReadNullableBool(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value)
+            ? value.ValueKind switch
+            {
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                _ => null
+            }
+            : null;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~ProjectionWireTests"`
+
+Expected: PASS, eleven tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/ProjectionWire.cs tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
+git commit -m "feat: translate mapping wire payloads into projection inputs"
+```
+
+## Task A2: Row serialisation
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/ProjectionWire.cs`
+- Test: `tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs`
+
+**Why:** six payload shapes (`:4181`, `:4305`, `:2632`, `:2666`, and the two `voice.userLeft` variants) each rebuild a user row by hand, with different field names and different null handling. One serialiser replaces all of them, and Stage D reuses it unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ProjectionWireTests`:
+
+```csharp
+    [TestMethod]
+    public void ToWireRow_EmitsEveryFieldWithNullsExplicit()
+    {
+        var row = new UserProjection
+        {
+            SessionId = 3,
+            Name = "Alice",
+            ChannelId = 5,
+            Muted = true,
+            Deafened = false,
+            Comment = "hi",
+            MumbleCertHash = "live",
+            IsSelf = true,
+            MatrixUserId = "@alice:test",
+            CompanionId = null,
+            IsBrmbleClient = null,
+            ServerCertHash = "stored"
+        };
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(ProjectionWire.ToWireRow(row)));
+        var json = doc.RootElement;
+
+        Assert.AreEqual(3, json.GetProperty("session").GetInt32());
+        Assert.AreEqual("Alice", json.GetProperty("name").GetString());
+        Assert.AreEqual(5, json.GetProperty("channelId").GetInt32());
+        Assert.IsTrue(json.GetProperty("muted").GetBoolean());
+        Assert.IsTrue(json.GetProperty("self").GetBoolean());
+        Assert.AreEqual("live", json.GetProperty("certHash").GetString(),
+            "the live certificate wins over the server's recorded copy");
+
+        // Nulls must be present rather than omitted: React replaces rows wholesale, so an
+        // absent key and a null key must not mean different things.
+        Assert.AreEqual(JsonValueKind.Null, json.GetProperty("companionId").ValueKind);
+        Assert.AreEqual(JsonValueKind.Null, json.GetProperty("isBrmbleClient").ValueKind);
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~ToWireRow"`
+
+Expected: FAIL — `'ProjectionWire' does not contain a definition for 'ToWireRow'`.
+
+- [ ] **Step 3: Add the serialiser**
+
+Append to `ProjectionWire`:
+
+```csharp
+    /// <summary>
+    /// The single wire shape for a user row. Every field is always present, nulls included, so a
+    /// consumer replaces by session id and never merges field-by-field.
+    /// </summary>
+    internal static object ToWireRow(UserProjection row) => new
+    {
+        session = row.SessionId,
+        name = row.Name,
+        channelId = row.ChannelId,
+        muted = row.Muted,
+        deafened = row.Deafened,
+        self = row.IsSelf,
+        comment = row.Comment,
+        certHash = row.CertHash,
+        matrixUserId = row.MatrixUserId,
+        companionId = row.CompanionId,
+        isBrmbleClient = row.IsBrmbleClient
+    };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~ProjectionWireTests"`
+
+Expected: PASS, twelve tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/ProjectionWire.cs tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
+git commit -m "feat: add one wire row shape for the projection"
+```
+
+## Task A3: Feed the store from Mumble
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` (`:66`, `:4247-4393`, `:4495-4595`, `:4174-4212`)
+- Test: `tests/Brmble.Client.Tests/Services/MumbleAdapterProjectionTests.cs` (create)
+
+**Why:** Mumble owns existence. Until `UserState` and `UserRemove` reach the store, nothing else can.
+
+- [ ] **Step 1: Add the field and a translation helper**
+
+In `MumbleAdapter.cs`, immediately after `_sessionMappings` (`:66`), add:
+
+```csharp
+    /// <summary>
+    /// The authoritative user projection. Replaces _sessionMappings, _pendingBrmbleStatus and
+    /// _userMappings: it merges Mumble presence and Brmble identity under one set of rules
+    /// rather than three ad-hoc ones spread across the adapter and App.tsx.
+    /// </summary>
+    private readonly Projection.UserProjectionStore _projection = new();
+```
+
+Add near `SendVoiceConnected`:
+
+```csharp
+    /// <summary>
+    /// Reduces a MumbleSharp user to the fields Mumble owns. Muted folds server mute, self mute
+    /// and both deafen flags together, matching what the UI has always shown.
+    /// </summary>
+    private Projection.MumbleUserInput ToProjectionInput(MumbleSharp.Model.User user) =>
+        new(user.Id,
+            user.Name,
+            user.Channel?.Id ?? 0,
+            user.Muted || user.SelfMuted || user.Deaf || user.SelfDeaf,
+            user.Deaf || user.SelfDeaf,
+            user.Comment,
+            user.CertificateHash,
+            user == LocalUser);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/Brmble.Client.Tests/Services/MumbleAdapterProjectionTests.cs`. Test the store contract the adapter depends on, since `MumbleAdapter` itself needs a live protocol stack:
+
+```csharp
+using Brmble.Client.Services.Voice;
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+/// <summary>
+/// The ordering guarantees MumbleAdapter relies on when it drives the store from three threads.
+/// </summary>
+[TestClass]
+public class MumbleAdapterProjectionTests
+{
+    [TestMethod]
+    public void AuthTokenSnapshotBeforeUserStateStillEnrichesTheRow()
+    {
+        // The real connect ordering: ServerSync -> FetchAndSendCredentials -> SendVoiceConnected.
+        var store = new UserProjectionStore();
+        var snapshot = ProjectionWire.ReadSnapshot(System.Text.Json.JsonDocument.Parse("""
+        { "instanceId": "inst-a", "revision": 3,
+          "mappings": { "1": { "matrixUserId": "@alice:test", "companionId": "retro",
+                               "isBrmbleClient": true } } }
+        """).RootElement);
+
+        store.ApplyServerSnapshot(snapshot!);
+        var change = store.ApplyMumbleReset([new MumbleUserInput(1, "Alice", 0, false, false, null, null, true)]);
+
+        var row = change.Changed.Single();
+        Assert.AreEqual("@alice:test", row.MatrixUserId);
+        Assert.AreEqual("retro", row.CompanionId);
+        Assert.AreEqual(true, row.IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void AChannelMoveDoesNotDisturbIdentity()
+    {
+        var store = new UserProjectionStore();
+        store.ApplyMumbleUserState(new MumbleUserInput(1, "Alice", 0, false, false, null, null, false));
+        store.ApplyServerSnapshot(new ServerSnapshot("i", 1,
+            new Dictionary<uint, ServerMappingEntry> { [1] = new("@a:t", "retro", true, null) }));
+
+        var change = store.ApplyMumbleUserState(
+            new MumbleUserInput(1, "Alice", 9, false, false, null, null, false));
+
+        Assert.AreEqual(9u, change.Changed.Single().ChannelId);
+        Assert.AreEqual(true, change.Changed.Single().IsBrmbleClient);
+    }
+}
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~MumbleAdapterProjectionTests"`
+
+Expected: FAIL — compile error, `ProjectionWire` is `internal` to `Brmble.Client` but `InternalsVisibleTo` already covers the test project, so the real failure is `MumbleUserInput` ambiguity only if `using` lines are wrong. If it compiles and passes immediately, the store already satisfies the contract — that is acceptable here because these are regression pins for Stage A's wiring, not new behaviour. Note it and continue.
+
+- [ ] **Step 4: Drive the store from the protocol handlers**
+
+In `UserState` (`:4247`), after `base.UserState(userState);` (`:4261`), add:
+
+```csharp
+        // Mumble resends the complete UserState on every change, so this is authoritative for
+        // every Mumble-owned field including the ones that went empty.
+        if (user is not null) _projection.ApplyMumbleUserState(ToProjectionInput(user));
+```
+
+In `UserRemove` (`:4495`), after `base.UserRemove(userRemove);` (`:4505`), add:
+
+```csharp
+        // The only path that deletes a row: Mumble alone owns existence.
+        _projection.ApplyMumbleUserRemove(userRemove.Session);
+```
+
+In `SendVoiceConnected` (`:4174`), before building the payload, add:
+
+```csharp
+        // A reconnect replaces membership wholesale. Server-owned fields survive for sessions
+        // present both before and after, so a voice reconnect costs no identity.
+        _projection.ApplyMumbleReset([.. Users.Select(ToProjectionInput)]);
+```
+
+- [ ] **Step 5: Run the full client suite**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj`
+
+Expected: PASS. The store is being written but not yet read, so nothing changes behaviourally.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/MumbleAdapter.cs tests/Brmble.Client.Tests/Services/MumbleAdapterProjectionTests.cs
+git commit -m "feat: drive the user projection from Mumble presence"
+```
+
+## Task A4: Feed the store from the server, and read from it
+
+**Files:**
+- Modify: `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` (`:2000-2020`, `:2611-2714`, `:4174-4212`, `:4303-4321`)
+
+**Why:** this is the switch-over. After it, `_sessionMappings`, `_pendingBrmbleStatus` and `_userMappings` are dead.
+
+- [ ] **Step 1: Route `/auth/token` through the store**
+
+Replace `:2013-2018` (the `sessionMappings` block) with:
+
+```csharp
+        // The credential body carries the same envelope as a WebSocket snapshot, so it
+        // establishes the cursor too. Without this the first event after connect looks like a
+        // gap and the client resyncs immediately.
+        if (ProjectionWire.ReadSnapshot(credentials.Value) is { } tokenSnapshot)
+        {
+            var change = _projection.ApplyServerSnapshot(tokenSnapshot);
+            EmitProjectionChange(change);
+        }
+```
+
+Delete the `userMappings` block at `:2001-2010` and the `_userMappings` field at `:65`. Its two readers (`:4191`, `:4315`) are replaced in Step 3.
+
+- [ ] **Step 2: Route WebSocket messages through the store**
+
+In `HandleWebSocketMessage` (`:2611`), replace the five mapping cases (`sessionMappingSnapshot`, `userMappingAdded`, `companionChanged`, `userMappingRemoved`, `brmbleClientActivated`, `brmbleClientDeactivated`) with a single pre-dispatch block placed immediately after `var type = ...` (`:2617`):
+
+```csharp
+            // Every mapping payload goes through the projection. The store decides whether the
+            // event is contiguous, a duplicate or a gap; the adapter only relays the result.
+            if (type == "sessionMappingSnapshot")
+            {
+                if (ProjectionWire.ReadSnapshot(root) is { } wsSnapshot)
+                    EmitProjectionChange(_projection.ApplyServerSnapshot(wsSnapshot));
+                return;
+            }
+
+            if (ProjectionWire.ReadEvent(type, root) is { } mappingEvent)
+            {
+                EmitProjectionChange(_projection.ApplyServerEvent(mappingEvent));
+                return;
+            }
+```
+
+Leave the `screenShare.*` and `acl.changed` cases untouched.
+
+- [ ] **Step 3: Emit the existing eight events from the store**
+
+Add:
+
+```csharp
+    /// <summary>
+    /// Relays a change set to the UI. Stage A keeps the legacy event set so React is unchanged;
+    /// Stage D replaces the body with two events.
+    /// </summary>
+    /// <remarks>
+    /// Called after Apply* has returned and released the store's lock — never inside it.
+    /// </remarks>
+    private void EmitProjectionChange(Projection.ChangeSet change)
+    {
+        if (change.IsEmpty) return;
+
+        foreach (var row in change.Changed)
+            _bridge?.Send("voice.userJoined", ProjectionWire.ToWireRow(row));
+
+        foreach (var sessionId in change.Removed)
+            _bridge?.Send("voice.userLeft", new { session = sessionId, moved = false });
+
+        if (change.Changed.Count > 0 || change.Removed.Count > 0) _bridge?.NotifyUiThread();
+    }
+```
+
+In `SendVoiceConnected` (`:4178-4195`), replace the hand-built `users` projection with:
+
+```csharp
+            users = _projection.Snapshot().Values.Select(ProjectionWire.ToWireRow).ToArray(),
+```
+
+In `UserState` (`:4303-4321`), replace the whole `voice.userJoined` emit with a call driven by the store:
+
+```csharp
+        if (user is not null)
+            EmitProjectionChange(_projection.ApplyMumbleUserState(ToProjectionInput(user)));
+```
+
+(This supersedes the `ApplyMumbleUserState` call added in Task A3 Step 4 — there must be exactly one.)
+
+- [ ] **Step 4: Delete the dead state**
+
+Remove: `_sessionMappings` (`:66`), `_pendingBrmbleStatus` (`:68-75`), `_userMappings` (`:65`), `SessionMappingEntry` (`:110`), `ParseSessionMappings` (`:117-139`), `ParseWireCompanionId` (`:141-142`), `ParseWireCompanionIdOrNull` (`:144-159`), `RecordBrmbleStatus` (`:2586-2600`), `ApplyPendingBrmbleStatus` (`:2602-2609`), and the `_sessionMappings.Clear()` at `:546` and `:2015`.
+
+Point `GetSelfCompanionOrDefault` (`:2104`) and `UpdateSelfCompanionMapping` (`:2116`) at the store:
+
+```csharp
+    private string GetSelfCompanionOrDefault()
+    {
+        if (LocalUser is null) return "floppy";
+        // "floppy" is a render-time fallback for an unknown companion, never a stored value.
+        return _projection.Snapshot().TryGetValue(LocalUser.Id, out var row)
+               && !string.IsNullOrWhiteSpace(row.CompanionId)
+            ? row.CompanionId!
+            : "floppy";
+    }
+```
+
+`UpdateSelfCompanionMapping` is deleted outright: the server announces the change and the store applies it, so writing a local guess is exactly the "confidently wrong value" the design removes. Delete its only call site at `:2180`.
+
+- [ ] **Step 5: Fix the fallout and run everything**
+
+Run: `dotnet build`
+
+Expect errors at every deleted symbol. Any test referencing `ParseSessionMappings` or `SessionMappingEntry` moves to `ProjectionWireTests`; delete tests that only asserted the `"floppy"` default, and note in the commit body which ones and why.
+
+Run: `dotnet test`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src tests
+git commit -m "feat: make the projection the client's only user state"
+```
+
+---
+
+# STAGE B — Resync and socket lifetime
+
+**Outcome:** a gap or a restart repairs itself. Today `NeedsSnapshot` has nowhere to go.
+
+## Task B1: Hoist the stream and add a send lock
+
+**Files:** `src/Brmble.Client/Services/Voice/MumbleAdapter.cs` (`:2272-2438`, `:2536`)
+
+- [ ] **Step 1: Add the fields**
+
+```csharp
+    /// <summary>
+    /// The live WebSocket stream, or null when disconnected. Hoisted out of the reconnect loop
+    /// so application messages can be sent; guarded by _wsSendGate because the read loop answers
+    /// pings on the same socket and two interleaved frames corrupt the stream.
+    /// </summary>
+    private Stream? _wsStream;
+    private readonly SemaphoreSlim _wsSendGate = new(1, 1);
+```
+
+- [ ] **Step 2: Assign and clear it**
+
+At `:2318`, after `var stream = tlsProtocol.Stream;`, add `_wsStream = stream;`. In the `finally` at `:2419`, add `_wsStream = null;` **before** `tlsProtocol?.Close()`.
+
+- [ ] **Step 3: Route every send through the gate**
+
+Change `SendWebSocketFrame` from `static` to an instance method and wrap its body:
+
+```csharp
+    private async Task SendWebSocketFrame(Stream stream, int opcode, byte[] data)
+    {
+        await _wsSendGate.WaitAsync();
+        try
+        {
+            // ... existing body unchanged ...
+        }
+        finally
+        {
+            _wsSendGate.Release();
+        }
+    }
+```
+
+`ReadWebSocketFrame` is `static` and calls this for pongs (`:2503`, `:2519`); make it an instance method too, or pass a `Func<int, byte[], Task>` sender. Prefer the former — it is a smaller diff.
+
+- [ ] **Step 4: Build and commit**
+
+```bash
+dotnet build
+git add src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+git commit -m "refactor: hoist the websocket stream so the client can send"
+```
+
+## Task B2: Request a snapshot when the store asks
+
+**Files:** `MumbleAdapter.cs`; Test: `tests/Brmble.Client.Tests/Services/ResyncThrottleTests.cs` (create)
+
+**Why:** item 7 — a persistent mismatch must never become a hot loop. Extract the throttle so it is testable without a socket.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Brmble.Client.Services.Voice;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class ResyncThrottleTests
+{
+    [TestMethod]
+    public void AllowsTheFirstRequestImmediately()
+    {
+        var throttle = new ResyncThrottle();
+        Assert.IsTrue(throttle.TryBegin(TimeSpan.Zero));
+    }
+
+    [TestMethod]
+    public void RefusesASecondRequestWhileOneIsInFlight()
+    {
+        var throttle = new ResyncThrottle();
+        throttle.TryBegin(TimeSpan.Zero);
+
+        Assert.IsFalse(throttle.TryBegin(TimeSpan.FromSeconds(5)),
+            "one in flight at a time, or a burst of events becomes a burst of snapshots");
+    }
+
+    [TestMethod]
+    public void EnforcesMinimumSpacingAfterCompletion()
+    {
+        var throttle = new ResyncThrottle();
+        throttle.TryBegin(TimeSpan.Zero);
+        throttle.Complete(TimeSpan.FromMilliseconds(100));
+
+        Assert.IsFalse(throttle.TryBegin(TimeSpan.FromMilliseconds(200)));
+        Assert.IsTrue(throttle.TryBegin(TimeSpan.FromMilliseconds(1200)));
+    }
+
+    [TestMethod]
+    public void BacksOffExponentiallyToThirtySeconds()
+    {
+        var throttle = new ResyncThrottle();
+        var now = TimeSpan.Zero;
+
+        for (var i = 0; i < 12; i++)
+        {
+            now += TimeSpan.FromMinutes(1);
+            Assert.IsTrue(throttle.TryBegin(now), $"attempt {i} should be allowed after a long wait");
+            throttle.Complete(now);
+        }
+
+        Assert.AreEqual(TimeSpan.FromSeconds(30), throttle.CurrentDelay,
+            "backoff must saturate rather than grow without bound");
+    }
+
+    [TestMethod]
+    public void ResetsBackoffOnceASnapshotArrives()
+    {
+        var throttle = new ResyncThrottle();
+        throttle.TryBegin(TimeSpan.Zero);
+        throttle.Complete(TimeSpan.Zero);
+        throttle.TryBegin(TimeSpan.FromSeconds(10));
+        throttle.Complete(TimeSpan.FromSeconds(10));
+
+        throttle.OnSnapshotApplied();
+
+        Assert.AreEqual(TimeSpan.FromSeconds(1), throttle.CurrentDelay);
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj --filter "FullyQualifiedName~ResyncThrottleTests"`
+
+Expected: FAIL — `The type or namespace name 'ResyncThrottle' could not be found`.
+
+- [ ] **Step 3: Write it**
+
+Create `src/Brmble.Client/Services/Voice/ResyncThrottle.cs`:
+
+```csharp
+namespace Brmble.Client.Services.Voice;
+
+/// <summary>
+/// Rate-limits snapshot requests. A client whose cursor cannot be repaired — a server bug, a
+/// truncated event stream — would otherwise request a snapshot for every event it receives.
+/// </summary>
+/// <remarks>
+/// Time is passed in rather than read from a clock so the policy is testable without waiting.
+/// </remarks>
+internal sealed class ResyncThrottle
+{
+    private static readonly TimeSpan MinimumSpacing = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan MaximumDelay = TimeSpan.FromSeconds(30);
+
+    private readonly object _gate = new();
+    private bool _inFlight;
+    private TimeSpan? _lastCompleted;
+
+    public TimeSpan CurrentDelay { get; private set; } = MinimumSpacing;
+
+    public bool TryBegin(TimeSpan now)
+    {
+        lock (_gate)
+        {
+            if (_inFlight) return false;
+            if (_lastCompleted is { } last && now - last < CurrentDelay) return false;
+
+            _inFlight = true;
+            return true;
+        }
+    }
+
+    /// <summary>Marks the request finished and widens the delay for the next one.</summary>
+    public void Complete(TimeSpan now)
+    {
+        lock (_gate)
+        {
+            _inFlight = false;
+            _lastCompleted = now;
+            var doubled = CurrentDelay * 2;
+            CurrentDelay = doubled > MaximumDelay ? MaximumDelay : doubled;
+        }
+    }
+
+    /// <summary>A snapshot landed and the cursor is healthy, so the backoff has done its job.</summary>
+    public void OnSnapshotApplied()
+    {
+        lock (_gate) CurrentDelay = MinimumSpacing;
+    }
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Expected: PASS, five tests.
+
+- [ ] **Step 5: Wire it in**
+
+Add `private readonly ResyncThrottle _resync = new();` and a stopwatch field `private readonly System.Diagnostics.Stopwatch _resyncClock = System.Diagnostics.Stopwatch.StartNew();`.
+
+In `EmitProjectionChange`, before the row loop:
+
+```csharp
+        if (change.NeedsSnapshot) RequestSnapshot();
+```
+
+Add:
+
+```csharp
+    /// <summary>
+    /// Asks the server to restate the mapping table. Fire-and-forget: the reply arrives as a
+    /// normal sessionMappingSnapshot on the read loop.
+    /// </summary>
+    private void RequestSnapshot()
+    {
+        if (!_resync.TryBegin(_resyncClock.Elapsed)) return;
+
+        var stream = _wsStream;
+        if (stream is null)
+        {
+            // No socket: the reconnect will bring a bootstrap snapshot anyway.
+            _resync.Complete(_resyncClock.Elapsed);
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var payload = System.Text.Json.JsonSerializer.Serialize(new { type = "requestSnapshot" });
+                await SendWebSocketFrame(stream, 0x1, System.Text.Encoding.UTF8.GetBytes(payload));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Brmble] resync request failed: {ex.Message}");
+            }
+            finally
+            {
+                _resync.Complete(_resyncClock.Elapsed);
+            }
+        });
+    }
+```
+
+In the `sessionMappingSnapshot` branch added in Task A4, call `_resync.OnSnapshotApplied();` after applying.
+
+- [ ] **Step 6: Build, test, commit**
+
+```bash
+dotnet build
+dotnet test tests/Brmble.Client.Tests/Brmble.Client.Tests.csproj
+git add src tests
+git commit -m "feat: request a snapshot when the projection detects a gap"
+```
+
+## Task B3: Stop tearing down a working socket
+
+**Files:** `MumbleAdapter.cs:2033-2034`
+
+**Why:** `FetchAndSendCredentials` calls `StartWebSocketConnection` unconditionally. It is reachable from `ServerSync` on every reconnect and from the health-check path, so a credential refresh kills a socket that was working — and because `ReadExactAsync` (`:2579`) calls `stream.ReadAsync` **without** the cancellation token, the old read only unblocks when the TLS stream is disposed, racing the new connection.
+
+- [ ] **Step 1: Add the guard**
+
+Replace `:2034`:
+
+```csharp
+        // Only connect if we do not already have a live socket. A credential refresh — which the
+        // health check can trigger at any time — must not tear down a working connection: the
+        // old read loop does not observe cancellation until its stream is disposed, so the two
+        // connections race and the surviving one may be the one being torn down.
+        if (_wsStream is null) StartWebSocketConnection(apiUrl);
+```
+
+- [ ] **Step 2: Pass the token to the blocking read**
+
+At `:2579`, add the token so cancellation is observed promptly:
+
+```csharp
+            var read = await stream.ReadAsync(buffer.AsMemory(offset + totalRead, count - totalRead), ct);
+```
+
+- [ ] **Step 3: Verify manually**
+
+```bash
+docker compose -f docker-local/docker-compose.yml up -d --build brmble
+dotnet run --project src/Brmble.Client
+```
+
+Connect, wait for two health-check cycles, confirm the log shows exactly one `session/connected` and no reconnect churn.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+git commit -m "fix: do not restart a live websocket on credential refresh"
+```
+
+---
+
+# STAGE C — Version negotiation and the companion collapse
+
+**Outcome:** one truthful `companionId` for clients that announce support; the legacy lie confined to the compatibility boundary.
+
+## Task C1: Server reads `pv`
+
+**Files:** `src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs`; Test: `tests/Brmble.Server.Tests/WebSockets/ProjectionVersionTests.cs` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Brmble.Server.WebSockets;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.WebSockets;
+
+[TestClass]
+public class ProjectionVersionTests
+{
+    [TestMethod]
+    public void AbsentQueryParameterIsVersionZero() =>
+        Assert.AreEqual(0, BrmbleWebSocketHandler.ParseProjectionVersion(null));
+
+    [TestMethod]
+    public void ParsesAnExplicitVersion() =>
+        Assert.AreEqual(1, BrmbleWebSocketHandler.ParseProjectionVersion("1"));
+
+    [TestMethod]
+    public void GarbageIsVersionZero()
+    {
+        // A malformed parameter must degrade to the legacy shape, never throw a client off.
+        Assert.AreEqual(0, BrmbleWebSocketHandler.ParseProjectionVersion("banana"));
+        Assert.AreEqual(0, BrmbleWebSocketHandler.ParseProjectionVersion("-3"));
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Expected: FAIL — `does not contain a definition for 'ParseProjectionVersion'`.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+    /// <summary>
+    /// Reads the client's projection version from the <c>pv</c> query parameter. Absent or
+    /// malformed means version 0, which gets the legacy companion split.
+    /// </summary>
+    internal static int ParseProjectionVersion(string? raw) =>
+        int.TryParse(raw, out var version) && version > 0 ? version : 0;
+```
+
+Call it in `HandleAsync` **before** `AcceptWebSocketAsync`, so the version is known while initial payloads are built:
+
+```csharp
+        var projectionVersion = ParseProjectionVersion(context.Request.Query["pv"]);
+```
+
+Thread it through `InitializeAcceptedClientAsync` and `BuildInitialPayloadsAsync` as a parameter.
+
+- [ ] **Step 4: Run, then commit**
+
+```bash
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter "FullyQualifiedName~ProjectionVersionTests"
+git add src/Brmble.Server tests/Brmble.Server.Tests
+git commit -m "feat: negotiate a projection version on the websocket"
+```
+
+## Task C2: One companion field for `pv>=1`
+
+**Files:** `src/Brmble.Server/Mumble/CompanionWireSelection.cs`, every payload builder that calls it
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing companion wire test suite:
+
+```csharp
+    [TestMethod]
+    public void Version1SendsTheCustomSelectionInCompanionId()
+    {
+        var wire = CompanionWireSelection.For("custom:$abc", projectionVersion: 1);
+
+        Assert.AreEqual("custom:$abc", wire.CompanionId);
+        Assert.IsNull(wire.CustomCompanionId, "the split exists only for clients that need it");
+    }
+
+    [TestMethod]
+    public void Version0KeepsTheLegacySplit()
+    {
+        var wire = CompanionWireSelection.For("custom:$abc", projectionVersion: 0);
+
+        Assert.AreEqual("floppy", wire.CompanionId);
+        Assert.AreEqual("custom:$abc", wire.CustomCompanionId);
+    }
+
+    [TestMethod]
+    public void AnUnknownCompanionIsNullAtVersion1()
+    {
+        // Absent must not be transmitted as "floppy": that is the defect the design removes.
+        Assert.IsNull(CompanionWireSelection.For(null, projectionVersion: 1).CompanionId);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails, then implement**
+
+```csharp
+    /// <summary>
+    /// Builds the companion fields for a client at the given projection version.
+    /// </summary>
+    /// <remarks>
+    /// Version 0 predates custom companions being first-class and cannot parse
+    /// <c>custom:$…</c> in <c>companionId</c>, so it gets <c>"floppy"</c> plus the truth in
+    /// <c>customCompanionId</c>. That is a lie told at the compatibility boundary; it must never
+    /// reach the projection.
+    /// </remarks>
+    public static CompanionWireSelection For(string? persisted, int projectionVersion)
+    {
+        if (projectionVersion >= 1) return new CompanionWireSelection(persisted, null);
+        return FromPersisted(persisted);
+    }
+```
+
+Keep `FromPersisted` as the version-0 implementation so existing callers and tests are undisturbed.
+
+- [ ] **Step 3: Thread the version through every mapping payload builder**
+
+`CreateUserMappingAddedPayload`, `SessionMappingWire.From`, `AuthEndpoints`' `/auth/token` and `PersistCompanionSelectionAsync`, `CustomCompanionEndpoints`, `SessionMappingHandler`. Broadcast events go to clients at mixed versions, so a broadcast **must** send the legacy split; only per-socket payloads (initial snapshot, and anything sent with `SendToClientAsync`) can use version 1.
+
+**Write this down in a comment at each broadcast site**, because it is the non-obvious constraint of this stage:
+
+```csharp
+        // Broadcast: recipients are at mixed projection versions, so this must carry the legacy
+        // split. Only per-socket payloads know their reader's version.
+```
+
+- [ ] **Step 4: Client announces the version**
+
+In `MumbleAdapter.cs:2286`, change the path construction:
+
+```csharp
+        // Announce projection version 1: send one truthful companion field rather than the split.
+        var wsPath = builder.Path.TrimEnd('/') + "/ws?pv=1";
+```
+
+- [ ] **Step 5: Test and commit**
+
+```bash
+dotnet test
+git add src tests
+git commit -m "feat: send one truthful companion field to pv>=1 clients"
+```
+
+## Task C3: Decide on `TryUpdateCompanionIdIfCurrent`
+
+**Files:** `src/Brmble.Server/Mumble/ISessionMappingService.cs` and implementation
+
+Item 12 is conditional. `TryUpdateCompanionIdIfCurrent` is a per-field compare-and-swap added by `custom-companion`; the spec proposes retiring it in favour of rejecting a whole mutation that carries a stale revision.
+
+- [ ] **Step 1: Establish whether the revision path covers the same race**
+
+The CAS guards: a moderator deletes a custom companion and resets that session to `"floppy"`, while the user concurrently selects something else. The revision path rejects a *stale-revision mutation*, but `CustomCompanionEndpoints` computes its target inside `PublishAsync`'s lock and does not carry a client revision at all — so there is nothing to reject.
+
+**Expected conclusion: keep it, and record why.** Add to `ISessionMappingService.cs`:
+
+```csharp
+    /// <summary>
+    /// Compare-and-swap on the companion field.
+    /// </summary>
+    /// <remarks>
+    /// Retained deliberately (spec §4.4 proposed retiring it). Revision rejection guards a client
+    /// submitting a mutation against a table it has since fallen behind. This guards a different
+    /// race entirely: a server-side moderator reset racing a user's own selection, where neither
+    /// party carries a client revision to reject. The two do not overlap.
+    /// </remarks>
+```
+
+Only remove it if you can write a failing test proving the revision path rejects that interleaving. If you cannot, say so in the commit message.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Brmble.Server
+git commit -m "docs: record why the companion CAS survives revision rejection"
+```
+
+---
+
+# STAGE D — Two bridge events and the React collapse
+
+**Outcome:** the user-visible one. 17 `setUsers` sites become 2; avatars stop being clobbered.
+
+## Task D1: Emit two events
+
+**Files:** `MumbleAdapter.cs`
+
+- [ ] **Step 1: Replace the body of `EmitProjectionChange`**
+
+```csharp
+    private void EmitProjectionChange(Projection.ChangeSet change)
+    {
+        if (change.NeedsSnapshot) RequestSnapshot();
+        if (change.IsEmpty) return;
+
+        if (change.IsReset)
+        {
+            // Membership was replaced wholesale, so the consumer replaces its list rather than
+            // reconciling additions against removals.
+            _bridge?.Send("voice.usersReset", new
+            {
+                users = change.Changed.Select(ProjectionWire.ToWireRow).ToArray()
+            });
+            _bridge?.NotifyUiThread();
+            return;
+        }
+
+        _bridge?.Send("voice.usersChanged", new
+        {
+            changed = change.Changed.Select(ProjectionWire.ToWireRow).ToArray(),
+            removed = change.Removed.ToArray()
+        });
+        _bridge?.NotifyUiThread();
+    }
+```
+
+- [ ] **Step 2: Stop `voice.connected` carrying users**
+
+In `SendVoiceConnected`, delete the `users = ...` member and instead emit a reset immediately after:
+
+```csharp
+        _bridge?.Send("voice.usersReset", new
+        {
+            users = _projection.Snapshot().Values.Select(ProjectionWire.ToWireRow).ToArray()
+        });
+```
+
+- [ ] **Step 3: Delete the superseded emit sites**
+
+`voice.userJoined` (`:4305`), both `voice.userLeft` (`:4291`, `:4513`), `voice.sessionMappingSnapshot` (`:2629`), both `voice.userMappingUpdated` (`:2666`, `:2691`), `voice.companionChanged` (`:2676`), `voice.brmbleClientActivated` (`:2702`), `voice.brmbleClientDeactivated` (`:2712`).
+
+Keep `voice.userCommentChanged` — comment is Mumble-owned and already flows through `UserState`, so it is redundant, but removing it is a separate change. **Note it as follow-up rather than doing it here.**
+
+The `voice.userLeft` payload carried `moved`, `previousChannelId` and `currentChannelId`, which the overlay and TTS use. Check `App.tsx:2721-2767` before deleting: if those fields are load-bearing, keep a **presentation-only** `voice.userMoved` event carrying just the channel transition, and say so in the commit message.
+
+- [ ] **Step 4: Build and commit**
+
+```bash
+dotnet build
+git add src/Brmble.Client
+git commit -m "feat: replace eight user bridge events with two"
+```
+
+## Task D2: `useUserDirectory`
+
+**Files:** Create `src/Brmble.Web/src/hooks/useUserDirectory.ts` and `useUserDirectory.test.ts`; modify `src/types/index.ts`
+
+- [ ] **Step 1: Merge the two `User` types**
+
+In `src/types/index.ts:22`, add the missing field and export the companion alias so `App.tsx` can drop its local shadow:
+
+```ts
+export interface User {
+  id?: string;
+  session: number;
+  name: string;
+  channelId?: number;
+  muted?: boolean;
+  deafened?: boolean;
+  self?: boolean;
+  matrixUserId?: string;
+  speaking?: boolean;
+  comment?: string;
+  prioritySpeaker?: boolean;
+  certHash?: string;
+  isBrmbleClient?: boolean;
+  /** Built-in id or `custom:$eventId`. `null` means unknown — render a fallback, do not store one. */
+  companionId?: CompanionSelection | null;
+}
+```
+
+Delete the local `interface User` at `App.tsx:651-664`. **`avatarUrl` is deliberately absent** — it moves to its own state in Step 3.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/Brmble.Web/src/hooks/useUserDirectory.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { applyChangeSet } from './useUserDirectory';
+import type { User } from '../types';
+
+const row = (session: number, over: Partial<User> = {}): User =>
+  ({ session, name: `u${session}`, companionId: null, isBrmbleClient: null, ...over }) as User;
+
+describe('applyChangeSet', () => {
+  it('replaces a row wholesale rather than merging fields', () => {
+    const before = [row(1, { companionId: 'retro', isBrmbleClient: true })];
+
+    const after = applyChangeSet(before, { changed: [row(1, { companionId: null })], removed: [] });
+
+    expect(after[0].companionId).toBeNull();
+    expect(after[0].isBrmbleClient).toBeNull();
+  });
+
+  it('appends an unknown session', () => {
+    expect(applyChangeSet([], { changed: [row(2)], removed: [] })).toHaveLength(1);
+  });
+
+  it('removes by session id', () => {
+    expect(applyChangeSet([row(1), row(2)], { changed: [], removed: [1] }))
+      .toEqual([row(2)]);
+  });
+
+  it('preserves the order of untouched rows', () => {
+    const after = applyChangeSet([row(1), row(2), row(3)], { changed: [row(2, { name: 'x' })], removed: [] });
+    expect(after.map(u => u.session)).toEqual([1, 2, 3]);
+  });
+});
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `cd src/Brmble.Web; npm run test -- --run useUserDirectory`
+
+Expected: FAIL — cannot resolve `./useUserDirectory`.
+
+- [ ] **Step 4: Write the hook**
+
+```ts
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { User } from '../types';
+
+export interface UserChangeSet {
+  changed: User[];
+  removed: number[];
+}
+
+/**
+ * Index-by-session replace and remove, with no field logic whatsoever.
+ *
+ * Rows arriving from the bridge are complete — every field present, nulls explicit — because
+ * UserProjectionStore has already merged them. Any `||`, `??` or `!== undefined` added here
+ * re-introduces the class of bug this project exists to remove: a merge rule on the consumer
+ * side that disagrees with the one on the producer side.
+ */
+export function applyChangeSet(previous: User[], change: UserChangeSet): User[] {
+  let next = previous;
+
+  if (change.removed.length > 0) {
+    const dropped = new Set(change.removed);
+    next = next.filter(user => !dropped.has(user.session));
+  }
+
+  if (change.changed.length > 0) {
+    const incoming = new Map(change.changed.map(user => [user.session, user]));
+    next = next.map(user => incoming.get(user.session) ?? user);
+    for (const user of change.changed) {
+      if (!previous.some(existing => existing.session === user.session)) next = [...next, user];
+    }
+  }
+
+  return next;
+}
+
+/**
+ * Owns the user list and the avatar map, joining them for consumers.
+ */
+export function useUserDirectory() {
+  const [users, setUsers] = useState<User[]>([]);
+  // Keyed by matrixUserId, not session: an avatar belongs to a person, not to a connection, so
+  // it survives reconnects and is shared by every session that person has open.
+  const [avatars, setAvatars] = useState<Map<string, string>>(() => new Map());
+
+  const usersRef = useRef(users);
+  usersRef.current = users;
+
+  const reset = useCallback((rows: User[]) => setUsers(rows), []);
+  const apply = useCallback(
+    (change: UserChangeSet) => setUsers(previous => applyChangeSet(previous, change)),
+    [],
+  );
+  const setAvatar = useCallback((matrixUserId: string, url: string | undefined) => {
+    setAvatars(previous => {
+      if (previous.get(matrixUserId) === url) return previous;
+      const next = new Map(previous);
+      if (url === undefined) next.delete(matrixUserId);
+      else next.set(matrixUserId, url);
+      return next;
+    });
+  }, []);
+
+  // The join happens at read time so a snapshot can never clobber an avatar.
+  const joined = useMemo(
+    () => users.map(user => ({
+      ...user,
+      avatarUrl: user.matrixUserId ? avatars.get(user.matrixUserId) : undefined,
+    })),
+    [users, avatars],
+  );
+
+  return { users: joined, usersRef, avatars, reset, apply, setAvatar };
+}
+```
+
+- [ ] **Step 5: Run it to verify it passes**
+
+Expected: PASS, four tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useUserDirectory.ts src/Brmble.Web/src/hooks/useUserDirectory.test.ts src/Brmble.Web/src/types/index.ts
+git commit -m "feat: add useUserDirectory with avatars keyed by matrix id"
+```
+
+## Task D3: Collapse `App.tsx`
+
+**Files:** `src/Brmble.Web/src/App.tsx`
+
+- [ ] **Step 1: Move `usersRef` before its first use**
+
+`usersRef` is declared at `:1778` but read at `:1064` inside `resolveGamePlayerName`. It works today only because that read is inside a `useCallback` body. The hook must be called before any consumer, so hoist the `useUserDirectory()` call above `:1050`.
+
+- [ ] **Step 2: Replace the 17 `setUsers` sites**
+
+| Old site | Replacement |
+|---|---|
+| `:2176` `onVoiceConnected` | delete — `voice.usersReset` handles it |
+| `:2273`, `:3043`, `:3718` resets to `[]` | `reset([])` |
+| `:2552` `onVoiceUserJoined` | delete handler; register `voice.usersChanged` → `apply(d)` |
+| `:2765` `onVoiceUserLeft` | delete the `setUsers` (keep the DM/TTS side effects) |
+| `:2892` comment changed | delete — comment arrives in the row |
+| `:3058`, `:3079`, `:3104`, `:3135`, `:3144` | delete all five handlers |
+| `:1434`, `:1562`, `:1615`, `:1630`, `:1910` avatars | `setAvatar(matrixUserId, url)` |
+
+Register two listeners in the block at `:3205`:
+
+```ts
+    bridge.on('voice.usersReset', (d: { users: User[] }) => reset(d.users));
+    bridge.on('voice.usersChanged', (d: UserChangeSet) => apply(d));
+```
+
+Mirror both in the teardown at `:3295`.
+
+- [ ] **Step 3: Rekey the avatar pipeline**
+
+`fetchedAvatarIdsRef` (`:1571`) is already keyed by `matrixUserId`, but `AvatarFetchRecord` carries `session` and `shouldFetchAvatar` (`utils/avatarFetch.ts:38-49`) compares `record.session !== user.session` to force a refetch on reconnect. With avatars keyed by identity that comparison is wrong — the avatar is still valid across sessions. Delete the `session` field from `AvatarFetchRecord` and simplify `shouldFetchAvatar` to "no avatar for this matrixUserId and not already attempted". Update `avatarFetch.test.ts` accordingly.
+
+- [ ] **Step 4: Make `resolveCompanionDisplay` treat null as unknown**
+
+`InterfaceSettingsTypes.ts:112`. `normalizeCompanionId` (`:67`) currently collapses anything unrecognised to `'floppy'`, which erases the distinction. Accept `CompanionSelection | null` and return `{ companionId: 'floppy' }` for null **without** writing that back anywhere, so the row self-corrects when the real value arrives. Verify no caller persists the result: `App.tsx:4155`, `:4157`, `:4173`.
+
+- [ ] **Step 5: Run everything**
+
+```bash
+cd src/Brmble.Web; npm run test -- --run; npx tsc --noEmit; npm run build; cd ../..
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web
+git commit -m "refactor: collapse user state into useUserDirectory"
+```
+
+---
+
+## Acceptance tests (spec §8)
+
+Run against `docker-local` with a Debug build so multiple clients can run side by side.
+
+```bash
+cd src/Brmble.Web; npm run build; cd ../..
+docker compose -f docker-local/docker-compose.yml up -d --build brmble
+dotnet run --project src/Brmble.Client
+```
+
+- [ ] **Restart.** Two clients connected, one plain Mumble and one Brmble with a custom companion. `docker compose -f docker-local/docker-compose.yml restart brmble`. Assert: no user-list flicker; the Brmble badge never disappears; the custom skin never reverts to floppy; voice uninterrupted. **All four currently fail.**
+- [ ] **Concurrency.** Start three clients within a second of each other. Assert every client's user list converges on the same rows, and no client sits in a resync loop (check for repeated `requestSnapshot` in the log).
+- [ ] **Moderation.** Redact a custom skin from a moderator client while a second client sits in another channel with that atlas cached. Assert it is dropped from memory and IndexedDB without a reconnect. Expected to pass already — pin it against regression.
+
+## Do NOT do
+
+Recorded in spec §9 with reasoning; all are follow-ups:
+
+- No shared Matrix media layer.
+- No avatar authenticated-media migration.
+- No IndexedDB keyspace reconciliation (`atlasCacheKey` stays `roomId\0eventId`).
+- No removal of `voice.userCommentChanged` (noted in Task D1 Step 3).
+
+## The invariant that governs all of it
+
+> **The projection carries identifiers, never resolved assets.** If a value can be re-derived from an identifier, it does not belong in the projection.
+
+`matrixUserId` and `companionId` are in. `avatarUrl` and `atlasCacheKey` are out — which is exactly why Task D2 moves avatars into a separate map joined at read time.
+
+## Done when
+
+- [ ] `dotnet build` clean, 0 warnings; `npx tsc --noEmit` clean
+- [ ] `dotnet test` green with more than the 1299 baseline; `npm run test -- --run` green
+- [ ] `Select-String -Path src/Brmble.Client/Services/Voice/MumbleAdapter.cs -Pattern "_sessionMappings|_pendingBrmbleStatus|_userMappings"` returns nothing
+- [ ] `Select-String -Path src/Brmble.Client/Services/Voice/Projection/*.cs -Pattern "MumbleSharp|HttpClient|JsonElement|System.Text.Json"` still returns nothing
+- [ ] `(Select-String -Path src/Brmble.Web/src/App.tsx -Pattern "setUsers\(").Count` is 0 — all writes go through `useUserDirectory`
+- [ ] No `||`, `??` or `!== undefined` in `applyChangeSet`
+- [ ] The three acceptance tests pass

--- a/docs/superpowers/plans/phase-2-fixes-and-phase-3-handoff.md
+++ b/docs/superpowers/plans/phase-2-fixes-and-phase-3-handoff.md
@@ -1,0 +1,177 @@
+# Phase 2 review fixes + Phase 3 handoff
+
+Paste the block below the rule into the session that implemented Phase 2.
+
+---
+
+Two jobs: fix four things found reviewing your Phase 2 work, then plan and build Phase 3.
+
+## Where you are
+
+Repo: `C:\Projects\brmble`
+Branch: `feature/user-projection-phase-2` (HEAD `71f89921`)
+
+Baseline — confirm before touching anything:
+- `dotnet build` clean, 0 warnings
+- `dotnet test` 1288 passing: Server 782, Client 334, MumbleVoiceEngine 99, Audio 73
+
+Reference docs:
+- Design: `docs/superpowers/specs/2026-07-31-user-projection-design.md`
+- Phase 2 plan: `docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md`
+
+Use **test-driven-development** throughout, and **verification-before-completion** before claiming anything passes. Commit each item separately. Do not push or open a PR.
+
+Your Phase 2 work reviewed well. The ownership split is structural rather than conventional, the snapshot's "null is knowledge here" exception is correct and well argued, and moving sequencing to `BaseRevision` was a genuine improvement over the spec — the spec's `revision == ours + 1` would have broken on `/auth/token`, which bumps three times. Your two pieces of feedback on the plan were both verified correct.
+
+---
+
+# PART A — Fixes
+
+## A1. Server data for a session Mumble has not announced is silently discarded (do this first)
+
+This is the significant one, and it affects both paths.
+
+**Event path**, `UserProjectionStore.cs:188-189`:
+
+```csharp
+if (!_rows.TryGetValue(evt.SessionId, out var existing))
+    return ChangeSet.Empty;   // cursor advanced, event consumed, data gone
+```
+
+**Snapshot path**, `UserProjectionStore.cs:108` — `ApplyServerSnapshot` iterates `_rows.Keys.ToArray()`, so snapshot entries for sessions not yet in `_rows` are ignored entirely.
+
+### Why this matters
+
+Spec §4.2 says an event naming a session Mumble has not shown should be *buffered briefly*, and spec §11 question 2 explicitly deferred "how long is briefly" **to Phase 2**. Phase 2 neither buffered nor resynced — it chose a third option, dropping, and encoded it in a test name (`ApplyServerEvent_ForASessionMumbleHasNotShownIsIgnoredButAdvancesTheCursor`). The deferred question is now answered silently.
+
+Your reasoning in that comment is right as far as it goes: treating an unknown session as a gap would resync on every unrelated user's join, which would be worse. But dropping is not the alternative the spec intended, and the snapshot case is the dangerous one.
+
+On voice connect, `/auth/token` returns a full snapshot. If it lands before Mumble's `UserState` batch has populated the rows, **every server-owned field is dropped for every user** — and nothing re-delivers it, because no gap occurs and no reconnect happens. That is exactly the "user shows up wrong on other clients" symptom this whole project exists to eliminate, reintroduced at the point where it is hardest to notice.
+
+Phase 1's `MumbleAdapter` had `_pendingBrmbleStatus` for precisely this race. Phase 2 removed the capability without replacing it.
+
+### What to build
+
+A pending-entry map inside the store, applied when a row first appears:
+
+- Hold `ServerMappingEntry` values for sessions not yet in `_rows`, from both `ApplyServerEvent` and `ApplyServerSnapshot`.
+- When `ApplyMumbleUserState` (or `ApplyMumbleReset`) first creates a row for that session, apply the held entry and include the row in the returned `ChangeSet`.
+- Bound it. Decide a cap and an eviction rule, and write the reasoning into a comment — an unbounded map fed by a remote server is a memory-exhaustion vector.
+- Drop a held entry when its session is superseded: a snapshot that omits the session, or a `MappingRemoved` for it.
+
+Keep the cursor advancing exactly as it does now. That part is right.
+
+**Resolve spec §11 question 2 explicitly.** Edit the spec to record what you chose and why — whether that is a pending map with no timeout, a bounded one, or something else. It must not stay open after this.
+
+Tests to add:
+- A `CompanionChanged` event for an unknown session, then `ApplyMumbleUserState` for that session — the row appears carrying the companion, and is reported in `Changed`.
+- A full snapshot arriving before any Mumble rows, then a Mumble reset — every user comes out enriched. Assert this against the real connect ordering, because this is the case that would otherwise silently break Phase 3.
+- A held entry is discarded when a later snapshot omits that session.
+- The bound is enforced.
+
+## A2. `ChangeSet.IsReset` documents behaviour that cannot exist
+
+`ChangeSet.cs:8-9` says `IsReset` is "Set by a Mumble reset and by a snapshot that changed membership." The second clause is not merely unimplemented — it is impossible. `ApplyServerSnapshot` only ever modifies existing rows; it cannot add or remove any, because only Mumble owns existence (spec §4.3). A snapshot can change *server-known* membership but never *row* membership.
+
+So this is not a decision between two options. Fix it as documentation:
+
+- Delete the "and by a snapshot that changed membership" clause.
+- Rename `ApplyServerSnapshot_FlagsAResetWhenMembershipChanged` to something truthful, e.g. `ApplyServerSnapshot_ReportsRowsItResets`.
+- Leave `IsReset` as Mumble-reset-only. Your instinct was right: making resyncs flag a reset would force Phase 3 to rebuild the whole list every time.
+- Make the same correction in the Phase 2 plan (`:520-523` and `:912`) so the two do not disagree.
+
+## A3. No guard against a malformed revision range
+
+`ApplyServerEvent` accepts `evt.Revision < evt.BaseRevision` and would move `_revision` backwards. The server should never emit that, but the store is the trust boundary. Reject it as a gap (`NeedsSnapshot`) rather than applying it. One test.
+
+## A4. Namespace drift in the spec
+
+Spec §6.4 says `Services/Voice/UserProjection/`; the code uses `Services/Voice/Projection/`. **The code is right** — commit `fced11b1` shows you avoided a type/namespace collision deliberately. Correct the spec so it does not read as accidental drift.
+
+---
+
+# PART B — Phase 3
+
+Do not start until Part A is committed and green.
+
+Phase 3 is where this becomes user-visible. Everything so far ships invisibly; this is the phase that stops badges disappearing and companions reverting to floppy.
+
+## Plan it first
+
+Use the **writing-plans** skill. Save to `docs/superpowers/plans/YYYY-MM-DD-user-projection-phase-3-wiring.md`.
+
+Write the plan against the code as it actually exists after Part A, not against the spec's description of it. The spec was written before Phases 1 and 2 were built and both diverged for good reasons — `baseRevision` and the `Projection` namespace being two examples.
+
+Read spec §3.4, §4.4, §5, §6 and §8 first.
+
+## Scope
+
+**Client C# — `MumbleAdapter`**
+
+1. Delete `_sessionMappings` and `_pendingBrmbleStatus`. `UserProjectionStore` replaces both.
+2. Feed the store from the three inputs: Mumble `UserState`/`UserRemove`, the `/auth/token` snapshot, and WebSocket events.
+3. Emit exactly two bridge events, replacing eight: `voice.usersReset` and `voice.usersChanged`. Rows must be **complete** — every field present, nulls explicit — so React has nothing to merge. One row serializer, replacing the six duplicated shapes.
+4. `voice.connected` keeps channels and connection metadata but stops carrying `users`.
+5. Companion consumers (`GetSelfCompanionOrDefault`, `UpdateSelfCompanionMapping`) read the projection.
+
+**Client C# — resync**
+
+6. Send `{"type":"requestSnapshot", ...}` when the store returns `NeedsSnapshot`. The client currently has `SendWebSocketFrame` (`MumbleAdapter.cs:2536`) but uses it only for pongs, and the stream is a local inside the reconnect loop. Hoist it to a field and add a send lock, since pongs share the socket. Server side already exists from Phase 1.
+7. Rate-limit resync: one in flight, minimum 1s spacing, exponential backoff to 30s. A persistent mismatch must never become a hot loop.
+8. Fix the teardown bug at `MumbleAdapter.cs:2034` — `FetchAndSendCredentials` unconditionally calls `StartWebSocketConnection`, so a health-triggered credential refresh tears down a socket that was already working. Make it conditional on the socket not already being connected.
+
+**Wire — companion collapse and negotiation**
+
+9. Client appends `?pv=1` to the `/ws` URL (`MumbleAdapter.cs:2283`). Server reads `context.Request.Query["pv"]` in `HandleAsync` *before* `AcceptWebSocketAsync`, so the version is known before initial payloads are built.
+10. For `pv>=1`, send one truthful companion field; for absent `pv`, keep the legacy `companionId`/`customCompanionId` split. The legacy shim sends `companionId: "floppy"` for custom skins — that lie must live only at the compatibility boundary, never in the projection.
+11. `"floppy"` becomes a render-time fallback only. `null` means unknown everywhere else.
+12. Retire `TryUpdateCompanionIdIfCurrent` in favour of revision rejection, **only if** you can show the revision path covers the same race. If not, say so and keep it.
+
+**React — `App.tsx`**
+
+13. 17 `setUsers` sites become 2. `applyChangeSet` does index-by-session replace and remove with **no field logic** — no `||`, no `??`, no `!== undefined`.
+14. Avatars move out of `users` into their own state keyed by `matrixUserId`, joined in a selector. Without this, every snapshot clobbers avatars. Key by asset identity, not session, so a future shared media layer is a substitution rather than a rewrite.
+15. Extract into a `useUserDirectory` hook alongside the existing ones. Consumers keep the same row shape.
+16. Collapse the two `User` types — `types/index.ts:22` lacks `companionId`, the local one in `App.tsx` has it.
+17. `resolveCompanionDisplay` treats `null` as unknown and renders floppy **without caching that as a decision**, so the row self-corrects when the real value arrives.
+
+**Do NOT do**
+
+18. No shared Matrix media layer. No avatar authenticated-media migration. No IndexedDB keyspace reconciliation. All are recorded in spec §9 as follow-ups with reasoning.
+
+## The invariant that governs all of it
+
+> **The projection carries identifiers, never resolved assets.** If a value can be re-derived from an identifier, it does not belong in the projection.
+
+`matrixUserId` and `companionId` are in. `avatarUrl` and `atlasCacheKey` are out.
+
+## Acceptance tests (spec §8)
+
+These are the point of the whole project. Phase 3 is not done until they pass.
+
+- **Restart.** Two clients connected, one plain Mumble and one Brmble with a custom companion. Restart only the `brmble` container. No user-list flicker, the Brmble badge never disappears, the custom skin never reverts to floppy, voice uninterrupted. Currently fails on all four counts.
+- **Concurrency.** Several clients register simultaneously; every one receives a complete snapshot and converges on the same projection. This is what exposed the whole bug class originally.
+- **Moderation.** A moderator redacts a skin while a client sits in another channel with that atlas cached; it is dropped from memory and disk without a reconnect. Expected to pass already via Matrix sync — pin it against regression.
+
+Manual, against `docker-local`:
+
+```bash
+cd src/Brmble.Web; npm run build; cd ../..
+docker compose -f docker-local/docker-compose.yml up -d --build brmble
+dotnet run --project src/Brmble.Client
+docker compose -f docker-local/docker-compose.yml restart brmble
+```
+
+Debug builds allow multiple clients, so you can run several side by side.
+
+## Things that will bite you
+
+- **UI work requires `docs/UI_GUIDE.md`.** Read it before touching any component or CSS. Never hardcode colours, sizes, spacing or radii — use the existing tokens.
+- **`App.tsx` is ~5,600 lines and `MumbleAdapter.cs` ~4,700.** Both are actively edited. Rebase early and often; `main` has moved repeatedly during this work.
+- **LSP noise is false.** The language server reports unresolved `Moq`, `TestClass`, `Microsoft.Extensions` and `Ice` in files you have not touched. `dotnet build` is the truth.
+- **PowerShell, not bash.** No `&&`; use `;` or `if ($?) { }`.
+- **Never commit to main.** Branch `feature/user-projection-phase-3`. Ask before pushing or opening a PR.
+
+## Report back with
+
+What you changed, test counts before and after, the acceptance-test results, and anything in the spec or plan that turned out to be wrong. That last one has been the most valuable output of every phase so far — Phase 1 found two unannounced revision bumps, Phase 2 found the `IsReset` contradiction.

--- a/docs/superpowers/plans/phase-2-handoff.md
+++ b/docs/superpowers/plans/phase-2-handoff.md
@@ -9,64 +9,86 @@ Implement Phase 2 of the Brmble user projection.
 ## Start here
 
 Repo: `C:\Projects\brmble`
-Branch: `feature/user-projection-phase-1` (HEAD should be `fced11b1`)
+Branch: `feature/user-projection-phase-2` — already created for you, branched from `feature/user-projection-phase-1` at `50ee5f07`.
 
 Read these, in this order:
 
 1. `docs/superpowers/plans/2026-08-01-user-projection-phase-2-store.md` — the plan you are executing. Read it in full, including "Background you need", before writing any code.
-2. `docs/superpowers/specs/2026-07-31-user-projection-design.md` — the approved design. §3.1, §3.2, §4.2, §4.3, §6.6 and §8 are the sections Phase 2 implements. Skim the rest.
+2. `docs/superpowers/specs/2026-07-31-user-projection-design.md` — the approved design. §3.1, §3.2, §4.2, §4.3, §6.6 and §8 are what Phase 2 implements. Skim the rest.
 
 The plan is self-contained: 6 tasks with complete code, exact commands and expected failure messages. Follow it in order.
 
 ## Sanity check you're in the right place
 
 ```powershell
-git rev-parse --abbrev-ref HEAD        # feature/user-projection-phase-1
-git log --oneline -1                   # fced11b1
+git rev-parse --abbrev-ref HEAD        # feature/user-projection-phase-2
+git log --oneline -1                   # a0c4baa9 if no Phase 2 work has started
 Select-String -Path src/Brmble.Server/Events/MappingEventPublisher.cs -Pattern PublishExceptAsync
 ```
 
-Baseline before you start — confirm both, so you can tell your own failures from pre-existing ones:
+Baseline — confirm both before starting, so you can tell your own failures from pre-existing ones:
 
 ```powershell
 dotnet build     # 0 warnings, 0 errors
-dotnet test      # 1250 passing: Server 777, Client 301, MumbleVoiceEngine 99, Audio 73
+dotnet test      # 1253 passing: Server 780, Client 301, MumbleVoiceEngine 99, Audio 73
 ```
 
 If the baseline doesn't match, stop and ask rather than guessing which failures are yours.
 
 ## Context you need that isn't in the plan
 
-**Phase 1 is open as PR #619** (`https://github.com/brmble/brmble/pull/619`), 18 commits, not yet merged. Phase 2 lands on the *same branch* — the PR picks up new commits automatically. Do not open a second PR.
+**Phase 1 is open as PR #619** (`https://github.com/brmble/brmble/pull/619`) and is **not merged**. Your branch is stacked on top of it.
 
-**The branch is not based on `main`.** It diverges from `origin/main` at `a4c993fa` and carries an unmerged prior fix (`cd7b48fa`). `git diff main` is misleading; use `git diff origin/main...HEAD` if you need it.
+That has two consequences:
 
-**Task 1 touches files that are under review in #619.** If review comments land on `MappingEventPublisher.cs`, `SessionMappingHandler.cs`, `AuthEndpoints.cs`, `AuthService.cs`, `CustomCompanionEndpoints.cs`, `MumbleServerCallback.cs` or `BrmbleWebSocketHandler.cs` while you work, rebase before continuing. Tasks 2-6 touch only new files and cannot conflict.
+- When you open a PR, **base it on `feature/user-projection-phase-1`, not `main`.** Basing it on `main` would show Phase 1's 22 commits as part of your diff.
+- If review changes land on #619, rebase onto it before continuing: `git fetch origin && git rebase origin/feature/user-projection-phase-1`. Task 1 touches files that are under review there; Tasks 2-6 touch only new files and cannot conflict.
 
-## Environment traps that cost time in Phase 1
+**Neither branch is based on `main`.** They diverge from `origin/main` at `a4c993fa` and carry an unmerged prior fix (`cd7b48fa`). `git diff main` is misleading — use `git diff origin/feature/user-projection-phase-1...HEAD` to see only your work.
+
+**Phase 1 has already been reviewed twice**, and the plan was refreshed in `a0c4baa9` to match what actually shipped. In particular, Task 1's step about `MappingPayloadEnvelopeTests` now says the `AssertHasEnvelope` / `AssertHasSnapshotEnvelope` split **already exists** — do not recreate it, just add the `baseRevision` assertion.
+
+## Environment traps that cost real time in Phases 1 and 2 planning
 
 **1. The language server lies.** It reports unresolved `Moq`, `TestClass`, `Microsoft.Extensions`, `Ice`, `ProtoBuf`, `WebApplicationFactory` and similar in files you have not touched. These are false. `dotnet build` is the source of truth — trust it, not the inline diagnostics. Do not "fix" imports that are already correct.
 
-**2. Moq mocks silently return defaults for new interface members.** When Phase 1 added `InstanceId` and `Revision` to `ISessionMappingService`, every `Mock<ISessionMappingService>` returned `null` and `0`, so payloads went out with blank envelopes and tests failed with confusing assertions rather than compile errors. Task 1 does not add interface members, so this specific trap should not recur — but if an envelope assertion fails with a blank or zero value, check the mock setup before suspecting the production code. The stubs live in:
-   - `tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs` (delegates to a real `SessionMappingService`)
-   - `tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs` (`CompanionAuthFactory` hides the base mock with a bare one)
+**2. Moq returns silent defaults, and this has already caused a hang.** A `Mock<ISessionMappingService>` returns `false` from every `TryUpdate*` and `0`/`null` from every property unless explicitly stubbed. During Phase 1 review fixes, tightening the registration path so it only announces when a mutation actually changed something caused an existing test to **hang forever**, because its fixture left `TryUpdateBrmbleStatus`/`TryUpdateCertHash` at the default `false` and waited on a broadcast that consequently never happened. If a test hangs or an envelope assertion sees a blank/zero value, check the mock setup before suspecting production code. Relevant fixtures:
+   - `tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs` — delegates to a real `SessionMappingService`
+   - `tests/Brmble.Server.Tests/Auth/AuthEndpointsCompanionTests.cs` — `CompanionAuthFactory` hides the base mock with a bare one
    - `tests/Brmble.Server.Tests/Events/SessionMappingHandlerTests.cs`
+   - `tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs`
 
-**3. Hand-written test doubles break on interface changes.** `tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs` implements `ISessionMappingService` by hand, and `MappingEventPublisherTests` / `BrmbleWebSocketHandlerTests` implement `IBrmbleEventBus` by hand. Task 1 changes neither interface, but if you widen one you must update these.
+**3. `SetupSequence` does not support the out-parameter delegate overload.** `TryGetMappingByUserId` has two `out` parameters, and `SetupSequence(...).Returns((long _, out int a, out SessionMapping? b) => ...)` fails with `CS1660`. Use a single `Setup` with a call counter instead:
+   ```csharp
+   var reads = 0;
+   mappings.Setup(x => x.TryGetMappingByUserId(42, out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
+       .Returns((long _, out int sessionId, out SessionMapping? value) =>
+       {
+           sessionId = 7;
+           value = Interlocked.Increment(ref reads) == 1 ? first : second;
+           return true;
+       });
+   ```
 
-**4. Adding a wire field breaks exact-string payload assertions.** Task 1 adds `baseRevision` to every event payload. At least one test previously asserted a full serialised JSON string; it was converted to a structural assertion in Phase 1, but check for others if a test fails on an unexpected substring. Prefer structural assertions — `instanceId` is a per-process GUID and can never be matched exactly.
+**4. Hand-written test doubles break on interface changes.** `tests/Brmble.Server.Tests/Games/SessionMappingGamePresenceTests.cs` implements `ISessionMappingService` by hand; `MappingEventPublisherTests` and `BrmbleWebSocketHandlerTests` implement `IBrmbleEventBus` by hand. Task 1 changes neither interface, but if you widen one you must update these.
 
-**5. `dotnet test --no-build` after an edit runs stale binaries.** Only use `--no-build` immediately after a successful `dotnet build`.
+**5. Adding a wire field breaks exact-string payload assertions.** Task 1 adds `baseRevision` to every event payload. Prefer structural assertions over full-JSON string equality — `instanceId` is a per-process GUID and can never be matched exactly.
 
-**6. Git prints CRLF warnings on nearly every commit.** Cosmetic, ignore them.
+**6. `InitializeAcceptedClientAsync` tests need a duel-free path.** If `TryGetSessionByUserId` returns a non-zero session, the duel snapshot payload is built and a `Mock<IDuelSnapshotProvider>` returning `null` will throw `NullReferenceException` inside `DuelWire.From`. Stub it to return `false`/`0` unless the test is about duels.
+
+**7. `dotnet test --no-build` after an edit runs stale binaries.** Only use `--no-build` immediately after a successful `dotnet build`.
+
+**8. Git prints CRLF warnings on nearly every commit.** Cosmetic, ignore them.
+
+**9. PowerShell splits `gh api graphql -f query=...` on spaces.** If you need GraphQL, write the query to a file and use `-F query='@file.txt'` with the quotes.
 
 ## How to work
 
-- Stay on `feature/user-projection-phase-1`. Do not create a new branch, and never commit to `main`.
-- Use the **test-driven-development** skill. Every task starts with a failing test, and the plan states the expected failure message. Actually run it and watch it fail for that reason before implementing.
+- Stay on `feature/user-projection-phase-2`. Never commit to `main` or to the Phase 1 branch.
+- Use the **test-driven-development** skill. Every task starts with a failing test and the plan states the expected failure message. Actually run it and watch it fail for that reason before implementing.
 - Use the **verification-before-completion** skill before claiming anything works. Run the command, read the output, then make the claim.
 - Commit after each task with the message given in that task's final step.
-- Do not push or comment on the PR without asking first.
+- Do not push or open a PR without asking first.
 
 ## Things the plan warns about — do not get these wrong
 
@@ -76,28 +98,28 @@ If the baseline doesn't match, stop and ask rather than guessing which failures 
 
 **3. A gap must apply nothing at all.** When `baseRevision > ours`, return `NeedsSnapshot` and change no row. Partially applying a gapped event is precisely what produces the confidently-wrong values this design exists to eliminate.
 
-**4. Advance the cursor even when the event touches no row you hold.** An event for a session Mumble has not shown you is still an observed event. If you skip the cursor update, the next event looks like a gap and the client resyncs on every unrelated user's join. There is a test for this.
+**4. Advance the cursor even when the event touches no row you hold.** An event for a session Mumble has not shown you is still an observed event. Skipping the cursor update makes the next event look like a gap, so the client resyncs on every unrelated user's join. There is a test for this.
 
-**5. Do not weaken the convergence test.** It is the design's core property in one assertion. If it fails, one of Tasks 3-5 has a real bug. Its final snapshot deliberately omits a session the events enrich — that omission is what makes it able to catch a snapshot-reconciliation regression instead of passing trivially. Do not "simplify" it by making the final snapshot complete.
+**5. Do not weaken the convergence test.** It is the design's core property in one assertion. Its final snapshot deliberately omits a session the events enrich — that omission is what lets it catch a snapshot-reconciliation regression instead of passing trivially. Do not "simplify" it by making the final snapshot complete.
 
-**6. Phase 2 ships no behaviour.** Nothing calls the store. `MumbleAdapter.cs` and `App.tsx` must be untouched — that is an explicit "Done when" item. If you find yourself editing either, you have drifted into Phase 3.
+**6. Phase 2 ships no behaviour.** Nothing calls the store. `MumbleAdapter.cs` and `App.tsx` must be untouched — an explicit "Done when" item. If you find yourself editing either, you have drifted into Phase 3.
 
 ## Done when
 
 The plan's "Done when" checklist passes, including:
 
 - `dotnet build` clean, 0 warnings
-- `dotnet test` green with more than the 1250 baseline
+- `dotnet test` green with more than the 1253 baseline
 - Every mapping **event** carries `baseRevision`; every **snapshot** carries `instanceId` and `revision` and no `baseRevision`
 - Consecutive events from one publisher are contiguous — each event's `baseRevision` equals the previous event's `revision`
 - The store has no Mumble, HTTP or JSON dependency:
   `Select-String -Path src/Brmble.Client/Services/Voice/Projection/*.cs -Pattern "MumbleSharp|HttpClient|JsonElement|System.Text.Json"` returns nothing
-- `git diff origin/main...HEAD -- src/Brmble.Client/Services/Voice/MumbleAdapter.cs src/Brmble.Web/src/App.tsx` shows no changes
+- `git diff origin/feature/user-projection-phase-1...HEAD -- src/Brmble.Client/Services/Voice/MumbleAdapter.cs src/Brmble.Web/src/App.tsx` shows no changes
 
-Report back with: what you built, test counts before and after, and anything in the plan that turned out to be wrong. The last two phases each found real defects in their own plan — say so plainly if you find one rather than working around it silently.
+Report back with: what you built, test counts before and after, and anything in the plan that turned out to be wrong. Every phase so far has found a real defect in its own plan — say so plainly if you find one rather than working around it silently.
 
 ## What happens after this (context, not your task)
 
 **Phase 3** wires the store in and is where the user-visible fixes land: delete `_sessionMappings`, translate wire payloads into the Task 2 input records, collapse 17 `setUsers` sites in `App.tsx` to 2, move avatars into their own state keyed by `matrixUserId`, and add client version negotiation via a `pv` query parameter so the server can send one truthful `companionId` instead of the legacy `companionId`/`customCompanionId` split.
 
-Phase 3 is **not planned yet, deliberately** — it touches the repo's two most actively edited files, and plans against them go stale fast. It gets planned after Phase 2 lands, against shipped code. Do not start it.
+Phase 3 is **not planned yet, deliberately** — it touches the repo's two most actively edited files and plans against them go stale fast. It gets planned after Phase 2 lands, against shipped code. Do not start it.

--- a/docs/superpowers/specs/2026-07-31-user-projection-design.md
+++ b/docs/superpowers/specs/2026-07-31-user-projection-design.md
@@ -165,7 +165,7 @@ Client rules:
 | `revision <= ours` | Ignore — duplicate or reorder, already applied |
 | `revision == ours + 1` | Apply |
 | `revision > ours + 1` | Gap — apply nothing, request snapshot |
-| Event for a session Mumble has not shown us | Buffer briefly, then request snapshot |
+| Event for a session Mumble has not shown us | Hold the entry until the row appears (§11 Q2) |
 
 **This requires all projection events to be broadcast server-wide.** Channel-scoped delivery would
 make out-of-channel clients observe phantom gaps and resync continuously. PR #617 already made
@@ -451,10 +451,34 @@ Absent `pv` means version 0, which gets the legacy `companionId` / `customCompan
 Implemented in **Phase 3**, alongside the companion field collapse it exists to serve — reading a
 query parameter is purely additive, so no earlier phase needs to reserve anything for it.
 
-**2. How long is "buffer briefly" for an event naming an unknown session? → Deferred to Phase 2.**
+**2. How long is "buffer briefly" for an event naming an unknown session? → Resolved in Phase 2: no timeout. The entry is held until the row appears or the server supersedes it.**
 
-Purely client-side, with no effect on the wire contract. Decide it against the real store, where
-the trade-off between a redundant resync and a delayed row can actually be measured.
+"Briefly" turned out to be the wrong axis. A timeout only helps if the alternative to waiting is a
+resync that would fix things — but an event for an unannounced session is not evidence of a gap.
+The cursor is contiguous, the client has missed nothing, and Mumble simply has not delivered that
+`UserState` yet. Resyncing would fetch the same data the client is already holding, and would fire
+on every unrelated user's join.
+
+So the store holds the entry indefinitely and consumes it when `ApplyMumbleUserState` or
+`ApplyMumbleReset` first creates the row. Lifetime is bounded by events, not by a clock:
+
+- A snapshot replaces the held set outright, so any hold it omits is dropped — the snapshot is
+  authoritative for server-known membership (§4.3).
+- A `userMappingRemoved` for a held session drops that hold.
+- A hold is removed when consumed, so a session that leaves and rejoins is re-enriched by the
+  server rather than by a stale hold.
+
+Holds are capped at 1024 entries, evicting oldest-first, because the map is fed by a remote server
+and must not be an unbounded allocation. The legitimate population is "sessions this client has not
+seen a `UserState` for yet", which is at most the server's user count for the few hundred
+milliseconds between `/auth/token` resolving and the `UserState` batch arriving; reaching the cap
+means the server is misbehaving rather than busy.
+
+This also fixes the case that made the question urgent, which the original wording did not
+anticipate: **snapshots have the same race, and worse consequences.** On voice connect
+`/auth/token` routinely resolves before Mumble's `UserState` batch. Without holds, every
+server-owned field for every user is discarded at connect, and nothing re-delivers it — no gap
+occurs, so no resync is triggered. §4.2's table row should be read as covering snapshots too.
 
 **3. Does `userMappingRemoved` still earn its place? → Yes.**
 

--- a/docs/superpowers/specs/2026-07-31-user-projection-design.md
+++ b/docs/superpowers/specs/2026-07-31-user-projection-design.md
@@ -322,8 +322,10 @@ than a rewrite.
 In scope because the work lands here; not a general refactor:
 
 - `MumbleAdapter.cs` is 4,698 lines and not `partial`. `UserProjectionStore` and `UserProjection`
-  become standalone types in `Services/Voice/UserProjection/` with no Mumble dependency, so they
-  unit-test without a protocol stack.
+  become standalone types in `Services/Voice/Projection/` with no Mumble dependency, so they
+  unit-test without a protocol stack. The folder is `Projection/`, not `UserProjection/`: a
+  namespace whose last segment matches a type it contains trips CA1724 and can produce
+  `CS0118 'namespace used like a type'` when that type is referenced from inside it.
 - `App.tsx` is 5,623 lines. User and avatar state move into a `useUserDirectory` hook alongside the
   existing 20 hooks, exposing `users` (joined), `usersRef` and the avatar map. Consumers keep the
   same row shape and do not change.

--- a/src/Brmble.Client/Services/Voice/Projection/ChangeSet.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/ChangeSet.cs
@@ -1,0 +1,24 @@
+namespace Brmble.Client.Services.Voice.Projection;
+
+/// <summary>
+/// What one <c>Apply</c> changed. Rows in <see cref="Changed"/> are always complete — every
+/// field present — so a consumer replaces by session id and never merges field-by-field.
+/// </summary>
+/// <param name="IsReset">
+/// The caller should replace its whole list rather than patch it. Set by a Mumble reset and by
+/// a snapshot that changed membership.
+/// </param>
+/// <param name="NeedsSnapshot">
+/// The store detected a gap or a restart and cannot proceed from incremental events. The caller
+/// should request a snapshot. Nothing in the projection was changed by the event that set this.
+/// </param>
+internal sealed record ChangeSet(
+    IReadOnlyList<UserProjection> Changed,
+    IReadOnlyList<uint> Removed,
+    bool IsReset = false,
+    bool NeedsSnapshot = false)
+{
+    public static readonly ChangeSet Empty = new([], []);
+
+    public bool IsEmpty => Changed.Count == 0 && Removed.Count == 0 && !IsReset && !NeedsSnapshot;
+}

--- a/src/Brmble.Client/Services/Voice/Projection/ChangeSet.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/ChangeSet.cs
@@ -5,8 +5,10 @@ namespace Brmble.Client.Services.Voice.Projection;
 /// field present — so a consumer replaces by session id and never merges field-by-field.
 /// </summary>
 /// <param name="IsReset">
-/// The caller should replace its whole list rather than patch it. Set by a Mumble reset and by
-/// a snapshot that changed membership.
+/// The caller should replace its whole list rather than patch it. Set by a Mumble reset only.
+/// A snapshot never sets it: <see cref="UserProjectionStore.ApplyServerSnapshot"/> can change
+/// what the server knows about a session, but it can neither add nor remove a row, because only
+/// Mumble owns existence (spec §4.3). Every row it resets is reported in <see cref="Changed"/>.
 /// </param>
 /// <param name="NeedsSnapshot">
 /// The store detected a gap or a restart and cannot proceed from incremental events. The caller

--- a/src/Brmble.Client/Services/Voice/Projection/ProjectionInputs.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/ProjectionInputs.cs
@@ -1,0 +1,60 @@
+namespace Brmble.Client.Services.Voice.Projection;
+
+/// <summary>
+/// A Mumble <c>UserState</c>, reduced to the fields Mumble owns. Complete every time: Mumble
+/// resends the full state on every change, so these values are authoritative even when empty.
+/// </summary>
+internal sealed record MumbleUserInput(
+    uint SessionId,
+    string? Name,
+    uint ChannelId,
+    bool Muted,
+    bool Deafened,
+    string? Comment,
+    string? CertHash,
+    bool IsSelf);
+
+/// <summary>
+/// The server-owned half of one session. Every field is nullable and <c>null</c> means "not
+/// known", never "cleared".
+/// </summary>
+internal sealed record ServerMappingEntry(
+    string? MatrixUserId,
+    string? CompanionId,
+    bool? IsBrmbleClient,
+    string? CertHash);
+
+/// <summary>
+/// A complete statement of every session the server knows about, from <c>/auth/token</c> or a
+/// WebSocket <c>sessionMappingSnapshot</c>. Authoritative for membership: a session absent from
+/// it has its server-owned fields reset to unknown (spec §4.3).
+/// </summary>
+internal sealed record ServerSnapshot(
+    string InstanceId,
+    long Revision,
+    IReadOnlyDictionary<uint, ServerMappingEntry> Mappings);
+
+internal enum ServerEventKind
+{
+    MappingAdded,
+    MappingRemoved,
+    CompanionChanged,
+    BrmbleActivated,
+    BrmbleDeactivated
+}
+
+/// <summary>
+/// One incremental server event.
+/// </summary>
+/// <param name="BaseRevision">
+/// The revision this event applies on top of. The client applies when this equals its own
+/// cursor — see the table in the Phase 2 plan. Not <c>Revision - 1</c>: one operation may bump
+/// the server's counter several times.
+/// </param>
+internal sealed record ServerEvent(
+    ServerEventKind Kind,
+    string InstanceId,
+    long BaseRevision,
+    long Revision,
+    uint SessionId,
+    ServerMappingEntry? Entry = null);

--- a/src/Brmble.Client/Services/Voice/Projection/UserProjection.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/UserProjection.cs
@@ -1,0 +1,36 @@
+namespace Brmble.Client.Services.Voice.Projection;
+
+/// <summary>
+/// One row of the authoritative user projection: Mumble-native presence merged with
+/// Brmble-owned identity.
+/// </summary>
+/// <remarks>
+/// Fields are grouped by owner and never cross. A Mumble input may write only the first group,
+/// a server input only the second. In the server group, <c>null</c> means "not known" rather
+/// than "empty" — see <see cref="UserProjectionStore"/> for the rule that preserves it.
+/// </remarks>
+internal sealed record UserProjection
+{
+    public required uint SessionId { get; init; }
+
+    // ---- Mumble-owned. Authoritative, including when empty: UserState is complete every time.
+    public string? Name { get; init; }
+    public uint ChannelId { get; init; }
+    public bool Muted { get; init; }
+    public bool Deafened { get; init; }
+    public string? Comment { get; init; }
+    public string? MumbleCertHash { get; init; }
+    public bool IsSelf { get; init; }
+
+    // ---- Server-owned. null means unknown, never "cleared".
+    public string? MatrixUserId { get; init; }
+    public string? CompanionId { get; init; }
+    public bool? IsBrmbleClient { get; init; }
+    public string? ServerCertHash { get; init; }
+
+    /// <summary>
+    /// The live connection's certificate wins over the server's recorded copy, so a server
+    /// restart clearing its own copy cannot blank a hash Mumble can still see.
+    /// </summary>
+    public string? CertHash => MumbleCertHash ?? ServerCertHash;
+}

--- a/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
@@ -1,0 +1,125 @@
+namespace Brmble.Client.Services.Voice.Projection;
+
+/// <summary>
+/// The single authoritative user projection. Merges Mumble presence and Brmble identity under
+/// two rules: each input writes only the fields it owns, and a null server field means "not
+/// known" rather than "cleared".
+/// </summary>
+/// <remarks>
+/// Every Apply takes one lock, mutates, computes the change set and releases. No callback runs
+/// under the lock — the caller emits from the returned value (spec §6.6). Inputs arrive on the
+/// Mumble protocol thread, the WebSocket read loop and an HTTP continuation.
+/// </remarks>
+internal sealed class UserProjectionStore
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<uint, UserProjection> _rows = [];
+
+    private string? _instanceId;
+    private long _revision;
+
+    /// <summary>A copy of the current projection, for tests and for building a full reset.</summary>
+    public IReadOnlyDictionary<uint, UserProjection> Snapshot()
+    {
+        lock (_gate) return new Dictionary<uint, UserProjection>(_rows);
+    }
+
+    public ChangeSet ApplyMumbleUserState(MumbleUserInput input)
+    {
+        lock (_gate)
+        {
+            _rows.TryGetValue(input.SessionId, out var existing);
+            var updated = WithMumbleFields(existing, input);
+            if (existing == updated) return ChangeSet.Empty;
+
+            _rows[input.SessionId] = updated;
+            return new ChangeSet([updated], []);
+        }
+    }
+
+    public ChangeSet ApplyMumbleUserRemove(uint sessionId)
+    {
+        lock (_gate)
+        {
+            // Mumble alone owns existence, so this is the only path that deletes a row.
+            return _rows.Remove(sessionId)
+                ? new ChangeSet([], [sessionId])
+                : ChangeSet.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Replaces membership wholesale on voice connect or reconnect. Server-owned fields survive
+    /// for sessions present in both the old and new list.
+    /// </summary>
+    public ChangeSet ApplyMumbleReset(IReadOnlyList<MumbleUserInput> users)
+    {
+        lock (_gate)
+        {
+            var rebuilt = new Dictionary<uint, UserProjection>(users.Count);
+            foreach (var input in users)
+            {
+                _rows.TryGetValue(input.SessionId, out var existing);
+                rebuilt[input.SessionId] = WithMumbleFields(existing, input);
+            }
+
+            _rows.Clear();
+            foreach (var (sessionId, row) in rebuilt) _rows[sessionId] = row;
+
+            return new ChangeSet([.. rebuilt.Values], [], IsReset: true);
+        }
+    }
+
+    /// <summary>
+    /// Writes only Mumble-owned fields. Server-owned fields are carried across untouched, which
+    /// is why a channel move cannot blank a badge.
+    /// </summary>
+    private static UserProjection WithMumbleFields(UserProjection? existing, MumbleUserInput input)
+    {
+        var row = existing ?? new UserProjection { SessionId = input.SessionId };
+        return row with
+        {
+            Name = input.Name,
+            ChannelId = input.ChannelId,
+            Muted = input.Muted,
+            Deafened = input.Deafened,
+            Comment = input.Comment,
+            MumbleCertHash = input.CertHash,
+            IsSelf = input.IsSelf
+        };
+    }
+
+    public ChangeSet ApplyServerSnapshot(ServerSnapshot snapshot)
+    {
+        lock (_gate)
+        {
+            _instanceId = snapshot.InstanceId;
+            _revision = snapshot.Revision;
+
+            var changed = new List<UserProjection>();
+            foreach (var (sessionId, entry) in snapshot.Mappings)
+            {
+                if (!_rows.TryGetValue(sessionId, out var existing)) continue;
+                var updated = WithServerFields(existing, entry);
+                if (existing == updated) continue;
+                _rows[sessionId] = updated;
+                changed.Add(updated);
+            }
+
+            return changed.Count == 0 ? ChangeSet.Empty : new ChangeSet(changed, []);
+        }
+    }
+
+    /// <summary>
+    /// Writes only server-owned fields, and only those the input actually knows: a null leaves
+    /// the current value alone. This is the rule that stops a missing field becoming a wrong one.
+    /// </summary>
+    private static UserProjection WithServerFields(UserProjection row, ServerMappingEntry entry) =>
+        row with
+        {
+            MatrixUserId = entry.MatrixUserId ?? row.MatrixUserId,
+            CompanionId = entry.CompanionId ?? row.CompanionId,
+            IsBrmbleClient = entry.IsBrmbleClient ?? row.IsBrmbleClient,
+            ServerCertHash = entry.CertHash ?? row.ServerCertHash
+        };
+}

--- a/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
@@ -150,4 +150,64 @@ internal sealed class UserProjectionStore
             IsBrmbleClient = entry.IsBrmbleClient ?? row.IsBrmbleClient,
             ServerCertHash = entry.CertHash ?? row.ServerCertHash
         };
+
+    /// <summary>
+    /// Applies one incremental server event, or reports that a snapshot is needed.
+    /// </summary>
+    /// <remarks>
+    /// Sequencing uses <c>BaseRevision</c>, not <c>Revision - 1</c>: a single server operation
+    /// may bump the counter several times, so only the range's start tells us whether we are
+    /// contiguous. An event that cannot be applied changes nothing at all — a partially applied
+    /// gap is what produces a confidently wrong row.
+    /// </remarks>
+    public ChangeSet ApplyServerEvent(ServerEvent evt)
+    {
+        lock (_gate)
+        {
+            // No cursor yet: nothing to sequence against, so ask for the snapshot that
+            // establishes one.
+            if (_instanceId is null)
+                return new ChangeSet([], [], NeedsSnapshot: true);
+
+            // The server restarted. Everything it told us belongs to a table that no longer
+            // exists, so take nothing from this event and resync.
+            if (!string.Equals(evt.InstanceId, _instanceId, StringComparison.Ordinal))
+                return new ChangeSet([], [], NeedsSnapshot: true);
+
+            // Already reflected — a duplicate or a reorder. Silently correct.
+            if (evt.BaseRevision < _revision) return ChangeSet.Empty;
+
+            // A genuine gap: we missed something in between and cannot infer it.
+            if (evt.BaseRevision > _revision)
+                return new ChangeSet([], [], NeedsSnapshot: true);
+
+            // Contiguous. Advance the cursor even if the event turns out not to touch a row we
+            // hold, or the next event would look like a gap.
+            _revision = evt.Revision;
+
+            if (!_rows.TryGetValue(evt.SessionId, out var existing))
+                return ChangeSet.Empty;
+
+            var updated = evt.Kind switch
+            {
+                ServerEventKind.MappingRemoved => existing with
+                {
+                    MatrixUserId = null,
+                    CompanionId = null,
+                    IsBrmbleClient = null,
+                    ServerCertHash = null
+                },
+                // Activation and deactivation are both knowledge, so they write a real bool.
+                ServerEventKind.BrmbleActivated => existing with { IsBrmbleClient = true },
+                ServerEventKind.BrmbleDeactivated => existing with { IsBrmbleClient = false },
+                // Everything else carries a partial entry: null means unknown, so leave it.
+                _ => evt.Entry is null ? existing : WithServerFields(existing, evt.Entry)
+            };
+
+            if (existing == updated) return ChangeSet.Empty;
+
+            _rows[evt.SessionId] = updated;
+            return new ChangeSet([updated], []);
+        }
+    }
 }

--- a/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
@@ -89,18 +89,46 @@ internal sealed class UserProjectionStore
         };
     }
 
+    /// <summary>
+    /// Applies a complete statement of server-known sessions. Sessions the snapshot omits have
+    /// their server-owned fields reset to unknown — stale enrichment is worse than none — but
+    /// their rows survive, because only Mumble owns existence.
+    /// </summary>
     public ChangeSet ApplyServerSnapshot(ServerSnapshot snapshot)
     {
         lock (_gate)
         {
+            // A different instance means the old revision line is meaningless. Nothing special
+            // is needed beyond taking this snapshot as truth, which the reset below does.
             _instanceId = snapshot.InstanceId;
             _revision = snapshot.Revision;
 
             var changed = new List<UserProjection>();
-            foreach (var (sessionId, entry) in snapshot.Mappings)
+
+            foreach (var sessionId in _rows.Keys.ToArray())
             {
-                if (!_rows.TryGetValue(sessionId, out var existing)) continue;
-                var updated = WithServerFields(existing, entry);
+                var existing = _rows[sessionId];
+
+                var updated = snapshot.Mappings.TryGetValue(sessionId, out var entry)
+                    // Present: overwrite the server half outright. A snapshot states every
+                    // server-owned field, so null here is knowledge, not absence — this is the
+                    // one place the null-means-unknown rule does not apply.
+                    ? existing with
+                    {
+                        MatrixUserId = entry.MatrixUserId,
+                        CompanionId = entry.CompanionId,
+                        IsBrmbleClient = entry.IsBrmbleClient,
+                        ServerCertHash = entry.CertHash
+                    }
+                    // Absent: the server does not know this session. Back to unknown.
+                    : existing with
+                    {
+                        MatrixUserId = null,
+                        CompanionId = null,
+                        IsBrmbleClient = null,
+                        ServerCertHash = null
+                    };
+
                 if (existing == updated) continue;
                 _rows[sessionId] = updated;
                 changed.Add(updated);

--- a/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
@@ -83,8 +83,8 @@ internal sealed class UserProjectionStore
 
     /// <summary>
     /// Replaces membership wholesale on voice connect or reconnect. Server-owned fields survive
-    /// for sessions present in both the old and new list, and sessions appearing for the first
-    /// time claim any held server data.
+    /// only where the session is demonstrably still the same person; every other row is rebuilt
+    /// from scratch and claims any held server data.
     /// </summary>
     public ChangeSet ApplyMumbleReset(IReadOnlyList<MumbleUserInput> users)
     {
@@ -94,8 +94,14 @@ internal sealed class UserProjectionStore
             foreach (var input in users)
             {
                 _rows.TryGetValue(input.SessionId, out var existing);
-                var row = WithMumbleFields(existing, input);
-                if (existing is null) row = TakePending(input.SessionId, row);
+
+                // A reset happens precisely when the client has been away and may have missed
+                // events, and Mumble recycles session ids. Carrying a row across by id alone
+                // would hand a new occupant the previous one's identity.
+                var continues = existing is not null && IsSameOccupant(existing, input);
+
+                var row = WithMumbleFields(continues ? existing : null, input);
+                if (!continues) row = TakePending(input.SessionId, row);
                 rebuilt[input.SessionId] = row;
             }
 
@@ -104,6 +110,33 @@ internal sealed class UserProjectionStore
 
             return new ChangeSet([.. rebuilt.Values], [], IsReset: true);
         }
+    }
+
+    /// <summary>
+    /// Whether a session id that appears on both sides of a reset still holds the same person.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately conservative. Losing enrichment we still had is a brief cosmetic gap that
+    /// the next snapshot repairs; keeping enrichment that now belongs to somebody else shows one
+    /// user under another's identity. The design trades the first for the second every time.
+    /// <para>
+    /// Not applied to <see cref="ApplyMumbleUserState"/>: within a live connection Mumble sends
+    /// <c>UserRemove</c> before reusing an id, so there is no missed-event window there, and a
+    /// legitimate rename by a user without a certificate would otherwise discard identity that
+    /// is still correct.
+    /// </para>
+    /// </remarks>
+    private static bool IsSameOccupant(UserProjection existing, MumbleUserInput input)
+    {
+        // A certificate identifies a person independently of the session id, so when both sides
+        // have one it settles the question outright — including across a rename.
+        if (existing.MumbleCertHash is { } previousCert && input.CertHash is { } currentCert)
+            return string.Equals(previousCert, currentCert, StringComparison.Ordinal);
+
+        // Otherwise the name is all there is. Mumble keeps names unique among connected users,
+        // so an id that kept its name across a reconnect kept its occupant.
+        return existing.Name is not null
+               && string.Equals(existing.Name, input.Name, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -175,6 +208,18 @@ internal sealed class UserProjectionStore
     {
         lock (_gate)
         {
+            // Snapshots arrive over two transports with no ordering between them — the
+            // /auth/token HTTP body and the WebSocket sessionMappingSnapshot — so a slow
+            // response can land after a newer snapshot. Applying it would rewind the cursor,
+            // overwrite newer state, reset sessions the older snapshot happens to omit, and
+            // replace held entries with stale ones, with nothing to repair it until the next
+            // server mutation. This is the snapshot-side twin of the duplicate/reorder guard in
+            // ApplyServerEvent. A lower revision from a *different* instance is not stale: a
+            // restart resets the revision line, so that case must still apply.
+            if (string.Equals(snapshot.InstanceId, _instanceId, StringComparison.Ordinal)
+                && snapshot.Revision < _revision)
+                return ChangeSet.Empty;
+
             // A different instance means the old revision line is meaningless. Nothing special
             // is needed beyond taking this snapshot as truth, which the reset below does.
             _instanceId = snapshot.InstanceId;

--- a/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
@@ -12,11 +12,39 @@ namespace Brmble.Client.Services.Voice.Projection;
 /// </remarks>
 internal sealed class UserProjectionStore
 {
+    /// <summary>
+    /// Ceiling on held server entries for sessions Mumble has not announced yet.
+    /// </summary>
+    /// <remarks>
+    /// The map is fed by a remote server, so it cannot be unbounded. The legitimate population
+    /// is "sessions on this Mumble server that the client has not seen a UserState for yet",
+    /// which is at most the server's user count for the few hundred milliseconds between
+    /// <c>/auth/token</c> resolving and the UserState batch arriving. 1024 is comfortably above
+    /// any real Murmur deployment, so reaching it means the server is misbehaving rather than
+    /// busy. Overflow evicts the oldest hold, because the newest statement is the one most
+    /// likely to still be true.
+    /// </remarks>
+    internal const int MaxPendingEntries = 1024;
+
     private readonly object _gate = new();
     private readonly Dictionary<uint, UserProjection> _rows = [];
 
+    /// <summary>
+    /// Server-owned data for sessions that have no row yet. Consumed when the row appears.
+    /// </summary>
+    /// <remarks>
+    /// Without this, server data for an unannounced session is lost with nothing to re-deliver
+    /// it: no gap occurs, so no resync is triggered. The worst case is voice connect, where
+    /// <c>/auth/token</c> routinely resolves before Mumble's UserState batch — every badge and
+    /// companion for every user would be dropped on every connect.
+    /// </remarks>
+    private readonly Dictionary<uint, PendingEntry> _pending = [];
+    private long _pendingSequence;
+
     private string? _instanceId;
     private long _revision;
+
+    private readonly record struct PendingEntry(long Sequence, ServerMappingEntry Entry);
 
     /// <summary>A copy of the current projection, for tests and for building a full reset.</summary>
     public IReadOnlyDictionary<uint, UserProjection> Snapshot()
@@ -30,6 +58,11 @@ internal sealed class UserProjectionStore
         {
             _rows.TryGetValue(input.SessionId, out var existing);
             var updated = WithMumbleFields(existing, input);
+
+            // A row appearing for the first time claims anything the server said about it
+            // while it did not exist.
+            if (existing is null) updated = TakePending(input.SessionId, updated);
+
             if (existing == updated) return ChangeSet.Empty;
 
             _rows[input.SessionId] = updated;
@@ -50,7 +83,8 @@ internal sealed class UserProjectionStore
 
     /// <summary>
     /// Replaces membership wholesale on voice connect or reconnect. Server-owned fields survive
-    /// for sessions present in both the old and new list.
+    /// for sessions present in both the old and new list, and sessions appearing for the first
+    /// time claim any held server data.
     /// </summary>
     public ChangeSet ApplyMumbleReset(IReadOnlyList<MumbleUserInput> users)
     {
@@ -60,7 +94,9 @@ internal sealed class UserProjectionStore
             foreach (var input in users)
             {
                 _rows.TryGetValue(input.SessionId, out var existing);
-                rebuilt[input.SessionId] = WithMumbleFields(existing, input);
+                var row = WithMumbleFields(existing, input);
+                if (existing is null) row = TakePending(input.SessionId, row);
+                rebuilt[input.SessionId] = row;
             }
 
             _rows.Clear();
@@ -88,6 +124,47 @@ internal sealed class UserProjectionStore
             IsSelf = input.IsSelf
         };
     }
+
+    /// <summary>
+    /// Consumes any held server data for a newly created row. The hold is removed: it has done
+    /// its job, and a session that later leaves and rejoins must be re-enriched by the server
+    /// rather than by a stale hold.
+    /// </summary>
+    private UserProjection TakePending(uint sessionId, UserProjection row)
+    {
+        if (!_pending.Remove(sessionId, out var held)) return row;
+        return WithServerFields(row, held.Entry);
+    }
+
+    /// <summary>
+    /// Holds server data for a session with no row, merging under the null-means-unknown rule
+    /// so a later partial event cannot blank what an earlier one established.
+    /// </summary>
+    private void HoldPending(uint sessionId, ServerMappingEntry delta)
+    {
+        if (_pending.TryGetValue(sessionId, out var held))
+        {
+            _pending[sessionId] = held with { Entry = MergeEntries(held.Entry, delta) };
+            return;
+        }
+
+        EvictOldestPendingIfFull();
+        _pending[sessionId] = new PendingEntry(_pendingSequence++, delta);
+    }
+
+    private void EvictOldestPendingIfFull()
+    {
+        if (_pending.Count < MaxPendingEntries) return;
+
+        var oldest = _pending.MinBy(p => p.Value.Sequence).Key;
+        _pending.Remove(oldest);
+    }
+
+    private static ServerMappingEntry MergeEntries(ServerMappingEntry existing, ServerMappingEntry delta) =>
+        new(delta.MatrixUserId ?? existing.MatrixUserId,
+            delta.CompanionId ?? existing.CompanionId,
+            delta.IsBrmbleClient ?? existing.IsBrmbleClient,
+            delta.CertHash ?? existing.CertHash);
 
     /// <summary>
     /// Applies a complete statement of server-known sessions. Sessions the snapshot omits have
@@ -134,7 +211,24 @@ internal sealed class UserProjectionStore
                 changed.Add(updated);
             }
 
+            // The snapshot is authoritative for membership, so it replaces the held set outright
+            // rather than merging into it. Holds it omits are superseded and dropped; entries it
+            // carries for sessions Mumble has not announced are held for when they appear —
+            // which on voice connect is every session.
+            RebuildPendingFrom(snapshot);
+
             return changed.Count == 0 ? ChangeSet.Empty : new ChangeSet(changed, []);
+        }
+    }
+
+    private void RebuildPendingFrom(ServerSnapshot snapshot)
+    {
+        _pending.Clear();
+        foreach (var (sessionId, entry) in snapshot.Mappings)
+        {
+            if (_rows.ContainsKey(sessionId)) continue;
+            EvictOldestPendingIfFull();
+            _pending[sessionId] = new PendingEntry(_pendingSequence++, entry);
         }
     }
 
@@ -150,6 +244,18 @@ internal sealed class UserProjectionStore
             IsBrmbleClient = entry.IsBrmbleClient ?? row.IsBrmbleClient,
             ServerCertHash = entry.CertHash ?? row.ServerCertHash
         };
+
+    /// <summary>
+    /// The server-owned change an event asserts, expressed as an entry so that the row path and
+    /// the hold path apply identical semantics. Activation and deactivation are knowledge, so
+    /// they carry a real bool rather than a null.
+    /// </summary>
+    private static ServerMappingEntry? DeltaFor(ServerEvent evt) => evt.Kind switch
+    {
+        ServerEventKind.BrmbleActivated => new ServerMappingEntry(null, null, true, null),
+        ServerEventKind.BrmbleDeactivated => new ServerMappingEntry(null, null, false, null),
+        _ => evt.Entry
+    };
 
     /// <summary>
     /// Applies one incremental server event, or reports that a snapshot is needed.
@@ -174,6 +280,12 @@ internal sealed class UserProjectionStore
             if (!string.Equals(evt.InstanceId, _instanceId, StringComparison.Ordinal))
                 return new ChangeSet([], [], NeedsSnapshot: true);
 
+            // A range that ends before it starts is malformed. The server should never emit one,
+            // but the store is the trust boundary: applying it would drag the cursor backwards
+            // and make every subsequent event look like a duplicate. Treat it as a gap.
+            if (evt.Revision < evt.BaseRevision)
+                return new ChangeSet([], [], NeedsSnapshot: true);
+
             // Already reflected — a duplicate or a reorder. Silently correct.
             if (evt.BaseRevision < _revision) return ChangeSet.Empty;
 
@@ -186,7 +298,14 @@ internal sealed class UserProjectionStore
             _revision = evt.Revision;
 
             if (!_rows.TryGetValue(evt.SessionId, out var existing))
+            {
+                // No row yet. Hold what the event said rather than dropping it — Mumble may
+                // simply not have announced this session to us yet.
+                if (evt.Kind == ServerEventKind.MappingRemoved) _pending.Remove(evt.SessionId);
+                else if (DeltaFor(evt) is { } delta) HoldPending(evt.SessionId, delta);
+
                 return ChangeSet.Empty;
+            }
 
             var updated = evt.Kind switch
             {
@@ -197,11 +316,8 @@ internal sealed class UserProjectionStore
                     IsBrmbleClient = null,
                     ServerCertHash = null
                 },
-                // Activation and deactivation are both knowledge, so they write a real bool.
-                ServerEventKind.BrmbleActivated => existing with { IsBrmbleClient = true },
-                ServerEventKind.BrmbleDeactivated => existing with { IsBrmbleClient = false },
                 // Everything else carries a partial entry: null means unknown, so leave it.
-                _ => evt.Entry is null ? existing : WithServerFields(existing, evt.Entry)
+                _ => DeltaFor(evt) is { } delta ? WithServerFields(existing, delta) : existing
             };
 
             if (existing == updated) return ChangeSet.Empty;

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -124,6 +124,7 @@ public static class AuthEndpoints
                             {
                                 type = "userMappingAdded",
                                 instanceId = envelope.InstanceId,
+                                baseRevision = envelope.BaseRevision,
                                 revision = envelope.Revision,
                                 sessionId = sid,
                                 matrixUserId = result.MatrixUserId,
@@ -137,6 +138,7 @@ public static class AuthEndpoints
                             {
                                 type = "brmbleClientActivated",
                                 instanceId = envelope.InstanceId,
+                                baseRevision = envelope.BaseRevision,
                                 revision = envelope.Revision,
                                 sessionId = sid
                             };
@@ -360,6 +362,7 @@ public static class AuthEndpoints
                 {
                     type = "companionChanged",
                     instanceId = envelope.InstanceId,
+                    baseRevision = envelope.BaseRevision,
                     revision = envelope.Revision,
                     sessionId,
                     matrixUserId = user.MatrixUserId,

--- a/src/Brmble.Server/Auth/AuthService.cs
+++ b/src/Brmble.Server/Auth/AuthService.cs
@@ -265,6 +265,7 @@ public class AuthService : IActiveBrmbleSessions
             {
                 type = "brmbleClientActivated",
                 instanceId = envelope.InstanceId,
+                baseRevision = envelope.BaseRevision,
                 revision = envelope.Revision,
                 sessionId = activatedSessionId
             });
@@ -290,6 +291,7 @@ public class AuthService : IActiveBrmbleSessions
                     {
                         type = "brmbleClientDeactivated",
                         instanceId = envelope.InstanceId,
+                        baseRevision = envelope.BaseRevision,
                         revision = envelope.Revision,
                         sessionId = deactivatedSessionId
                     });

--- a/src/Brmble.Server/Companions/CustomCompanionEndpoints.cs
+++ b/src/Brmble.Server/Companions/CustomCompanionEndpoints.cs
@@ -82,6 +82,7 @@ public static class CustomCompanionEndpoints
                         {
                             type = "companionChanged",
                             instanceId = envelope.InstanceId,
+                            baseRevision = envelope.BaseRevision,
                             revision = envelope.Revision,
                             sessionId,
                             matrixUserId = mapping.MatrixUserId,

--- a/src/Brmble.Server/Events/MappingEnvelope.cs
+++ b/src/Brmble.Server/Events/MappingEnvelope.cs
@@ -4,5 +4,17 @@ namespace Brmble.Server.Events;
 /// Stamped on every session-mapping payload so a client can tell a restart from a gap.
 /// </summary>
 /// <param name="InstanceId">Identifies the server's mapping table; changes on restart.</param>
-/// <param name="Revision">The table revision produced by the mutation being announced.</param>
-public readonly record struct MappingEnvelope(string InstanceId, long Revision);
+/// <param name="Revision">The table revision after the mutation being announced.</param>
+/// <param name="BaseRevision">
+/// The table revision before it. One logical operation may bump the counter several times, so a
+/// client applies on <c>BaseRevision == ours</c> rather than on <c>Revision == ours + 1</c>.
+/// </param>
+public readonly record struct MappingEnvelope(string InstanceId, long Revision, long BaseRevision)
+{
+    /// <summary>
+    /// A snapshot is absolute rather than a delta — it sets the client's cursor outright — so it
+    /// is its own base.
+    /// </summary>
+    public static MappingEnvelope Snapshot(string instanceId, long revision) =>
+        new(instanceId, revision, revision);
+}

--- a/src/Brmble.Server/Events/MappingEventPublisher.cs
+++ b/src/Brmble.Server/Events/MappingEventPublisher.cs
@@ -27,7 +27,9 @@ public sealed class MappingEventPublisher(
             // revision, or enqueued after the snapshot and so applies on top of it. Splitting
             // these — capturing here and enqueuing after an await — lets a later event overtake
             // the snapshot it was supposed to be repaired by.
-            var envelope = new MappingEnvelope(mappings.InstanceId, mappings.Revision);
+            // A snapshot is absolute rather than a delta, so it is its own base and carries no
+            // baseRevision: it sets the client's cursor outright instead of advancing it.
+            var envelope = MappingEnvelope.Snapshot(mappings.InstanceId, mappings.Revision);
             pending = eventBus.SendToClientAsync(target, payload(envelope, mappings.GetSnapshot()));
         }
 
@@ -43,9 +45,12 @@ public sealed class MappingEventPublisher(
         Task pending;
         lock (_gate)
         {
+            // Read before, mutate, read after — all inside the lock, so the range provably
+            // belongs to this mutation and cannot straddle a concurrent one.
+            var baseRevision = mappings.Revision;
             if (!mutate()) return Task.CompletedTask;
 
-            var envelope = new MappingEnvelope(mappings.InstanceId, mappings.Revision);
+            var envelope = new MappingEnvelope(mappings.InstanceId, mappings.Revision, baseRevision);
 
             // Safe under the lock: BrmbleEventBus's broadcast paths are deliberately not async
             // and enqueue to every per-socket queue before returning, so no socket I/O happens

--- a/src/Brmble.Server/Events/SessionMappingHandler.cs
+++ b/src/Brmble.Server/Events/SessionMappingHandler.cs
@@ -66,6 +66,7 @@ public class SessionMappingHandler : IMumbleEventHandler
                 {
                     ["type"] = "userMappingAdded",
                     ["instanceId"] = envelope.InstanceId,
+                    ["baseRevision"] = envelope.BaseRevision,
                     ["revision"] = envelope.Revision,
                     ["sessionId"] = user.SessionId,
                     ["matrixUserId"] = dbUser.MatrixUserId,
@@ -95,6 +96,7 @@ public class SessionMappingHandler : IMumbleEventHandler
                 {
                     type = "brmbleClientActivated",
                     instanceId = announced.InstanceId,
+                    baseRevision = announced.BaseRevision,
                     revision = announced.Revision,
                     sessionId = user.SessionId
                 });

--- a/src/Brmble.Server/Mumble/MumbleServerCallback.cs
+++ b/src/Brmble.Server/Mumble/MumbleServerCallback.cs
@@ -198,6 +198,7 @@ public class MumbleServerCallback : MumbleServer.ServerCallbackDisp_
             {
                 type = "userMappingRemoved",
                 instanceId = envelope.InstanceId,
+                baseRevision = envelope.BaseRevision,
                 revision = envelope.Revision,
                 sessionId = user.SessionId
             });

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -131,6 +131,7 @@ public static class BrmbleWebSocketHandler
         {
             type = "userMappingAdded",
             instanceId = envelope.InstanceId,
+            baseRevision = envelope.BaseRevision,
             revision = envelope.Revision,
             sessionId,
             matrixUserId = mapping.MatrixUserId,
@@ -184,7 +185,7 @@ public static class BrmbleWebSocketHandler
             sessionMapping.TryGetSessionByUserId(userId, out var queueSessionId);
             // Revision before snapshot: see the note on the resync path. Under-claiming is
             // self-correcting, over-claiming silently drops the intervening events.
-            var bootstrapEnvelope = new MappingEnvelope(
+            var bootstrapEnvelope = MappingEnvelope.Snapshot(
                 sessionMapping.InstanceId, sessionMapping.Revision);
             return await BuildInitialPayloadsAsync(
                 snapshots, queueSessionId, sessionMapping.GetSnapshot(), bootstrapEnvelope);

--- a/tests/Brmble.Client.Tests/Services/UserProjectionConvergenceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionConvergenceTests.cs
@@ -1,0 +1,140 @@
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+/// <summary>
+/// The design's central property: given the same starting point and the same final snapshot,
+/// any permutation of the intervening events — with any subset dropped — converges on the same
+/// projection. Ordering and delivery become irrelevant to correctness.
+/// </summary>
+[TestClass]
+public class UserProjectionConvergenceTests
+{
+    private static readonly MumbleUserInput[] Users =
+    [
+        new(1, "Alice", 0, false, false, null, null, false),
+        new(2, "Bob", 0, false, false, null, null, false),
+        new(3, "Carol", 0, false, false, null, null, false)
+    ];
+
+    private static readonly ServerSnapshot Final = new("inst-a", 100,
+        new Dictionary<uint, ServerMappingEntry>
+        {
+            [1] = new("@alice:test", "retro", true, "cert-a"),
+            // Session 2 is deliberately absent. Events below enrich it, so a patch-only
+            // reconciliation would leave it enriched in some trials and not others — this is
+            // what makes the property test able to catch a §4.3 regression rather than passing
+            // trivially because the final snapshot overwrites everything.
+            [3] = new("@carol:test", "pip", null, null)
+        });
+
+    private static ServerEvent[] BuildEvents() =>
+    [
+        new(ServerEventKind.CompanionChanged, "inst-a", 10, 11, 1, new ServerMappingEntry(null, "bee", null, null)),
+        new(ServerEventKind.BrmbleActivated, "inst-a", 11, 12, 2),
+        new(ServerEventKind.CompanionChanged, "inst-a", 12, 20, 3, new ServerMappingEntry(null, "floppy", null, null)),
+        new(ServerEventKind.BrmbleDeactivated, "inst-a", 20, 21, 1),
+        new(ServerEventKind.MappingRemoved, "inst-a", 21, 25, 2),
+        new(ServerEventKind.CompanionChanged, "inst-a", 25, 26, 1, new ServerMappingEntry(null, "pip", null, null))
+    ];
+
+    private static UserProjectionStore Seeded()
+    {
+        var store = new UserProjectionStore();
+        foreach (var user in Users) store.ApplyMumbleUserState(user);
+        store.ApplyServerSnapshot(new ServerSnapshot("inst-a", 10,
+            new Dictionary<uint, ServerMappingEntry>
+            {
+                [1] = new("@alice:test", "retro", null, null),
+                [2] = new("@bob:test", "bee", null, null),
+                [3] = new("@carol:test", "pip", null, null)
+            }));
+        return store;
+    }
+
+    private static string Describe(IReadOnlyDictionary<uint, UserProjection> rows) =>
+        string.Join("|", rows.OrderBy(r => r.Key).Select(r =>
+            $"{r.Key}:{r.Value.Name}:{r.Value.MatrixUserId}:{r.Value.CompanionId}:" +
+            $"{r.Value.IsBrmbleClient?.ToString() ?? "unknown"}:{r.Value.CertHash ?? "none"}"));
+
+    [TestMethod]
+    public void AnyPermutationWithAnyDropsConvergesOnTheSameProjection()
+    {
+        var reference = Seeded();
+        foreach (var evt in BuildEvents()) reference.ApplyServerEvent(evt);
+        reference.ApplyServerSnapshot(Final);
+        var expected = Describe(reference.Snapshot());
+
+        var random = new Random(20260801);
+
+        for (var trial = 0; trial < 500; trial++)
+        {
+            var events = BuildEvents().ToList();
+
+            // Shuffle.
+            for (var i = events.Count - 1; i > 0; i--)
+            {
+                var j = random.Next(i + 1);
+                (events[i], events[j]) = (events[j], events[i]);
+            }
+
+            // Drop an arbitrary subset.
+            events = events.Where(_ => random.Next(4) != 0).ToList();
+
+            var store = Seeded();
+            foreach (var evt in events) store.ApplyServerEvent(evt);
+            store.ApplyServerSnapshot(Final);
+
+            Assert.AreEqual(expected, Describe(store.Snapshot()),
+                $"trial {trial} diverged with {events.Count} of 6 events");
+        }
+    }
+
+    [TestMethod]
+    public void ASessionTheFinalSnapshotOmitsEndsUnknownRegardlessOfWhatEventsSaid()
+    {
+        // Guards the guard: this is the case that makes the permutation test load-bearing. If
+        // snapshot reconciliation regressed to patch-only, session 2 would keep whatever the
+        // events happened to set and the permutations would diverge.
+        var withEvent = Seeded();
+        withEvent.ApplyServerEvent(new ServerEvent(ServerEventKind.BrmbleActivated, "inst-a", 10, 12, 2));
+        withEvent.ApplyServerSnapshot(Final);
+
+        var withoutEvent = Seeded();
+        withoutEvent.ApplyServerSnapshot(Final);
+
+        Assert.IsNull(withEvent.Snapshot()[2].IsBrmbleClient);
+        Assert.IsNull(withEvent.Snapshot()[2].MatrixUserId);
+        Assert.AreEqual(Describe(withoutEvent.Snapshot()), Describe(withEvent.Snapshot()));
+    }
+
+    [TestMethod]
+    public void ADroppedEventNeverProducesAConfidentlyWrongValue()
+    {
+        // The failure this design exists to remove: a lost event must leave a field unknown or
+        // stale-but-true, never asserted wrong.
+        var store = Seeded();
+
+        // Alice's deactivation is dropped; her later companion change still arrives.
+        store.ApplyServerEvent(new ServerEvent(
+            ServerEventKind.CompanionChanged, "inst-a", 20, 26, 1,
+            new ServerMappingEntry(null, "pip", null, null)));
+
+        var alice = store.Snapshot()[1];
+        Assert.AreEqual("retro", alice.CompanionId, "the gapped event must not be applied");
+        Assert.IsNull(alice.IsBrmbleClient, "and must not invent a badge state");
+    }
+
+    [TestMethod]
+    public void AGapIsAlwaysReportedSoTheCallerCanRepairIt()
+    {
+        var store = Seeded();
+
+        var change = store.ApplyServerEvent(new ServerEvent(
+            ServerEventKind.CompanionChanged, "inst-a", 50, 51, 1,
+            new ServerMappingEntry(null, "pip", null, null)));
+
+        Assert.IsTrue(change.NeedsSnapshot);
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs
@@ -142,10 +142,11 @@ public class UserProjectionStoreEventTests
     }
 
     [TestMethod]
-    public void ApplyServerEvent_ForASessionMumbleHasNotShownIsIgnoredButAdvancesTheCursor()
+    public void ApplyServerEvent_ForASessionMumbleHasNotShownIsHeldAndAdvancesTheCursor()
     {
-        // The row does not exist yet, so there is nothing to enrich — but the event was still
-        // observed, and treating it as a gap would resync on every unrelated user's join.
+        // The row does not exist yet, so there is nothing to enrich — the entry is held for
+        // when it appears. The cursor still advances, because the event was observed, and
+        // treating it as a gap would resync on every unrelated user's join.
         var change = _store.ApplyServerEvent(
             new ServerEvent(ServerEventKind.CompanionChanged, "inst-a", 10, 11, 77,
                 new ServerMappingEntry(null, "bee", null, null)));

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs
@@ -1,0 +1,160 @@
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class UserProjectionStoreEventTests
+{
+    private UserProjectionStore _store = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _store = new UserProjectionStore();
+        _store.ApplyMumbleUserState(new MumbleUserInput(1, "Alice", 0, false, false, null, null, false));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst-a", 10,
+            new Dictionary<uint, ServerMappingEntry>
+            {
+                [1] = new("@alice:test", "retro", true, "cert-a")
+            }));
+    }
+
+    private static ServerEvent Companion(long baseRevision, long revision, string? companionId) =>
+        new(ServerEventKind.CompanionChanged, "inst-a", baseRevision, revision, 1,
+            new ServerMappingEntry(null, companionId, null, null));
+
+    [TestMethod]
+    public void ApplyServerEvent_AppliesWhenBaseRevisionMatchesTheCursor()
+    {
+        var change = _store.ApplyServerEvent(Companion(10, 13, "bee"));
+
+        Assert.AreEqual("bee", _store.Snapshot()[1].CompanionId);
+        Assert.AreEqual(1, change.Changed.Count);
+        Assert.IsFalse(change.NeedsSnapshot);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_AcceptsAMultiBumpRange()
+    {
+        // One server operation can bump the counter several times; the client must not read
+        // that as a gap.
+        var change = _store.ApplyServerEvent(Companion(10, 40, "bee"));
+
+        Assert.AreEqual("bee", _store.Snapshot()[1].CompanionId);
+        Assert.IsFalse(change.NeedsSnapshot);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_IgnoresAnAlreadyAppliedEvent()
+    {
+        _store.ApplyServerEvent(Companion(10, 13, "bee"));
+
+        var change = _store.ApplyServerEvent(Companion(10, 13, "bee"));
+
+        Assert.IsTrue(change.IsEmpty, "a duplicate must not re-emit");
+        Assert.AreEqual("bee", _store.Snapshot()[1].CompanionId);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_IgnoresAReorderedOlderEvent()
+    {
+        _store.ApplyServerEvent(Companion(10, 20, "bee"));
+
+        var change = _store.ApplyServerEvent(Companion(12, 15, "stale"));
+
+        Assert.AreEqual("bee", _store.Snapshot()[1].CompanionId);
+        Assert.IsTrue(change.IsEmpty);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_RequestsASnapshotOnAGapAndChangesNothing()
+    {
+        var change = _store.ApplyServerEvent(Companion(30, 33, "bee"));
+
+        Assert.IsTrue(change.NeedsSnapshot);
+        Assert.AreEqual(0, change.Changed.Count);
+        Assert.AreEqual("retro", _store.Snapshot()[1].CompanionId, "a gap must apply nothing");
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_RequestsASnapshotWhenTheInstanceChanged()
+    {
+        var change = _store.ApplyServerEvent(
+            new ServerEvent(ServerEventKind.CompanionChanged, "inst-b", 0, 1, 1,
+                new ServerMappingEntry(null, "bee", null, null)));
+
+        Assert.IsTrue(change.NeedsSnapshot);
+        Assert.AreEqual("retro", _store.Snapshot()[1].CompanionId);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_BeforeAnySnapshotRequestsOne()
+    {
+        var fresh = new UserProjectionStore();
+        fresh.ApplyMumbleUserState(new MumbleUserInput(1, "Alice", 0, false, false, null, null, false));
+
+        var change = fresh.ApplyServerEvent(Companion(0, 1, "bee"));
+
+        Assert.IsTrue(change.NeedsSnapshot, "without a cursor there is nothing to sequence against");
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_NullFieldsLeaveKnownValuesAlone()
+    {
+        // The rule that makes a lost field harmless: unknown never overwrites known.
+        var change = _store.ApplyServerEvent(Companion(10, 11, null));
+
+        Assert.AreEqual("retro", _store.Snapshot()[1].CompanionId);
+        Assert.IsTrue(change.IsEmpty);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_BrmbleDeactivatedIsKnowledgeAndClearsTheBadge()
+    {
+        var change = _store.ApplyServerEvent(
+            new ServerEvent(ServerEventKind.BrmbleDeactivated, "inst-a", 10, 11, 1));
+
+        Assert.AreEqual(false, _store.Snapshot()[1].IsBrmbleClient);
+        Assert.AreEqual(1, change.Changed.Count);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_BrmbleActivatedSetsTheBadge()
+    {
+        _store.ApplyServerEvent(new ServerEvent(ServerEventKind.BrmbleDeactivated, "inst-a", 10, 11, 1));
+
+        _store.ApplyServerEvent(new ServerEvent(ServerEventKind.BrmbleActivated, "inst-a", 11, 12, 1));
+
+        Assert.AreEqual(true, _store.Snapshot()[1].IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_MappingRemovedClearsServerFieldsButKeepsTheRow()
+    {
+        var change = _store.ApplyServerEvent(
+            new ServerEvent(ServerEventKind.MappingRemoved, "inst-a", 10, 11, 1));
+
+        Assert.IsTrue(_store.Snapshot().ContainsKey(1), "only Mumble removes rows");
+        Assert.IsNull(_store.Snapshot()[1].MatrixUserId);
+        Assert.IsNull(_store.Snapshot()[1].IsBrmbleClient);
+        Assert.AreEqual(0, change.Removed.Count);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_ForASessionMumbleHasNotShownIsIgnoredButAdvancesTheCursor()
+    {
+        // The row does not exist yet, so there is nothing to enrich — but the event was still
+        // observed, and treating it as a gap would resync on every unrelated user's join.
+        var change = _store.ApplyServerEvent(
+            new ServerEvent(ServerEventKind.CompanionChanged, "inst-a", 10, 11, 77,
+                new ServerMappingEntry(null, "bee", null, null)));
+
+        Assert.IsFalse(change.NeedsSnapshot);
+        Assert.IsFalse(_store.Snapshot().ContainsKey(77));
+
+        var next = _store.ApplyServerEvent(Companion(11, 12, "pip"));
+        Assert.AreEqual("pip", _store.Snapshot()[1].CompanionId);
+        Assert.IsFalse(next.NeedsSnapshot);
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStoreEventTests.cs
@@ -142,6 +142,20 @@ public class UserProjectionStoreEventTests
     }
 
     [TestMethod]
+    public void ApplyServerEvent_RejectsARangeThatEndsBeforeItStarts()
+    {
+        // The server should never emit this, but the store is the trust boundary. Applying it
+        // would drag the cursor backwards and make every later event look like a duplicate.
+        var change = _store.ApplyServerEvent(Companion(10, 4, "bee"));
+
+        Assert.IsTrue(change.NeedsSnapshot);
+        Assert.AreEqual("retro", _store.Snapshot()[1].CompanionId, "a malformed range must apply nothing");
+
+        var next = _store.ApplyServerEvent(Companion(10, 11, "pip"));
+        Assert.AreEqual("pip", _store.Snapshot()[1].CompanionId, "the cursor must not have moved");
+    }
+
+    [TestMethod]
     public void ApplyServerEvent_ForASessionMumbleHasNotShownIsHeldAndAdvancesTheCursor()
     {
         // The row does not exist yet, so there is nothing to enrich — the entry is held for

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs
@@ -1,0 +1,99 @@
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class UserProjectionStoreMumbleTests
+{
+    private UserProjectionStore _store = null!;
+
+    [TestInitialize]
+    public void Setup() => _store = new UserProjectionStore();
+
+    private static MumbleUserInput User(uint session, string name = "Alice", uint channel = 0) =>
+        new(session, name, channel, false, false, null, null, false);
+
+    [TestMethod]
+    public void ApplyMumbleUserState_AddsARowAndReportsIt()
+    {
+        var change = _store.ApplyMumbleUserState(User(1));
+
+        Assert.AreEqual(1, change.Changed.Count);
+        Assert.AreEqual(1u, change.Changed[0].SessionId);
+        Assert.AreEqual("Alice", change.Changed[0].Name);
+        Assert.AreEqual(1, _store.Snapshot().Count);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleUserState_IsIdempotentForAnUnchangedState()
+    {
+        _store.ApplyMumbleUserState(User(1));
+
+        var change = _store.ApplyMumbleUserState(User(1));
+
+        Assert.IsTrue(change.IsEmpty, "an identical UserState must not churn the UI");
+    }
+
+    [TestMethod]
+    public void ApplyMumbleUserState_UpdatesMumbleFieldsWithoutTouchingServerFields()
+    {
+        _store.ApplyMumbleUserState(User(1));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst", 5, new Dictionary<uint, ServerMappingEntry>
+        {
+            [1] = new("@alice:test", "retro", true, "cert-server")
+        }));
+
+        var change = _store.ApplyMumbleUserState(User(1, "Alice", channel: 7));
+
+        var row = change.Changed.Single();
+        Assert.AreEqual(7u, row.ChannelId);
+        Assert.AreEqual("@alice:test", row.MatrixUserId, "a Mumble input must not clear identity");
+        Assert.AreEqual("retro", row.CompanionId);
+        Assert.AreEqual(true, row.IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleUserRemove_DeletesTheRowEntirely()
+    {
+        _store.ApplyMumbleUserState(User(1));
+
+        var change = _store.ApplyMumbleUserRemove(1);
+
+        CollectionAssert.AreEqual(new[] { 1u }, change.Removed.ToArray());
+        Assert.AreEqual(0, _store.Snapshot().Count);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleUserRemove_IsSilentForAnUnknownSession()
+    {
+        Assert.IsTrue(_store.ApplyMumbleUserRemove(99).IsEmpty);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleReset_ReplacesMembershipAndFlagsAReset()
+    {
+        _store.ApplyMumbleUserState(User(1));
+        _store.ApplyMumbleUserState(User(2, "Bob"));
+
+        var change = _store.ApplyMumbleReset([User(2, "Bob"), User(3, "Carol")]);
+
+        Assert.IsTrue(change.IsReset);
+        CollectionAssert.AreEquivalent(new[] { 2u, 3u }, _store.Snapshot().Keys.ToArray());
+    }
+
+    [TestMethod]
+    public void ApplyMumbleReset_KeepsServerFieldsForSessionsThatSurvive()
+    {
+        // A voice reconnect must not cost us identity we already know.
+        _store.ApplyMumbleUserState(User(1));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst", 5, new Dictionary<uint, ServerMappingEntry>
+        {
+            [1] = new("@alice:test", "retro", true, null)
+        }));
+
+        _store.ApplyMumbleReset([User(1)]);
+
+        Assert.AreEqual("@alice:test", _store.Snapshot()[1].MatrixUserId);
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStoreMumbleTests.cs
@@ -96,4 +96,90 @@ public class UserProjectionStoreMumbleTests
 
         Assert.AreEqual("@alice:test", _store.Snapshot()[1].MatrixUserId);
     }
+
+    private static MumbleUserInput UserWithCert(uint session, string name, string? certHash) =>
+        new(session, name, 0, false, false, null, certHash, false);
+
+    [TestMethod]
+    public void ApplyMumbleReset_DropsServerFieldsWhenTheCertificateOnASessionChanged()
+    {
+        // Mumble recycles session ids. If the client misses Alice's UserRemove while
+        // disconnected and session 7 has been reassigned to Bob by the time it reconnects,
+        // carrying the row across by session id alone would show Bob as Alice — the exact
+        // "confidently wrong value" this design exists to remove.
+        _store.ApplyMumbleUserState(UserWithCert(7, "Alice", "cert-alice"));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst", 5, new Dictionary<uint, ServerMappingEntry>
+        {
+            [7] = new("@alice:test", "retro", true, "cert-alice")
+        }));
+
+        _store.ApplyMumbleReset([UserWithCert(7, "Bob", "cert-bob")]);
+
+        var row = _store.Snapshot()[7];
+        Assert.AreEqual("Bob", row.Name);
+        Assert.IsNull(row.MatrixUserId, "Bob must not inherit Alice's identity");
+        Assert.IsNull(row.CompanionId);
+        Assert.IsNull(row.IsBrmbleClient);
+        Assert.AreEqual("cert-bob", row.CertHash, "and must not inherit her certificate either");
+    }
+
+    [TestMethod]
+    public void ApplyMumbleReset_DropsServerFieldsWhenTheNameOnASessionChangedAndThereIsNoCert()
+    {
+        // Without certificates the name is the only continuity signal available. Mumble keeps
+        // names unique among connected users, so a changed name on a recycled id is a changed
+        // occupant.
+        _store.ApplyMumbleUserState(User(7, "Alice"));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst", 5, new Dictionary<uint, ServerMappingEntry>
+        {
+            [7] = new("@alice:test", "retro", true, null)
+        }));
+
+        _store.ApplyMumbleReset([User(7, "Bob")]);
+
+        Assert.IsNull(_store.Snapshot()[7].MatrixUserId);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleReset_KeepsServerFieldsWhenTheCertificateMatchesAcrossARename()
+    {
+        // A certificate identifies a person independently of the session id, so it settles
+        // continuity outright — including across a legitimate rename, where the name check
+        // alone would wrongly discard identity we still know to be correct.
+        _store.ApplyMumbleUserState(UserWithCert(7, "Alice", "cert-alice"));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst", 5, new Dictionary<uint, ServerMappingEntry>
+        {
+            [7] = new("@alice:test", "retro", true, "cert-alice")
+        }));
+
+        _store.ApplyMumbleReset([UserWithCert(7, "Alice In Chains", "cert-alice")]);
+
+        Assert.AreEqual("@alice:test", _store.Snapshot()[7].MatrixUserId);
+        Assert.AreEqual("retro", _store.Snapshot()[7].CompanionId);
+    }
+
+    [TestMethod]
+    public void ApplyMumbleReset_ANewOccupantIsEnrichedByTheSnapshotThatFollows()
+    {
+        // Dropping the previous occupant's identity leaves the row unknown, not wrong, and the
+        // snapshot that follows a reconnect fills it in correctly. Unknown-then-correct is the
+        // trade this design makes against confidently-wrong every time.
+        _store.ApplyMumbleUserState(UserWithCert(7, "Alice", "cert-alice"));
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst", 5, new Dictionary<uint, ServerMappingEntry>
+        {
+            [7] = new("@alice:test", "retro", true, "cert-alice")
+        }));
+
+        _store.ApplyMumbleReset([UserWithCert(7, "Bob", "cert-bob")]);
+        Assert.IsNull(_store.Snapshot()[7].MatrixUserId, "Alice's identity must not survive");
+
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst", 6, new Dictionary<uint, ServerMappingEntry>
+        {
+            [7] = new("@bob:test", "bee", true, "cert-bob")
+        }));
+
+        Assert.AreEqual("@bob:test", _store.Snapshot()[7].MatrixUserId);
+        Assert.AreEqual("bee", _store.Snapshot()[7].CompanionId);
+    }
 }
+

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStorePendingTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStorePendingTests.cs
@@ -1,0 +1,177 @@
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+/// <summary>
+/// Server data can arrive before Mumble has announced the session it describes — most
+/// importantly on voice connect, where <c>/auth/token</c> returns a full snapshot that can beat
+/// Mumble's <c>UserState</c> batch. Dropping it there would blank every badge and companion on
+/// every connect, with nothing to re-deliver them.
+/// </summary>
+[TestClass]
+public class UserProjectionStorePendingTests
+{
+    private UserProjectionStore _store = null!;
+
+    [TestInitialize]
+    public void Setup() => _store = new UserProjectionStore();
+
+    private static MumbleUserInput User(uint session, string name = "Alice") =>
+        new(session, name, 0, false, false, null, null, false);
+
+    private static ServerSnapshot Snapshot(long revision, params (uint Session, ServerMappingEntry Entry)[] entries) =>
+        new("inst-a", revision, entries.ToDictionary(e => e.Session, e => e.Entry));
+
+    [TestMethod]
+    public void ApplyServerEvent_ForAnUnknownSessionIsHeldUntilMumbleAnnouncesIt()
+    {
+        _store.ApplyServerSnapshot(Snapshot(10));
+
+        _store.ApplyServerEvent(new ServerEvent(ServerEventKind.CompanionChanged, "inst-a", 10, 11, 77,
+            new ServerMappingEntry(null, "bee", null, null)));
+
+        var change = _store.ApplyMumbleUserState(User(77, "Carol"));
+
+        Assert.AreEqual("bee", _store.Snapshot()[77].CompanionId);
+        Assert.AreEqual("bee", change.Changed.Single().CompanionId,
+            "the held enrichment must be reported, or the UI never learns about it");
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_BrmbleActivatedForAnUnknownSessionIsHeld()
+    {
+        _store.ApplyServerSnapshot(Snapshot(10));
+
+        _store.ApplyServerEvent(new ServerEvent(ServerEventKind.BrmbleActivated, "inst-a", 10, 11, 77));
+        _store.ApplyMumbleUserState(User(77));
+
+        Assert.AreEqual(true, _store.Snapshot()[77].IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_ArrivingBeforeAnyMumbleRowEnrichesTheSubsequentReset()
+    {
+        // The real connect ordering: /auth/token resolves before the UserState batch lands.
+        _store.ApplyServerSnapshot(Snapshot(10,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, "cert-a")),
+            (2, new ServerMappingEntry("@bob:test", "bee", true, null))));
+
+        _store.ApplyMumbleReset([User(1, "Alice"), User(2, "Bob")]);
+
+        var rows = _store.Snapshot();
+        Assert.AreEqual("@alice:test", rows[1].MatrixUserId);
+        Assert.AreEqual("retro", rows[1].CompanionId);
+        Assert.AreEqual(true, rows[1].IsBrmbleClient);
+        Assert.AreEqual("@bob:test", rows[2].MatrixUserId);
+        Assert.AreEqual("bee", rows[2].CompanionId);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_ArrivingBeforeAnyMumbleRowEnrichesASingleUserState()
+    {
+        _store.ApplyServerSnapshot(Snapshot(10,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, "cert-a"))));
+
+        var change = _store.ApplyMumbleUserState(User(1));
+
+        Assert.AreEqual("@alice:test", change.Changed.Single().MatrixUserId);
+        Assert.AreEqual("cert-a", _store.Snapshot()[1].CertHash);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_DiscardsAHeldEntryItOmits()
+    {
+        _store.ApplyServerSnapshot(Snapshot(10,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+
+        // Session 1 vanished from the server before Mumble ever announced it.
+        _store.ApplyServerSnapshot(Snapshot(11));
+        _store.ApplyMumbleUserState(User(1));
+
+        Assert.IsNull(_store.Snapshot()[1].MatrixUserId,
+            "a superseded held entry must not resurrect stale identity");
+        Assert.IsNull(_store.Snapshot()[1].CompanionId);
+    }
+
+    [TestMethod]
+    public void ApplyServerEvent_MappingRemovedDiscardsAHeldEntry()
+    {
+        _store.ApplyServerSnapshot(Snapshot(10,
+            (77, new ServerMappingEntry("@carol:test", "bee", true, null))));
+
+        _store.ApplyServerEvent(new ServerEvent(ServerEventKind.MappingRemoved, "inst-a", 10, 11, 77));
+        _store.ApplyMumbleUserState(User(77));
+
+        Assert.IsNull(_store.Snapshot()[77].MatrixUserId);
+        Assert.IsNull(_store.Snapshot()[77].IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void HeldEntries_AreConsumedOnceAndNotReappliedAfterAMumbleRemove()
+    {
+        _store.ApplyServerSnapshot(Snapshot(10,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+
+        _store.ApplyMumbleUserState(User(1));
+        _store.ApplyMumbleUserRemove(1);
+        _store.ApplyMumbleUserState(User(1));
+
+        Assert.IsNull(_store.Snapshot()[1].MatrixUserId,
+            "the entry was consumed; a rejoining session must be re-enriched by the server, not by a stale hold");
+    }
+
+    [TestMethod]
+    public void HeldEntries_MergeUnderTheNullMeansUnknownRule()
+    {
+        _store.ApplyServerSnapshot(Snapshot(10));
+
+        _store.ApplyServerEvent(new ServerEvent(ServerEventKind.CompanionChanged, "inst-a", 10, 11, 77,
+            new ServerMappingEntry("@carol:test", "bee", null, null)));
+        _store.ApplyServerEvent(new ServerEvent(ServerEventKind.BrmbleActivated, "inst-a", 11, 12, 77));
+
+        _store.ApplyMumbleUserState(User(77));
+
+        var row = _store.Snapshot()[77];
+        Assert.AreEqual("@carol:test", row.MatrixUserId, "a later partial event must not blank an earlier field");
+        Assert.AreEqual("bee", row.CompanionId);
+        Assert.AreEqual(true, row.IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void HeldEntries_AreBoundedAndEvictTheOldestFirst()
+    {
+        // The map is fed by a remote server, so it must not be allowed to grow without limit.
+        _store.ApplyServerSnapshot(Snapshot(0));
+
+        var overflow = UserProjectionStore.MaxPendingEntries + 1;
+        for (var i = 0; i < overflow; i++)
+        {
+            _store.ApplyServerEvent(new ServerEvent(ServerEventKind.CompanionChanged, "inst-a", i, i + 1,
+                (uint)(1000 + i), new ServerMappingEntry(null, $"c{i}", null, null)));
+        }
+
+        // The first session inserted was evicted to make room for the last.
+        _store.ApplyMumbleUserState(User(1000));
+        Assert.IsNull(_store.Snapshot()[1000].CompanionId, "the oldest held entry should have been evicted");
+
+        _store.ApplyMumbleUserState(User((uint)(1000 + overflow - 1)));
+        Assert.AreEqual($"c{overflow - 1}", _store.Snapshot()[(uint)(1000 + overflow - 1)].CompanionId,
+            "the newest held entry must survive");
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_DoesNotHoldEntriesForSessionsItAlreadyApplied()
+    {
+        _store.ApplyMumbleUserState(User(1));
+        _store.ApplyServerSnapshot(Snapshot(10,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+
+        // Session 1 leaves and rejoins with no server statement in between.
+        _store.ApplyMumbleUserRemove(1);
+        _store.ApplyMumbleUserState(User(1));
+
+        Assert.IsNull(_store.Snapshot()[1].MatrixUserId,
+            "an entry applied to a live row must not also be held for later");
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
@@ -77,7 +77,7 @@ public class UserProjectionStoreSnapshotTests
     }
 
     [TestMethod]
-    public void ApplyServerSnapshot_FlagsAResetWhenMembershipChanged()
+    public void ApplyServerSnapshot_ReportsRowsItResets()
     {
         _store.ApplyServerSnapshot(Snapshot(5,
             (1, new ServerMappingEntry("@alice:test", null, null, null)),

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
@@ -1,0 +1,108 @@
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class UserProjectionStoreSnapshotTests
+{
+    private UserProjectionStore _store = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _store = new UserProjectionStore();
+        _store.ApplyMumbleUserState(new MumbleUserInput(1, "Alice", 0, false, false, null, null, false));
+        _store.ApplyMumbleUserState(new MumbleUserInput(2, "Bob", 0, false, false, null, null, false));
+    }
+
+    private static ServerSnapshot Snapshot(long revision, params (uint Session, ServerMappingEntry Entry)[] entries) =>
+        new("inst-a", revision, entries.ToDictionary(e => e.Session, e => e.Entry));
+
+    [TestMethod]
+    public void ApplyServerSnapshot_FillsServerFieldsForKnownSessions()
+    {
+        var change = _store.ApplyServerSnapshot(
+            Snapshot(5, (1, new ServerMappingEntry("@alice:test", "retro", true, "cert-a"))));
+
+        Assert.AreEqual("@alice:test", _store.Snapshot()[1].MatrixUserId);
+        Assert.AreEqual(1, change.Changed.Count);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_ResetsServerFieldsForSessionsItOmits()
+    {
+        // Session 2 was known to the server, then vanished during an outage. The snapshot is
+        // authoritative for membership, so its enrichment goes back to unknown rather than
+        // lingering as a confident wrong answer.
+        _store.ApplyServerSnapshot(Snapshot(5,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, null)),
+            (2, new ServerMappingEntry("@bob:test", "bee", true, null))));
+
+        _store.ApplyServerSnapshot(Snapshot(6,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+
+        var bob = _store.Snapshot()[2];
+        Assert.IsNull(bob.MatrixUserId);
+        Assert.IsNull(bob.CompanionId);
+        Assert.IsNull(bob.IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_DoesNotDeleteRowsMumbleStillShows()
+    {
+        _store.ApplyServerSnapshot(Snapshot(5, (1, new ServerMappingEntry("@alice:test", null, null, null))));
+
+        Assert.IsTrue(_store.Snapshot().ContainsKey(2), "only Mumble may remove a row");
+        Assert.AreEqual("Bob", _store.Snapshot()[2].Name);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_KeepsMumbleFieldsIntact()
+    {
+        _store.ApplyServerSnapshot(Snapshot(5, (1, new ServerMappingEntry("@alice:test", null, null, null))));
+
+        Assert.AreEqual("Alice", _store.Snapshot()[1].Name);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_ForAnEntryWithNoMumbleRowIsIgnored()
+    {
+        // The server knows a session Mumble has not shown us. Existence is Mumble's to grant,
+        // so nothing is created; the next UserState will pick the enrichment up via the
+        // snapshot that follows it.
+        _store.ApplyServerSnapshot(Snapshot(5, (99, new ServerMappingEntry("@ghost:test", null, null, null))));
+
+        Assert.IsFalse(_store.Snapshot().ContainsKey(99));
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_FlagsAResetWhenMembershipChanged()
+    {
+        _store.ApplyServerSnapshot(Snapshot(5,
+            (1, new ServerMappingEntry("@alice:test", null, null, null)),
+            (2, new ServerMappingEntry("@bob:test", null, null, null))));
+
+        var change = _store.ApplyServerSnapshot(Snapshot(6,
+            (1, new ServerMappingEntry("@alice:test", null, null, null))));
+
+        Assert.IsTrue(change.Changed.Any(r => r.SessionId == 2),
+            "the reset row must be reported so the UI drops the badge");
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_FromANewInstanceReplacesEverything()
+    {
+        _store.ApplyServerSnapshot(Snapshot(90, (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst-b", 2,
+            new Dictionary<uint, ServerMappingEntry>
+            {
+                [1] = new("@alice:test", "bee", null, null)
+            }));
+
+        var alice = _store.Snapshot()[1];
+        Assert.AreEqual("bee", alice.CompanionId);
+        Assert.IsNull(alice.IsBrmbleClient, "a restart invalidates what the old instance told us");
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
@@ -91,6 +91,54 @@ public class UserProjectionStoreSnapshotTests
     }
 
     [TestMethod]
+    public void ApplyServerSnapshot_IgnoresAStaleSnapshotFromTheSameInstance()
+    {
+        // Snapshots reach the store over two transports with no ordering between them: the
+        // /auth/token HTTP body and the WebSocket sessionMappingSnapshot. Phase 1's publisher
+        // gate orders snapshot-against-event on one socket; it cannot order HTTP against WS.
+        // A slow /auth/token captured at an older revision must not rewind the cursor and
+        // overwrite newer state — nothing repairs that until the next server mutation.
+        _store.ApplyServerSnapshot(Snapshot(12,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+
+        var change = _store.ApplyServerSnapshot(Snapshot(10,
+            (1, new ServerMappingEntry("@alice:test", "bee", null, null))));
+
+        Assert.IsTrue(change.IsEmpty);
+        Assert.AreEqual("retro", _store.Snapshot()[1].CompanionId, "the newer snapshot must stand");
+        Assert.AreEqual(true, _store.Snapshot()[1].IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_AStaleSnapshotDoesNotDisturbTheCursor()
+    {
+        // The rewind is the dangerous part: a rolled-back cursor makes the next legitimate
+        // event look like a gap and forces a needless resync.
+        _store.ApplyServerSnapshot(Snapshot(12, (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+        _store.ApplyServerSnapshot(Snapshot(10, (1, new ServerMappingEntry("@alice:test", "bee", null, null))));
+
+        var change = _store.ApplyServerEvent(new ServerEvent(
+            ServerEventKind.CompanionChanged, "inst-a", 12, 13, 1,
+            new ServerMappingEntry(null, "pip", null, null)));
+
+        Assert.IsFalse(change.NeedsSnapshot);
+        Assert.AreEqual("pip", _store.Snapshot()[1].CompanionId);
+    }
+
+    [TestMethod]
+    public void ApplyServerSnapshot_AcceptsAnOlderRevisionFromADifferentInstance()
+    {
+        // A restart resets the revision line, so a lower number from a new instance is not
+        // stale — it is the only truth there is.
+        _store.ApplyServerSnapshot(Snapshot(90, (1, new ServerMappingEntry("@alice:test", "retro", true, null))));
+
+        _store.ApplyServerSnapshot(new ServerSnapshot("inst-b", 2,
+            new Dictionary<uint, ServerMappingEntry> { [1] = new("@alice:test", "bee", null, null) }));
+
+        Assert.AreEqual("bee", _store.Snapshot()[1].CompanionId);
+    }
+
+    [TestMethod]
     public void ApplyServerSnapshot_FromANewInstanceReplacesEverything()
     {
         _store.ApplyServerSnapshot(Snapshot(90, (1, new ServerMappingEntry("@alice:test", "retro", true, null))));

--- a/tests/Brmble.Client.Tests/Services/UserProjectionTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionTests.cs
@@ -1,0 +1,37 @@
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class UserProjectionTests
+{
+    [TestMethod]
+    public void CertHash_PrefersMumbleOverServer()
+    {
+        // Mumble observes the certificate on the live connection; the server's copy is a
+        // record of one. When both exist the live one wins, matching today's behaviour.
+        var row = new UserProjection
+        {
+            SessionId = 1,
+            MumbleCertHash = "from-mumble",
+            ServerCertHash = "from-server"
+        };
+
+        Assert.AreEqual("from-mumble", row.CertHash);
+    }
+
+    [TestMethod]
+    public void CertHash_FallsBackToServerWhenMumbleHasNone()
+    {
+        var row = new UserProjection { SessionId = 1, ServerCertHash = "from-server" };
+
+        Assert.AreEqual("from-server", row.CertHash);
+    }
+
+    [TestMethod]
+    public void CertHash_IsNullWhenNeitherSourceKnows()
+    {
+        Assert.IsNull(new UserProjection { SessionId = 1 }.CertHash);
+    }
+}

--- a/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
+++ b/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
@@ -61,6 +61,31 @@ public class MappingEventPublisherTests
     }
 
     [TestMethod]
+    public async Task PublishSnapshotAsync_StampsASnapshotEnvelopeThatIsItsOwnBase()
+    {
+        // The resync path is a second way to deliver a snapshot, added after the envelope rules
+        // were written. A snapshot is absolute, not a delta: it sets the client's cursor rather
+        // than advancing it, so it must be its own base and must carry no baseRevision on the
+        // wire. Stamping a real range here would make the client treat a repair as a delta and
+        // and leave the gap it was sent to close.
+        _mappings.TryUpdateCompanionId(1, "retro");
+        var socket = new Moq.Mock<System.Net.WebSockets.WebSocket>().Object;
+        MappingEnvelope captured = default;
+
+        await _publisher.PublishSnapshotAsync(socket, (envelope, snapshot) =>
+        {
+            captured = envelope;
+            return Brmble.Server.WebSockets.BrmbleWebSocketHandler
+                .CreateSessionMappingSnapshotPayload(snapshot, envelope);
+        });
+
+        Assert.AreEqual(captured.Revision, captured.BaseRevision,
+            "a snapshot is its own base");
+        MappingPayloadEnvelopeTests.AssertHasSnapshotEnvelope(
+            _bus.Broadcasts.Single(), "sessionMappingSnapshot");
+    }
+
+    [TestMethod]
     public async Task PublishAsync_StampsTheRevisionRangeTheMutationSpanned()
     {
         // One logical operation may bump several times. baseRevision is the revision before

--- a/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
+++ b/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
@@ -60,6 +60,62 @@ public class MappingEventPublisherTests
             "enqueue order must match revision order, or clients discard newer payloads as duplicates");
     }
 
+    [TestMethod]
+    public async Task PublishAsync_StampsTheRevisionRangeTheMutationSpanned()
+    {
+        // One logical operation may bump several times. baseRevision is the revision before
+        // the mutation, revision the one after, so a client can apply on "baseRevision ==
+        // ours" without caring how many bumps happened in between.
+        var before = _mappings.Revision;
+
+        await _publisher.PublishAsync(
+            () =>
+            {
+                _mappings.TryUpdateCompanionId(1, "retro");
+                _mappings.TryUpdateCertHash(1, "abc");
+                return true;
+            },
+            envelope => new
+            {
+                type = "companionChanged",
+                instanceId = envelope.InstanceId,
+                baseRevision = envelope.BaseRevision,
+                revision = envelope.Revision
+            });
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(_bus.Broadcasts.Single()));
+        Assert.AreEqual(before, doc.RootElement.GetProperty("baseRevision").GetInt64());
+        Assert.AreEqual(before + 2, doc.RootElement.GetProperty("revision").GetInt64());
+    }
+
+    [TestMethod]
+    public async Task PublishAsync_RangesAreContiguousUnderConcurrency()
+    {
+        // Each event's baseRevision must equal the previous event's revision, or a client
+        // applying on "baseRevision == ours" stalls and resyncs forever.
+        await Task.WhenAll(Enumerable.Range(0, 100).Select(i => Task.Run(() =>
+            _publisher.PublishAsync(
+                () => _mappings.TryUpdateCompanionId(1, $"c{i}"),
+                envelope => new
+                {
+                    type = "companionChanged",
+                    instanceId = envelope.InstanceId,
+                    baseRevision = envelope.BaseRevision,
+                    revision = envelope.Revision
+                }))));
+
+        var ranges = _bus.Broadcasts
+            .Select(p => JsonDocument.Parse(JsonSerializer.Serialize(p)).RootElement)
+            .Select(e => (Base: e.GetProperty("baseRevision").GetInt64(),
+                          Rev: e.GetProperty("revision").GetInt64()))
+            .ToList();
+
+        Assert.AreEqual(100, ranges.Count);
+        for (var i = 1; i < ranges.Count; i++)
+            Assert.AreEqual(ranges[i - 1].Rev, ranges[i].Base,
+                $"event {i} does not start where event {i - 1} ended");
+    }
+
     private sealed class RecordingEventBus : IBrmbleEventBus
     {
         private readonly object _gate = new();

--- a/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
+++ b/tests/Brmble.Server.Tests/Events/MappingEventPublisherTests.cs
@@ -67,7 +67,7 @@ public class MappingEventPublisherTests
         // were written. A snapshot is absolute, not a delta: it sets the client's cursor rather
         // than advancing it, so it must be its own base and must carry no baseRevision on the
         // wire. Stamping a real range here would make the client treat a repair as a delta and
-        // and leave the gap it was sent to close.
+        // leave the gap it was sent to close.
         _mappings.TryUpdateCompanionId(1, "retro");
         var socket = new Moq.Mock<System.Net.WebSockets.WebSocket>().Object;
         MappingEnvelope captured = default;

--- a/tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs
+++ b/tests/Brmble.Server.Tests/Events/MappingPayloadEnvelopeTests.cs
@@ -42,6 +42,10 @@ public class MappingPayloadEnvelopeTests
         var root = AssertHasEnvelopeCore(payload, expectedType);
         Assert.IsTrue(root.GetProperty("revision").GetInt64() > 0,
             $"{expectedType} must carry the post-mutation revision");
+        Assert.IsTrue(root.TryGetProperty("baseRevision", out var baseRevision),
+            $"{expectedType} is missing baseRevision, so a client cannot tell a gap from a jump");
+        Assert.IsTrue(baseRevision.GetInt64() <= root.GetProperty("revision").GetInt64(),
+            $"{expectedType} has baseRevision above revision");
     }
 
     /// <summary>
@@ -54,6 +58,8 @@ public class MappingPayloadEnvelopeTests
         var root = AssertHasEnvelopeCore(payload, expectedType);
         Assert.IsTrue(root.GetProperty("revision").GetInt64() >= 0,
             $"{expectedType} must carry a revision");
+        Assert.IsFalse(root.TryGetProperty("baseRevision", out _),
+            $"{expectedType} is a snapshot and must not carry baseRevision");
     }
 
     private static JsonElement AssertHasEnvelopeCore(object payload, string expectedType)

--- a/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
+++ b/tests/Brmble.Server.Tests/Mumble/MumbleServerCallbackTests.cs
@@ -648,10 +648,19 @@ public class MumbleServerCallbackTests
     [TestMethod]
     public async Task DispatchUserStateChanged_RevokesPaintOnlyForRealChannelChange()
     {
+        // Paint participation is dispatched fire-and-forget (DispatchPaintParticipation wraps it
+        // in Task.Run), so it has not necessarily run by the time DispatchUserStateChanged
+        // returns. Signal from the stub and wait for it rather than racing the scheduler — the
+        // sibling fan-out test does the same thing for the same reason.
+        var paintCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var paint = new Mock<IPaintParticipationLifecycle>();
         paint.Setup(service =>
                 service.HandleSessionChannelChangedAsync(42, 5, 10))
-            .Returns(Task.CompletedTask);
+            .Returns(() =>
+            {
+                paintCalled.TrySetResult();
+                return Task.CompletedTask;
+            });
         var membership = new Mock<IChannelMembershipService>();
         membership.Setup(service => service.TryGetChannel(42, out It.Ref<int>.IsAny))
             .Returns((int _, out int channelId) =>
@@ -672,6 +681,9 @@ public class MumbleServerCallbackTests
             new MumbleUser("Alice", "abc", 42),
             10);
 
+        Assert.AreSame(paintCalled.Task,
+            await Task.WhenAny(paintCalled.Task, Task.Delay(TimeSpan.FromSeconds(5))),
+            "paint participation was never dispatched");
         paint.Verify(service =>
             service.HandleSessionChannelChangedAsync(42, 5, 10),
             Times.Once);

--- a/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
+++ b/tests/Brmble.Server.Tests/WebSockets/BrmbleWebSocketHandlerTests.cs
@@ -55,7 +55,7 @@ public class BrmbleWebSocketHandlerTests
             CertHash: null,
             IsBrmbleClient: false);
 
-        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash", new MappingEnvelope("inst", 1L));
+        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash", new MappingEnvelope("inst", 1L, 0L));
 
         Assert.AreEqual("fresh-hash", payload.GetType().GetProperty("certHash")!.GetValue(payload));
     }
@@ -74,7 +74,7 @@ public class BrmbleWebSocketHandlerTests
     {
         var mapping = new SessionMapping("@alice:test", "Alice", 42, "custom:$sprite:test");
 
-        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash", new MappingEnvelope("inst", 1L));
+        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash", new MappingEnvelope("inst", 1L, 0L));
 
         Assert.AreEqual("floppy", payload.GetType().GetProperty("companionId")!.GetValue(payload));
         Assert.AreEqual("custom:$sprite:test", payload.GetType().GetProperty("customCompanionId")!.GetValue(payload));
@@ -85,7 +85,7 @@ public class BrmbleWebSocketHandlerTests
     {
         var mapping = new SessionMapping("@alice:test", "Alice", 42, "floppy");
 
-        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash", new MappingEnvelope("inst", 1L));
+        var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(7, mapping, "fresh-hash", new MappingEnvelope("inst", 1L, 0L));
 
         Assert.AreEqual("floppy", payload.GetType().GetProperty("companionId")!.GetValue(payload));
         Assert.IsNull(payload.GetType().GetProperty("customCompanionId")!.GetValue(payload));
@@ -226,7 +226,7 @@ public class BrmbleWebSocketHandlerTests
 
         var payloads = await BrmbleWebSocketHandler.BuildInitialPayloadsAsync(
             new Mock<IDuelSnapshotProvider>().Object, 0, mappings.GetSnapshot(),
-            new MappingEnvelope(mappings.InstanceId, mappings.Revision));
+            MappingEnvelope.Snapshot(mappings.InstanceId, mappings.Revision));
 
         using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payloads[0]));
         Assert.AreEqual("sessionMappingSnapshot", doc.RootElement.GetProperty("type").GetString());
@@ -257,7 +257,7 @@ public class BrmbleWebSocketHandlerTests
         // bumped the revision. Unstamped, those bumps are silent and every client sees a gap.
         var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(
             42, new SessionMapping("@alice:test", "Alice", 1L, "floppy"), "cert",
-            new MappingEnvelope("inst", 9L));
+            new MappingEnvelope("inst", 9L, 8L));
 
         Events.MappingPayloadEnvelopeTests.AssertHasEnvelope(payload, "userMappingAdded");
     }
@@ -276,7 +276,7 @@ public class BrmbleWebSocketHandlerTests
 
         var payloads = await BrmbleWebSocketHandler.BuildInitialPayloadsAsync(
             new Mock<IDuelSnapshotProvider>().Object, 0, mappings.GetSnapshot(),
-            new MappingEnvelope(mappings.InstanceId, mappings.Revision));
+            MappingEnvelope.Snapshot(mappings.InstanceId, mappings.Revision));
 
         using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payloads[0]));
         var entries = doc.RootElement.GetProperty("mappings");
@@ -392,7 +392,7 @@ public class BrmbleWebSocketHandlerTests
 
         var payloads = await BrmbleWebSocketHandler.BuildInitialPayloadsAsync(
             new Mock<IDuelSnapshotProvider>().Object, 0, mappings.GetSnapshot(),
-            new MappingEnvelope(mappings.InstanceId, mappings.Revision));
+            MappingEnvelope.Snapshot(mappings.InstanceId, mappings.Revision));
 
         using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payloads[0]));
         Assert.AreEqual(0L, doc.RootElement.GetProperty("revision").GetInt64());
@@ -406,7 +406,7 @@ public class BrmbleWebSocketHandlerTests
         // is the proof. It is the one place true is knowledge rather than an assumption.
         var payload = BrmbleWebSocketHandler.CreateUserMappingAddedPayload(
             42, new SessionMapping("@alice:test", "Alice", 1L, "floppy", IsBrmbleClient: null),
-            "cert", new MappingEnvelope("inst", 9L));
+            "cert", new MappingEnvelope("inst", 9L, 8L));
 
         using var doc = JsonDocument.Parse(JsonSerializer.Serialize(payload));
         Assert.IsTrue(doc.RootElement.GetProperty("isBrmbleClient").GetBoolean());


### PR DESCRIPTION
## Summary

Phase 2 of the user projection: the client-side store that merges Mumble presence with Brmble identity under one set of rules, plus the `baseRevision` wire field it sequences on.

**This phase ships no user-visible behaviour.** `MumbleAdapter.cs` and `App.tsx` are deliberately untouched — the store is built and tested in isolation so that Phase 3, which touches the repo's two most actively edited files, is a small wiring change rather than a rewrite.

Builds on #619 (merged). Design: `docs/superpowers/specs/2026-07-31-user-projection-design.md` §3.1, §3.2, §4.2, §4.3, §6.6, §8.

## What's here

**Server — `baseRevision` on the wire.** Phase 1 stamped `revision`; a client applying on `revision == ours + 1` breaks the moment one logical operation bumps the counter twice. Two still do: `SessionMappingHandler.OnUserConnected` (three bumps) and `/auth/token` (two). `MappingEnvelope` now carries the revision *before* the mutation as well, read inside the same lock so the range provably belongs to that mutation. Clients apply on `baseRevision == ours` and don't care how many bumps happened in between.

Snapshots are exempt: `MappingEnvelope.Snapshot()` makes them their own base and they emit no `baseRevision`, because a snapshot sets the client's cursor outright rather than advancing it.

**Client — `UserProjectionStore`.** Two rules, applied structurally rather than by convention:

1. **Each input writes only the fields it owns.** Mumble owns presence and existence; the server owns identity. A channel move cannot blank a badge because the Mumble path physically cannot write that field.
2. **`null` from the server means "not known", never "cleared".** Except in a snapshot, where `null` *is* knowledge — a snapshot states every server-owned field, so it overwrites. This is the one deliberate exception, and it's what makes reconciliation converge.

Sequencing rejects gaps whole: an event that can't be applied changes nothing at all, since a partially-applied gap is exactly what produces a confidently wrong row.

## Test coverage

**+56 tests (1252 → 1308), all green, 0 build warnings.**

The load-bearing one is `UserProjectionConvergenceTests`: 500 trials of shuffled-and-arbitrarily-dropped event streams, each followed by the same final snapshot, all converging on an identical projection. Its final snapshot deliberately *omits* a session the events enrich — that omission is what makes it able to catch a §4.3 reconciliation regression instead of passing trivially.

## Review notes

Two defects were found in this phase's own plan and fixed rather than worked around:

- **`ChangeSet.IsReset` documented something impossible.** "Set by … a snapshot that changed membership" cannot happen — a snapshot can change what the server *knows* about a session but can never add or remove a row, because only Mumble owns existence. Corrected in code, test name, and the plan.
- **Server data for a session Mumble hadn't announced was silently discarded.** The dangerous case is voice connect, where `/auth/token` routinely resolves before Mumble's `UserState` batch: every badge and companion for every user was dropped, with nothing to re-deliver them — no gap occurs, so no resync fires. Now held in a bounded map (1024, oldest-evicted) and consumed when the row appears. This also resolves spec §11 Q2, which was deferred to this phase; the answer is *no timeout*, with lifetime bounded by events rather than a clock.

Also included: a guard rejecting a malformed revision range (`revision < baseRevision`) that would otherwise drag the cursor backwards, and coverage for `PublishSnapshotAsync` — the second snapshot delivery path added late to #619, which the envelope assertions didn't reach.

One unrelated fix: `DispatchUserStateChanged_RevokesPaintOnlyForRealChannelChange` asserted `Times.Once` on a fire-and-forget `Task.Run` immediately after the awaited call returned, so it raced the scheduler. Pre-existing and latent; surfaced by the added scheduling pressure. Now synchronises through the stub the way its sibling fan-out test already did.

## Next

Phase 3 (`docs/superpowers/plans/2026-08-01-user-projection-phase-3-wiring.md`, included here) wires the store in and is where the user-visible fixes land — badges surviving a server restart, companions not reverting to floppy. Not started.
