### PR TITLE
FIX copy paint

### DIFF
--- a/src/Brmble.Web/src/App.paintFlow.test.tsx
+++ b/src/Brmble.Web/src/App.paintFlow.test.tsx
@@ -80,6 +80,12 @@ beforeAll(() => {
   }
   vi.stubGlobal('ResizeObserver', ResizeObserverMock);
   vi.stubGlobal('IntersectionObserver', IntersectionObserverMock);
+  vi.stubGlobal('Image', class {
+    src = '';
+    naturalWidth = 1280;
+    naturalHeight = 720;
+    decode = vi.fn().mockResolvedValue(undefined);
+  });
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
@@ -204,6 +210,7 @@ async function openActivePaintSession(user: ReturnType<typeof userEvent.setup>, 
   await user.click(screen.getByRole('button', { name: 'Start paint' }));
   await user.click(screen.getByLabelText('Bob'));
   await user.upload(screen.getByLabelText('Source image'), new File(['source'], 'source.png', { type: 'image/png' }));
+  expect(await screen.findByText('source.png')).toBeInTheDocument();
   await user.click(within(screen.getByRole('dialog', { name: 'Start collaborative paint' })).getByRole('button', { name: 'Start paint' }));
   expect(await screen.findByLabelText('Collaborative paint')).toBeInTheDocument();
 
@@ -237,6 +244,7 @@ describe('collaborative paint app flow', () => {
     await user.click(screen.getByRole('button', { name: 'Start paint' }));
     await user.click(screen.getByLabelText('Bob'));
     await user.upload(screen.getByLabelText('Source image'), new File(['source'], 'source.png', { type: 'image/png' }));
+    expect(await screen.findByText('source.png')).toBeInTheDocument();
     await user.click(within(screen.getByRole('dialog', { name: 'Start collaborative paint' })).getByRole('button', { name: 'Start paint' }));
     await waitFor(() => expect(paint.attachSource).toHaveBeenCalledWith('session-1', '$source'));
     expect(paint.createSession.mock.invocationCallOrder[0]).toBeLessThan(paint.attachSource.mock.invocationCallOrder[0]);

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -92,6 +92,40 @@ describe('ChatPanel image paint background menu', () => {
     })).not.toBeInTheDocument();
   });
 
+  it('does not offer an unsupported GIF as a Paint background', () => {
+    const gif = {
+      type: 'gif' as const,
+      url: 'https://matrix.example/animated.gif',
+      filename: 'animated.gif',
+      mimetype: 'image/gif',
+      size: 123,
+    };
+    const { container } = render(
+      <ChatPanel
+        channelId="42"
+        channelName="general"
+        messages={[{
+          ...imageMessage,
+          id: '$gif',
+          media: [gif],
+        }]}
+        onSendMessage={() => {}}
+        onMessageContextMenu={() => {}}
+        onUseAsPaintBackground={() => {}}
+      />,
+    );
+
+    fireEvent.load(container.querySelector('.image-attachment__img')!);
+    fireEvent.contextMenu(container.querySelector('.image-attachment')!, {
+      clientX: 40,
+      clientY: 50,
+    });
+
+    expect(screen.queryByRole('button', {
+      name: 'Use as paint background',
+    })).not.toBeInTheDocument();
+  });
+
   it('does not show the action for a plain-text message', () => {
     render(
       <ChatPanel

--- a/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.test.tsx
+++ b/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.test.tsx
@@ -613,4 +613,60 @@ describe('PaintSessionSetupModal', () => {
       resolveCreate({ sessionId: 'session-1', matrixRoomId: '!paint:server', channelId: 5 });
     });
   });
+
+  it('disables source file selection while the session is being started', async () => {
+    const user = userEvent.setup();
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    paintApi.createSession.mockImplementation(() => new Promise(() => {}));
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+        initialSourceFile={new File(['existing'], 'existing.png', { type: 'image/png' })}
+      />,
+    );
+
+    const sourceInput = screen.getByLabelText('Source image');
+    await user.click(screen.getByRole('button', { name: 'Start paint' }));
+
+    expect(sourceInput).toBeDisabled();
+  });
+
+  it('keeps file staging valid when a non-image paste occurs during validation', async () => {
+    let resolveMediaConfig!: (config: { 'm.upload.size': number }) => void;
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    matrixClient.getMediaConfig.mockImplementation(() => new Promise((resolve) => {
+      resolveMediaConfig = resolve;
+    }));
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.upload(
+      screen.getByLabelText('Source image'),
+      new File(['image'], 'selected.png', { type: 'image/png' }),
+    );
+    pasteClipboardItems([{ type: 'text/plain', getAsFile: () => null }]);
+
+    resolveMediaConfig({ 'm.upload.size': 1024 });
+
+    expect(await screen.findByText('selected.png')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The clipboard does not contain an image.',
+    );
+  });
 });

--- a/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.test.tsx
+++ b/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.test.tsx
@@ -6,7 +6,13 @@ import {
   it,
   vi,
 } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PaintSessionSetupModal } from './PaintSessionSetupModal';
 
@@ -15,6 +21,12 @@ beforeEach(() => {
     ...URL,
     createObjectURL: vi.fn().mockReturnValue('blob:source-preview'),
     revokeObjectURL: vi.fn(),
+  });
+  vi.stubGlobal('Image', class {
+    src = '';
+    naturalWidth = 1280;
+    naturalHeight = 720;
+    decode = vi.fn().mockResolvedValue(undefined);
   });
 });
 
@@ -47,6 +59,17 @@ function createHarness() {
   return { paintApi, matrixClient, attachSource };
 }
 
