### PR TITLE
Fix DM chat viewport sizing

### DIFF
--- a/src/Brmble.Web/src/App.css
+++ b/src/Brmble.Web/src/App.css
@@ -69,23 +69,22 @@
 
 .content-slider {
   display: flex;
-  width: 200%;
+  width: 100%;
   height: 100%;
   transition: transform var(--transition-slow);
   will-change: transform;
 }
 
 .content-slider.dm-active {
-  transform: translateX(-50%);
+  transform: translateX(-100%);
 }
 
 .content-slide {
-  width: 50%;
+  flex: 0 0 100%;
   height: 100%;
   min-width: 0;
   display: flex;
   flex-direction: column;
-  flex-shrink: 0;
   overflow: hidden;
 }
 

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
@@ -243,6 +243,12 @@ describe('DMContactList directory behavior', () => {
     expect(dmContactListCss).toContain('min-width: var(--messages-rail-width, 48px);');
   });
 
+  it('keeps each conversation slide exactly the width of the main content viewport', () => {
+    expect(appCss).toContain('width: 100%;\n  height: 100%;');
+    expect(appCss).toContain('transform: translateX(-100%);');
+    expect(appCss).toContain('flex: 0 0 100%;');
+  });
+
   it('keeps search results in their route sections when both routes match', async () => {
     const user = userEvent.setup();
     renderList();

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
@@ -244,9 +244,9 @@ describe('DMContactList directory behavior', () => {
   });
 
   it('keeps each conversation slide exactly the width of the main content viewport', () => {
-    expect(appCss).toContain('width: 100%;\n  height: 100%;');
-    expect(appCss).toContain('transform: translateX(-100%);');
-    expect(appCss).toContain('flex: 0 0 100%;');
+    expect(appCss).toMatch(/\.content-slider\s*\{[\s\S]*?\bwidth:\s*100%;/);
+    expect(appCss).toMatch(/\.content-slider\.dm-active\s*\{[\s\S]*?transform:\s*translateX\(-100%\);/);
+    expect(appCss).toMatch(/\.content-slide\s*\{[\s\S]*?\bflex:\s*0 0 100%;/);
   });
 
   it('keeps search results in their route sections when both routes match', async () => {


### PR DESCRIPTION
## Summary

- Fix the DM conversation slider so the active chat fills the full main-content viewport.
- Add a regression test covering the full-width slide sizing.

## Root cause

The slider used a 200% track with 50% slides and a -50% transform. That made the active DM panel depend on the resolved track width and could leave the chat short of the available viewport.

The track now uses the viewport width, each conversation slide is 100% wide, and the DM transition moves by -100%.

## Validation

- `npm.cmd run test -- --run src/components/DMContactList/DMContactList.test.tsx src/App.dmDirectoryBehavior.test.tsx`
- `npm.cmd run build`
