### PR TITLE
Fix Matrix chat auto-scroll for new messages

### DIFF
--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -197,6 +197,54 @@ describe('ChatPanel typing indicator', () => {
   });
 });
 
+describe('ChatPanel message scrolling', () => {
+  it('scrolls to a new message when the user was already at the bottom', () => {
+    const messages = [{
+      id: '$first',
+      channelId: '42',
+      sender: 'Alice',
+      content: 'first',
+      timestamp: new Date('2026-01-01T00:00:00Z'),
+      msgType: 'm.text' as const,
+    }];
+    const { container, rerender } = render(
+      <ChatPanel
+        channelId="42"
+        channelName="general"
+        messages={messages}
+        onSendMessage={() => {}}
+      />,
+    );
+    const messagesContainer = container.querySelector('.chat-messages') as HTMLDivElement;
+    Object.defineProperties(messagesContainer, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 100 },
+      scrollTop: { configurable: true, writable: true, value: 0 },
+    });
+    fireEvent.scroll(messagesContainer);
+    vi.clearAllMocks();
+
+    Object.defineProperty(messagesContainer, 'scrollHeight', { configurable: true, value: 300 });
+    rerender(
+      <ChatPanel
+        channelId="42"
+        channelName="general"
+        messages={[...messages, {
+          id: '$second',
+          channelId: '42',
+          sender: 'Bob',
+          content: 'second',
+          timestamp: new Date('2026-01-01T00:01:00Z'),
+          msgType: 'm.text' as const,
+        }]}
+        onSendMessage={() => {}}
+      />,
+    );
+
+    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+});
+
 describe('ChatPanel edit flow', () => {
   it('sends a Matrix replacement event when saving an edited message', async () => {
     const user = userEvent.setup();

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -199,49 +199,54 @@ describe('ChatPanel typing indicator', () => {
 
 describe('ChatPanel message scrolling', () => {
   it('scrolls to a new message when the user was already at the bottom', () => {
-    const messages = [{
-      id: '$first',
-      channelId: '42',
-      sender: 'Alice',
-      content: 'first',
-      timestamp: new Date('2026-01-01T00:00:00Z'),
-      msgType: 'm.text' as const,
-    }];
-    const { container, rerender } = render(
-      <ChatPanel
-        channelId="42"
-        channelName="general"
-        messages={messages}
-        onSendMessage={() => {}}
-      />,
-    );
-    const messagesContainer = container.querySelector('.chat-messages') as HTMLDivElement;
-    Object.defineProperties(messagesContainer, {
-      clientHeight: { configurable: true, value: 100 },
-      scrollHeight: { configurable: true, value: 100 },
-      scrollTop: { configurable: true, writable: true, value: 0 },
-    });
-    fireEvent.scroll(messagesContainer);
-    vi.clearAllMocks();
+    vi.useFakeTimers();
+    try {
+      const messages = [{
+        id: '$first',
+        channelId: '42',
+        sender: 'Alice',
+        content: 'first',
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        msgType: 'm.text' as const,
+      }];
+      const { container, rerender } = render(
+        <ChatPanel
+          channelId="42"
+          channelName="general"
+          messages={messages}
+          onSendMessage={() => {}}
+        />,
+      );
+      const messagesContainer = container.querySelector('.chat-messages') as HTMLDivElement;
+      Object.defineProperties(messagesContainer, {
+        clientHeight: { configurable: true, value: 100 },
+        scrollHeight: { configurable: true, value: 100 },
+        scrollTop: { configurable: true, writable: true, value: 0 },
+      });
+      fireEvent.scroll(messagesContainer);
+      vi.clearAllMocks();
 
-    Object.defineProperty(messagesContainer, 'scrollHeight', { configurable: true, value: 300 });
-    rerender(
-      <ChatPanel
-        channelId="42"
-        channelName="general"
-        messages={[...messages, {
-          id: '$second',
-          channelId: '42',
-          sender: 'Bob',
-          content: 'second',
-          timestamp: new Date('2026-01-01T00:01:00Z'),
-          msgType: 'm.text' as const,
-        }]}
-        onSendMessage={() => {}}
-      />,
-    );
+      Object.defineProperty(messagesContainer, 'scrollHeight', { configurable: true, value: 300 });
+      rerender(
+        <ChatPanel
+          channelId="42"
+          channelName="general"
+          messages={[...messages, {
+            id: '$second',
+            channelId: '42',
+            sender: 'Bob',
+            content: 'second',
+            timestamp: new Date('2026-01-01T00:01:00Z'),
+            msgType: 'm.text' as const,
+          }]}
+          onSendMessage={() => {}}
+        />,
+      );
 
-    expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+      expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -166,6 +166,7 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const shouldAutoScrollRef = useRef(true);
   const unreadDividerRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
@@ -413,6 +414,7 @@ const [replyState, setReplyState] = useState<{
     const container = messagesContainerRef.current;
     if (!container) return;
     const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+    shouldAutoScrollRef.current = distanceFromBottom < SCROLL_THRESHOLD;
     const shouldShow = distanceFromBottom > SCROLL_THRESHOLD;
     setShowScrollButton(prev => prev !== shouldShow ? shouldShow : prev);
   }, []);
@@ -516,9 +518,10 @@ const [replyState, setReplyState] = useState<{
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
       return;
     }
-    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-    // Only auto-scroll if user is within threshold of bottom
-    if (distanceFromBottom < SCROLL_THRESHOLD) {
+    // Use the position from before the message update. Measuring after the
+    // update would count the new message as distance from the bottom and can
+    // incorrectly decide that the user has scrolled away.
+    if (shouldAutoScrollRef.current) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     }
   }, [messages]);
@@ -527,6 +530,7 @@ const [replyState, setReplyState] = useState<{
   // Delay must exceed the slide transition (400ms) so layout has settled.
   // Also arm the one-shot ResizeObserver scroll for the slide-in transition.
   useEffect(() => {
+    shouldAutoScrollRef.current = true;
     pendingSlideScrollRef.current = true;
     const timer = setTimeout(() => {
       pendingSlideScrollRef.current = false;


### PR DESCRIPTION
## Summary

- Fix Matrix chat auto-scroll when new messages arrive while the user is already at the bottom.
- Add a regression test covering the behavior.

## Root cause

The chat measured the distance from the bottom after rendering the new message. The added message increased scrollHeight, so the code could mistake the new message's height for user scrolling and suppress the auto-scroll.

The fix records whether the user was at the bottom before the message update, then uses that state to decide whether to follow the new message. Intentional scrolling away from the bottom remains respected.

## Validation

- npm.cmd run test -- src/components/ChatPanel/ChatPanel.test.tsx
- npm.cmd run test -- --run
- 122 test files passed, 1,482 tests passed