+function pasteClipboardItems(items: Array<{
+  type: string;
+  getAsFile: () => File | null;
+}>) {
+  fireEvent.paste(screen.getByRole('dialog', {
+    name: 'Start collaborative paint',
+  }), {
+    clipboardData: { items },
+  });
+}
+
 describe('PaintSessionSetupModal', () => {
   it('creates the session before uploading the source event', async () => {
     const user = userEvent.setup();
@@ -64,6 +87,7 @@ describe('PaintSessionSetupModal', () => {
 
     await user.click(screen.getByLabelText('Bob'));
     await user.upload(screen.getByLabelText('Source image'), new File(['image'], 'source.png', { type: 'image/png' }));
+    expect(await screen.findByText('source.png')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /start paint/i }));
 
     expect(paintApi.createSession).toHaveBeenCalledWith({ channelId: 5, participantSessionIds: [2] });
@@ -107,7 +131,7 @@ describe('PaintSessionSetupModal', () => {
       />,
     );
 
-    expect(screen.getByAltText('Selected paint source'))
+    expect(screen.getByAltText(/^Selected paint source:/))
       .toHaveAttribute('src', 'blob:source-preview');
     expect(screen.getByText('shared-board.png')).toBeInTheDocument();
 
@@ -151,7 +175,7 @@ describe('PaintSessionSetupModal', () => {
       screen.getByLabelText('Source image'),
       replacement,
     );
-    expect(screen.getByText('replacement.webp')).toBeInTheDocument();
+    expect(await screen.findByText('replacement.webp')).toBeInTheDocument();
     await user.click(screen.getByRole('button', {
       name: 'Start paint',
     }));
@@ -246,11 +270,12 @@ describe('PaintSessionSetupModal', () => {
       screen.getByLabelText('Source image'),
       new File(['next'], 'next.png', { type: 'image/png' }),
     );
+    expect(await screen.findByText('next.png')).toBeInTheDocument();
     expect(URL.revokeObjectURL)
       .toHaveBeenCalledWith('blob:source-preview');
 
     view.unmount();
-    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(3);
   });
 
   it('checks the Matrix upload limit before creating a paint session', async () => {
@@ -260,9 +285,11 @@ describe('PaintSessionSetupModal', () => {
     render(<PaintSessionSetupModal channelId={5} channelRoomId="!channel:server" candidates={[]} hostUserId={7} paintApi={paintApi} matrixClient={matrixClient} onAttachSource={attachSource} />);
 
     await user.upload(screen.getByLabelText('Source image'), new File(['too large'], 'source.png', { type: 'image/png' }));
-    await user.click(screen.getByRole('button', { name: 'Start paint' }));
 
-    expect(await screen.findByRole('alert')).toHaveTextContent('exceeds the Matrix upload limit');
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The selected image is too large to use as a Paint source.',
+    );
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(paintApi.createSession).not.toHaveBeenCalled();
   });
 
@@ -273,9 +300,317 @@ describe('PaintSessionSetupModal', () => {
     render(<PaintSessionSetupModal channelId={5} channelRoomId="!channel:server" candidates={[]} hostUserId={7} paintApi={paintApi} matrixClient={matrixClient} onAttachSource={attachSource} />);
 
     await user.upload(screen.getByLabelText('Source image'), new File(['image'], 'source.png', { type: 'image/png' }));
+    expect(await screen.findByText('source.png')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Start paint' }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Upload failed');
     expect(paintApi.leave).toHaveBeenCalledWith('session-1');
+  });
+
+  it('pastes an image anywhere in the active dialog and starts with it', async () => {
+    const user = userEvent.setup();
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[{ userId: 2, name: 'Bob' }]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+      />,
+    );
+    await user.click(screen.getByLabelText('Bob'));
+    screen.getByRole('button', { name: 'Cancel' }).focus();
+    const pasted = new File(['clipboard-pixels'], 'image.png', {
+      type: 'image/png',
+    });
+
+    pasteClipboardItems([{ type: 'image/png', getAsFile: () => pasted }]);
+
+    expect(await screen.findByText('Pasted screenshot.png'))
+      .toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Pasted screenshot.png',
+    );
+    expect(screen.getByAltText(
+      'Selected paint source: Pasted screenshot.png',
+    )).toHaveAttribute('src', 'blob:source-preview');
+    expect(screen.getByLabelText('Bob')).toBeChecked();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+    expect(paintApi.createSession).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Start paint' }));
+
+    const uploaded = matrixClient.uploadContent.mock.calls[0][0] as File;
+    expect(uploaded.name).toBe('Pasted screenshot.png');
+    expect(uploaded.type).toBe('image/png');
+    expect(paintApi.createSession).toHaveBeenCalledOnce();
+  });
+
+  it('replaces a selected file with a valid paste without changing participants', async () => {
+    const user = userEvent.setup();
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[{ userId: 2, name: 'Bob' }]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+      />,
+    );
+    await user.click(screen.getByLabelText('Bob'));
+    await user.upload(
+      screen.getByLabelText('Source image'),
+      new File(['first'], 'first.webp', { type: 'image/webp' }),
+    );
+    await screen.findByText('first.webp');
+
+    pasteClipboardItems([{
+      type: 'image/jpeg',
+      getAsFile: () => new File(['second'], 'image', { type: 'image/jpeg' }),
+    }]);
+
+    expect(await screen.findByText('Pasted screenshot.jpg'))
+      .toBeInTheDocument();
+    expect(screen.queryByText('first.webp')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Bob')).toBeChecked();
+    expect(screen.getByLabelText('Source image')).toHaveValue('');
+  });
+
+  it('replaces a pasted image with a valid selected file', async () => {
+    const user = userEvent.setup();
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+      />,
+    );
+    pasteClipboardItems([{
+      type: 'image/png',
+      getAsFile: () => new File(['pasted'], 'image.png', { type: 'image/png' }),
+    }]);
+    await screen.findByText('Pasted screenshot.png');
+
+    await user.upload(
+      screen.getByLabelText('Source image'),
+      new File(['selected'], 'selected.webp', { type: 'image/webp' }),
+    );
+
+    expect(await screen.findByText('selected.webp')).toBeInTheDocument();
+    expect(screen.queryByText('Pasted screenshot.png'))
+      .not.toBeInTheDocument();
+  });
+
+  it('reports non-image clipboard content and preserves the valid source', async () => {
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+        initialSourceFile={new File(['valid'], 'existing.png', { type: 'image/png' })}
+      />,
+    );
+    screen.getByRole('button', { name: 'Cancel' }).focus();
+
+    pasteClipboardItems([{ type: 'text/plain', getAsFile: () => null }]);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The clipboard does not contain an image.',
+    );
+    expect(screen.getByText('existing.png')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+    expect(paintApi.createSession).not.toHaveBeenCalled();
+  });
+
+  it('reports non-image clipboard content without selecting a source', () => {
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+      />,
+    );
+
+    pasteClipboardItems([{ type: 'text/plain', getAsFile: () => null }]);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The clipboard does not contain an image.',
+    );
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(paintApi.createSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported clipboard image without replacing the valid source', async () => {
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+        initialSourceFile={new File(['valid'], 'existing.png', { type: 'image/png' })}
+      />,
+    );
+
+    pasteClipboardItems([{
+      type: 'image/gif',
+      getAsFile: () => new File(['gif'], 'animated.gif', { type: 'image/gif' }),
+    }]);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Copy a PNG, JPEG, or WebP image, or choose a file.',
+    );
+    expect(screen.getByText('existing.png')).toBeInTheDocument();
+  });
+
+  it('rejects a pasted image above the Matrix limit before replacing or starting', async () => {
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    matrixClient.getMediaConfig.mockResolvedValue({ 'm.upload.size': 1 });
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+        initialSourceFile={new File(['valid'], 'existing.png', { type: 'image/png' })}
+      />,
+    );
+
+    pasteClipboardItems([{
+      type: 'image/png',
+      getAsFile: () => new File(['too-large'], 'large.png', { type: 'image/png' }),
+    }]);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The pasted image is too large to use as a Paint source.',
+    );
+    expect(screen.getByText('existing.png')).toBeInTheDocument();
+    expect(paintApi.createSession).not.toHaveBeenCalled();
+  });
+
+  it('checks the Matrix limit for a source prepared from chat before creating', async () => {
+    const user = userEvent.setup();
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    matrixClient.getMediaConfig.mockResolvedValue({ 'm.upload.size': 1 });
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+        initialSourceFile={new File(['chat-image'], 'shared.png', { type: 'image/png' })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Start paint' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The source image exceeds the Matrix upload limit.',
+    );
+    expect(paintApi.createSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps only the latest result when paste validation completes out of order', async () => {
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    let resolveFirst!: () => void;
+    let decodeCall = 0;
+    vi.stubGlobal('Image', class {
+      src = '';
+      naturalWidth = 1280;
+      naturalHeight = 720;
+      decode = vi.fn(() => {
+        decodeCall += 1;
+        return decodeCall === 1
+          ? new Promise<void>((resolve) => { resolveFirst = resolve; })
+          : Promise.resolve();
+      });
+    });
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+      />,
+    );
+
+    pasteClipboardItems([{ type: 'image/png', getAsFile: () => new File(['first'], 'first', { type: 'image/png' }) }]);
+    pasteClipboardItems([{ type: 'image/webp', getAsFile: () => new File(['second'], 'second', { type: 'image/webp' }) }]);
+
+    expect(await screen.findByText('Pasted screenshot.webp'))
+      .toBeInTheDocument();
+    resolveFirst();
+    await waitFor(() => {
+      expect(screen.queryByText('Pasted screenshot.png'))
+        .not.toBeInTheDocument();
+    });
+    expect(paintApi.createSession).not.toHaveBeenCalled();
+  });
+
+  it('ignores paste while the session is being started', async () => {
+    const user = userEvent.setup();
+    const { paintApi, matrixClient, attachSource } = createHarness();
+    let resolveCreate!: (created: {
+      sessionId: string;
+      matrixRoomId: string;
+      channelId: number;
+    }) => void;
+    paintApi.createSession.mockImplementation(() => new Promise((resolve) => {
+      resolveCreate = resolve;
+    }));
+    render(
+      <PaintSessionSetupModal
+        channelId={5}
+        channelRoomId="!channel:server"
+        candidates={[]}
+        hostUserId={7}
+        paintApi={paintApi}
+        matrixClient={matrixClient}
+        onAttachSource={attachSource}
+        initialSourceFile={new File(['existing'], 'existing.png', { type: 'image/png' })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Start paint' }));
+    pasteClipboardItems([{ type: 'image/png', getAsFile: () => new File(['ignored'], 'ignored.png', { type: 'image/png' }) }]);
+
+    expect(screen.getByText('existing.png')).toBeInTheDocument();
+    expect(paintApi.createSession).toHaveBeenCalledOnce();
+    await act(async () => {
+      resolveCreate({ sessionId: 'session-1', matrixRoomId: '!paint:server', channelId: 5 });
+    });
   });
 });

--- a/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.tsx
+++ b/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.tsx
@@ -143,16 +143,12 @@ export function PaintSessionSetupModal({
     event.preventDefault();
 
     if (!imageItem) {
-      ++sourceRevisionRef.current;
-      setPreparingSource(false);
       setError('The clipboard does not contain an image.');
       return;
     }
 
     const candidate = imageItem.getAsFile();
     if (!candidate) {
-      ++sourceRevisionRef.current;
-      setPreparingSource(false);
       setError(
         'This clipboard image cannot be used. Try copying another image or choose a file.',
       );
@@ -279,6 +275,7 @@ export function PaintSessionSetupModal({
             type="file"
             accept={PAINT_SOURCE_ACCEPT}
             onChange={handleFileChange}
+            disabled={saving}
           />
         </label>
         {file && previewUrl && (

--- a/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.tsx
+++ b/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.tsx
@@ -1,5 +1,17 @@
-import { useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ClipboardEvent,
+} from 'react';
 import { MsgType, type MatrixClient } from 'matrix-js-sdk';
+import {
+  PAINT_SOURCE_ACCEPT,
+  preparePaintSourceFile,
+  type PaintSourceOrigin,
+} from '../../utils/paintSourceFile';
 import './PaintSessionSetupModal.css';
 
 type Candidate = { userId: number; name: string };
@@ -44,6 +56,9 @@ export function PaintSessionSetupModal({
 }: PaintSessionSetupModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const cancelRef = useRef<HTMLButtonElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const sourceRevisionRef = useRef(0);
+  const uploadLimitPromiseRef = useRef<Promise<number | undefined> | null>(null);
   const [selected, setSelected] = useState<number[]>([]);
   const [file, setFile] = useState<File | null>(
     () => initialSourceFile ?? null,
@@ -51,6 +66,7 @@ export function PaintSessionSetupModal({
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [preparingSource, setPreparingSource] = useState(false);
 
   useEffect(() => {
     if (!file) {
@@ -66,6 +82,85 @@ export function PaintSessionSetupModal({
     cancelRef.current?.focus();
   }, []);
 
+  const getUploadLimit = useCallback(() => {
+    uploadLimitPromiseRef.current ??= matrixClient.getMediaConfig()
+      .then((config) => config['m.upload.size'])
+      .catch(() => {
+        uploadLimitPromiseRef.current = null;
+        throw new Error(
+          'Unable to check this image right now. Try again or choose a file.',
+        );
+      });
+    return uploadLimitPromiseRef.current;
+  }, [matrixClient]);
+
+  const stageSource = useCallback(async (
+    candidate: File,
+    origin: PaintSourceOrigin,
+  ) => {
+    if (saving) return;
+    const revision = ++sourceRevisionRef.current;
+    setPreparingSource(true);
+    setError(null);
+
+    try {
+      const prepared = await preparePaintSourceFile(
+        candidate,
+        origin,
+        await getUploadLimit(),
+      );
+      if (revision !== sourceRevisionRef.current) return;
+      setFile(prepared);
+      if (origin === 'paste' && fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    } catch (reason) {
+      if (revision !== sourceRevisionRef.current) return;
+      if (origin === 'file' && fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+      setError(
+        reason instanceof Error
+          ? reason.message
+          : 'This image cannot be used. Try another image or choose a file.',
+      );
+    } finally {
+      if (revision === sourceRevisionRef.current) {
+        setPreparingSource(false);
+      }
+    }
+  }, [getUploadLimit, saving]);
+
+  const handleFileChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const candidate = event.currentTarget.files?.[0];
+    if (candidate) void stageSource(candidate, 'file');
+  }, [stageSource]);
+
+  const handlePaste = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
+    if (saving) return;
+    const imageItem = Array.from(event.clipboardData.items)
+      .find((item) => item.type.startsWith('image/'));
+    event.preventDefault();
+
+    if (!imageItem) {
+      ++sourceRevisionRef.current;
+      setPreparingSource(false);
+      setError('The clipboard does not contain an image.');
+      return;
+    }
+
+    const candidate = imageItem.getAsFile();
+    if (!candidate) {
+      ++sourceRevisionRef.current;
+      setPreparingSource(false);
+      setError(
+        'This clipboard image cannot be used. Try copying another image or choose a file.',
+      );
+      return;
+    }
+    void stageSource(candidate, 'paste');
+  }, [saving, stageSource]);
+
   const start = async () => {
     if (!file) {
       setError('Choose a source image.');
@@ -77,8 +172,7 @@ export function PaintSessionSetupModal({
     let created: Created | null = null;
 
     try {
-      const config = await matrixClient.getMediaConfig();
-      const limit = config['m.upload.size'];
+      const limit = await getUploadLimit();
       if (limit && file.size > limit) {
         throw new Error('The source image exceeds the Matrix upload limit.');
       }
@@ -137,6 +231,7 @@ export function PaintSessionSetupModal({
         aria-modal="true"
         aria-label="Start collaborative paint"
         onClick={(event) => event.stopPropagation()}
+        onPaste={handlePaste}
         onKeyDown={(event) => {
           if (event.key === 'Escape') {
             event.preventDefault();
@@ -179,18 +274,23 @@ export function PaintSessionSetupModal({
         <label>
           Source image
           <input
+            ref={fileInputRef}
             aria-label="Source image"
             type="file"
-            accept="image/*"
-            onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+            accept={PAINT_SOURCE_ACCEPT}
+            onChange={handleFileChange}
           />
         </label>
         {file && previewUrl && (
-          <div className="paint-setup-source">
+          <div
+            className="paint-setup-source"
+            role="status"
+            aria-live="polite"
+          >
             <img
               className="paint-setup-source__preview"
               src={previewUrl}
-              alt="Selected paint source"
+              alt={`Selected paint source: ${file.name}`}
             />
             <span className="paint-setup-source__name">{file.name}</span>
           </div>
@@ -204,7 +304,7 @@ export function PaintSessionSetupModal({
             type="button"
             className="btn btn-primary"
             onClick={() => void start()}
-            disabled={saving}
+            disabled={saving || preparingSource}
           >
             {saving ? 'Starting...' : 'Start paint'}
           </button>

--- a/src/Brmble.Web/src/utils/chatImagePaintSource.test.ts
+++ b/src/Brmble.Web/src/utils/chatImagePaintSource.test.ts
@@ -4,13 +4,20 @@ import {
   prepareChatImagePaintSource,
 } from './chatImagePaintSource';
 
+const TEN_MIB = 10 * 1024 * 1024;
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function installDecodeHarness(decode = vi.fn().mockResolvedValue(undefined)) {
+function installDecodeHarness(options: {
+  width?: number;
+  height?: number;
+  decode?: () => Promise<void>;
+} = {}) {
   const createObjectURL = vi.fn().mockReturnValue('blob:paint-source');
   const revokeObjectURL = vi.fn();
+  const decode = options.decode ?? vi.fn().mockResolvedValue(undefined);
 
   vi.stubGlobal('URL', {
     ...URL,
@@ -18,31 +25,45 @@ function installDecodeHarness(decode = vi.fn().mockResolvedValue(undefined)) {
     revokeObjectURL,
   });
   vi.stubGlobal('Image', class {
-    set src(_value: string) {}
+    src = '';
+    naturalWidth = options.width ?? 1280;
+    naturalHeight = options.height ?? 720;
     decode = decode;
   });
 
   return { createObjectURL, revokeObjectURL, decode };
 }
 
+function successfulFetch(blob: Blob): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    blob: vi.fn().mockResolvedValue(blob),
+  }) as unknown as typeof fetch;
+}
+
 describe('isPaintSourceAttachment', () => {
-  it('accepts a displayed image with a supported or unknown image MIME type', () => {
+  it('accepts a supported image and an image whose MIME must be discovered', () => {
     expect(isPaintSourceAttachment({
       type: 'image',
       url: 'https://matrix.example/image',
       mimetype: 'image/png',
     })).toBe(true);
     expect(isPaintSourceAttachment({
-      type: 'gif',
-      url: 'data:image/gif;base64,R0lG',
+      type: 'image',
+      url: 'https://matrix.example/unknown',
     })).toBe(true);
   });
 
-  it('rejects empty URLs and known unsupported MIME types', () => {
+  it('rejects empty URLs, GIFs, and known unsupported MIME types', () => {
     expect(isPaintSourceAttachment({
       type: 'image',
       url: '',
       mimetype: 'image/png',
+    })).toBe(false);
+    expect(isPaintSourceAttachment({
+      type: 'gif',
+      url: 'data:image/gif;base64,R0lG',
+      mimetype: 'image/gif',
     })).toBe(false);
     expect(isPaintSourceAttachment({
       type: 'image',
@@ -53,13 +74,10 @@ describe('isPaintSourceAttachment', () => {
 });
 
 describe('prepareChatImagePaintSource', () => {
-  it('downloads, decodes, and preserves the Matrix filename and MIME type', async () => {
-    const fetcher = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: vi.fn().mockResolvedValue(
-        new Blob(['png-bytes'], { type: 'image/png' }),
-      ),
-    });
+  it('downloads, validates, and preserves the Matrix filename and MIME type', async () => {
+    const fetcher = successfulFetch(
+      new Blob(['png-bytes'], { type: 'image/png' }),
+    );
     const { createObjectURL, revokeObjectURL, decode } =
       installDecodeHarness();
 
@@ -68,7 +86,7 @@ describe('prepareChatImagePaintSource', () => {
       url: 'https://matrix.example/image',
       mimetype: 'image/png',
       filename: 'shared-board.png',
-    }, fetcher as unknown as typeof fetch);
+    }, fetcher);
 
     expect(fetcher).toHaveBeenCalledWith(
       'https://matrix.example/image',
@@ -82,19 +100,13 @@ describe('prepareChatImagePaintSource', () => {
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:paint-source');
   });
 
-  it('uses the response MIME type and a deterministic fallback filename', async () => {
-    const fetcher = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: vi.fn().mockResolvedValue(
-        new Blob(['jpg-bytes'], { type: 'image/jpeg' }),
-      ),
-    });
+  it('uses the response MIME type and shared extension for a fallback filename', async () => {
     installDecodeHarness();
 
     const file = await prepareChatImagePaintSource({
       type: 'image',
       url: 'data:image/jpeg;base64,anBn',
-    }, fetcher as unknown as typeof fetch);
+    }, successfulFetch(new Blob(['jpg-bytes'], { type: 'image/jpeg' })));
 
     expect(file.name).toBe('chat-image.jpg');
     expect(file.type).toBe('image/jpeg');
@@ -111,38 +123,57 @@ describe('prepareChatImagePaintSource', () => {
       .rejects.toThrow('Unable to download the chat image.');
   });
 
-  it('rejects unsupported downloaded content', async () => {
-    const fetcher = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: vi.fn().mockResolvedValue(
-        new Blob(['bmp-bytes'], { type: 'image/bmp' }),
-      ),
-    });
-
+  it('rejects unsupported downloaded content through the shared MIME policy', async () => {
     await expect(prepareChatImagePaintSource({
       type: 'image',
       url: 'https://matrix.example/image',
-    }, fetcher as unknown as typeof fetch))
-      .rejects.toThrow('This image type cannot be used for paint.');
+    }, successfulFetch(new Blob(['bmp-bytes'], { type: 'image/bmp' }))))
+      .rejects.toThrow(
+        'This chat image type cannot be used. Use a PNG, JPEG, or WebP image.',
+      );
   });
 
-  it('rejects undecodable image bytes and always revokes the object URL', async () => {
-    const fetcher = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: vi.fn().mockResolvedValue(
-        new Blob(['not-an-image'], { type: 'image/png' }),
-      ),
-    });
-    const { revokeObjectURL } = installDecodeHarness(
-      vi.fn().mockRejectedValue(new Error('decode failed')),
+  it('rejects a downloaded chat image above the Paint 10 MiB limit', async () => {
+    await expect(prepareChatImagePaintSource({
+      type: 'image',
+      url: 'https://matrix.example/large',
+      mimetype: 'image/png',
+    }, successfulFetch(new Blob(
+      [new Uint8Array(TEN_MIB + 1)],
+      { type: 'image/png' },
+    )))).rejects.toThrow(
+      'This chat image is too large to use as a Paint source.',
     );
+  });
+
+  it('rejects a downloaded chat image above 4096 pixels', async () => {
+    installDecodeHarness({ width: 4097 });
+
+    await expect(prepareChatImagePaintSource({
+      type: 'image',
+      url: 'https://matrix.example/wide',
+      mimetype: 'image/webp',
+    }, successfulFetch(new Blob(['webp-bytes'], { type: 'image/webp' }))))
+      .rejects.toThrow(
+        'This image is too large. Choose an image no larger than 4096 by 4096 pixels.',
+      );
+  });
+
+  it('rejects undecodable chat image bytes and revokes the object URL', async () => {
+    const { revokeObjectURL } = installDecodeHarness({
+      decode: vi.fn().mockRejectedValue(new Error('decode failed')),
+    });
 
     await expect(prepareChatImagePaintSource({
       type: 'image',
       url: 'https://matrix.example/broken',
       mimetype: 'image/png',
-    }, fetcher as unknown as typeof fetch))
-      .rejects.toThrow('Unable to decode the chat image.');
+    }, successfulFetch(new Blob(
+      ['not-an-image'],
+      { type: 'image/png' },
+    )))).rejects.toThrow(
+      'This chat image cannot be used as a Paint source.',
+    );
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:paint-source');
   });
 });

--- a/src/Brmble.Web/src/utils/chatImagePaintSource.test.ts
+++ b/src/Brmble.Web/src/utils/chatImagePaintSource.test.ts
@@ -37,7 +37,13 @@ function installDecodeHarness(options: {
 function successfulFetch(blob: Blob): typeof fetch {
   return vi.fn().mockResolvedValue({
     ok: true,
-    blob: vi.fn().mockResolvedValue(blob),
+    headers: new Headers({ 'content-type': blob.type }),
+    body: new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(new Uint8Array(await blob.arrayBuffer()));
+        controller.close();
+      },
+    }),
   }) as unknown as typeof fetch;
 }
 
@@ -144,6 +150,42 @@ describe('prepareChatImagePaintSource', () => {
     )))).rejects.toThrow(
       'This chat image is too large to use as a Paint source.',
     );
+  });
+
+  it('stops reading a streamed chat image when it exceeds the Paint 10 MiB limit', async () => {
+    const firstChunk = new Uint8Array(TEN_MIB);
+    const secondChunk = new Uint8Array(1);
+    let pullCount = 0;
+    let cancelReason: unknown;
+    const fetcher = vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pullCount += 1;
+          if (pullCount === 1) {
+            controller.enqueue(firstChunk);
+          } else if (pullCount === 2) {
+            controller.enqueue(secondChunk);
+          }
+        },
+        cancel(reason) {
+          cancelReason = reason;
+        },
+      }),
+      headers: new Headers({ 'content-type': 'image/png' }),
+      blob: vi.fn().mockRejectedValue(new Error('full body was materialized')),
+    });
+
+    await expect(prepareChatImagePaintSource({
+      type: 'image',
+      url: 'https://matrix.example/streaming-large',
+      mimetype: 'image/png',
+    }, fetcher as unknown as typeof fetch)).rejects.toThrow(
+      'This chat image is too large to use as a Paint source.',
+    );
+
+    expect(pullCount).toBeLessThanOrEqual(3);
+    expect(cancelReason).toBeDefined();
   });
 
   it('rejects a downloaded chat image above 4096 pixels', async () => {

--- a/src/Brmble.Web/src/utils/chatImagePaintSource.ts
+++ b/src/Brmble.Web/src/utils/chatImagePaintSource.ts
@@ -1,14 +1,60 @@
 import type { MediaAttachment } from '../types';
 import {
+  MAX_PAINT_SOURCE_BYTES,
   isSupportedPaintSourceMimeType,
   paintSourceExtension,
   preparePaintSourceFile,
 } from './paintSourceFile';
 
 const DOWNLOAD_TIMEOUT_MS = 15_000;
+const DOWNLOAD_SIZE_ERROR =
+  'This chat image is too large to use as a Paint source.';
 
 function normalizedMime(value?: string): string {
   return value?.split(';', 1)[0].trim().toLowerCase() ?? '';
+}
+
+async function readResponseBlob(response: Response): Promise<Blob> {
+  const contentLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > MAX_PAINT_SOURCE_BYTES) {
+    throw new Error(DOWNLOAD_SIZE_ERROR);
+  }
+
+  if (!response.body) {
+    throw new Error('Unable to download the chat image.');
+  }
+
+  const reader = response.body.getReader();
+  const chunks: ArrayBuffer[] = [];
+  let bytesRead = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      bytesRead += value.byteLength;
+      if (bytesRead > MAX_PAINT_SOURCE_BYTES) {
+        throw new Error(DOWNLOAD_SIZE_ERROR);
+      }
+      const chunk = new ArrayBuffer(value.byteLength);
+      new Uint8Array(chunk).set(value);
+      chunks.push(chunk);
+    }
+  } catch (error) {
+    try {
+      await reader.cancel(error);
+    } catch {
+      // The stream may already be closed by the time the limit is detected.
+    }
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+
+  return new Blob(chunks, {
+    type: response.headers.get('content-type') ?? '',
+  });
 }
 
 export function isPaintSourceAttachment(
@@ -36,7 +82,7 @@ export async function prepareChatImagePaintSource(
     throw new Error('Unable to download the chat image.');
   }
 
-  const blob = await response.blob();
+  const blob = await readResponseBlob(response);
   const mime = normalizedMime(attachment.mimetype)
     || normalizedMime(blob.type);
   const extension = paintSourceExtension(mime);

--- a/src/Brmble.Web/src/utils/chatImagePaintSource.ts
+++ b/src/Brmble.Web/src/utils/chatImagePaintSource.ts
@@ -1,13 +1,11 @@
 import type { MediaAttachment } from '../types';
-import { ALLOWED_MIMETYPES } from './parseMessageMedia';
+import {
+  isSupportedPaintSourceMimeType,
+  paintSourceExtension,
+  preparePaintSourceFile,
+} from './paintSourceFile';
 
 const DOWNLOAD_TIMEOUT_MS = 15_000;
-const EXTENSION_BY_MIME: Record<string, string> = {
-  'image/png': 'png',
-  'image/jpeg': 'jpg',
-  'image/gif': 'gif',
-  'image/webp': 'webp',
-};
 
 function normalizedMime(value?: string): string {
   return value?.split(';', 1)[0].trim().toLowerCase() ?? '';
@@ -19,8 +17,8 @@ export function isPaintSourceAttachment(
   if (!attachment.url.trim()) return false;
   const mime = normalizedMime(attachment.mimetype);
   return mime
-    ? ALLOWED_MIMETYPES.includes(mime)
-    : attachment.type === 'image' || attachment.type === 'gif';
+    ? isSupportedPaintSourceMimeType(mime)
+    : attachment.type === 'image';
 }
 
 export async function prepareChatImagePaintSource(
@@ -41,24 +39,10 @@ export async function prepareChatImagePaintSource(
   const blob = await response.blob();
   const mime = normalizedMime(attachment.mimetype)
     || normalizedMime(blob.type);
-  if (!ALLOWED_MIMETYPES.includes(mime)) {
-    throw new Error('This image type cannot be used for paint.');
-  }
-
+  const extension = paintSourceExtension(mime);
   const filename = attachment.filename?.trim()
-    || `chat-image.${EXTENSION_BY_MIME[mime]}`;
+    || (extension ? `chat-image.${extension}` : 'chat-image');
   const file = new File([blob], filename, { type: mime });
-  const objectUrl = URL.createObjectURL(file);
 
-  try {
-    const image = new Image();
-    image.src = objectUrl;
-    await image.decode();
-  } catch {
-    throw new Error('Unable to decode the chat image.');
-  } finally {
-    URL.revokeObjectURL(objectUrl);
-  }
-
-  return file;
+  return preparePaintSourceFile(file, 'chat');
 }

--- a/src/Brmble.Web/src/utils/paintSourceFile.test.ts
+++ b/src/Brmble.Web/src/utils/paintSourceFile.test.ts
@@ -1,0 +1,182 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  PAINT_SOURCE_ACCEPT,
+  isSupportedPaintSourceMimeType,
+  paintSourceExtension,
+  preparePaintSourceFile,
+} from './paintSourceFile';
+
+const TEN_MIB = 10 * 1024 * 1024;
+
+let naturalWidth = 1280;
+let naturalHeight = 720;
+let decode = vi.fn<() => Promise<void>>();
+
+beforeEach(() => {
+  naturalWidth = 1280;
+  naturalHeight = 720;
+  decode = vi.fn().mockResolvedValue(undefined);
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn().mockReturnValue('blob:paint-source'),
+    revokeObjectURL: vi.fn(),
+  });
+  vi.stubGlobal('Image', class {
+    src = '';
+    get naturalWidth() { return naturalWidth; }
+    get naturalHeight() { return naturalHeight; }
+    decode = decode;
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('preparePaintSourceFile', () => {
+  it('advertises exactly the Paint-supported picker formats', () => {
+    expect(PAINT_SOURCE_ACCEPT).toBe(
+      '.png,.jpg,.jpeg,.webp,image/png,image/jpeg,image/webp',
+    );
+  });
+
+  it('exposes the same MIME and extension policy to chat-image preparation', () => {
+    expect(isSupportedPaintSourceMimeType('image/png')).toBe(true);
+    expect(isSupportedPaintSourceMimeType('IMAGE/JPEG')).toBe(true);
+    expect(isSupportedPaintSourceMimeType('image/gif')).toBe(false);
+    expect(paintSourceExtension('image/webp')).toBe('webp');
+    expect(paintSourceExtension('image/svg+xml')).toBeNull();
+  });
+
+  it.each([
+    ['image/png', 'png'],
+    ['image/jpeg', 'jpg'],
+    ['image/webp', 'webp'],
+  ])('accepts a decodable %s paste and gives it a useful name', async (
+    type,
+    extension,
+  ) => {
+    const clipboardFile = new File(['pixels'], 'image', { type });
+
+    const result = await preparePaintSourceFile(
+      clipboardFile,
+      'paste',
+      TEN_MIB,
+    );
+
+    expect(result).not.toBe(clipboardFile);
+    expect(result.name).toBe(`Pasted screenshot.${extension}`);
+    expect(result.type).toBe(type);
+    expect(result.size).toBe(clipboardFile.size);
+    expect(decode).toHaveBeenCalledOnce();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:paint-source');
+  });
+
+  it('preserves the original filename and object for a selected file', async () => {
+    const selected = new File(['pixels'], 'diagram.png', {
+      type: 'image/png',
+    });
+
+    await expect(preparePaintSourceFile(selected, 'file', TEN_MIB))
+      .resolves.toBe(selected);
+  });
+
+  it('preserves a valid chat-image file after applying the same checks', async () => {
+    const chatImage = new File(['pixels'], 'shared-board.jpg', {
+      type: 'image/jpeg',
+    });
+
+    await expect(preparePaintSourceFile(chatImage, 'chat', TEN_MIB))
+      .resolves.toBe(chatImage);
+  });
+
+  it.each(['image/gif', 'image/bmp', 'image/svg+xml'])
+  ('rejects unsupported image type %s before decoding', async (type) => {
+    await expect(preparePaintSourceFile(
+      new File(['pixels'], 'unsupported', { type }),
+      'paste',
+      TEN_MIB,
+    )).rejects.toThrow(
+      'This clipboard image cannot be used. Copy a PNG, JPEG, or WebP image, or choose a file.',
+    );
+    expect(decode).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty clipboard image', async () => {
+    await expect(preparePaintSourceFile(
+      new File([], 'empty.png', { type: 'image/png' }),
+      'paste',
+      TEN_MIB,
+    )).rejects.toThrow(
+      'This clipboard image cannot be used. Try copying another image or choose a file.',
+    );
+  });
+
+  it('rejects a file above the Paint 10 MiB limit', async () => {
+    const oversized = new File(
+      [new Uint8Array(TEN_MIB + 1)],
+      'large.png',
+      { type: 'image/png' },
+    );
+
+    await expect(preparePaintSourceFile(oversized, 'file'))
+      .rejects.toThrow(
+        'The selected image is too large to use as a Paint source.',
+      );
+  });
+
+  it('uses a smaller Matrix upload limit for pasted images', async () => {
+    await expect(preparePaintSourceFile(
+      new File(['pixels'], 'image.png', { type: 'image/png' }),
+      'paste',
+      1,
+    )).rejects.toThrow(
+      'The pasted image is too large to use as a Paint source.',
+    );
+  });
+
+  it('uses the Paint byte limit and chat-specific copy for a chat image', async () => {
+    const oversized = new File(
+      [new Uint8Array(TEN_MIB + 1)],
+      'shared.png',
+      { type: 'image/png' },
+    );
+
+    await expect(preparePaintSourceFile(oversized, 'chat'))
+      .rejects.toThrow(
+        'This chat image is too large to use as a Paint source.',
+      );
+  });
+
+  it('rejects a file whose decoded dimensions exceed 4096 pixels', async () => {
+    naturalWidth = 4097;
+
+    await expect(preparePaintSourceFile(
+      new File(['pixels'], 'wide.webp', { type: 'image/webp' }),
+      'file',
+      TEN_MIB,
+    )).rejects.toThrow(
+      'This image is too large. Choose an image no larger than 4096 by 4096 pixels.',
+    );
+  });
+
+  it('rejects image bytes that the browser cannot decode and revokes the URL', async () => {
+    decode.mockRejectedValue(new Error('decode failed'));
+
+    await expect(preparePaintSourceFile(
+      new File(['broken'], 'broken.png', { type: 'image/png' }),
+      'paste',
+      TEN_MIB,
+    )).rejects.toThrow(
+      'This clipboard image cannot be used. Try copying another image or choose a file.',
+    );
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:paint-source');
+  });
+});

--- a/src/Brmble.Web/src/utils/paintSourceFile.ts
+++ b/src/Brmble.Web/src/utils/paintSourceFile.ts
@@ -3,7 +3,7 @@ export type PaintSourceOrigin = 'file' | 'paste' | 'chat';
 export const PAINT_SOURCE_ACCEPT =
   '.png,.jpg,.jpeg,.webp,image/png,image/jpeg,image/webp';
 
-const MAX_PAINT_SOURCE_BYTES = 10 * 1024 * 1024;
+export const MAX_PAINT_SOURCE_BYTES = 10 * 1024 * 1024;
 const MAX_PAINT_SOURCE_DIMENSION = 4096;
 const EXTENSION_BY_MIME: Record<string, 'png' | 'jpg' | 'webp'> = {
   'image/png': 'png',

--- a/src/Brmble.Web/src/utils/paintSourceFile.ts
+++ b/src/Brmble.Web/src/utils/paintSourceFile.ts
@@ -1,0 +1,113 @@
+export type PaintSourceOrigin = 'file' | 'paste' | 'chat';
+
+export const PAINT_SOURCE_ACCEPT =
+  '.png,.jpg,.jpeg,.webp,image/png,image/jpeg,image/webp';
+
+const MAX_PAINT_SOURCE_BYTES = 10 * 1024 * 1024;
+const MAX_PAINT_SOURCE_DIMENSION = 4096;
+const EXTENSION_BY_MIME: Record<string, 'png' | 'jpg' | 'webp'> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+};
+
+export function paintSourceExtension(
+  mimeType: string,
+): 'png' | 'jpg' | 'webp' | null {
+  return EXTENSION_BY_MIME[mimeType.toLowerCase()] ?? null;
+}
+
+export function isSupportedPaintSourceMimeType(mimeType: string): boolean {
+  return paintSourceExtension(mimeType) !== null;
+}
+
+function unusableMessage(origin: PaintSourceOrigin): string {
+  if (origin === 'paste') {
+    return 'This clipboard image cannot be used. Try copying another image or choose a file.';
+  }
+  return origin === 'chat'
+    ? 'This chat image cannot be used as a Paint source.'
+    : 'This image cannot be used. Try choosing another file.';
+}
+
+function typeMessage(origin: PaintSourceOrigin): string {
+  if (origin === 'paste') {
+    return 'This clipboard image cannot be used. Copy a PNG, JPEG, or WebP image, or choose a file.';
+  }
+  return origin === 'chat'
+    ? 'This chat image type cannot be used. Use a PNG, JPEG, or WebP image.'
+    : 'This image type cannot be used. Choose a PNG, JPEG, or WebP image.';
+}
+
+function sizeMessage(origin: PaintSourceOrigin): string {
+  if (origin === 'paste') {
+    return 'The pasted image is too large to use as a Paint source.';
+  }
+  return origin === 'chat'
+    ? 'This chat image is too large to use as a Paint source.'
+    : 'The selected image is too large to use as a Paint source.';
+}
+
+async function decodedDimensions(file: File): Promise<{
+  width: number;
+  height: number;
+}> {
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const image = new Image();
+    image.src = objectUrl;
+    await image.decode();
+    return {
+      width: image.naturalWidth,
+      height: image.naturalHeight,
+    };
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+export async function preparePaintSourceFile(
+  file: File,
+  origin: PaintSourceOrigin,
+  matrixUploadLimit?: number,
+): Promise<File> {
+  const extension = paintSourceExtension(file.type);
+  if (!extension) {
+    throw new Error(typeMessage(origin));
+  }
+  if (file.size === 0) {
+    throw new Error(unusableMessage(origin));
+  }
+
+  const effectiveLimit = matrixUploadLimit && matrixUploadLimit > 0
+    ? Math.min(MAX_PAINT_SOURCE_BYTES, matrixUploadLimit)
+    : MAX_PAINT_SOURCE_BYTES;
+  if (file.size > effectiveLimit) {
+    throw new Error(sizeMessage(origin));
+  }
+
+  let dimensions: { width: number; height: number };
+  try {
+    dimensions = await decodedDimensions(file);
+  } catch {
+    throw new Error(unusableMessage(origin));
+  }
+  if (dimensions.width < 1 || dimensions.height < 1) {
+    throw new Error(unusableMessage(origin));
+  }
+  if (
+    dimensions.width > MAX_PAINT_SOURCE_DIMENSION
+    || dimensions.height > MAX_PAINT_SOURCE_DIMENSION
+  ) {
+    throw new Error(
+      'This image is too large. Choose an image no larger than 4096 by 4096 pixels.',
+    );
+  }
+
+  return origin === 'paste'
+    ? new File([file], `Pasted screenshot.${extension}`, {
+        type: file.type.toLowerCase(),
+        lastModified: file.lastModified,
+      })
+    : file;
+}


### PR DESCRIPTION
## Summary

Improves image handling when starting collaborative Paint sessions.

### Changes

- Added validation for Paint source files:
  - Supports PNG, JPEG, and WebP.
  - Checks MIME type, file size, image dimensions, and image validity.
  - Respects the Matrix upload limit.

- Added validation for chat images used as Paint backgrounds.

- Added clipboard screenshot paste support to the Paint setup dialog.

- Added safe limits for remote chat-image downloads:
  - 15-second download timeout.
  - Maximum 10 MB streamed download size.
  - Rejects oversized images before completing the download.

- Added comprehensive tests for file validation, chat-image sources, clipboard paste, and Paint setup behavior.