### PR TITLE
Phase 3: wire the user projection into the client, server and UI

### DIFF
--- a/docs/superpowers/plans/phase-3-handoff.md
+++ b/docs/superpowers/plans/phase-3-handoff.md
@@ -1,0 +1,121 @@
+# Phase 3 handoff — wiring the user projection
+
+Implement Phase 3 of the Brmble user projection.
+
+## Start here
+
+Repo: `C:\Projects\brmble`
+Branch: `feature/user-projection-phase-3` — already created for you, branched from `feature/user-projection-phase-2` at `b22c1f88`.
+
+Read these, in this order:
+
+1. `docs/superpowers/plans/2026-08-01-user-projection-phase-3-wiring.md` — the plan you are executing. Read it in full, including "Background you need" and "What Phase 1's late review fixes changed under this plan", before writing any code.
+2. `docs/superpowers/specs/2026-07-31-user-projection-design.md` — the approved design. §3.4, §4.4, §5, §6, §8, §9 and §11 are what Phase 3 implements. Skim the rest.
+
+The plan is self-contained: four stages (A–D), each independently shippable and green, with complete code, exact commands and expected failure messages. Follow it in order. **Stage D is the only one that changes user-visible behaviour** — A, B and C are groundwork, and shipping them green is the point.
+
+## Sanity check you're in the right place
+
+```powershell
+git rev-parse --abbrev-ref HEAD        # feature/user-projection-phase-3
+git log --oneline -1                   # b22c1f88 if no Phase 3 work has started
+Select-String -Path src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs -Pattern MaxPendingEntries
+```
+
+Baseline — confirm all of these before starting, so you can tell your own failures from pre-existing ones:
+
+```powershell
+dotnet build     # 0 warnings, 0 errors
+dotnet test      # 1308 passing: Server 791, Client 345, MumbleVoiceEngine 99, Audio 73
+cd src/Brmble.Web; npm run test -- --run; npx tsc --noEmit; cd ../..
+```
+
+Record the frontend test count yourself before you start — it is not written down here, and Stage D changes it.
+
+If the baseline doesn't match, stop and ask rather than guessing which failures are yours.
+
+## Context you need that isn't in the plan
+
+**Phase 1 is merged.** PR #619 landed on `main` as merge commit `4fef8f13`, with history preserved. `git diff main` is meaningful again — the warnings in earlier handoffs about it being misleading no longer apply.
+
+**Phase 2 is open as PR #622 and is not merged.** Your branch is stacked on it. Two consequences:
+
+- When you open a PR, base it on `feature/user-projection-phase-2`, not `main` — otherwise Phase 2's 15 commits appear in your diff.
+- If review changes land on #622, rebase before continuing: `git fetch origin; git rebase origin/feature/user-projection-phase-2`. Stage A touches only new files plus `MumbleAdapter.cs`, which Phase 2 does not touch, so conflicts are unlikely. Stage C touches `BrmbleWebSocketHandler.cs` and `MappingEventPublisher.cs`, which Phase 2 does touch.
+
+**The plan's line numbers were taken before the Phase 1 merge.** Client-side references (`MumbleAdapter.cs`, `App.tsx`) were spot-checked afterwards and are accurate. `BrmbleWebSocketHandler.cs` shifted, so the plan deliberately names *methods* rather than lines in that file — if you find a line reference into it, re-derive it.
+
+## Environment traps that cost real time
+
+**1. The language server lies.** It reports unresolved `Moq`, `TestClass`, `Microsoft.Extensions`, `Ice`, `ProtoBuf`, `WebApplicationFactory` in files you haven't touched. False. `dotnet build` is the source of truth. Don't "fix" imports that are already correct.
+
+**2. Moq returns silent defaults, and this causes hangs, not failures.** A `Mock<ISessionMappingService>` returns `false` from every `TryUpdate*`/`TryClaim*` and `0`/`null` from every property unless stubbed. In `InitializeAcceptedClientAsync` the relevant one is now **`TryClaimBrmbleSession`** (it replaced the `TryUpdateBrmbleStatus` + `TryUpdateCertHash` pair in Phase 1's `3c996dd1`). Unstubbed, no `userMappingAdded` is broadcast and any test awaiting that broadcast **waits forever**. Stage C changes this method's signature, so you will be in exactly this code. Fixtures: `Integration/BrmbleServerFactory.cs`, `Auth/AuthEndpointsCompanionTests.cs` (its `CompanionAuthFactory` hides the base mock), `Events/SessionMappingHandlerTests.cs`, `WebSockets/BrmbleWebSocketHandlerTests.cs`.
+
+**3. `SetupSequence` doesn't support the out-parameter delegate overload.** `TryGetMappingByUserId` has two out params; `SetupSequence(...).Returns((long _, out int a, out SessionMapping? b) => ...)` fails with CS1660. Use one `Setup` with a call counter:
+
+```csharp
+var reads = 0;
+mappings.Setup(x => x.TryGetMappingByUserId(42, out It.Ref<int>.IsAny, out It.Ref<SessionMapping?>.IsAny))
+    .Returns((long _, out int sessionId, out SessionMapping? value) =>
+    {
+        sessionId = 7;
+        value = Interlocked.Increment(ref reads) == 1 ? first : second;
+        return true;
+    });
+```
+
+**4. Hand-written test doubles break on interface changes.** `Games/SessionMappingGamePresenceTests.cs` implements `ISessionMappingService` by hand; `MappingEventPublisherTests` and `BrmbleWebSocketHandlerTests` implement `IBrmbleEventBus` by hand. Widening any of those interfaces means updating these.
+
+**5. Beware asserting on fire-and-forget work.** `MumbleServerCallback.DispatchPaintParticipation` wraps its call in `_ = Task.Run(...)`. A test that awaits the outer method and then asserts `Times.Once` races the scheduler and flakes under load — one such test was fixed during Phase 2. Signal from the stub and await that, the way `DispatchUserStateChanged_DoesNotWaitForPaintParticipationFanOut` does.
+
+**6. `dotnet test --no-build` after an edit runs stale binaries.** Only use it right after a successful build.
+
+**7. `git rebase --continue` hangs.** It opens an editor for the commit message and waits forever. Set `$env:GIT_EDITOR="true"` first.
+
+**8. `gh api --input <file>` returns HTTP 400 if the file has a UTF-8 BOM.** PowerShell's `Out-File -Encoding utf8` adds one. Use:
+
+```powershell
+[System.IO.File]::WriteAllText("$PWD\.git\body.json", $json, (New-Object System.Text.UTF8Encoding $false))
+```
+
+**9. PowerShell splits `gh api graphql -f query=...` on spaces.** Write the query to a file and use `-F query='@file.txt'` with quotes.
+
+**10. Git prints CRLF warnings on nearly every commit.** Cosmetic.
+
+## How to work
+
+- Stay on `feature/user-projection-phase-3`. Never commit to `main` or the Phase 2 branch.
+- Use the **test-driven-development** skill. Every task starts with a failing test and the plan states the expected failure message. Run it and watch it fail *for that reason* before implementing.
+- Use the **verification-before-completion** skill before claiming anything works.
+- Commit after each task with the message given in that task's final step.
+- Do not push or open a PR without asking first.
+
+## Things the plan warns about — do not get these wrong
+
+- **`ProjectionWire` must live outside `Projection/`.** The store's value is that it has no JSON and no MumbleSharp dependency, which is what makes it testable without a protocol stack. There is a "Done when" grep enforcing this.
+- **A snapshot's `null` is knowledge; an event's `null` is absence.** Phase 2 already implements both. Stage A's translator must not "helpfully" default absent fields — in particular `companionId` must become `null`, never `"floppy"`. The old `ParseSessionMappings` got this wrong in both directions and is being deleted, not patched.
+- **`"floppy"` is a render-time fallback, never a stored or transmitted value.**
+- **Broadcasts go to clients at mixed `pv` versions.** Only per-socket payloads may use the collapsed companion field. There are now **three** snapshot paths to thread the version through, not one — bootstrap, resync, and the shared `CreateSessionMappingSnapshotPayload`. Missing the resync one produces a bug that only appears after a gap.
+- **The client's resync throttle must complete on *send*, not on receipt.** The server silently drops requests inside its 1s cooldown, so waiting for a reply that will never come wedges the throttle permanently.
+- **`applyChangeSet` must contain no `||`, `??` or `!== undefined`.** Rows arriving from the bridge are already complete. Any merge logic there re-creates the exact class of bug this project exists to remove. There is a "Done when" item for it.
+- **Delete `_userMappings` too.** It is a third identity store, keyed by mumble name, easy to miss, and read as a fallback in two places.
+
+## Done when
+
+The plan's "Done when" checklist passes, including:
+
+- `dotnet build` clean, 0 warnings; `npx tsc --noEmit` clean
+- `dotnet test` green with more than the 1308 baseline; `npm run test -- --run` green
+- `Select-String -Path src/Brmble.Client/Services/Voice/MumbleAdapter.cs -Pattern "_sessionMappings|_pendingBrmbleStatus|_userMappings"` returns nothing
+- `Select-String -Path src/Brmble.Client/Services/Voice/Projection/*.cs -Pattern "MumbleSharp|HttpClient|JsonElement|System.Text.Json"` returns nothing
+- `(Select-String -Path src/Brmble.Web/src/App.tsx -Pattern "setUsers\(").Count` is 0
+- The three acceptance tests in the plan pass — in particular the restart test, whose four assertions **all currently fail**
+
+## Report back with
+
+What you built, test counts before and after, and **anything in the plan that turned out to be wrong**. Every phase so far has found real defects in its own plan — Phase 2 found two, and Part A of the review found four more. Say so plainly if you find one rather than working around it silently.
+
+Two items in the plan are explicitly flagged as judgement calls rather than instructions — resolve them with evidence and say which way you went:
+
+- **Task C3** (`TryUpdateCompanionIdIfCurrent`): the expected answer is *keep it*, because the CAS guards a moderator reset racing a user's own selection, where neither party carries a client revision for the revision path to reject. Remove it only if you can write a failing test proving otherwise.
+- **Task D1 Step 3** (`voice.userLeft`): it carries `moved` / `previousChannelId` / `currentChannelId`, which the overlay and TTS consume. Check whether those are load-bearing before deleting the event, and keep a presentation-only `voice.userMoved` if they are.

--- a/docs/superpowers/plans/pr-629-review-findings.md
+++ b/docs/superpowers/plans/pr-629-review-findings.md
@@ -1,0 +1,107 @@
+# PR #629 (Phase 3) — review findings
+
+Two small findings, one doc correction, and one accepted risk. Nothing blocks the merge.
+
+Branch: `feature/user-projection-phase-3`. Verified independently: build clean, `dotnet test` 1342, `npm run test` 1490, `npx tsc --noEmit` clean.
+
+**Work list: items 2, 3 and 4. Item 1 is an accepted risk — do not implement it.**
+
+---
+
+## 1. New client against an old server loses all identity — ACCEPTED RISK, DO NOT FIX
+
+**Decision: not fixing. Brmble is in beta and both sides of the deployment are controlled, so client/server version skew is not a scenario worth engineering for. Recorded only so it is not rediscovered as a bug.**
+
+The one thing possibly worth doing is the diagnostic at the end of this section — three lines, and it makes the failure loud instead of silent if it is ever hit for a reason other than version skew. Everything above that line is context, not a task.
+
+### What happens
+
+`ProjectionWire.ReadSnapshot` (`src/Brmble.Client/Services/Voice/ProjectionWire.cs:22-23`) returns `null` when `instanceId` is missing:
+
+```csharp
+var instanceId = ReadString(root, "instanceId");
+if (string.IsNullOrEmpty(instanceId)) return null;
+```
+
+The adapter then silently skips the snapshot at both call sites — `MumbleAdapter.cs:1974` (`/auth/token`) and `:2643` (WebSocket).
+
+A server predating Phase 1 sends no `instanceId`, so against one of those:
+
+1. No snapshot is ever applied, so the store never establishes a cursor
+2. `_instanceId is null`, so **every** event returns `NeedsSnapshot`
+3. `RequestSnapshot()` fires, and an old server's read loop discards non-Close frames
+4. Nothing ever repairs it — a resync request every 1s widening to 30s, forever
+
+Every user renders with no `matrixUserId`, no companion, no Brmble badge and no avatar. Permanently. No error is surfaced.
+
+### Why it was raised
+
+This is a **new** incompatibility — the pre-Phase-3 client parsed `sessionMappings` without needing an envelope, so the combination worked before. It is being accepted rather than fixed because version skew is not a real scenario during beta.
+
+### Optional: make the failure loud (the only part worth doing)
+
+The mechanism is not strictly limited to old servers — any snapshot that fails to yield an envelope takes the same path, and it does so **silently and permanently**. A log line, or a `SendBrmbleServiceStatus` degraded marker, at the point where `ReadSnapshot` returns null would turn "identities mysteriously blank" into something diagnosable in seconds.
+
+Three lines, no behaviour change, worth it independently of the version-skew decision. Skip if you disagree.
+
+### Not doing
+
+Do **not** implement a legacy snapshot mode, a cursor-less enriched state, or compatibility tests for envelope-free payloads. That work is out of scope.
+
+
+---
+
+## 2. A discarded event creates a phantom gap
+
+**Severity: minor, latent rather than live.**
+
+`ProjectionWire.ReadEvent` returns `null` — dropping the event **and its revision** — in three cases:
+
+| Line | Condition |
+|---|---|
+| `:87` | missing or empty `instanceId` |
+| `:92` | `sessionId == 0` |
+| `:94-95` | missing or non-numeric `revision` |
+
+Because the event never reaches `ApplyServerEvent`, the cursor does not advance, so the next event looks like a gap and triggers a resync.
+
+It self-heals, and I could not find a producer that emits `sessionId: 0` — `AuthService`'s publisher lambda guards on `TryGetSessionByUserId`, and `b632d0a3` tightened registration announcements. So this is latent.
+
+Worth either a comment recording that the resync is the intended cost, or advancing the cursor for a payload that is well-formed enough to sequence but unusable for other reasons.
+
+---
+
+## 3. `applyChangeSet` append loop is quadratic
+
+**Severity: trivial.**
+
+`src/Brmble.Web/src/hooks/useUserDirectory.ts:34-36`:
+
+```ts
+for (const user of change.changed) {
+  if (!previous.some(existing => existing.session === user.session)) next = [...next, user];
+}
+```
+
+`previous.some(...)` inside the loop, and the array is rebuilt per append. Irrelevant at channel scale. A `Set` of existing session ids would make it linear if the list ever grows — for example a large snapshot arriving after a reset.
+
+---
+
+## 4. The spec should record what Phase 3 actually settled
+
+Not a code change — the spec now overstates what was done, and the next reader will think work is missing.
+
+**Spec §4.4** describes collapsing the companion to one truthful field. In practice only the WebSocket snapshot does this. `/auth/token` and every broadcast keep the legacy split, both for good reasons that are documented in the code:
+
+- `/auth/token` is fetched before the WebSocket exists, so it carries no `pv`
+- Broadcast recipients are at mixed projection versions
+
+So the "lie at the compatibility boundary" §4.4 wanted still lives in the core protocol; the client just handles it correctly in `ReadCompanionId`. That is the right outcome given the constraints, but the spec should say so rather than describing an end state that was deliberately not reached.
+
+Also worth recording in the spec: `TryUpdateCompanionIdIfCurrent` was **kept**, and §4.4's proposal to retire it was wrong — `CustomCompanionEndpoints` computes its reset target inside `PublishAsync`'s gate and carries no client revision, so there is nothing for revision rejection to reject.
+
+---
+
+## Still outstanding from the PR body
+
+Custom companions were not manually verified. Stage C is exactly where a regression would hide: a custom skin rendering as floppy on other clients, because that is the wire format Stage C changed.

--- a/docs/superpowers/specs/2026-07-31-user-projection-design.md
+++ b/docs/superpowers/specs/2026-07-31-user-projection-design.md
@@ -192,12 +192,33 @@ fact, which §3.2 rule 2 exists to prevent.
 Resolution: `UserProjection` carries a single `CompanionSelection` (a built-in id or
 `custom:$eventId`), with `null` meaning unknown. The client announces a projection version at
 WebSocket registration; the server sends the single truthful field to clients that support it and
-the legacy split to those that do not. The compatibility lie lives at the compatibility boundary
-rather than in the core protocol, and `ParseWireCompanionId`'s `"floppy"` defaults collapse to one
+the legacy split to those that do not. `ParseWireCompanionId`'s `"floppy"` defaults collapse to one
 render-time fallback.
 
-`TryUpdateCompanionIdIfCurrent` (the per-field CAS added by `custom-companion`) is retired: a
-mutation carrying a stale revision is rejected wholesale.
+**As built (Phase 3).** The negotiation covers less than the paragraph above claimed, deliberately.
+Only the two per-socket snapshot paths — the bootstrap payload and the resync reply — collapse the
+companion to one field, because only there is the reader's `pv` known:
+
+- `/auth/token` keeps the legacy split. It is fetched before the WebSocket exists, so there is no
+  projection version to negotiate against.
+- Every broadcast keeps the legacy split. Its recipients are at mixed projection versions, and one
+  payload cannot be truthful to a `pv=1` client and parseable by a `pv=0` one simultaneously.
+
+So the compatibility lie still lives in the core protocol, not only at the boundary. What changed is
+that it is now lossless to a projection-aware reader: `ProjectionWire.ReadCompanionId` prefers
+`customCompanionId` over the legacy `companionId`, so a custom skin never degrades to a floppy on a
+client that understands the field. Removing the split outright would require every client on a
+server to be at `pv>=1`, a deployment guarantee this design does not make.
+
+`TryUpdateCompanionIdIfCurrent` (the per-field CAS added by `custom-companion`) was **kept**; the
+proposal above to retire it was wrong. Revision rejection guards a client submitting a mutation
+against a table it has fallen behind. The CAS guards a different race: a moderator deleting a custom
+companion resets affected sessions to `"floppy"` while an affected user may concurrently be choosing
+something else. Neither party carries a client revision — `CustomCompanionEndpoints` computes its
+target inside `PublishAsync`'s own gate — so there is no stale revision for the revision path to
+reject. The CAS also gates the announcement: `PublishAsync` publishes only when the mutation returns
+true, so a refused reset emits no `companionChanged` and cannot overwrite the user's newer choice on
+every other client.
 
 ### 4.5 Client → server resync request
 

--- a/docs/superpowers/specs/2026-07-31-user-projection-design.md
+++ b/docs/superpowers/specs/2026-07-31-user-projection-design.md
@@ -291,7 +291,7 @@ The moderation path is sound. The WebSocket `companionChanged` is only the selec
 
 - `voice.usersReset { users: [...] }` — the complete list. Voice connect, disconnect (empty),
   reconnect.
-- `voice.usersChanged { users: [...], removed: [sessions] }` — full rows for changed sessions.
+- `voice.usersChanged { changed: [...], removed: [sessions] }` — full rows for changed sessions.
 
 `voice.connected` survives, but stops carrying `users`: it keeps the channel list and connection
 metadata, and the user list arrives as the first `voice.usersReset`. This removes the only

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -4118,6 +4118,14 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     /// Reduces a MumbleSharp user to the fields Mumble owns. Muted folds server mute, self mute
     /// and both deafen flags together, matching what the UI has always shown.
     /// </summary>
+    /// <remarks>
+    /// The certificate hash is normalised to null when empty. MumbleSharp initialises
+    /// <c>CertificateHash</c> to <see cref="string.Empty"/> and never nulls it, so an
+    /// unauthenticated user would otherwise reach the store as "has a certificate, and it is the
+    /// empty string". Two such users then compare equal, which lets the reset occupant check
+    /// carry one user's identity onto another across a session-id reuse, and also stops
+    /// <c>UserProjection.CertHash</c> falling back to the server's recorded copy.
+    /// </remarks>
     private Projection.MumbleUserInput ToProjectionInput(MumbleSharp.Model.User user) =>
         new(user.Id,
             user.Name,
@@ -4125,7 +4133,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             user.Muted || user.SelfMuted || user.Deaf || user.SelfDeaf,
             user.Deaf || user.SelfDeaf,
             user.Comment,
-            user.CertificateHash,
+            string.IsNullOrEmpty(user.CertificateHash) ? null : user.CertificateHash,
             user == LocalUser);
 
     private void SendVoiceConnected(uint? overrideChannelId = null)

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -4407,17 +4407,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         }
     }
 
-    protected override void UserStateCommentChanged(User user, string oldComment)
-    {
-        base.UserStateCommentChanged(user, oldComment);
-        _bridge?.Send("voice.userCommentChanged", new
-        {
-            session = user.Id,
-            comment = user.Comment
-        });
-        _bridge?.NotifyUiThread();
-    }
-
     public override void UserStats(UserStats userStats)
     {
         base.UserStats(userStats);

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -4159,6 +4159,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         var rows = _projection.Snapshot().Values.Select(ProjectionWire.ToWireRow).ToArray();
         _bridge?.Send("voice.usersReset", new { users = rows });
 
+        // Send only enqueues; the caller owns the flush. Both messages are already queued, and
+        // one notify drains the whole queue in order, so this delivers the connect and the
+        // membership that follows it together.
+        _bridge?.NotifyUiThread();
+
         // Voice lifecycle transition: force-release any held input so PTT
         // cannot remain latched across a reconnect (#538).
         _inputRouter?.ReleaseAllHeld();

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -66,6 +66,13 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private readonly ConcurrentDictionary<uint, SessionMappingEntry> _sessionMappings = new();
 
     /// <summary>
+    /// The authoritative user projection. Replaces _sessionMappings, _pendingBrmbleStatus and
+    /// _userMappings: it merges Mumble presence and Brmble identity under one set of rules
+    /// rather than three ad-hoc ones spread across the adapter and App.tsx.
+    /// </summary>
+    private readonly Projection.UserProjectionStore _projection = new();
+
+    /// <summary>
     /// Brmble status for sessions this client has not been told the mapping for yet. The
     /// server may announce that a session became a Brmble client before this client learns
     /// who that session is, and every later user state re-asserts the flag from the mapping
@@ -4171,10 +4178,29 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     /// <c>LocalUser.Channel.Id</c>.  This avoids a race when the server hasn't
     /// echoed a channel move yet (e.g. fresh connect moving to root).
     /// </param>
+    /// <summary>
+    /// Reduces a MumbleSharp user to the fields Mumble owns. Muted folds server mute, self mute
+    /// and both deafen flags together, matching what the UI has always shown.
+    /// </summary>
+    private Projection.MumbleUserInput ToProjectionInput(MumbleSharp.Model.User user) =>
+        new(user.Id,
+            user.Name,
+            (uint)(user.Channel?.Id ?? 0),
+            user.Muted || user.SelfMuted || user.Deaf || user.SelfDeaf,
+            user.Deaf || user.SelfDeaf,
+            user.Comment,
+            user.CertificateHash,
+            user == LocalUser);
+
     private void SendVoiceConnected(uint? overrideChannelId = null)
     {
         var channelId = overrideChannelId ?? (uint)(LocalUser?.Channel?.Id ?? 0);
         var channels = Channels.Select(CreateChannelPayload).ToList();
+
+        // A reconnect replaces membership wholesale. Server-owned fields survive for sessions
+        // present both before and after, so a voice reconnect costs no identity.
+        _projection.ApplyMumbleReset([.. Users.Select(ToProjectionInput)]);
+
         var users = Users.Select(u =>
         {
             var hasMap = _sessionMappings.TryGetValue(u.Id, out var sm);
@@ -4261,6 +4287,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         base.UserState(userState);
 
         UserDictionary.TryGetValue(userState.Session, out var user);
+
+        // Mumble resends the complete UserState on every change, so this is authoritative for
+        // every Mumble-owned field including the ones that went empty.
+        if (user is not null) _projection.ApplyMumbleUserState(ToProjectionInput(user));
 
         // Request full comment if only hash was received
         if (userState.ShouldSerializeCommentHash() && !userState.ShouldSerializeComment())
@@ -4503,6 +4533,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         }
 
         base.UserRemove(userRemove);
+
+        // The only path that deletes a row: Mumble alone owns existence.
+        _projection.ApplyMumbleUserRemove(userRemove.Session);
 
         Debug.WriteLine($"[Mumble] UserRemove: session {userRemove.Session}, name: {userName}, isSelf: {isSelf}");
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -2240,7 +2240,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         // Keep the original scheme for TCP connection; we do TLS via BouncyCastle
         var host = builder.Host;
         var port = builder.Port > 0 ? builder.Port : (builder.Scheme == "https" ? 443 : 80);
-        var wsPath = builder.Path.TrimEnd('/') + "/ws";
+        // Announce projection version 1: send one truthful companion field rather than the split.
+        var wsPath = builder.Path.TrimEnd('/') + "/ws?pv=1";
 
         _ = Task.Run(async () =>
         {

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1976,6 +1976,16 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 var change = _projection.ApplyServerSnapshot(tokenSnapshot);
                 EmitProjectionChange(change);
             }
+            else
+            {
+                // A rejected snapshot leaves the store without a cursor, so every subsequent
+                // event asks for a resync that this payload was supposed to satisfy. Nothing
+                // recovers on its own, and the visible result is only that identities are
+                // blank, so say so here rather than leaving it to be inferred.
+                Console.WriteLine(
+                    "[Brmble] /auth/token carried no usable mapping snapshot (missing envelope " +
+                    "or mappings block); identities will stay unknown until one arrives");
+            }
 
             ApplyPasswordProtectedChannelIdsFromCredentials(credentials.Value);
 
@@ -2644,6 +2654,15 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 {
                     EmitProjectionChange(_projection.ApplyServerSnapshot(wsSnapshot));
                     _resync.OnSnapshotApplied();
+                }
+                else
+                {
+                    // As on the /auth/token path: without a cursor every later event asks for a
+                    // resync this payload should have satisfied, and the only symptom is blank
+                    // identities. Make the cause visible.
+                    Console.WriteLine(
+                        "[Brmble] sessionMappingSnapshot carried no usable envelope or mappings " +
+                        "block; identities will stay unknown until one arrives");
                 }
                 return;
             }

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -69,6 +69,14 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     /// rather than three ad-hoc ones spread across the adapter and App.tsx.
     /// </summary>
     private readonly Projection.UserProjectionStore _projection = new();
+
+    /// <summary>
+    /// Serializes apply+emit pairs. The store's own lock orders the applies, but emission
+    /// happens after release from three threads, and the consumer replaces rows wholesale —
+    /// so a change set computed first must also be enqueued first, or a stale full row
+    /// enqueued late silently wins until the next event for that session.
+    /// </summary>
+    private readonly object _projectionEmitGate = new();
     private readonly System.Collections.Concurrent.ConcurrentDictionary<uint, bool> _channelPasswordRestrictions = new();
     private CancellationTokenSource? _wsCts;
     private long _wsGeneration;
@@ -510,6 +518,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         _wsCts?.Cancel();
         _wsCts?.Dispose();
         _wsCts = null;
+        // The read loop clears _wsStream asynchronously, and cancellation of a read blocked
+        // inside the TLS stream is not prompt. A quick reconnect would otherwise see the stale
+        // stream, skip StartWebSocketConnection, and nothing would ever start the socket again.
+        _wsStream = null;
         Interlocked.Increment(ref _wsGeneration);
         StopHealthCheck();
         _serverHealthWasConnected = false;
@@ -519,6 +531,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         UserDictionary.Clear();
         ChannelDictionary.Clear();
         _channelPasswordRestrictions.Clear();
+        // The store's within-connection invariants (session-id continuity, one revision line)
+        // do not hold across connections: a different or restarted server reuses session ids,
+        // and leftover rows would hand its users the previous server's identities.
+        _projection.Reset();
         _lastWelcomeText = null;
         _previousChannelId = null;
         _pendingLocalJoinChannelId = null;
@@ -1973,8 +1989,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             // gap and the client resyncs immediately.
             if (ProjectionWire.ReadSnapshot(credentials.Value) is { } tokenSnapshot)
             {
-                var change = _projection.ApplyServerSnapshot(tokenSnapshot);
-                EmitProjectionChange(change);
+                lock (_projectionEmitGate)
+                {
+                    EmitProjectionChange(_projection.ApplyServerSnapshot(tokenSnapshot));
+                }
             }
             else
             {
@@ -1982,7 +2000,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 // event asks for a resync that this payload was supposed to satisfy. Nothing
                 // recovers on its own, and the visible result is only that identities are
                 // blank, so say so here rather than leaving it to be inferred.
-                Console.WriteLine(
+                LogToFile(
                     "[Brmble] /auth/token carried no usable mapping snapshot (missing envelope " +
                     "or mappings block); identities will stay unknown until one arrives");
             }
@@ -2004,7 +2022,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             // Only connect if we do not already have a live socket. A credential refresh -- which
             // the health check can trigger at any time -- must not tear down a working
             // connection: the old read loop and the new one would then race, and the survivor
-            // may be the one being torn down.
+            // may be the one being torn down. Disconnect() nulls _wsStream synchronously, so a
+            // reconnect always passes this guard even while the old read loop is still unwinding.
             if (_wsStream is null) StartWebSocketConnection(apiUrl);
 
             // Start periodic health checks (runs from C# to avoid CORS issues)
@@ -2262,6 +2281,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             {
                 TlsClientProtocol? tlsProtocol = null;
                 TcpClient? tcp = null;
+                Stream? stream = null;
                 try
                 {
                     using var cert = _certService?.GetExportableCertificate();
@@ -2283,10 +2303,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                     tlsProtocol = new TlsClientProtocol(tcp.GetStream());
                     tlsProtocol.Connect(tlsClient);
 
-                    var stream = tlsProtocol.Stream;
-                    _wsStream = stream;
+                    stream = tlsProtocol.Stream;
 
-                    var wsKey = Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(16));
+                    var wsKey =Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(16));
                     var hostHeader = port == 443 ? host : $"{host}:{port}";
                     var upgradeRequest =
                         $"GET {wsPath} HTTP/1.1\r\n" +
@@ -2367,6 +2386,11 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                         throw new InvalidOperationException("WebSocket upgrade rejected");
                     }
 
+                    // Published only after the upgrade is validated: a pre-upgrade publish would
+                    // let a concurrent RequestSnapshot interleave a masked frame with the HTTP
+                    // handshake and corrupt it.
+                    _wsStream = stream;
+
                     backoff = TimeSpan.FromSeconds(1); // reset on successful connect
                     Debug.WriteLine("[WS] Connected to Brmble WebSocket (BouncyCastle TLS)");
                     SendBrmbleServiceStatus("session", "connected");
@@ -2387,7 +2411,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 finally
                 {
                     // Cleared before the stream is disposed so no send can pick up a dead socket.
-                    _wsStream = null;
+                    // CAS, not assignment: Disconnect() nulls the field synchronously and a
+                    // successor loop may already have published a new stream — only clear our own.
+                    Interlocked.CompareExchange(ref _wsStream, null, stream);
                     try { tlsProtocol?.Close(); } catch { }
                     try { tcp?.Dispose(); } catch { }
                 }
@@ -2608,6 +2634,13 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     /// Asks the server to restate the mapping table. Fire-and-forget: the reply arrives as a
     /// normal sessionMappingSnapshot on the read loop.
     /// </summary>
+    /// <remarks>
+    /// Deliberately no retry timer. If the send fails, or the server discards the request
+    /// inside its cooldown (measured at the server, so client-side spacing does not fully
+    /// prevent it), the gap stays until the next event that reports NeedsSnapshot or the next
+    /// (re)connect bootstrap. Accepted: a server quiet enough never to trigger that repair is
+    /// also one where the stale window has nothing visible in it.
+    /// </remarks>
     private void RequestSnapshot()
     {
         if (!_resync.TryBegin(_resyncClock.Elapsed)) return;
@@ -2629,7 +2662,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[Brmble] resync request failed: {ex.Message}");
+                LogToFile($"[Brmble] resync request failed: {ex.Message}");
             }
             finally
             {
@@ -2652,7 +2685,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             {
                 if (ProjectionWire.ReadSnapshot(root) is { } wsSnapshot)
                 {
-                    EmitProjectionChange(_projection.ApplyServerSnapshot(wsSnapshot));
+                    lock (_projectionEmitGate)
+                    {
+                        EmitProjectionChange(_projection.ApplyServerSnapshot(wsSnapshot));
+                    }
                     _resync.OnSnapshotApplied();
                 }
                 else
@@ -2660,7 +2696,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                     // As on the /auth/token path: without a cursor every later event asks for a
                     // resync this payload should have satisfied, and the only symptom is blank
                     // identities. Make the cause visible.
-                    Console.WriteLine(
+                    LogToFile(
                         "[Brmble] sessionMappingSnapshot carried no usable envelope or mappings " +
                         "block; identities will stay unknown until one arrives");
                 }
@@ -2669,7 +2705,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
             if (ProjectionWire.ReadEvent(type, root) is { } mappingEvent)
             {
-                EmitProjectionChange(_projection.ApplyServerEvent(mappingEvent));
+                lock (_projectionEmitGate)
+                {
+                    EmitProjectionChange(_projection.ApplyServerEvent(mappingEvent));
+                }
                 return;
             }
 
@@ -4162,21 +4201,25 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         // A reconnect replaces membership wholesale. Server-owned fields survive for sessions
         // present both before and after, so a voice reconnect costs no identity.
-        _projection.ApplyMumbleReset([.. Users.Select(ToProjectionInput)]);
-
-        _bridge?.Send("voice.connected", new
+        object[] rows;
+        lock (_projectionEmitGate)
         {
-            username = LocalUser?.Name,
-            channelId,
-            channels,
-            registered = LocalUser?.IsRegistered ?? false,
-            registeredName = LocalUser?.IsRegistered == true ? LocalUser.Name : (string?)null
-        });
+            _projection.ApplyMumbleReset([.. Users.Select(ToProjectionInput)]);
 
-        // Membership travels as a reset rather than riding on voice.connected, so there is
-        // exactly one path by which the user list is ever populated.
-        var rows = _projection.Snapshot().Values.Select(ProjectionWire.ToWireRow).ToArray();
-        _bridge?.Send("voice.usersReset", new { users = rows });
+            _bridge?.Send("voice.connected", new
+            {
+                username = LocalUser?.Name,
+                channelId,
+                channels,
+                registered = LocalUser?.IsRegistered ?? false,
+                registeredName = LocalUser?.IsRegistered == true ? LocalUser.Name : (string?)null
+            });
+
+            // Membership travels as a reset rather than riding on voice.connected, so there is
+            // exactly one path by which the user list is ever populated.
+            rows = _projection.Snapshot().Values.Select(ProjectionWire.ToWireRow).ToArray();
+            _bridge?.Send("voice.usersReset", new { users = rows });
+        }
 
         // Send only enqueues; the caller owns the flush. Both messages are already queued, and
         // one notify drains the whole queue in order, so this delivers the connect and the
@@ -4284,7 +4327,12 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         var joinedUserName = user?.Name ?? userState.Name;
         if (user is not null)
-            EmitProjectionChange(_projection.ApplyMumbleUserState(ToProjectionInput(user)));
+        {
+            lock (_projectionEmitGate)
+            {
+                EmitProjectionChange(_projection.ApplyMumbleUserState(ToProjectionInput(user)));
+            }
+        }
         _bridge?.NotifyUiThread();
 
         // Emit system message for genuinely new users (not initial sync, not self)
@@ -4472,7 +4520,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         base.UserRemove(userRemove);
 
         // The only path that deletes a row: Mumble alone owns existence.
-        EmitProjectionChange(_projection.ApplyMumbleUserRemove(userRemove.Session));
+        lock (_projectionEmitGate)
+        {
+            EmitProjectionChange(_projection.ApplyMumbleUserRemove(userRemove.Session));
+        }
 
         Debug.WriteLine($"[Mumble] UserRemove: session {userRemove.Session}, name: {userName}, isSelf: {isSelf}");
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -80,6 +80,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     /// </summary>
     private Stream? _wsStream;
     private readonly SemaphoreSlim _wsSendGate = new(1, 1);
+    private readonly ResyncThrottle _resync = new();
+    private readonly System.Diagnostics.Stopwatch _resyncClock = System.Diagnostics.Stopwatch.StartNew();
     private readonly IAppConfigService? _appConfigService;
     private readonly VoiceIdleTracker? _voiceIdleTracker;
     private readonly ChannelRequestBridgeHandler _channelRequestBridgeHandler;
@@ -2557,6 +2559,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     /// </remarks>
     private void EmitProjectionChange(Projection.ChangeSet change)
     {
+        if (change.NeedsSnapshot) RequestSnapshot();
         if (change.IsEmpty) return;
 
         foreach (var row in change.Changed)
@@ -2566,6 +2569,40 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             _bridge?.Send("voice.userLeft", new { session = sessionId, moved = false });
 
         if (change.Changed.Count > 0 || change.Removed.Count > 0) _bridge?.NotifyUiThread();
+    }
+
+    /// <summary>
+    /// Asks the server to restate the mapping table. Fire-and-forget: the reply arrives as a
+    /// normal sessionMappingSnapshot on the read loop.
+    /// </summary>
+    private void RequestSnapshot()
+    {
+        if (!_resync.TryBegin(_resyncClock.Elapsed)) return;
+
+        var stream = _wsStream;
+        if (stream is null)
+        {
+            // No socket: the reconnect will bring a bootstrap snapshot anyway.
+            _resync.Complete(_resyncClock.Elapsed);
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var payload = System.Text.Json.JsonSerializer.Serialize(new { type = "requestSnapshot" });
+                await SendWebSocketFrame(stream, 0x1, System.Text.Encoding.UTF8.GetBytes(payload));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Brmble] resync request failed: {ex.Message}");
+            }
+            finally
+            {
+                _resync.Complete(_resyncClock.Elapsed);
+            }
+        });
     }
 
     private void HandleWebSocketMessage(string json)
@@ -2581,7 +2618,10 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             if (type == "sessionMappingSnapshot")
             {
                 if (ProjectionWire.ReadSnapshot(root) is { } wsSnapshot)
+                {
                     EmitProjectionChange(_projection.ApplyServerSnapshot(wsSnapshot));
+                    _resync.OnSnapshotApplied();
+                }
                 return;
             }
 

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -1990,8 +1990,12 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             _sawServerHealthFailureSinceCredentials = false;
             SendBrmbleServiceStatus("server", "connected");
 
-            // Start WebSocket connection for real-time session mapping updates
-            StartWebSocketConnection(apiUrl);
+            // Start WebSocket connection for real-time session mapping updates.
+            // Only connect if we do not already have a live socket. A credential refresh -- which
+            // the health check can trigger at any time -- must not tear down a working
+            // connection: the old read loop and the new one would then race, and the survivor
+            // may be the one being torn down.
+            if (_wsStream is null) StartWebSocketConnection(apiUrl);
 
             // Start periodic health checks (runs from C# to avoid CORS issues)
             StartHealthCheck(apiUrl);
@@ -2543,7 +2547,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         while (totalRead < count)
         {
             ct.ThrowIfCancellationRequested();
-            var read = await stream.ReadAsync(buffer, offset + totalRead, count - totalRead);
+            // Pass the token: without it the read only unblocks when the stream is disposed,
+            // so a cancelled connection lingers and races its own replacement.
+            var read = await stream.ReadAsync(buffer.AsMemory(offset + totalRead, count - totalRead), ct);
             if (read == 0) return false;
             totalRead += read;
         }

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -62,8 +62,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private readonly Stopwatch _notifyThrottle = Stopwatch.StartNew();
     private string? _apiUrl;
     private string? _activeServerId;
-    private Dictionary<string, string> _userMappings = new();
-    private readonly ConcurrentDictionary<uint, SessionMappingEntry> _sessionMappings = new();
 
     /// <summary>
     /// The authoritative user projection. Replaces _sessionMappings, _pendingBrmbleStatus and
@@ -71,15 +69,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     /// rather than three ad-hoc ones spread across the adapter and App.tsx.
     /// </summary>
     private readonly Projection.UserProjectionStore _projection = new();
-
-    /// <summary>
-    /// Brmble status for sessions this client has not been told the mapping for yet. The
-    /// server may announce that a session became a Brmble client before this client learns
-    /// who that session is, and every later user state re-asserts the flag from the mapping
-    /// cache, so an activation that had nowhere to land would not merely be missed once, it
-    /// would be contradicted from then on.
-    /// </summary>
-    private readonly ConcurrentDictionary<uint, bool> _pendingBrmbleStatus = new();
     private readonly System.Collections.Concurrent.ConcurrentDictionary<uint, bool> _channelPasswordRestrictions = new();
     private CancellationTokenSource? _wsCts;
     private long _wsGeneration;
@@ -113,40 +102,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
     })
     { Timeout = TimeSpan.FromSeconds(5) };
-
-    internal record SessionMappingEntry(string MatrixUserId, string MumbleName, string CompanionId, bool IsBrmbleClient = false, string? CertHash = null);
-
-    /// <summary>
-    /// Parses a JSON object whose keys are session IDs and values contain
-    /// matrixUserId, mumbleName, companionId, and optionally isBrmbleClient into a dictionary.
-    /// Shared by the auth-response and WebSocket snapshot parsers.
-    /// </summary>
-    internal static Dictionary<uint, SessionMappingEntry> ParseSessionMappings(System.Text.Json.JsonElement mappingsElement)
-    {
-        var result = new Dictionary<uint, SessionMappingEntry>();
-        foreach (var prop in mappingsElement.EnumerateObject())
-        {
-            if (uint.TryParse(prop.Name, out var sid))
-            {
-                var matrixId = prop.Value.TryGetProperty("matrixUserId", out var m) ? m.GetString() : null;
-                var name = prop.Value.TryGetProperty("mumbleName", out var n) ? n.GetString() : null;
-                var companionId = ParseWireCompanionId(prop.Value);
-                var certHash = prop.Value.TryGetProperty("certHash", out var h) ? h.GetString() : null;
-                if (matrixId is not null && name is not null && companionId is not null)
-                {
-                    // Only an explicit `true` counts. A JSON null means "unknown" and
-                    // TryGetProperty reports it as present, so GetBoolean() would throw.
-                    var isBrmble = prop.Value.TryGetProperty("isBrmbleClient", out var b)
-                        && b.ValueKind == System.Text.Json.JsonValueKind.True;
-                    result[sid] = new SessionMappingEntry(matrixId, name, companionId, isBrmble, certHash);
-                }
-            }
-        }
-        return result;
-    }
-
-    internal static string ParseWireCompanionId(System.Text.Json.JsonElement element)
-        => ParseWireCompanionIdOrNull(element) ?? "floppy";
 
     /// <summary>
     /// Reads the companion from a wire payload, preferring a custom companion id.
@@ -550,7 +505,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         _serverHealthWasConnected = false;
         _credentialsAlreadyFetched = false;
         _sawServerHealthFailureSinceCredentials = false;
-        _sessionMappings.Clear();
 
         UserDictionary.Clear();
         ChannelDictionary.Clear();
@@ -2004,24 +1958,13 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 return;
             }
 
-            // Parse user mappings (displayName -> matrixUserId) from the auth response
-            if (credentials.Value.TryGetProperty("userMappings", out var mappingsElement))
+            // The credential body carries the same envelope as a WebSocket snapshot, so it
+            // establishes the cursor too. Without this the first event after connect looks like a
+            // gap and the client resyncs immediately.
+            if (ProjectionWire.ReadSnapshot(credentials.Value) is { } tokenSnapshot)
             {
-                _userMappings = new Dictionary<string, string>();
-                foreach (var prop in mappingsElement.EnumerateObject())
-                {
-                    var matrixId = prop.Value.GetString();
-                    if (matrixId is not null)
-                        _userMappings[prop.Name] = matrixId;
-                }
-            }
-
-            // Parse session mappings (sessionId -> matrixUserId + mumbleName) from the auth response
-            if (credentials.Value.TryGetProperty("sessionMappings", out var sessionMappingsElement))
-            {
-                _sessionMappings.Clear();
-                foreach (var (sid, entry) in ParseSessionMappings(sessionMappingsElement))
-                    _sessionMappings[sid] = ApplyPendingBrmbleStatus(sid, entry);
+                var change = _projection.ApplyServerSnapshot(tokenSnapshot);
+                EmitProjectionChange(change);
             }
 
             ApplyPasswordProtectedChannelIdsFromCredentials(credentials.Value);
@@ -2110,23 +2053,12 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
     private string GetSelfCompanionOrDefault()
     {
-        if (LocalUser is not null &&
-            _sessionMappings.TryGetValue(LocalUser.Id, out var mapping) &&
-            !string.IsNullOrWhiteSpace(mapping.CompanionId))
-        {
-            return mapping.CompanionId;
-        }
-
-        return "floppy";
-    }
-
-    private void UpdateSelfCompanionMapping(string companionId)
-    {
-        if (LocalUser is null) return;
-        if (_sessionMappings.TryGetValue(LocalUser.Id, out var existing))
-        {
-            _sessionMappings[LocalUser.Id] = existing with { CompanionId = companionId };
-        }
+        if (LocalUser is null) return "floppy";
+        // "floppy" is a render-time fallback for an unknown companion, never a stored value.
+        return _projection.Snapshot().TryGetValue(LocalUser.Id, out var row)
+               && !string.IsNullOrWhiteSpace(row.CompanionId)
+            ? row.CompanionId!
+            : "floppy";
     }
 
     private async Task<object> SyncCompanionAsync(string companionId)
@@ -2181,10 +2113,14 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             if (!string.IsNullOrWhiteSpace(result.Body))
             {
                 using var doc = System.Text.Json.JsonDocument.Parse(result.Body);
-                synced = ParseWireCompanionId(doc.RootElement);
+                // The reply echoes what the server stored. If it names no companion, the value
+                // we asked for is a better answer than "floppy", which would be a default
+                // reported as a fact.
+                synced = ParseWireCompanionIdOrNull(doc.RootElement) ?? companionId;
             }
 
-            UpdateSelfCompanionMapping(synced);
+            // No local write-back: the server announces the change and the store applies it.
+            // Guessing here is exactly the confidently-wrong value the projection removes.
             return new { success = true, companionId = synced };
         }
         catch (Exception ex)
@@ -2591,29 +2527,24 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     }
 
     /// <summary>
-    /// Records a Brmble status announcement against the session's mapping, holding it aside
-    /// when the mapping is not known yet so the next mapping for that session adopts it.
+    /// Relays a change set to the UI. Stage A keeps the legacy event set so React is unchanged;
+    /// Stage D replaces the body with two events.
     /// </summary>
-    private void RecordBrmbleStatus(uint sessionId, bool isBrmbleClient)
+    /// <remarks>
+    /// Called after Apply* has returned and released the store's lock — never inside it.
+    /// </remarks>
+    private void EmitProjectionChange(Projection.ChangeSet change)
     {
-        if (_sessionMappings.TryGetValue(sessionId, out var entry))
-        {
-            _sessionMappings[sessionId] = entry with { IsBrmbleClient = isBrmbleClient };
-            _pendingBrmbleStatus.TryRemove(sessionId, out _);
-            return;
-        }
+        if (change.IsEmpty) return;
 
-        _pendingBrmbleStatus[sessionId] = isBrmbleClient;
+        foreach (var row in change.Changed)
+            _bridge?.Send("voice.userJoined", ProjectionWire.ToWireRow(row));
+
+        foreach (var sessionId in change.Removed)
+            _bridge?.Send("voice.userLeft", new { session = sessionId, moved = false });
+
+        if (change.Changed.Count > 0 || change.Removed.Count > 0) _bridge?.NotifyUiThread();
     }
-
-    /// <summary>
-    /// Folds a status announcement that arrived before this mapping into it. The announcement
-    /// is the newer of the two, so it wins over the status the mapping was built with.
-    /// </summary>
-    private SessionMappingEntry ApplyPendingBrmbleStatus(uint sessionId, SessionMappingEntry entry)
-        => _pendingBrmbleStatus.TryRemove(sessionId, out var pending)
-            ? entry with { IsBrmbleClient = pending }
-            : entry;
 
     private void HandleWebSocketMessage(string json)
     {
@@ -2623,103 +2554,23 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             var root = doc.RootElement;
             var type = root.TryGetProperty("type", out var t) ? t.GetString() : null;
 
+            // Every mapping payload goes through the projection. The store decides whether the
+            // event is contiguous, a duplicate or a gap; the adapter only relays the result.
+            if (type == "sessionMappingSnapshot")
+            {
+                if (ProjectionWire.ReadSnapshot(root) is { } wsSnapshot)
+                    EmitProjectionChange(_projection.ApplyServerSnapshot(wsSnapshot));
+                return;
+            }
+
+            if (ProjectionWire.ReadEvent(type, root) is { } mappingEvent)
+            {
+                EmitProjectionChange(_projection.ApplyServerEvent(mappingEvent));
+                return;
+            }
+
             switch (type)
             {
-                case "sessionMappingSnapshot":
-        _sessionMappings.Clear();
-        _pendingBrmbleStatus.Clear();
-                    if (root.TryGetProperty("mappings", out var mappings))
-                    {
-                        foreach (var (sid, entry) in ParseSessionMappings(mappings))
-                            _sessionMappings[sid] = ApplyPendingBrmbleStatus(sid, entry);
-                    }
-                    _bridge?.Send("voice.sessionMappingSnapshot",
-                        new
-                        {
-                            mappings = _sessionMappings.ToDictionary(k => k.Key, k => new
-                            {
-                                k.Value.MatrixUserId,
-                                k.Value.MumbleName,
-                                k.Value.CompanionId,
-                                k.Value.CertHash,
-                                k.Value.IsBrmbleClient
-                            })
-                        });
-                    _bridge?.NotifyUiThread();
-                    break;
-
-                case "userMappingAdded":
-                    var addSid = root.TryGetProperty("sessionId", out var sidProp) ? sidProp.GetUInt32() : 0u;
-                    var addMatrixId = root.TryGetProperty("matrixUserId", out var matrixProp) ? matrixProp.GetString() : null;
-                    var addName = root.TryGetProperty("mumbleName", out var nameProp) ? nameProp.GetString() : null;
-                    // An announcement that carries no companion is not a claim that the user has
-                    // none. It is sent for a session this client may already know in full, so the
-                    // known companion is kept rather than replaced with the default.
-                    var announcedCompanionId = ParseWireCompanionIdOrNull(root);
-                    var addCertHash = root.TryGetProperty("certHash", out var certProp) ? certProp.GetString() : null;
-                    // As in ParseSessionMappings: null means unknown, not false, and
-                    // GetBoolean() would throw on it.
-                    var addIsBrmble = root.TryGetProperty("isBrmbleClient", out var brmbleProp)
-                        && brmbleProp.ValueKind == System.Text.Json.JsonValueKind.True;
-                    if (addSid > 0 && addMatrixId is not null && addName is not null)
-                    {
-                        var knownCompanionId = _sessionMappings.TryGetValue(addSid, out var priorMapping)
-                            ? priorMapping.CompanionId
-                            : null;
-                        var addCompanionId = announcedCompanionId ?? knownCompanionId ?? "floppy";
-                        _sessionMappings[addSid] = ApplyPendingBrmbleStatus(
-                            addSid, new SessionMappingEntry(addMatrixId, addName, addCompanionId, addIsBrmble, addCertHash));
-                        var storedMapping = _sessionMappings[addSid];
-                        _bridge?.Send("voice.userMappingUpdated", new { sessionId = addSid, matrixUserId = addMatrixId, mumbleName = addName, companionId = addCompanionId, certHash = addCertHash, isBrmbleClient = storedMapping.IsBrmbleClient, action = "added" });
-                        _bridge?.NotifyUiThread();
-                    }
-                    break;
-
-                case "companionChanged":
-                    var changedSid = root.GetProperty("sessionId").GetUInt32();
-                    var changedCompanionId = ParseWireCompanionId(root);
-                    if (_sessionMappings.TryGetValue(changedSid, out var changed))
-                        _sessionMappings[changedSid] = changed with { CompanionId = changedCompanionId };
-                    _bridge?.Send("voice.companionChanged", new
-                    {
-                        session = changedSid,
-                        matrixUserId = root.TryGetProperty("matrixUserId", out var matrixIdProp) ? matrixIdProp.GetString() : null,
-                        companionId = changedCompanionId
-                    });
-                    _bridge?.NotifyUiThread();
-                    break;
-
-                case "userMappingRemoved":
-                    var rmSid = root.TryGetProperty("sessionId", out var rmSidProp) ? rmSidProp.GetUInt32() : 0u;
-                    if (rmSid > 0)
-                    {
-                        _sessionMappings.TryRemove(rmSid, out _);
-                        _pendingBrmbleStatus.TryRemove(rmSid, out _);
-                        _bridge?.Send("voice.userMappingUpdated", new { sessionId = rmSid, action = "removed" });
-                        _bridge?.NotifyUiThread();
-                    }
-                    break;
-
-                case "brmbleClientActivated":
-                    var actSid = root.TryGetProperty("sessionId", out var actSidProp) ? actSidProp.GetUInt32() : 0u;
-                    if (actSid > 0)
-                    {
-                        RecordBrmbleStatus(actSid, true);
-                    }
-                    _bridge?.Send("voice.brmbleClientActivated", new { sessionId = actSid });
-                    _bridge?.NotifyUiThread();
-                    break;
-
-                case "brmbleClientDeactivated":
-                    var deactSid = root.TryGetProperty("sessionId", out var deactSidProp) ? deactSidProp.GetUInt32() : 0u;
-                    if (deactSid > 0)
-                    {
-                        RecordBrmbleStatus(deactSid, false);
-                    }
-                    _bridge?.Send("voice.brmbleClientDeactivated", new { sessionId = deactSid });
-                    _bridge?.NotifyUiThread();
-                    break;
-
                 case "screenShare.started":
                     var startRoom = root.TryGetProperty("roomName", out var startRoomProp) ? startRoomProp.GetString() : null;
                     var startUser = root.TryGetProperty("userName", out var startUserProp) ? startUserProp.GetString() : null;
@@ -4201,31 +4052,12 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         // present both before and after, so a voice reconnect costs no identity.
         _projection.ApplyMumbleReset([.. Users.Select(ToProjectionInput)]);
 
-        var users = Users.Select(u =>
-        {
-            var hasMap = _sessionMappings.TryGetValue(u.Id, out var sm);
-            return new
-            {
-                session = u.Id,
-                name = u.Name,
-                channelId = u.Channel?.Id ?? 0,
-                muted = u.Muted || u.SelfMuted || u.Deaf || u.SelfDeaf,
-                deafened = u.Deaf || u.SelfDeaf,
-                self = u == LocalUser,
-                comment = u.Comment,
-                certHash = u.CertificateHash ?? (hasMap ? sm!.CertHash : null),
-                matrixUserId = hasMap ? sm!.MatrixUserId : _userMappings.GetValueOrDefault(u.Name),
-                companionId = hasMap ? sm!.CompanionId : null,
-                isBrmbleClient = hasMap ? sm!.IsBrmbleClient : _pendingBrmbleStatus.GetValueOrDefault(u.Id)
-            };
-        }).ToList();
-
         _bridge?.Send("voice.connected", new
         {
             username = LocalUser?.Name,
             channelId,
             channels,
-            users,
+            users = _projection.Snapshot().Values.Select(ProjectionWire.ToWireRow).ToArray(),
             registered = LocalUser?.IsRegistered ?? false,
             registeredName = LocalUser?.IsRegistered == true ? LocalUser.Name : (string?)null
         });
@@ -4234,7 +4066,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         // cannot remain latched across a reconnect (#538).
         _inputRouter?.ReleaseAllHeld();
 
-        Debug.WriteLine($"[Mumble] Sent {channels.Count} channels and {users.Count} users");
+        Debug.WriteLine($"[Mumble] Sent {channels.Count} channels and {_projection.Snapshot().Count} users");
     }
 
     private object CreateChannelPayload(Channel channel) => new
@@ -4288,10 +4120,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
 
         UserDictionary.TryGetValue(userState.Session, out var user);
 
-        // Mumble resends the complete UserState on every change, so this is authoritative for
-        // every Mumble-owned field including the ones that went empty.
-        if (user is not null) _projection.ApplyMumbleUserState(ToProjectionInput(user));
-
         // Request full comment if only hash was received
         if (userState.ShouldSerializeCommentHash() && !userState.ShouldSerializeComment())
         {
@@ -4331,23 +4159,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         }
 
         var joinedUserName = user?.Name ?? userState.Name;
-        var hasJoinMapping = _sessionMappings.TryGetValue(userState.Session, out var joinMapping);
-        _bridge?.Send("voice.userJoined", new
-        {
-            session = userState.Session,
-            name = joinedUserName,
-            channelId = currentChannelId,
-            muted = user != null ? (user.Muted || user.SelfMuted || user.Deaf || user.SelfDeaf) : (userState.Mute || userState.SelfMute || userState.Deaf || userState.SelfDeaf),
-            deafened = user != null ? (user.Deaf || user.SelfDeaf) : (userState.Deaf || userState.SelfDeaf),
-            self = isSelf,
-            comment = user?.Comment,
-            certHash = user?.CertificateHash ?? (hasJoinMapping ? joinMapping!.CertHash : null),
-            matrixUserId = hasJoinMapping ? joinMapping!.MatrixUserId : _userMappings.GetValueOrDefault(joinedUserName),
-            companionId = hasJoinMapping ? joinMapping!.CompanionId : null,
-            isBrmbleClient = hasJoinMapping
-                ? joinMapping!.IsBrmbleClient
-                : _pendingBrmbleStatus.GetValueOrDefault(userState.Session)
-        });
+        if (user is not null)
+            EmitProjectionChange(_projection.ApplyMumbleUserState(ToProjectionInput(user)));
         _bridge?.NotifyUiThread();
 
         // Emit system message for genuinely new users (not initial sync, not self)

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -72,6 +72,14 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     private readonly System.Collections.Concurrent.ConcurrentDictionary<uint, bool> _channelPasswordRestrictions = new();
     private CancellationTokenSource? _wsCts;
     private long _wsGeneration;
+
+    /// <summary>
+    /// The live WebSocket stream, or null when disconnected. Hoisted out of the reconnect loop
+    /// so application messages can be sent; guarded by _wsSendGate because the read loop answers
+    /// pings on the same socket and two interleaved frames corrupt the stream.
+    /// </summary>
+    private Stream? _wsStream;
+    private readonly SemaphoreSlim _wsSendGate = new(1, 1);
     private readonly IAppConfigService? _appConfigService;
     private readonly VoiceIdleTracker? _voiceIdleTracker;
     private readonly ChannelRequestBridgeHandler _channelRequestBridgeHandler;
@@ -2259,8 +2267,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                     tlsProtocol.Connect(tlsClient);
 
                     var stream = tlsProtocol.Stream;
+                    _wsStream = stream;
 
-                    // Perform WebSocket upgrade handshake
                     var wsKey = Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(16));
                     var hostHeader = port == 443 ? host : $"{host}:{port}";
                     var upgradeRequest =
@@ -2361,6 +2369,8 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
                 }
                 finally
                 {
+                    // Cleared before the stream is disposed so no send can pick up a dead socket.
+                    _wsStream = null;
                     try { tlsProtocol?.Close(); } catch { }
                     try { tcp?.Dispose(); } catch { }
                 }
@@ -2385,7 +2395,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     /// Handles continuation frames, ping/pong, and close frames.
     /// Returns null on connection close.
     /// </summary>
-    private static async Task<string?> ReadWebSocketFrame(Stream stream, CancellationToken ct)
+    private async Task<string?> ReadWebSocketFrame(Stream stream, CancellationToken ct)
     {
         using var payload = new MemoryStream();
 
@@ -2476,40 +2486,52 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     /// <summary>
     /// Sends a masked WebSocket frame (client-to-server frames must be masked per RFC 6455).
     /// </summary>
-    private static async Task SendWebSocketFrame(Stream stream, int opcode, byte[] data)
+    /// <remarks>
+    /// Serialised on _wsSendGate: the read loop answers pings on this same socket, and two
+    /// frames interleaved mid-write corrupt the stream for both.
+    /// </remarks>
+    private async Task SendWebSocketFrame(Stream stream, int opcode, byte[] data)
     {
-        // Client frames must be masked
-        var maskKey = System.Security.Cryptography.RandomNumberGenerator.GetBytes(4);
-
-        using var frame = new MemoryStream();
-        frame.WriteByte((byte)(0x80 | opcode)); // FIN + opcode
-
-        if (data.Length < 126)
-            frame.WriteByte((byte)(0x80 | data.Length)); // masked + length
-        else if (data.Length <= 65535)
+        await _wsSendGate.WaitAsync();
+        try
         {
-            frame.WriteByte(0x80 | 126);
-            frame.WriteByte((byte)(data.Length >> 8));
-            frame.WriteByte((byte)(data.Length & 0xFF));
+            // Client frames must be masked
+            var maskKey = System.Security.Cryptography.RandomNumberGenerator.GetBytes(4);
+
+            using var frame = new MemoryStream();
+            frame.WriteByte((byte)(0x80 | opcode)); // FIN + opcode
+
+            if (data.Length < 126)
+                frame.WriteByte((byte)(0x80 | data.Length)); // masked + length
+            else if (data.Length <= 65535)
+            {
+                frame.WriteByte(0x80 | 126);
+                frame.WriteByte((byte)(data.Length >> 8));
+                frame.WriteByte((byte)(data.Length & 0xFF));
+            }
+            else
+            {
+                frame.WriteByte(0x80 | 127);
+                var len = (long)data.Length;
+                for (int i = 7; i >= 0; i--)
+                    frame.WriteByte((byte)((len >> (i * 8)) & 0xFF));
+            }
+
+            frame.Write(maskKey, 0, 4);
+
+            var masked = new byte[data.Length];
+            for (int i = 0; i < data.Length; i++)
+                masked[i] = (byte)(data[i] ^ maskKey[i % 4]);
+            frame.Write(masked, 0, masked.Length);
+
+            var bytes = frame.ToArray();
+            await stream.WriteAsync(bytes, 0, bytes.Length);
+            await stream.FlushAsync();
         }
-        else
+        finally
         {
-            frame.WriteByte(0x80 | 127);
-            var len = (long)data.Length;
-            for (int i = 7; i >= 0; i--)
-                frame.WriteByte((byte)((len >> (i * 8)) & 0xFF));
+            _wsSendGate.Release();
         }
-
-        frame.Write(maskKey, 0, 4);
-
-        var masked = new byte[data.Length];
-        for (int i = 0; i < data.Length; i++)
-            masked[i] = (byte)(data[i] ^ maskKey[i % 4]);
-        frame.Write(masked, 0, masked.Length);
-
-        var bytes = frame.ToArray();
-        await stream.WriteAsync(bytes, 0, bytes.Length);
-        await stream.FlushAsync();
     }
 
     /// <summary>Reads exactly count bytes from stream. Returns false on EOF.</summary>

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -2558,24 +2558,40 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
     }
 
     /// <summary>
-    /// Relays a change set to the UI. Stage A keeps the legacy event set so React is unchanged;
-    /// Stage D replaces the body with two events.
+    /// Relays a change set to the UI as the projection's two state events.
     /// </summary>
     /// <remarks>
     /// Called after Apply* has returned and released the store's lock — never inside it.
+    ///
+    /// <para>
+    /// These two events are the only source of user state. <c>voice.userLeft</c> still fires
+    /// alongside them but is presentation-only: it announces "left your channel", which is not
+    /// a removal at all when the user merely moved.
+    /// </para>
     /// </remarks>
     private void EmitProjectionChange(Projection.ChangeSet change)
     {
         if (change.NeedsSnapshot) RequestSnapshot();
         if (change.IsEmpty) return;
 
-        foreach (var row in change.Changed)
-            _bridge?.Send("voice.userJoined", ProjectionWire.ToWireRow(row));
+        if (change.IsReset)
+        {
+            // Membership was replaced wholesale, so the consumer replaces its list rather than
+            // reconciling additions against removals.
+            _bridge?.Send("voice.usersReset", new
+            {
+                users = change.Changed.Select(ProjectionWire.ToWireRow).ToArray()
+            });
+            _bridge?.NotifyUiThread();
+            return;
+        }
 
-        foreach (var sessionId in change.Removed)
-            _bridge?.Send("voice.userLeft", new { session = sessionId, moved = false });
-
-        if (change.Changed.Count > 0 || change.Removed.Count > 0) _bridge?.NotifyUiThread();
+        _bridge?.Send("voice.usersChanged", new
+        {
+            changed = change.Changed.Select(ProjectionWire.ToWireRow).ToArray(),
+            removed = change.Removed.ToArray()
+        });
+        _bridge?.NotifyUiThread();
     }
 
     /// <summary>
@@ -4126,16 +4142,20 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             username = LocalUser?.Name,
             channelId,
             channels,
-            users = _projection.Snapshot().Values.Select(ProjectionWire.ToWireRow).ToArray(),
             registered = LocalUser?.IsRegistered ?? false,
             registeredName = LocalUser?.IsRegistered == true ? LocalUser.Name : (string?)null
         });
+
+        // Membership travels as a reset rather than riding on voice.connected, so there is
+        // exactly one path by which the user list is ever populated.
+        var rows = _projection.Snapshot().Values.Select(ProjectionWire.ToWireRow).ToArray();
+        _bridge?.Send("voice.usersReset", new { users = rows });
 
         // Voice lifecycle transition: force-release any held input so PTT
         // cannot remain latched across a reconnect (#538).
         _inputRouter?.ReleaseAllHeld();
 
-        Debug.WriteLine($"[Mumble] Sent {channels.Count} channels and {_projection.Snapshot().Count} users");
+        Debug.WriteLine($"[Mumble] Sent {channels.Count} channels and {rows.Length} users");
     }
 
     private object CreateChannelPayload(Channel channel) => new
@@ -4215,6 +4235,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             previousUserChannel == previousChannel && currentChannelId != previousChannel)
         {
             var leftUserName = user?.Name ?? userState.Name;
+            // Presentation only: the user still exists and their row is merely changed. State
+            // travels in voice.usersChanged; this drives the "left your channel" TTS line and
+            // the overlay's user-left event, neither of which a removal could express.
             _bridge?.Send("voice.userLeft", new { 
                 session = userState.Session, 
                 name = leftUserName, 
@@ -4417,7 +4440,7 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         base.UserRemove(userRemove);
 
         // The only path that deletes a row: Mumble alone owns existence.
-        _projection.ApplyMumbleUserRemove(userRemove.Session);
+        EmitProjectionChange(_projection.ApplyMumbleUserRemove(userRemove.Session));
 
         Debug.WriteLine($"[Mumble] UserRemove: session {userRemove.Session}, name: {userName}, isSelf: {isSelf}");
 
@@ -4425,6 +4448,9 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         _audioManager?.RemoveUser(userRemove.Session);
         var channelId = user?.Channel?.Id;
         var certHash = user?.CertificateHash;
+        // Presentation only, as above: it carries the name, channel and cert hash the TTS,
+        // overlay and DM-presence side effects need. The row itself is removed by the
+        // ApplyMumbleUserRemove change set.
         _bridge?.Send("voice.userLeft", new { session = userRemove.Session, name = userName, channelId, certHash, moved = false });
         _bridge?.NotifyUiThread();
 

--- a/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
+++ b/src/Brmble.Client/Services/Voice/Projection/UserProjectionStore.cs
@@ -52,6 +52,22 @@ internal sealed class UserProjectionStore
         lock (_gate) return new Dictionary<uint, UserProjection>(_rows);
     }
 
+    /// <summary>
+    /// Forgets everything: rows, holds and the revision cursor. For disconnect — the
+    /// within-connection invariants (session-id continuity, one revision line per instance)
+    /// do not survive into the next connection, so nothing derived from them may either.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_gate)
+        {
+            _rows.Clear();
+            _pending.Clear();
+            _instanceId = null;
+            _revision = 0;
+        }
+    }
+
     public ChangeSet ApplyMumbleUserState(MumbleUserInput input)
     {
         lock (_gate)

--- a/src/Brmble.Client/Services/Voice/ProjectionWire.cs
+++ b/src/Brmble.Client/Services/Voice/ProjectionWire.cs
@@ -84,6 +84,25 @@ internal static class ProjectionWire
     }
 
     /// <summary>
+    /// The single wire shape for a user row. Every field is always present, nulls included, so a
+    /// consumer replaces by session id and never merges field-by-field.
+    /// </summary>
+    internal static object ToWireRow(UserProjection row) => new
+    {
+        session = row.SessionId,
+        name = row.Name,
+        channelId = row.ChannelId,
+        muted = row.Muted,
+        deafened = row.Deafened,
+        self = row.IsSelf,
+        comment = row.Comment,
+        certHash = row.CertHash,
+        matrixUserId = row.MatrixUserId,
+        companionId = row.CompanionId,
+        isBrmbleClient = row.IsBrmbleClient
+    };
+
+    /// <summary>
     /// Reads the server-owned half of one session. Every absent field becomes null, which the
     /// store reads as "not known" — this is where the old parser's <c>"floppy"</c> default and
     /// its <c>isBrmbleClient: false</c> default are removed.

--- a/src/Brmble.Client/Services/Voice/ProjectionWire.cs
+++ b/src/Brmble.Client/Services/Voice/ProjectionWire.cs
@@ -15,7 +15,7 @@ internal static class ProjectionWire
 {
     /// <summary>
     /// Reads a <c>sessionMappingSnapshot</c> or an <c>/auth/token</c> body. Returns null when the
-    /// payload carries no envelope, because a snapshot without one cannot establish a cursor.
+    /// payload carries no envelope or no mappings block, because neither can establish a cursor.
     /// </summary>
     internal static ServerSnapshot? ReadSnapshot(JsonElement root)
     {
@@ -24,17 +24,46 @@ internal static class ProjectionWire
         if (!root.TryGetProperty("revision", out var revision) ||
             revision.ValueKind != JsonValueKind.Number) return null;
 
+        // The two bootstrap transports name the same block differently: the WebSocket snapshot
+        // calls it "mappings", the /auth/token body "sessionMappings". Both must be understood,
+        // because the store takes whatever it is handed as the complete truth about every session.
+        if (!TryReadMappingsBlock(root, out var raw))
+            // No block under either name means this is a payload we failed to understand, not a
+            // server stating that it knows nobody. Applying an empty table as authoritative would
+            // reset every row's identity on the strength of a parsing miss -- precisely the
+            // "absent is not known-empty" rule the projection exists to enforce.
+            return null;
+
         var mappings = new Dictionary<uint, ServerMappingEntry>();
-        if (root.TryGetProperty("mappings", out var raw) && raw.ValueKind == JsonValueKind.Object)
+        foreach (var property in raw.EnumerateObject())
         {
-            foreach (var property in raw.EnumerateObject())
-            {
-                if (!uint.TryParse(property.Name, out var sessionId)) continue;
-                mappings[sessionId] = ReadEntry(property.Value);
-            }
+            if (!uint.TryParse(property.Name, out var sessionId)) continue;
+            mappings[sessionId] = ReadEntry(property.Value);
         }
 
         return new ServerSnapshot(instanceId, revision.GetInt64(), mappings);
+    }
+
+    /// <summary>
+    /// Finds the mappings object under either transport's name. An explicitly empty object is a
+    /// legitimate statement and succeeds; a missing one does not.
+    /// </summary>
+    private static bool TryReadMappingsBlock(JsonElement root, out JsonElement mappings)
+    {
+        if (root.TryGetProperty("mappings", out var wire) && wire.ValueKind == JsonValueKind.Object)
+        {
+            mappings = wire;
+            return true;
+        }
+
+        if (root.TryGetProperty("sessionMappings", out var auth) && auth.ValueKind == JsonValueKind.Object)
+        {
+            mappings = auth;
+            return true;
+        }
+
+        mappings = default;
+        return false;
     }
 
     /// <summary>

--- a/src/Brmble.Client/Services/Voice/ProjectionWire.cs
+++ b/src/Brmble.Client/Services/Voice/ProjectionWire.cs
@@ -70,6 +70,13 @@ internal static class ProjectionWire
     /// Reads one incremental mapping event. Returns null for any payload that is not one — the
     /// caller dispatches every WebSocket message through here.
     /// </summary>
+    /// <remarks>
+    /// Rejecting a payload drops its revision as well as its content, so the next event looks
+    /// like a gap and costs one resync. That is the intended trade: a resync repairs, whereas
+    /// advancing the cursor past an event we could not interpret would silently skip whatever
+    /// the server actually changed, with nothing left to detect it. Cheap and self-correcting
+    /// beats quiet and permanent.
+    /// </remarks>
     internal static ServerEvent? ReadEvent(string? type, JsonElement root)
     {
         var kind = type switch

--- a/src/Brmble.Client/Services/Voice/ProjectionWire.cs
+++ b/src/Brmble.Client/Services/Voice/ProjectionWire.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+using Brmble.Client.Services.Voice.Projection;
+
+namespace Brmble.Client.Services.Voice;
+
+/// <summary>
+/// Translates Brmble wire payloads into <see cref="UserProjectionStore"/> inputs.
+/// </summary>
+/// <remarks>
+/// This is the only place that knows both JSON and the projection. Keeping it out of the
+/// <c>Projection</c> namespace is what lets the store be unit-tested without a protocol stack,
+/// and what stops wire quirks leaking into the merge rules.
+/// </remarks>
+internal static class ProjectionWire
+{
+    /// <summary>
+    /// Reads a <c>sessionMappingSnapshot</c> or an <c>/auth/token</c> body. Returns null when the
+    /// payload carries no envelope, because a snapshot without one cannot establish a cursor.
+    /// </summary>
+    internal static ServerSnapshot? ReadSnapshot(JsonElement root)
+    {
+        var instanceId = ReadString(root, "instanceId");
+        if (string.IsNullOrEmpty(instanceId)) return null;
+        if (!root.TryGetProperty("revision", out var revision) ||
+            revision.ValueKind != JsonValueKind.Number) return null;
+
+        var mappings = new Dictionary<uint, ServerMappingEntry>();
+        if (root.TryGetProperty("mappings", out var raw) && raw.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in raw.EnumerateObject())
+            {
+                if (!uint.TryParse(property.Name, out var sessionId)) continue;
+                mappings[sessionId] = ReadEntry(property.Value);
+            }
+        }
+
+        return new ServerSnapshot(instanceId, revision.GetInt64(), mappings);
+    }
+
+    /// <summary>
+    /// Reads one incremental mapping event. Returns null for any payload that is not one — the
+    /// caller dispatches every WebSocket message through here.
+    /// </summary>
+    internal static ServerEvent? ReadEvent(string? type, JsonElement root)
+    {
+        var kind = type switch
+        {
+            "userMappingAdded" => ServerEventKind.MappingAdded,
+            "userMappingRemoved" => ServerEventKind.MappingRemoved,
+            "companionChanged" => ServerEventKind.CompanionChanged,
+            "brmbleClientActivated" => ServerEventKind.BrmbleActivated,
+            "brmbleClientDeactivated" => ServerEventKind.BrmbleDeactivated,
+            _ => (ServerEventKind?)null
+        };
+        if (kind is null) return null;
+
+        var instanceId = ReadString(root, "instanceId");
+        if (string.IsNullOrEmpty(instanceId)) return null;
+
+        if (!root.TryGetProperty("sessionId", out var session) ||
+            session.ValueKind != JsonValueKind.Number) return null;
+        var sessionId = session.GetUInt32();
+        if (sessionId == 0) return null;
+
+        if (!root.TryGetProperty("revision", out var revisionProperty) ||
+            revisionProperty.ValueKind != JsonValueKind.Number) return null;
+        var revision = revisionProperty.GetInt64();
+
+        // A server predating Phase 1 sends no baseRevision. Assuming the operation bumped once
+        // is the only reading under which an old server can still drive a new client; a wrong
+        // guess costs one redundant snapshot, not a wrong value.
+        var baseRevision = root.TryGetProperty("baseRevision", out var b) &&
+                           b.ValueKind == JsonValueKind.Number
+            ? b.GetInt64()
+            : revision - 1;
+
+        // Removal and the two activation events assert their meaning through Kind alone; only
+        // the field-carrying events need an entry.
+        var entry = kind is ServerEventKind.MappingAdded or ServerEventKind.CompanionChanged
+            ? ReadEntry(root)
+            : null;
+
+        return new ServerEvent(kind.Value, instanceId, baseRevision, revision, sessionId, entry);
+    }
+
+    /// <summary>
+    /// Reads the server-owned half of one session. Every absent field becomes null, which the
+    /// store reads as "not known" — this is where the old parser's <c>"floppy"</c> default and
+    /// its <c>isBrmbleClient: false</c> default are removed.
+    /// </summary>
+    private static ServerMappingEntry ReadEntry(JsonElement element) =>
+        new(ReadString(element, "matrixUserId"),
+            ReadCompanionId(element),
+            ReadNullableBool(element, "isBrmbleClient"),
+            ReadString(element, "certHash"));
+
+    /// <summary>
+    /// Prefers the custom companion over the legacy field. The legacy split transmits
+    /// <c>companionId: "floppy"</c> alongside the real selection in <c>customCompanionId</c>,
+    /// so reading the legacy field first would turn every custom skin into a floppy.
+    /// </summary>
+    private static string? ReadCompanionId(JsonElement element)
+    {
+        if (ReadString(element, "customCompanionId") is { } custom &&
+            custom.StartsWith("custom:$", StringComparison.Ordinal))
+            return custom;
+
+        return ReadString(element, "companionId");
+    }
+
+    private static string? ReadString(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static bool? ReadNullableBool(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value)
+            ? value.ValueKind switch
+            {
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                _ => null
+            }
+            : null;
+}

--- a/src/Brmble.Client/Services/Voice/ResyncThrottle.cs
+++ b/src/Brmble.Client/Services/Voice/ResyncThrottle.cs
@@ -1,0 +1,84 @@
+namespace Brmble.Client.Services.Voice;
+
+/// <summary>
+/// Rate-limits snapshot requests. A client whose cursor cannot be repaired — a server bug, a
+/// truncated event stream — would otherwise request a snapshot for every event it receives.
+/// </summary>
+/// <remarks>
+/// Time is passed in rather than read from a clock so the policy is testable without waiting.
+///
+/// <para>
+/// <see cref="Complete"/> is called when the request is <em>sent</em>, not when a snapshot
+/// arrives. The server silently drops a <c>requestSnapshot</c> that lands inside its own
+/// one-second per-socket cooldown and sends no reply of any kind, so completing on receipt
+/// would wedge <c>_inFlight</c> permanently on the first refusal.
+/// </para>
+/// </remarks>
+internal sealed class ResyncThrottle
+{
+    /// <summary>
+    /// Matches the server's own per-socket cooldown. Below this, extra requests are not merely
+    /// wasteful — they are dropped without a reply, so the client waits for a snapshot the
+    /// server already decided not to send.
+    /// </summary>
+    private static readonly TimeSpan MinimumSpacing = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan MaximumDelay = TimeSpan.FromSeconds(30);
+
+    private readonly object _gate = new();
+    private bool _inFlight;
+    private TimeSpan? _lastCompleted;
+
+    /// <summary>
+    /// A request has been sent that no snapshot has yet answered. Only a request made while
+    /// this is set widens the delay — that is what "gaps persist" means. Widening on every
+    /// request instead would penalise the healthy single resync that immediately succeeds.
+    /// </summary>
+    private bool _awaitingRepair;
+
+    public TimeSpan CurrentDelay { get; private set; } = MinimumSpacing;
+
+    public bool TryBegin(TimeSpan now)
+    {
+        lock (_gate)
+        {
+            if (_inFlight) return false;
+            if (_lastCompleted is { } last && now - last < CurrentDelay) return false;
+
+            // Widen only now that we know the previous request failed to repair the cursor.
+            // Doing this in Complete would apply the wider delay to the very request that is
+            // still in flight and may yet succeed.
+            if (_awaitingRepair)
+            {
+                var doubled = CurrentDelay * 2;
+                CurrentDelay = doubled > MaximumDelay ? MaximumDelay : doubled;
+            }
+
+            _inFlight = true;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Marks the request sent. Called on send rather than on receipt: a request the server
+    /// drops inside its cooldown produces no reply at all.
+    /// </summary>
+    public void Complete(TimeSpan now)
+    {
+        lock (_gate)
+        {
+            _inFlight = false;
+            _lastCompleted = now;
+            _awaitingRepair = true;
+        }
+    }
+
+    /// <summary>A snapshot landed and the cursor is healthy, so the backoff has done its job.</summary>
+    public void OnSnapshotApplied()
+    {
+        lock (_gate)
+        {
+            CurrentDelay = MinimumSpacing;
+            _awaitingRepair = false;
+        }
+    }
+}

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -233,6 +233,11 @@ public static class AuthEndpoints
                 sessionMappings = sessionMapping.GetSnapshot()
                     .ToDictionary(
                         kvp => kvp.Key.ToString(),
+                        // Legacy split deliberately. /auth/token carries no projection version --
+                        // it is fetched before the WebSocket exists -- and the split is lossless
+                        // to a projection-aware reader, which prefers customCompanionId. An old
+                        // client still needs the split, so there is nothing to gain by changing
+                        // this and a compatibility break to lose.
                         kvp => SessionMappingWire.From(kvp.Value)),
                 registered = result.IsRegistered,
                 registeredName = result.DisplayName,

--- a/src/Brmble.Server/Companions/CustomCompanionModels.cs
+++ b/src/Brmble.Server/Companions/CustomCompanionModels.cs
@@ -73,11 +73,37 @@ public sealed record CustomCompanionCapability(
     int MaxActiveTotal);
 
 public sealed record CompanionWireSelection(
-    string CompanionId,
+    string? CompanionId,
     string? CustomCompanionId)
 {
-    public static CompanionWireSelection FromPersisted(string selection) =>
-        Brmble.Server.Companions.CustomCompanionId.TryParse(selection, out _)
+    /// <summary>
+    /// The legacy split: a custom skin is sent as <c>"floppy"</c> plus the truth in
+    /// <c>customCompanionId</c>, because clients predating custom companions cannot parse
+    /// <c>custom:$…</c> in <c>companionId</c>.
+    /// </summary>
+    public static CompanionWireSelection FromPersisted(string? selection)
+    {
+        // A mapping with no companion at all is unknown, not a floppy. Nothing writes this
+        // today — SessionMapping.CompanionId is non-null — but the wire type must be able to
+        // express "unknown" or the projection's null-means-unknown rule has no way to reach it.
+        if (selection is null) return new(null, null);
+
+        return Brmble.Server.Companions.CustomCompanionId.TryParse(selection, out _)
             ? new("floppy", selection)
             : new(selection, null);
+    }
+
+    /// <summary>
+    /// Builds the companion fields for a client at the given projection version.
+    /// </summary>
+    /// <remarks>
+    /// Version 0 predates custom companions being first-class and cannot parse
+    /// <c>custom:$…</c> in <c>companionId</c>, so it gets <c>"floppy"</c> plus the truth in
+    /// <c>customCompanionId</c>. That is a lie told at the compatibility boundary; it must never
+    /// reach the projection.
+    /// </remarks>
+    public static CompanionWireSelection For(string? persisted, int projectionVersion) =>
+        projectionVersion >= 1
+            ? new CompanionWireSelection(persisted, null)
+            : FromPersisted(persisted);
 }

--- a/src/Brmble.Server/Events/ISessionMappingService.cs
+++ b/src/Brmble.Server/Events/ISessionMappingService.cs
@@ -32,6 +32,23 @@ public interface ISessionMappingService
     bool TryGetSessionByUserId(long userId, out int sessionId);
     bool TryGetMappingByUserId(long userId, out int sessionId, out SessionMapping? mapping);
     bool TryUpdateCompanionId(int sessionId, string companionId);
+
+    /// <summary>
+    /// Compare-and-swap on the companion field.
+    /// </summary>
+    /// <remarks>
+    /// Retained deliberately (spec §4.4 proposed retiring it). Revision rejection guards a client
+    /// submitting a mutation against a table it has since fallen behind. This guards a different
+    /// race entirely: a moderator deleting a custom companion resets every affected session to
+    /// <c>"floppy"</c> while an affected user may concurrently be selecting something else.
+    /// Neither party carries a client revision — <c>CustomCompanionEndpoints</c> computes its
+    /// target inside <c>PublishAsync</c>'s own gate — so there is no stale revision for the
+    /// revision path to reject. The two do not overlap.
+    ///
+    /// The CAS also gates the announcement: <c>PublishAsync</c> publishes only when the mutation
+    /// returns true, so a refused reset emits no <c>companionChanged</c> and therefore cannot
+    /// overwrite the user's newer choice on every other client.
+    /// </remarks>
     bool TryUpdateCompanionIdIfCurrent(int sessionId, string expectedCompanionId, string companionId);
     bool TryUpdateCompanionIdIfOwnedBy(int sessionId, long userId, string companionId);
     bool TryUpdateBrmbleStatus(int sessionId, bool? isBrmbleClient);

--- a/src/Brmble.Server/Events/SessionMappingWire.cs
+++ b/src/Brmble.Server/Events/SessionMappingWire.cs
@@ -36,7 +36,7 @@ public sealed record SessionMappingWire
     public required string MumbleName { get; init; }
 
     [JsonPropertyName("companionId")]
-    public required string CompanionId { get; init; }
+    public required string? CompanionId { get; init; }
 
     [JsonPropertyName("customCompanionId")]
     public string? CustomCompanionId { get; init; }
@@ -48,9 +48,17 @@ public sealed record SessionMappingWire
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? IsBrmbleClient { get; init; }
 
-    public static SessionMappingWire From(SessionMapping mapping)
+    /// <summary>
+    /// Builds one snapshot entry for a reader at the given projection version.
+    /// </summary>
+    /// <param name="projectionVersion">
+    /// 0 gets the legacy companion split; 1 and above get one truthful <c>companionId</c>.
+    /// Snapshots are always per-socket, so the reader's version is always known here — unlike a
+    /// broadcast, whose recipients are at mixed versions.
+    /// </param>
+    public static SessionMappingWire From(SessionMapping mapping, int projectionVersion = 0)
     {
-        var wire = Companions.CompanionWireSelection.FromPersisted(mapping.CompanionId);
+        var wire = Companions.CompanionWireSelection.For(mapping.CompanionId, projectionVersion);
         return new SessionMappingWire
         {
             MatrixUserId = mapping.MatrixUserId,

--- a/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
+++ b/src/Brmble.Server/WebSockets/BrmbleWebSocketHandler.cs
@@ -38,12 +38,17 @@ public static class BrmbleWebSocketHandler
         var activeSessions = context.RequestServices.GetRequiredService<IActiveBrmbleSessions>();
         var publisher = context.RequestServices.GetRequiredService<IMappingEventPublisher>();
 
+        // Read before the socket is accepted, so the version is known while the bootstrap
+        // payloads are built.
+        var projectionVersion = ParseProjectionVersion(context.Request.Query["pv"]);
+
         using var ws = await context.WebSockets.AcceptWebSocketAsync();
         try
         {
             await InitializeAcceptedClientAsync(
                 ws, user.Id, hash, sessionMapping, eventBus, publisher, activeSessions,
-                context.RequestServices.GetRequiredService<IDuelSnapshotProvider>());
+                context.RequestServices.GetRequiredService<IDuelSnapshotProvider>(),
+                projectionVersion);
 
             // Read loop until close. Messages are reassembled across frames. A message that
             // exceeds the cap is discarded in full rather than truncated: truncating would let a
@@ -100,8 +105,12 @@ public static class BrmbleWebSocketHandler
                 // leave a window in which an event at a later revision reaches this socket first,
                 // and the client would either discard the repair it was waiting for or apply the
                 // event and be rolled back by the older snapshot.
+                //
+                // Per-socket, so it carries this reader's projection version. Forgetting that
+                // here would give a resyncing pv=1 client the legacy split — a bug that only
+                // shows after a gap, and only for custom companions.
                 await publisher.PublishSnapshotAsync(ws, (envelope, snapshot) =>
-                    CreateSessionMappingSnapshotPayload(snapshot, envelope));
+                    CreateSessionMappingSnapshotPayload(snapshot, envelope, projectionVersion));
 
                 // Unrelated to mapping ordering, so it can safely follow an await.
                 sessionMapping.TryGetSessionByUserId(user.Id, out var resyncSessionId);
@@ -123,9 +132,18 @@ public static class BrmbleWebSocketHandler
         }
     }
 
+    /// <summary>
+    /// Reads the client's projection version from the <c>pv</c> query parameter. Absent or
+    /// malformed means version 0, which gets the legacy companion split.
+    /// </summary>
+    internal static int ParseProjectionVersion(string? raw) =>
+        int.TryParse(raw, out var version) && version > 0 ? version : 0;
+
     internal static object CreateUserMappingAddedPayload(
         int sessionId, SessionMapping mapping, string certHash, MappingEnvelope envelope)
     {
+        // Broadcast: recipients are at mixed projection versions, so this must carry the legacy
+        // split. Only per-socket payloads know their reader's version.
         var wire = CompanionWireSelection.FromPersisted(mapping.CompanionId);
         return new
         {
@@ -157,7 +175,8 @@ public static class BrmbleWebSocketHandler
         IBrmbleEventBus eventBus,
         IMappingEventPublisher publisher,
         IActiveBrmbleSessions activeSessions,
-        IDuelSnapshotProvider snapshots) =>
+        IDuelSnapshotProvider snapshots,
+        int projectionVersion = 0) =>
         eventBus.AddClientAsync(socket, userId, async () =>
         {
             if (sessionMapping.TryGetMappingByUserId(userId, out var sessionId, out var mapping))
@@ -188,7 +207,8 @@ public static class BrmbleWebSocketHandler
             var bootstrapEnvelope = MappingEnvelope.Snapshot(
                 sessionMapping.InstanceId, sessionMapping.Revision);
             return await BuildInitialPayloadsAsync(
-                snapshots, queueSessionId, sessionMapping.GetSnapshot(), bootstrapEnvelope);
+                snapshots, queueSessionId, sessionMapping.GetSnapshot(), bootstrapEnvelope,
+                projectionVersion);
         });
 
     /// <summary>
@@ -200,9 +220,13 @@ public static class BrmbleWebSocketHandler
         IDuelSnapshotProvider snapshots,
         long sessionId,
         IReadOnlyDictionary<int, SessionMapping> mappings,
-        MappingEnvelope envelope)
+        MappingEnvelope envelope,
+        int projectionVersion = 0)
     {
-        var initial = new List<object> { CreateSessionMappingSnapshotPayload(mappings, envelope) };
+        var initial = new List<object>
+        {
+            CreateSessionMappingSnapshotPayload(mappings, envelope, projectionVersion)
+        };
         if (sessionId != 0)
             initial.Add(DuelWire.ToEvent(await snapshots.GetSnapshotForSessionAsync(sessionId)));
         return initial;
@@ -212,8 +236,14 @@ public static class BrmbleWebSocketHandler
     /// The complete statement of every session the server knows about. Shared by the bootstrap
     /// and resync paths so both describe membership identically.
     /// </summary>
+    /// <param name="projectionVersion">
+    /// The reader's projection version. Both callers are per-socket, so this is always known;
+    /// a snapshot is never broadcast.
+    /// </param>
     internal static object CreateSessionMappingSnapshotPayload(
-        IReadOnlyDictionary<int, SessionMapping> mappings, MappingEnvelope envelope) =>
+        IReadOnlyDictionary<int, SessionMapping> mappings,
+        MappingEnvelope envelope,
+        int projectionVersion = 0) =>
         new
         {
             type = "sessionMappingSnapshot",
@@ -221,7 +251,7 @@ public static class BrmbleWebSocketHandler
             revision = envelope.Revision,
             mappings = mappings.ToDictionary(
                 kvp => kvp.Key.ToString(),
-                kvp => SessionMappingWire.From(kvp.Value))
+                kvp => SessionMappingWire.From(kvp.Value, projectionVersion))
         };
 
     /// <summary>

--- a/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
+++ b/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
@@ -124,6 +124,11 @@ vi.mock('./bridge', () => {
       }),
       __emit: (event: string, data?: unknown) => {
         handlers.get(event)?.forEach(handler => handler(data));
+        // The client emits membership as voice.usersReset immediately after voice.connected.
+        const users = (data as { users?: unknown[] } | undefined)?.users;
+        if (event === 'voice.connected' && users) {
+          handlers.get('voice.usersReset')?.forEach(handler => handler({ users }));
+        }
       },
       __reset: () => handlers.clear(),
     },

--- a/src/Brmble.Web/src/App.customCompanion.test.tsx
+++ b/src/Brmble.Web/src/App.customCompanion.test.tsx
@@ -145,6 +145,11 @@ vi.mock('./bridge', () => {
       }),
       __emit: (event: string, data?: unknown) => {
         handlers.get(event)?.forEach(handler => handler(data));
+        // The client emits membership as voice.usersReset immediately after voice.connected.
+        const users = (data as { users?: unknown[] } | undefined)?.users;
+        if (event === 'voice.connected' && users) {
+          handlers.get('voice.usersReset')?.forEach(handler => handler({ users }));
+        }
       },
       __reset: () => handlers.clear(),
     },

--- a/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
+++ b/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
@@ -117,7 +117,14 @@ vi.mock('./bridge', () => {
     send: vi.fn(),
     on: vi.fn((event: string, handler: (data: unknown) => void) => { if (!handlers.has(event)) handlers.set(event, new Set()); handlers.get(event)!.add(handler); }),
     off: vi.fn((event: string, handler: (data: unknown) => void) => handlers.get(event)?.delete(handler)),
-    __emit: (event: string, data?: unknown) => handlers.get(event)?.forEach(handler => handler(data)),
+    __emit: (event: string, data?: unknown) => {
+      handlers.get(event)?.forEach(handler => handler(data));
+      // The client emits membership as voice.usersReset immediately after voice.connected.
+      const users = (data as { users?: unknown[] } | undefined)?.users;
+      if (event === 'voice.connected' && users) {
+        handlers.get('voice.usersReset')?.forEach(handler => handler({ users }));
+      }
+    },
     __reset: () => handlers.clear(),
   } };
 });

--- a/src/Brmble.Web/src/App.duelOrchestration.test.tsx
+++ b/src/Brmble.Web/src/App.duelOrchestration.test.tsx
@@ -62,7 +62,14 @@ vi.mock('./bridge', () => {
       handlers.get(event)!.add(handler);
     }),
     off: vi.fn((event: string, handler: (data: unknown) => void) => handlers.get(event)?.delete(handler)),
-    __emit: (event: string, data?: unknown) => handlers.get(event)?.forEach(handler => handler(data)),
+    __emit: (event: string, data?: unknown) => {
+      handlers.get(event)?.forEach(handler => handler(data));
+      // The client emits membership as voice.usersReset immediately after voice.connected.
+      const users = (data as { users?: unknown[] } | undefined)?.users;
+      if (event === 'voice.connected' && users) {
+        handlers.get('voice.usersReset')?.forEach(handler => handler({ users }));
+      }
+    },
     __reset: () => handlers.clear(),
   } };
 });

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -101,6 +101,17 @@ const {
       for (const handler of handlers.get(type) ?? []) {
         handler(data);
       }
+      // The client emits membership as voice.usersReset immediately after voice.connected,
+      // and every incremental row change as voice.usersChanged.
+      const users = (data as { users?: unknown[] } | undefined)?.users;
+      if (type === 'voice.connected' && users) {
+        for (const handler of handlers.get('voice.usersReset') ?? []) handler({ users });
+      }
+      if (type === 'voice.userJoined') {
+        for (const handler of handlers.get('voice.usersChanged') ?? []) {
+          handler({ changed: [data], removed: [] });
+        }
+      }
     },
   };
 
@@ -3457,11 +3468,19 @@ describe('active share discovery', () => {
     });
 
     act(() => {
-      bridge.emit('voice.userMappingUpdated', {
-        sessionId: 2,
-        matrixUserId: '@alice:example.com',
-        companionId: 'retro',
-        action: 'added',
+      // The mapping now arrives as a complete row on voice.usersChanged rather than as a
+      // field-level voice.userMappingUpdated patch.
+      bridge.emit('voice.usersChanged', {
+        changed: [{
+          session: 2,
+          name: 'alice',
+          self: false,
+          channelId: 1,
+          matrixUserId: '@alice:example.com',
+          companionId: 'retro',
+          isBrmbleClient: null,
+        }],
+        removed: [],
       });
     });
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo, useReducer } from 'react';
 import bridge from './bridge';
-import type { ConnectionStatus, ChatMessage, MediaAttachment, NativeBrmbleServiceStatus, ServiceStatus, ServiceStatusMap } from './types';
+import type { ConnectionStatus, ChatMessage, MediaAttachment, NativeBrmbleServiceStatus, ServiceStatus, ServiceStatusMap, User } from './types';
 import { prepareImageForMumble, type PreparedMumbleImage } from './utils/imageUpload';
 import { useMatrixClient } from './hooks/useMatrixClient';
+import { useUserDirectory } from './hooks/useUserDirectory';
 import type { MatrixCredentials } from './hooks/useMatrixClient';
 import { useScreenShare } from './hooks/useScreenShare';
 import type { LocalShareStopReason, ShareInfo, WatchedShareEndReason } from './hooks/useScreenShare';
@@ -59,7 +60,6 @@ import {
   BUILT_IN_COMPANIONS,
   DEFAULT_OVERLAY,
   companionForServer,
-  normalizeCompanionBridgeSelection,
   normalizeCompanionId,
   normalizeOverlaySettings,
   resolveCompanionDisplay,
@@ -648,20 +648,6 @@ interface Channel {
   canSendChat?: boolean;
 }
 
-interface User {
-  session: number;
-  name: string;
-  channelId?: number;
-  muted?: boolean;
-  deafened?: boolean;
-  self?: boolean;
-  comment?: string;
-  matrixUserId?: string;
-  avatarUrl?: string;
-  certHash?: string;
-  companionId?: CompanionId;
-  isBrmbleClient?: boolean;
-}
 
 interface BrmbleDMUser {
   matrixUserId: string;
@@ -1029,7 +1015,9 @@ function App() {
   const [serverLabel, setServerLabel] = useState('');
   
   const [channels, setChannels] = useState<Channel[]>([]);
-  const [users, setUsers] = useState<User[]>([]);
+  // The user list, its avatar map, and the ref consumers read from. Declared here rather than
+  // beside the other refs because resolveGamePlayerName below reads usersRef.
+  const { users, usersRef, reset: resetUsers, apply: applyUsers, setAvatar } = useUserDirectory();
   const [currentChannelId, setCurrentChannelIdRaw] = useState<string | undefined>();
   const [currentChannelName, setCurrentChannelName] = useState<string>('');
   // Snapshot of the read-marker timestamp at the moment a channel/DM is opened,
@@ -1431,9 +1419,7 @@ function App() {
     },
     onUserAvatarChanged: (matrixUserId: string, avatarUrl: string | null) => {
       fetchedAvatarIdsRef.current.delete(matrixUserId);
-      setUsers(prev => prev.map(u =>
-        u.matrixUserId === matrixUserId ? { ...u, avatarUrl: avatarUrl ?? undefined } : u
-      ));
+      setAvatar(matrixUserId, avatarUrl ?? undefined);
     },
   }), []);
   const matrixClient = useMatrixClient(matrixCredentials, matrixOverlayCallbacks);
@@ -1556,15 +1542,14 @@ function App() {
     });
   }, [matrixCredentials?.userId, matrixClient.client, matrixClient.fetchAvatarUrl]);
 
-  // Keep the self user's avatarUrl in the users array in sync with currentUserAvatarUrl
+  // Keep the self user's avatar in the avatar map in sync with currentUserAvatarUrl.
+  // Keyed by matrix id like every other avatar, so it survives a reconnect.
   useEffect(() => {
     if (currentUserAvatarUrl === undefined) return;
-    setUsers(prev => {
-      const self = prev.find(u => u.self);
-      if (!self || self.avatarUrl === currentUserAvatarUrl) return prev;
-      return prev.map(u => u.self ? { ...u, avatarUrl: currentUserAvatarUrl } : u);
-    });
-  }, [currentUserAvatarUrl]);
+    const selfMatrixUserId = matrixCredentials?.userId;
+    if (!selfMatrixUserId) return;
+    setAvatar(selfMatrixUserId, currentUserAvatarUrl);
+  }, [currentUserAvatarUrl, matrixCredentials?.userId, setAvatar]);
 
   // Track which matrixUserIds we've already fetched avatars for to avoid re-fetching.
   // Maps matrixUserId -> what is known about the fetch already made for them.
@@ -1610,30 +1595,30 @@ function App() {
       await matrixClient.client.setAvatarUrl(mxcUrl);
       const httpUrl = matrixClient.client.mxcUrlToHttp(mxcUrl, 128, 128, 'crop');
       setCurrentUserAvatarUrl(httpUrl ?? undefined);
-      // Also update the self user in the users list so channel tree / chat show the new avatar
-      if (httpUrl) {
-        setUsers(prev => prev.map(u => u.self ? { ...u, avatarUrl: httpUrl } : u));
+      // Also update the self user in the avatar map so channel tree / chat show the new avatar
+      if (httpUrl && matrixCredentials?.userId) {
+        setAvatar(matrixCredentials.userId, httpUrl);
       }
       // Notify backend so Mumble texture sync won't overwrite this avatar
       bridge.send('avatar.setSource', { source: 'brmble' });
     } catch (e) {
       console.error('Failed to upload avatar:', e);
     }
-  }, [matrixClient.client]);
+  }, [matrixClient.client, matrixCredentials?.userId, setAvatar]);
 
   const onRemoveAvatar = useCallback(async () => {
     if (!matrixClient.client) return;
     try {
       await matrixClient.client.setAvatarUrl('');
       setCurrentUserAvatarUrl(undefined);
-      // Also clear the self user's avatar in the users list
-      setUsers(prev => prev.map(u => u.self ? { ...u, avatarUrl: undefined } : u));
+      // Also clear the self user's avatar in the avatar map
+      if (matrixCredentials?.userId) setAvatar(matrixCredentials.userId, undefined);
       // Clear avatar source so Mumble textures can take over again
       bridge.send('avatar.setSource', { source: null });
     } catch (e) {
       console.error('Failed to remove avatar:', e);
     }
-  }, [matrixClient.client]);
+  }, [matrixClient.client, matrixCredentials?.userId, setAvatar]);
 
   // Build set of DM room IDs from matrixClient.dmRoomMap
   const dmRoomIds = useMemo(() => {
@@ -1775,8 +1760,6 @@ function App() {
   }, [bridge]);
 
   // Refs to avoid re-registering bridge handlers on every state change
-  const usersRef = useRef(users);
-  usersRef.current = users;
   const isSharingRef = useRef(false);
   const stopSharingRef = useRef<(() => Promise<void>) | null>(null);
   const previousChannelIdRef = useRef<Map<number, number | undefined>>(new Map());
@@ -1907,9 +1890,7 @@ function App() {
       fetchedAvatarIdsRef.current.set(matrixUserId, { attempts: attempt + 1, session });
       fetchAvatarUrlRef.current(matrixUserId).then((url) => {
         if (url) {
-          setUsers(prev => prev.map(u =>
-            u.session === session ? { ...u, avatarUrl: url } : u
-          ));
+          setAvatar(matrixUserId, url);
           return;
         }
         // Avatar not available yet — schedule retry (e.g. Mumble texture still uploading)
@@ -2172,35 +2153,8 @@ function App() {
       if (d?.channels) {
         setChannels(getOrderedChannels(d.channels));
       }
-      if (d?.users) {
-        setUsers(d.users);
-        const selfUser = d.users.find(u => u.self);
-        if (selfUser) {
-          setSelfMuted(selfUser.muted || false);
-          setSelfDeafened(selfUser.deafened || false);
-          setSelfSession(selfUser.session);
-          const capability = matrixCredentialsRef.current?.customCompanions;
-          const storedSelection = capability
-            ? companionForServer(overlaySettingsRef.current, capability.galleryRoomId)
-            : normalizeCompanionId(overlaySettingsRef.current.myCompanion);
-          const desiredSelection = !capability && storedSelection.startsWith('custom:')
-            ? 'floppy'
-            : storedSelection;
-          if (selfUser.companionId && selfUser.companionId !== desiredSelection) {
-            const requestId = ++companionRequestIdRef.current;
-            pendingCompanionRef.current = {
-              requestId,
-            };
-            bridge.send('voice.setCompanion', { companionId: desiredSelection, requestId });
-          }
-        }
-        // Fetch avatars for users already present at connect time
-        for (const u of d.users) {
-          if (u.matrixUserId && !u.self && !u.avatarUrl) {
-            fetchAvatarForUser(u.session, u.matrixUserId);
-          }
-        }
-      }
+      // Membership no longer rides on voice.connected; it arrives as voice.usersReset,
+      // which fires immediately after this and owns the self-state derivation.
 
       // Persist Mumble registration status to the saved server entry.
       // Password is intentionally omitted here (not stored in localStorage);
@@ -2270,7 +2224,7 @@ function App() {
         updateStatus('voice', { state: 'disconnected', label: undefined });
       }
       setChannels([]);
-      setUsers([]);
+      resetUsers([]);
       setCurrentChannelId(undefined);
       setCurrentChannelName('');
       setSelfMuted(false);
@@ -2536,93 +2490,134 @@ function App() {
       }
     });
 
-    const onVoiceUserJoined = ((data: unknown) => {
-      const d = data as { session: number; name: string; channelId?: number; muted?: boolean; deafened?: boolean; self?: boolean; comment?: string; matrixUserId?: string; certHash?: string; companionId?: CompanionId; isBrmbleClient?: boolean } | undefined;
-      if (d?.session && d.channelId !== undefined) {
-        const previousChannelId = previousChannelIdRef.current.get(d.session);
-        const knownUser = usersRef.current.find(u => u.session === d.session);
-        const lastKnownChannelId = previousChannelId ?? knownUser?.channelId;
-        const selfUser = usersRef.current.find(u => u.self);
-        const selfChannelId = selfUser?.channelId;
-        const enteredSelfChannel = !d.self
-          && selfChannelId !== undefined
-          && d.channelId === selfChannelId
-          && lastKnownChannelId !== selfChannelId;
-        
-        setUsers(prev => {
-          const existing = prev.find(u => u.session === d.session);
-          if (existing) {
-            const updatedChannelId = d.channelId !== undefined ? d.channelId : existing.channelId;
-            // Preserve certHash and matrixUserId — don't let falsy updates overwrite valid values
-            const certHash = d.certHash || existing.certHash;
-            const matrixUserId = d.matrixUserId || existing.matrixUserId;
-            // A user state carries no companion for a session the client has no mapping for,
-            // which is not the same as the user having no companion.
-            const companionId = d.companionId ?? existing.companionId;
-            const isBrmbleClient = d.isBrmbleClient !== undefined ? d.isBrmbleClient : existing.isBrmbleClient;
-            return prev.map(u => u.session === d.session ? { ...u, ...d, channelId: updatedChannelId, certHash, matrixUserId, companionId, isBrmbleClient } : u);
-          }
-          return [...prev, d];
-        });
+    /**
+     * Presentation side effects for one changed row: join/mute announcements, avatar fetch and
+     * DM presence. The row itself is applied by the caller; this only reacts to it.
+     *
+     * Must be called BEFORE the row is applied, because it compares against usersRef to decide
+     * what actually changed.
+     */
+    const announceRowChange = (d: User) => {
+      if (!d?.session || d.channelId === undefined) return;
 
-        // Fetch avatar for newly joined user if they have a matrixUserId
-        if (d.matrixUserId && !d.self) {
-          fetchAvatarForUser(d.session, d.matrixUserId);
-        }
+      const previousChannelId = previousChannelIdRef.current.get(d.session);
+      const knownUser = usersRef.current.find(u => u.session === d.session);
+      const lastKnownChannelId = previousChannelId ?? knownUser?.channelId;
+      const selfUser = usersRef.current.find(u => u.self);
+      const selfChannelId = selfUser?.channelId;
+      const enteredSelfChannel = !d.self
+        && selfChannelId !== undefined
+        && d.channelId === selfChannelId
+        && lastKnownChannelId !== selfChannelId;
 
+      // Fetch avatar for newly joined user if they have a matrixUserId
+      if (d.matrixUserId && !d.self) {
+        fetchAvatarForUser(d.session, d.matrixUserId);
+      }
+
+      if (enteredSelfChannel) {
+        speakText(`${d.name} joined`);
+      }
+
+      previousChannelIdRef.current.set(d.session, d.channelId);
+
+      const overlaySettings = overlaySettingsRef.current;
+      if (overlaySettings.overlayEnabled) {
         if (enteredSelfChannel) {
-          speakText(`${d.name} joined`);
-        }
-        
-        previousChannelIdRef.current.set(d.session, d.channelId);
-
-        const overlaySettings = overlaySettingsRef.current;
-        if (overlaySettings.overlayEnabled) {
-          if (enteredSelfChannel) {
+          setOverlaySnapshot((prev) => {
+            const now = Date.now();
+            const next = appendOverlayEvent(
+              prev,
+              createMembershipOverlayEvent({
+                kind: 'user-joined',
+                actorName: d.name,
+                currentChannelId: prev.currentChannelId,
+                eventChannelId: String(d.channelId),
+                timestamp: now,
+              }),
+              overlaySettings,
+            );
+            return resolveFullCompanionDisplay(next, now);
+          });
+        } else if (knownUser && knownUser.muted !== undefined && d.muted !== undefined && knownUser.muted !== d.muted) {
+          const inSameChannel = !d.self && selfChannelId !== undefined && (d.channelId ?? knownUser.channelId) === selfChannelId;
+          if (inSameChannel) {
             setOverlaySnapshot((prev) => {
               const now = Date.now();
               const next = appendOverlayEvent(
                 prev,
                 createMembershipOverlayEvent({
-                  kind: 'user-joined',
+                  kind: d.muted ? 'user-muted' : 'user-unmuted',
                   actorName: d.name,
                   currentChannelId: prev.currentChannelId,
-                  eventChannelId: String(d.channelId),
+                  eventChannelId: String(d.channelId ?? knownUser.channelId),
                   timestamp: now,
                 }),
                 overlaySettings,
               );
               return resolveFullCompanionDisplay(next, now);
             });
-          } else if (knownUser && knownUser.muted !== undefined && d.muted !== undefined && knownUser.muted !== d.muted) {
-            const inSameChannel = !d.self && selfChannelId !== undefined && (d.channelId ?? knownUser.channelId) === selfChannelId;
-            if (inSameChannel) {
-              setOverlaySnapshot((prev) => {
-                const now = Date.now();
-                const next = appendOverlayEvent(
-                  prev,
-                  createMembershipOverlayEvent({
-                    kind: d.muted ? 'user-muted' : 'user-unmuted',
-                    actorName: d.name,
-                    currentChannelId: prev.currentChannelId,
-                    eventChannelId: String(d.channelId ?? knownUser.channelId),
-                    timestamp: now,
-                  }),
-                  overlaySettings,
-                );
-                return resolveFullCompanionDisplay(next, now);
-              });
-            }
           }
         }
+      }
 
-        // Update Mumble DM contact session on reconnect
-        if (d.certHash && !d.self) {
-          dmStoreRef.current.updateMumbleSession(d.certHash, d.session, d.name);
+      // Update Mumble DM contact session on reconnect
+      if (d.certHash && !d.self) {
+        dmStoreRef.current.updateMumbleSession(d.certHash, d.session, d.name);
+      }
+    };
+
+    /**
+     * Membership replaced wholesale. Owns the self-state derivation that used to hang off
+     * voice.connected, so there is one path by which the list is populated.
+     */
+    const onVoiceUsersReset = ((data: unknown) => {
+      const d = data as { users: User[] } | undefined;
+      if (!d?.users) return;
+
+      resetUsers(d.users);
+
+      const selfUser = d.users.find(u => u.self);
+      if (selfUser) {
+        setSelfMuted(selfUser.muted || false);
+        setSelfDeafened(selfUser.deafened || false);
+        setSelfSession(selfUser.session);
+        const capability = matrixCredentialsRef.current?.customCompanions;
+        const storedSelection = capability
+          ? companionForServer(overlaySettingsRef.current, capability.galleryRoomId)
+          : normalizeCompanionId(overlaySettingsRef.current.myCompanion);
+        const desiredSelection = !capability && storedSelection.startsWith('custom:')
+          ? 'floppy'
+          : storedSelection;
+        if (selfUser.companionId && selfUser.companionId !== desiredSelection) {
+          const requestId = ++companionRequestIdRef.current;
+          pendingCompanionRef.current = { requestId };
+          bridge.send('voice.setCompanion', { companionId: desiredSelection, requestId });
         }
+      }
 
+      for (const u of d.users) {
+        if (u.matrixUserId && !u.self) {
+          fetchAvatarForUser(u.session, u.matrixUserId);
+        }
+        if (u.channelId !== undefined) previousChannelIdRef.current.set(u.session, u.channelId);
       }
     });
+
+    /**
+     * The only incremental user-state event. Rows are complete, so they replace by session id;
+     * announcements run first, while usersRef still holds the previous state.
+     */
+    const onVoiceUsersChanged = ((data: unknown) => {
+      const d = data as { changed: User[]; removed: number[] } | undefined;
+      if (!d) return;
+
+      for (const row of d.changed ?? []) announceRowChange(row);
+      for (const session of d.removed ?? []) previousChannelIdRef.current.delete(session);
+
+      applyUsers({ changed: d.changed ?? [], removed: d.removed ?? [] });
+    });
+
 
     const onVoiceChannelJoined = ((data: unknown) => {
       const d = data as Channel | undefined;
@@ -2762,7 +2757,8 @@ function App() {
           });
         }
 
-        setUsers(prev => prev.filter(u => u.session !== d.session));
+        // No list mutation: voice.userLeft is presentation only. The row is removed by the
+        // removed[] entry in voice.usersChanged, which is the sole owner of membership.
       }
     });
 
@@ -2883,15 +2879,6 @@ function App() {
           );
           return resolveFullCompanionDisplay(next, now);
         });
-      }
-    });
-
-    const onVoiceUserCommentChanged = ((data: unknown) => {
-      const d = data as { session: number; comment?: string } | undefined;
-      if (d?.session !== undefined) {
-        setUsers(prev => prev.map(u =>
-          u.session === d.session ? { ...u, comment: d.comment } : u
-        ));
       }
     });
 
@@ -3040,7 +3027,7 @@ function App() {
       setServerAddress('');
       setServerLabel('');
       setChannels([]);
-      setUsers([]);
+      resetUsers([]);
       setCurrentChannelId(undefined);
       setCurrentChannelName('');
       setSelfMuted(false);
@@ -3050,58 +3037,6 @@ function App() {
       setSelfSession(0);
       setSpeakingUsers(new Map());
       setCurrentUserAvatarUrl(undefined);
-    };
-
-    const onUserMappingUpdated = (data: unknown) => {
-      const d = data as { sessionId: number; matrixUserId?: string; companionId?: CompanionId; certHash?: string; isBrmbleClient?: boolean; action: string } | undefined;
-      if (d?.sessionId !== undefined) {
-        setUsers(prev => prev.map(u =>
-          u.session === d.sessionId
-            ? {
-              ...u,
-              matrixUserId: d.action === 'added' ? d.matrixUserId : undefined,
-              companionId: d.action === 'added' ? (d.companionId ?? u.companionId) : u.companionId,
-              certHash: d.action === 'added' ? (d.certHash ?? u.certHash) : u.certHash,
-              isBrmbleClient: d.action === 'added' ? d.isBrmbleClient : undefined,
-            }
-            : u
-        ));
-        // Fetch avatar for the newly mapped user if they don't have one yet
-        if (d.action === 'added' && d.matrixUserId) {
-          fetchAvatarForUser(d.sessionId, d.matrixUserId);
-        }
-      }
-    };
-
-    const onSessionMappingSnapshot = (data: unknown) => {
-      const d = data as { mappings: Record<string, { matrixUserId: string; mumbleName: string; companionId?: CompanionId; certHash?: string; isBrmbleClient?: boolean }> } | undefined;
-      if (d?.mappings && typeof d.mappings === 'object') {
-        setUsers(prev => {
-          const mappingMap = new Map<number, { matrixUserId: string; companionId?: CompanionId; certHash?: string; isBrmbleClient?: boolean }>();
-          for (const [sid, entry] of Object.entries(d.mappings)) {
-            mappingMap.set(Number(sid), { matrixUserId: entry.matrixUserId, companionId: entry.companionId, certHash: entry.certHash, isBrmbleClient: entry.isBrmbleClient });
-          }
-          return prev.map(u => {
-            const m = mappingMap.get(u.session);
-            return m ? { ...u, matrixUserId: m.matrixUserId, companionId: m.companionId ?? u.companionId, certHash: m.certHash ?? u.certHash, isBrmbleClient: m.isBrmbleClient } : u;
-          });
-        });
-        // Fetch avatars for users that gained a matrixUserId
-        for (const [sid, entry] of Object.entries(d.mappings)) {
-          fetchAvatarForUser(Number(sid), entry.matrixUserId);
-        }
-      }
-    };
-
-    const onVoiceCompanionChanged = (data: unknown) => {
-      const d = data as {
-        session?: number;
-        companionId?: unknown;
-        customCompanionId?: unknown;
-      } | undefined;
-      if (d?.session === undefined) return;
-      const companionId = normalizeCompanionBridgeSelection(d);
-      setUsers(prev => prev.map(u => u.session === d.session ? { ...u, companionId } : u));
     };
 
     const onVoiceSetCompanionResponse = (data: unknown) => {
@@ -3127,24 +3062,6 @@ function App() {
       }
       setConnectionError(d?.error ?? 'Failed to sync companion');
       notifQueue.register('companion-sync-error', 'error');
-    };
-
-    const onBrmbleClientActivated = (data: unknown) => {
-      const d = data as { sessionId: number } | undefined;
-      if (d?.sessionId !== undefined) {
-        setUsers(prev => prev.map(u =>
-          u.session === d.sessionId ? { ...u, isBrmbleClient: true } : u
-        ));
-      }
-    };
-
-    const onBrmbleClientDeactivated = (data: unknown) => {
-      const d = data as { sessionId: number } | undefined;
-      if (d?.sessionId !== undefined) {
-        setUsers(prev => prev.map(u =>
-          u.session === d.sessionId ? { ...u, isBrmbleClient: false } : u
-        ));
-      }
     };
 
     const onRegistrationStatus = (data: unknown) => {
@@ -3208,7 +3125,8 @@ function App() {
     bridge.on('voice.message', onVoiceMessage);
     bridge.on('voice.system', onVoiceSystem);
     bridge.on('game.feed', onGameFeed);
-    bridge.on('voice.userJoined', onVoiceUserJoined);
+    bridge.on('voice.usersReset', onVoiceUsersReset);
+    bridge.on('voice.usersChanged', onVoiceUsersChanged);
     bridge.on('voice.channelJoined', onVoiceChannelJoined);
     bridge.on('voice.channelRemoved', onVoiceChannelRemoved);
     bridge.on('voice.userLeft', onVoiceUserLeft);
@@ -3220,7 +3138,6 @@ function App() {
     bridge.on('voice.userSpeaking', onVoiceUserSpeaking);
     bridge.on('voice.userSilent', onVoiceUserSilent);
     bridge.on('voice.moderation', onVoiceModeration);
-    bridge.on('voice.userCommentChanged', onVoiceUserCommentChanged);
     bridge.on('voice.shortcutPressed', onShortcutPressed);
     bridge.on('voice.shortcutReleased', onShortcutReleased);
     bridge.on('voice.toggleDmScreen', onToggleDmScreen);
@@ -3263,12 +3180,7 @@ function App() {
     bridge.on('voice.reconnectFailed', onVoiceReconnectFailed);
     bridge.on('server.credentials', onServerCredentials);
     bridge.on('voice.authError', onVoiceAuthError);
-    bridge.on('voice.userMappingUpdated', onUserMappingUpdated);
-    bridge.on('voice.sessionMappingSnapshot', onSessionMappingSnapshot);
-    bridge.on('voice.companionChanged', onVoiceCompanionChanged);
     bridge.on('voice.setCompanionResponse', onVoiceSetCompanionResponse);
-    bridge.on('voice.brmbleClientActivated', onBrmbleClientActivated);
-    bridge.on('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
     bridge.on('voice.registrationStatus', onRegistrationStatus);
     bridge.on('chat.channelAccess', onChatChannelAccess);
     bridge.on('chat.channelAccessError', onChatChannelAccessError);
@@ -3298,7 +3210,8 @@ function App() {
       bridge.off('voice.message', onVoiceMessage);
       bridge.off('voice.system', onVoiceSystem);
       bridge.off('game.feed', onGameFeed);
-      bridge.off('voice.userJoined', onVoiceUserJoined);
+      bridge.off('voice.usersReset', onVoiceUsersReset);
+      bridge.off('voice.usersChanged', onVoiceUsersChanged);
       bridge.off('voice.channelJoined', onVoiceChannelJoined);
       bridge.off('voice.channelRemoved', onVoiceChannelRemoved);
       bridge.off('voice.userLeft', onVoiceUserLeft);
@@ -3310,7 +3223,6 @@ function App() {
       bridge.off('voice.userSpeaking', onVoiceUserSpeaking);
       bridge.off('voice.userSilent', onVoiceUserSilent);
       bridge.off('voice.moderation', onVoiceModeration);
-      bridge.off('voice.userCommentChanged', onVoiceUserCommentChanged);
       bridge.off('voice.loss', onVoiceLoss);
       bridge.off('voice.shortcutPressed', onShortcutPressed);
       bridge.off('voice.shortcutReleased', onShortcutReleased);
@@ -3330,12 +3242,7 @@ function App() {
       bridge.off('voice.reconnectFailed', onVoiceReconnectFailed);
       bridge.off('server.credentials', onServerCredentials);
       bridge.off('voice.authError', onVoiceAuthError);
-      bridge.off('voice.userMappingUpdated', onUserMappingUpdated);
-      bridge.off('voice.sessionMappingSnapshot', onSessionMappingSnapshot);
-      bridge.off('voice.companionChanged', onVoiceCompanionChanged);
       bridge.off('voice.setCompanionResponse', onVoiceSetCompanionResponse);
-      bridge.off('voice.brmbleClientActivated', onBrmbleClientActivated);
-      bridge.off('voice.brmbleClientDeactivated', onBrmbleClientDeactivated);
       bridge.off('voice.registrationStatus', onRegistrationStatus);
       bridge.off('chat.channelAccess', onChatChannelAccess);
       bridge.off('chat.channelAccessError', onChatChannelAccessError);
@@ -3715,7 +3622,7 @@ const handleConnect = (serverData: SavedServer) => {
         setServerAddress('');
         setUsername('');
         setChannels([]);
-        setUsers([]);
+        resetUsers([]);
         setCurrentChannelId(undefined);
         setCurrentChannelName('');
         setSelfMuted(false);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1887,7 +1887,7 @@ function App() {
     const maxAttempts = 3;
 
     const attemptFetch = (attempt: number) => {
-      fetchedAvatarIdsRef.current.set(matrixUserId, { attempts: attempt + 1, session });
+      fetchedAvatarIdsRef.current.set(matrixUserId, { attempts: attempt + 1 });
       fetchAvatarUrlRef.current(matrixUserId).then((url) => {
         if (url) {
           setAvatar(matrixUserId, url);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1015,9 +1015,13 @@ function App() {
   const [serverLabel, setServerLabel] = useState('');
   
   const [channels, setChannels] = useState<Channel[]>([]);
+  // Hoisted above useUserDirectory, which needs our own Matrix id to resolve the self avatar
+  // without depending on the server having stated our mapping.
+  const [matrixCredentials, setMatrixCredentials] = useState<MatrixCredentials | null>(null);
   // The user list, its avatar map, and the ref consumers read from. Declared here rather than
   // beside the other refs because resolveGamePlayerName below reads usersRef.
-  const { users, usersRef, reset: resetUsers, apply: applyUsers, setAvatar } = useUserDirectory();
+  const { users, usersRef, reset: resetUsers, apply: applyUsers, setAvatar } =
+    useUserDirectory(matrixCredentials?.userId);
   const [currentChannelId, setCurrentChannelIdRaw] = useState<string | undefined>();
   const [currentChannelName, setCurrentChannelName] = useState<string>('');
   // Snapshot of the read-marker timestamp at the moment a channel/DM is opened,
@@ -1375,7 +1379,6 @@ function App() {
   const [unreadCount, setUnreadCount] = useState(0);
   const [hasPendingInvite] = useState(false);
 
-  const [matrixCredentials, setMatrixCredentials] = useState<MatrixCredentials | null>(null);
   const [brmbleDMUsers, setBrmbleDMUsers] = useState<BrmbleDMUser[]>([]);
   const matrixOverlayCallbacks = useMemo(() => ({
     onChannelMessage: (channelId: string, message: ChatMessage) => {

--- a/src/Brmble.Web/src/components/AvatarEditorModal/AvatarEditorModal.tsx
+++ b/src/Brmble.Web/src/components/AvatarEditorModal/AvatarEditorModal.tsx
@@ -11,7 +11,8 @@ interface AvatarEditorModalProps {
     matrixUserId?: string;
     avatarUrl?: string;
   };
-  comment?: string;
+  /** Tri-state on the projection: null means the server has not said yet. */
+  comment?: string | null;
   onSetComment: (comment: string) => void;
   onUploadAvatar: (blob: Blob, contentType: string) => void;
   onRemoveAvatar: () => void;

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -42,7 +42,8 @@ interface ChatPanelProps {
   onViewerQualityChange?: (userId: number, quality: ViewerQuality) => void;
   screenShareViewerMode?: 'in-app' | 'new-window';
   /** Connected users for avatar lookup by sender name */
-  users?: { session: number; name: string; channelId?: number; matrixUserId?: string; avatarUrl?: string }[];
+  /** `matrixUserId` is tri-state on the projection: null means the server has not said yet. */
+  users?: { session: number; name: string; channelId?: number; matrixUserId?: string | null; avatarUrl?: string }[];
   disabled?: boolean;
   /** Optional notice shown at the top of the message area (e.g. ephemeral chat warning). */
   topNotice?: string;
@@ -95,7 +96,8 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
     // Then, overwrite with live Mumble users (higher priority — online with fresh data)
     if (users) {
       for (const u of users) {
-        const entry = { avatarUrl: u.avatarUrl, matrixUserId: u.matrixUserId };
+        // An unresolved identity is simply no identity to look up by.
+        const entry = { avatarUrl: u.avatarUrl, matrixUserId: u.matrixUserId ?? undefined };
         byName.set(u.name, entry);
         if (u.matrixUserId) {
           byMatrixId.set(u.matrixUserId, entry);
@@ -128,7 +130,7 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
       for (const u of users) {
         result.push({
           displayName: u.name,
-          matrixUserId: u.matrixUserId,
+          matrixUserId: u.matrixUserId ?? undefined,
           avatarUrl: u.avatarUrl,
           isOnline: true,
         });

--- a/src/Brmble.Web/src/components/ChatPanel/MessageBubble.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/MessageBubble.tsx
@@ -50,7 +50,8 @@ interface MessageBubbleProps {
   onToggleReaction?: (messageId: string, emoji: string, isReacted: boolean) => void;
   edited?: boolean;
   currentUserId?: number;
-  users?: { session: number; name: string; channelId?: number; matrixUserId?: string; avatarUrl?: string }[];
+  /** `matrixUserId` is tri-state on the projection: null means the server has not said yet. */
+  users?: { session: number; name: string; channelId?: number; matrixUserId?: string | null; avatarUrl?: string }[];
   paintSessionStatuses?: Record<string, PaintSessionStatus>;
   onJoinPaint?: (sessionId: string) => Promise<void> | void;
   onOpenPaint?: (sessionId: string) => void;

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.tsx
@@ -19,8 +19,9 @@ interface AdminSettingsTabProps {
     name: string;
     channelId?: number;
     matrixUserId?: string;
-    companionId?: string;
-    isBrmbleClient?: boolean;
+    // Tri-state on the projection: null means the server has not said yet.
+    companionId?: string | null;
+    isBrmbleClient?: boolean | null;
   }>;
   customCompanions?: Pick<CustomCompanionCapability, 'canModerate'>;
   customCompanionGallery?: CustomCompanionGalleryController;

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import './AdminSettingsTab.css';
 import { ADMIN_WORKSPACE_TABS, type AdminWorkspaceTab } from './admin/AdminWorkspaceTypes';
+import type { CompanionSelection } from './InterfaceSettingsTypes';
 import { AdminModerationSection } from './admin/AdminModerationSection';
 import { AdminChannelsSection } from './admin/AdminChannelsSection';
 import { AdminChannelRequestsSection } from './admin/AdminChannelRequestsSection';
@@ -20,7 +21,7 @@ interface AdminSettingsTabProps {
     channelId?: number;
     matrixUserId?: string;
     // Tri-state on the projection: null means the server has not said yet.
-    companionId?: string | null;
+    companionId?: CompanionSelection | null;
     isBrmbleClient?: boolean | null;
   }>;
   customCompanions?: Pick<CustomCompanionCapability, 'canModerate'>;

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.tsx
@@ -19,8 +19,8 @@ interface AdminSettingsTabProps {
     session: number;
     name: string;
     channelId?: number;
-    matrixUserId?: string;
     // Tri-state on the projection: null means the server has not said yet.
+    matrixUserId?: string | null;
     companionId?: CompanionSelection | null;
     isBrmbleClient?: boolean | null;
   }>;

--- a/src/Brmble.Web/src/components/SettingsModal/InterfaceSettingsTypes.ts
+++ b/src/Brmble.Web/src/components/SettingsModal/InterfaceSettingsTypes.ts
@@ -109,8 +109,15 @@ export function normalizeCompanionBridgeSelection(payload: {
     : normalizeCompanionId(payload.companionId);
 }
 
+/**
+ * Resolves a companion selection to something renderable.
+ *
+ * `null` means the server has not told us this session's companion yet. It resolves to
+ * `floppy` for display only — the caller must never write that back, or an unknown value
+ * becomes a wrong one and the row stops self-correcting when the real value arrives.
+ */
 export function resolveCompanionDisplay(
-  selection: CompanionSelection,
+  selection: CompanionSelection | null,
   gallery: CompanionDisplayGallery,
 ): ResolvedCompanionDisplay {
   const normalized = normalizeCompanionId(selection);

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -59,8 +59,8 @@ interface SettingsModalProps {
     session: number;
     name: string;
     channelId?: number;
-    matrixUserId?: string;
     // Tri-state on the projection: null means the server has not said yet.
+    matrixUserId?: string | null;
     companionId?: CompanionSelection | null;
     isBrmbleClient?: boolean | null;
   }>;

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -60,8 +60,9 @@ interface SettingsModalProps {
     name: string;
     channelId?: number;
     matrixUserId?: string;
-    companionId?: string;
-    isBrmbleClient?: boolean;
+    // Tri-state on the projection: null means the server has not said yet.
+    companionId?: string | null;
+    isBrmbleClient?: boolean | null;
   }>;
   channels?: Channel[];
   onChannelsChange?: (channels: Channel[]) => void;

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -61,7 +61,7 @@ interface SettingsModalProps {
     channelId?: number;
     matrixUserId?: string;
     // Tri-state on the projection: null means the server has not said yet.
-    companionId?: string | null;
+    companionId?: CompanionSelection | null;
     isBrmbleClient?: boolean | null;
   }>;
   channels?: Channel[];

--- a/src/Brmble.Web/src/components/SettingsModal/admin/adminUserModels.ts
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/adminUserModels.ts
@@ -8,8 +8,10 @@ export interface AdminConnectedUser {
   name: string;
   channelId?: number;
   matrixUserId?: string;
-  companionId?: string;
-  isBrmbleClient?: boolean;
+  // Both are tri-state on the projection: null means the server has not said yet, which is
+  // distinct from a known absence.
+  companionId?: string | null;
+  isBrmbleClient?: boolean | null;
 }
 
 export interface AdminBannedUser {

--- a/src/Brmble.Web/src/components/SettingsModal/admin/adminUserModels.ts
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/adminUserModels.ts
@@ -1,3 +1,5 @@
+import type { CompanionSelection } from '../InterfaceSettingsTypes';
+
 export interface AdminRegisteredUser {
   registrationUserId: number;
   registeredName: string;
@@ -10,7 +12,7 @@ export interface AdminConnectedUser {
   matrixUserId?: string;
   // Both are tri-state on the projection: null means the server has not said yet, which is
   // distinct from a known absence.
-  companionId?: string | null;
+  companionId?: CompanionSelection | null;
   isBrmbleClient?: boolean | null;
 }
 

--- a/src/Brmble.Web/src/components/SettingsModal/admin/adminUserModels.ts
+++ b/src/Brmble.Web/src/components/SettingsModal/admin/adminUserModels.ts
@@ -9,9 +9,9 @@ export interface AdminConnectedUser {
   session: number;
   name: string;
   channelId?: number;
-  matrixUserId?: string;
-  // Both are tri-state on the projection: null means the server has not said yet, which is
-  // distinct from a known absence.
+  // All three are tri-state on the projection: null means the server has not said yet, which
+  // is distinct from a known absence.
+  matrixUserId?: string | null;
   companionId?: CompanionSelection | null;
   isBrmbleClient?: boolean | null;
 }
@@ -73,7 +73,8 @@ export function buildAdminUserRows(input: {
     if (existing) {
       existing.isConnected = true;
       existing.sessionId = connectedUser.session;
-      existing.matrixUserId = connectedUser.matrixUserId;
+      // A row is a view, not wire state: an unresolved identity is just no identity here.
+      existing.matrixUserId = connectedUser.matrixUserId ?? undefined;
       existing.aliases = Array.from(new Set([...existing.aliases, connectedUser.name]));
       existing.searchText = normalize([...existing.aliases, connectedUser.matrixUserId ?? ''].join(' '));
       existing.sourceKinds = Array.from(new Set([...existing.sourceKinds, 'connected']));
@@ -89,7 +90,7 @@ export function buildAdminUserRows(input: {
       isConnected: true,
       isBanned: false,
       sessionId: connectedUser.session,
-      matrixUserId: connectedUser.matrixUserId,
+      matrixUserId: connectedUser.matrixUserId ?? undefined,
       sourceKinds: ['connected'],
     });
   }

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -27,8 +27,9 @@ interface User {
   deafened?: boolean;
   self?: boolean;
   prioritySpeaker?: boolean;
-  comment?: string;
-  matrixUserId?: string;
+  /** Tri-state: null means the server has not said yet. */
+  comment?: string | null;
+  matrixUserId?: string | null;
   avatarUrl?: string;
   /** Tri-state: null means the server has not said yet. Renders as "not a Brmble user". */
   isBrmbleClient?: boolean | null;

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -30,7 +30,8 @@ interface User {
   comment?: string;
   matrixUserId?: string;
   avatarUrl?: string;
-  isBrmbleClient?: boolean;
+  /** Tri-state: null means the server has not said yet. Renders as "not a Brmble user". */
+  isBrmbleClient?: boolean | null;
 }
 
 interface Channel {

--- a/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
+++ b/src/Brmble.Web/src/components/UserInfoDialog/UserInfoDialog.tsx
@@ -12,8 +12,9 @@ export interface UserInfoDialogProps {
   userName: string;
   session: number;
   isSelf: boolean;
-  comment?: string;
-  matrixUserId?: string;
+  /** Tri-state on the projection: null means the server has not said yet. */
+  comment?: string | null;
+  matrixUserId?: string | null;
   avatarUrl?: string;
   onStartDM?: (userId: string, userName: string) => void;
 }

--- a/src/Brmble.Web/src/components/UserTooltip/UserTooltip.tsx
+++ b/src/Brmble.Web/src/components/UserTooltip/UserTooltip.tsx
@@ -12,9 +12,10 @@ type AnyProps = Record<string, any>;
 
 interface UserTooltipUser {
   name: string;
-  matrixUserId?: string;
+  /** The projection delivers explicit nulls for identity fields the server has not resolved. */
+  matrixUserId?: string | null;
   avatarUrl?: string;
-  comment?: string;
+  comment?: string | null;
   self?: boolean;
   muted?: boolean;
   deafened?: boolean;

--- a/src/Brmble.Web/src/hooks/useUserDirectory.selfAvatar.test.ts
+++ b/src/Brmble.Web/src/hooks/useUserDirectory.selfAvatar.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useUserDirectory } from './useUserDirectory';
+import type { User } from '../types';
+
+const SELF = '@me:test';
+
+const selfRow = (matrixUserId: string | null): User =>
+  ({ session: 1, name: 'Me', self: true, matrixUserId, companionId: null, isBrmbleClient: null }) as unknown as User;
+
+describe('useUserDirectory self avatar', () => {
+  it('keeps my own avatar when the server stops stating my mapping', () => {
+    // A Brmble server restart makes the client apply a snapshot that does not yet mention this
+    // session, and ApplyServerSnapshot correctly resets the server-owned half to unknown --
+    // matrixUserId included. My own avatar comes from my own Matrix client, not from the
+    // server, so it must not vanish just because the server has gone quiet about me.
+    const { result } = renderHook(() => useUserDirectory(SELF));
+
+    act(() => {
+      result.current.reset([selfRow(SELF)]);
+      result.current.setAvatar(SELF, 'https://x/me.png');
+    });
+    expect(result.current.users[0].avatarUrl).toBe('https://x/me.png');
+
+    // The restart: the row survives, its server-owned fields go back to unknown.
+    act(() => {
+      result.current.apply({ changed: [selfRow(null)], removed: [] });
+    });
+
+    expect(result.current.users[0].matrixUserId).toBeNull();
+    expect(result.current.users[0].avatarUrl).toBe('https://x/me.png');
+  });
+
+  it('does not invent an avatar for another user whose mapping is unknown', () => {
+    // The fallback is only ever legitimate for self, because only for self does the client hold
+    // an identity the server has not told it.
+    const { result } = renderHook(() => useUserDirectory(SELF));
+
+    act(() => {
+      result.current.setAvatar(SELF, 'https://x/me.png');
+      result.current.reset([
+        { session: 2, name: 'Alice', self: false, matrixUserId: null } as unknown as User,
+      ]);
+    });
+
+    expect(result.current.users[0].avatarUrl).toBeUndefined();
+  });
+
+  it('still resolves my avatar normally once the server restates my mapping', () => {
+    const { result } = renderHook(() => useUserDirectory(SELF));
+
+    act(() => {
+      result.current.reset([selfRow(SELF)]);
+      result.current.setAvatar(SELF, 'https://x/me.png');
+    });
+
+    expect(result.current.users[0].avatarUrl).toBe('https://x/me.png');
+  });
+});

--- a/src/Brmble.Web/src/hooks/useUserDirectory.test.ts
+++ b/src/Brmble.Web/src/hooks/useUserDirectory.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { applyChangeSet } from './useUserDirectory';
+import type { User } from '../types';
+
+const row = (session: number, over: Partial<User> = {}): User =>
+  ({ session, name: `u${session}`, companionId: null, isBrmbleClient: null, ...over }) as User;
+
+describe('applyChangeSet', () => {
+  it('replaces a row wholesale rather than merging fields', () => {
+    const before = [row(1, { companionId: 'retro', isBrmbleClient: true })];
+
+    const after = applyChangeSet(before, { changed: [row(1, { companionId: null })], removed: [] });
+
+    expect(after[0].companionId).toBeNull();
+    expect(after[0].isBrmbleClient).toBeNull();
+  });
+
+  it('appends an unknown session', () => {
+    expect(applyChangeSet([], { changed: [row(2)], removed: [] })).toHaveLength(1);
+  });
+
+  it('removes by session id', () => {
+    expect(applyChangeSet([row(1), row(2)], { changed: [], removed: [1] }))
+      .toEqual([row(2)]);
+  });
+
+  it('preserves the order of untouched rows', () => {
+    const after = applyChangeSet([row(1), row(2), row(3)], { changed: [row(2, { name: 'x' })], removed: [] });
+    expect(after.map(u => u.session)).toEqual([1, 2, 3]);
+  });
+
+  it('returns the same array reference when nothing changed', () => {
+    // Identity matters: this feeds a useState setter, and a new array every time would
+    // re-render every consumer on every no-op event.
+    const before = [row(1)];
+    expect(applyChangeSet(before, { changed: [], removed: [] })).toBe(before);
+  });
+
+  it('applies a removal and an addition in one change set', () => {
+    const after = applyChangeSet([row(1), row(2)], { changed: [row(3)], removed: [1] });
+    expect(after.map(u => u.session)).toEqual([2, 3]);
+  });
+});

--- a/src/Brmble.Web/src/hooks/useUserDirectory.ts
+++ b/src/Brmble.Web/src/hooks/useUserDirectory.ts
@@ -1,0 +1,80 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { User } from '../types';
+
+export interface UserChangeSet {
+  changed: User[];
+  removed: number[];
+}
+
+/**
+ * Index-by-session replace and remove, with no field logic whatsoever.
+ *
+ * Rows arriving from the bridge are complete — every field present, nulls explicit — because
+ * UserProjectionStore has already merged them. Any coalescing or defined-check added here
+ * re-introduces the class of bug this project exists to remove: a merge rule on the consumer
+ * side that disagrees with the one on the producer side.
+ */
+export function applyChangeSet(previous: User[], change: UserChangeSet): User[] {
+  let next = previous;
+
+  if (change.removed.length > 0) {
+    const dropped = new Set(change.removed);
+    next = next.filter(user => !dropped.has(user.session));
+  }
+
+  if (change.changed.length > 0) {
+    const incoming = new Map(change.changed.map(user => [user.session, user]));
+    // A map hit is always a complete row object, so a truthiness test is a row-level swap
+    // rather than a field-level fallback. No coalescing or defined-checks appear here by
+    // design: every one of them would be a merge rule competing with the store's.
+    next = next.map(user => {
+      const replacement = incoming.get(user.session);
+      return replacement ? replacement : user;
+    });
+    for (const user of change.changed) {
+      if (!previous.some(existing => existing.session === user.session)) next = [...next, user];
+    }
+  }
+
+  return next;
+}
+
+/**
+ * Owns the user list and the avatar map, joining them for consumers.
+ */
+export function useUserDirectory() {
+  const [users, setUsers] = useState<User[]>([]);
+  // Keyed by matrixUserId, not session: an avatar belongs to a person, not to a connection, so
+  // it survives reconnects and is shared by every session that person has open.
+  const [avatars, setAvatars] = useState<Map<string, string>>(() => new Map());
+
+  const reset = useCallback((rows: User[]) => setUsers(rows), []);
+  const apply = useCallback(
+    (change: UserChangeSet) => setUsers(previous => applyChangeSet(previous, change)),
+    [],
+  );
+  const setAvatar = useCallback((matrixUserId: string, url: string | undefined) => {
+    setAvatars(previous => {
+      if (previous.get(matrixUserId) === url) return previous;
+      const next = new Map(previous);
+      if (url === undefined) next.delete(matrixUserId);
+      else next.set(matrixUserId, url);
+      return next;
+    });
+  }, []);
+
+  // The join happens at read time so a snapshot can never clobber an avatar.
+  const joined = useMemo(
+    () => users.map(user => ({
+      ...user,
+      avatarUrl: user.matrixUserId ? avatars.get(user.matrixUserId) : undefined,
+    })),
+    [users, avatars],
+  );
+
+  // Tracks the joined list so callbacks can read the current users without re-subscribing.
+  const usersRef = useRef(joined);
+  usersRef.current = joined;
+
+  return { users: joined, usersRef, avatars, reset, apply, setAvatar };
+}

--- a/src/Brmble.Web/src/hooks/useUserDirectory.ts
+++ b/src/Brmble.Web/src/hooks/useUserDirectory.ts
@@ -31,9 +31,12 @@ export function applyChangeSet(previous: User[], change: UserChangeSet): User[] 
       const replacement = incoming.get(user.session);
       return replacement ? replacement : user;
     });
-    for (const user of change.changed) {
-      if (!previous.some(existing => existing.session === user.session)) next = [...next, user];
-    }
+    // Membership is decided against `previous`, not `next`, so a row replaced above is not
+    // also appended. Set membership and one concatenation keep this linear; a scan per
+    // candidate would go quadratic on a large snapshot arriving after a reset.
+    const known = new Set(previous.map(user => user.session));
+    const appended = change.changed.filter(user => !known.has(user.session));
+    if (appended.length > 0) next = [...next, ...appended];
   }
 
   return next;

--- a/src/Brmble.Web/src/hooks/useUserDirectory.ts
+++ b/src/Brmble.Web/src/hooks/useUserDirectory.ts
@@ -41,8 +41,12 @@ export function applyChangeSet(previous: User[], change: UserChangeSet): User[] 
 
 /**
  * Owns the user list and the avatar map, joining them for consumers.
+ *
+ * @param selfMatrixUserId
+ * This client's own Matrix id, taken from its own credentials. It is the one identity the
+ * client knows without being told, and the join falls back to it for the self row.
  */
-export function useUserDirectory() {
+export function useUserDirectory(selfMatrixUserId?: string) {
   const [users, setUsers] = useState<User[]>([]);
   // Keyed by matrixUserId, not session: an avatar belongs to a person, not to a connection, so
   // it survives reconnects and is shared by every session that person has open.
@@ -64,12 +68,22 @@ export function useUserDirectory() {
   }, []);
 
   // The join happens at read time so a snapshot can never clobber an avatar.
+  //
+  // The self row falls back to this client's own Matrix id. A server that has not stated our
+  // mapping -- a Brmble restart, before it has re-synced its session table from Mumble --
+  // correctly resets the server-owned half of every row to unknown, matrixUserId included.
+  // Our own avatar comes from our own Matrix client, not from the server, so it must not
+  // vanish when the server goes quiet about us.
+  //
+  // The fallback is deliberately confined to the self row: for anybody else an unknown mapping
+  // genuinely means there is no identity to look up, and substituting one would show a face
+  // that is not theirs.
   const joined = useMemo(
-    () => users.map(user => ({
-      ...user,
-      avatarUrl: user.matrixUserId ? avatars.get(user.matrixUserId) : undefined,
-    })),
-    [users, avatars],
+    () => users.map(user => {
+      const key = user.self ? (user.matrixUserId ?? selfMatrixUserId) : user.matrixUserId;
+      return { ...user, avatarUrl: key ? avatars.get(key) : undefined };
+    }),
+    [users, avatars, selfMatrixUserId],
   );
 
   // Tracks the joined list so callbacks can read the current users without re-subscribing.

--- a/src/Brmble.Web/src/hooks/useUserDirectory.ts
+++ b/src/Brmble.Web/src/hooks/useUserDirectory.ts
@@ -53,6 +53,10 @@ export function useUserDirectory(selfMatrixUserId?: string) {
   const [users, setUsers] = useState<User[]>([]);
   // Keyed by matrixUserId, not session: an avatar belongs to a person, not to a connection, so
   // it survives reconnects and is shared by every session that person has open.
+  //
+  // Never pruned, by the same reasoning: dropping entries on reset would refetch every avatar
+  // on every reconnect. Growth is bounded by distinct people encountered per app run and the
+  // values are short URLs — accepted. Add a size cap if profiling ever cares.
   const [avatars, setAvatars] = useState<Map<string, string>>(() => new Map());
 
   const reset = useCallback((rows: User[]) => setUsers(rows), []);

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -1,3 +1,7 @@
+import type { CompanionSelection } from '../components/SettingsModal/InterfaceSettingsTypes';
+
+export type { CompanionSelection };
+
 export interface Server {
   id: string;
   name: string;
@@ -31,9 +35,16 @@ export interface User {
   speaking?: boolean;
   comment?: string;
   prioritySpeaker?: boolean;
+  /**
+   * Resolved at read time by `useUserDirectory`, never stored in the user list. The projection
+   * carries identifiers, not assets: the avatar map is keyed by `matrixUserId` so it survives
+   * reconnects and cannot be clobbered by a snapshot.
+   */
   avatarUrl?: string;
   certHash?: string;
-  isBrmbleClient?: boolean;
+  isBrmbleClient?: boolean | null;
+  /** Built-in id or `custom:$eventId`. `null` means unknown — render a fallback, do not store one. */
+  companionId?: CompanionSelection | null;
 }
 
 export interface IdleUpdate {

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -31,9 +31,10 @@ export interface User {
   muted?: boolean;
   deafened?: boolean;
   self?: boolean;
-  matrixUserId?: string;
+  /** The wire delivers explicit nulls for absent identity fields; only local UI state is truly optional. */
+  matrixUserId?: string | null;
   speaking?: boolean;
-  comment?: string;
+  comment?: string | null;
   prioritySpeaker?: boolean;
   /**
    * Resolved at read time by `useUserDirectory`, never stored in the user list. The projection
@@ -41,7 +42,7 @@ export interface User {
    * reconnects and cannot be clobbered by a snapshot.
    */
   avatarUrl?: string;
-  certHash?: string;
+  certHash?: string | null;
   isBrmbleClient?: boolean | null;
   /** Built-in id or `custom:$eventId`. `null` means unknown — render a fallback, do not store one. */
   companionId?: CompanionSelection | null;

--- a/src/Brmble.Web/src/utils/avatarFetch.test.ts
+++ b/src/Brmble.Web/src/utils/avatarFetch.test.ts
@@ -8,26 +8,26 @@ describe('avatar fetch bookkeeping', () => {
   });
 
   it('does not fetch again for a user who already has an avatar', () => {
-    const fetched = new Map<string, AvatarFetchRecord>([['@broan:x', { attempts: 1, session: 1 }]]);
+    const fetched = new Map<string, AvatarFetchRecord>([['@broan:x', { attempts: 1 }]]);
     const user = { session: 1, matrixUserId: '@broan:x', avatarUrl: 'https://x/a.png' };
     expect(shouldFetchAvatar(user, fetched)).toBe(false);
   });
 
   it('forgets a user who left, so a later visit is fetched again', () => {
-    const fetched = new Map<string, AvatarFetchRecord>([['@broan:x', { attempts: 1, session: 1 }]]);
+    const fetched = new Map<string, AvatarFetchRecord>([['@broan:x', { attempts: 1 }]]);
     pruneFetchedAvatars(fetched, [{ session: 2, matrixUserId: '@query:x' }]);
     expect(fetched.has('@broan:x')).toBe(false);
   });
 
-  it('fetches again when a user reconnects onto a new session in one update', () => {
-    // A reconnect that replaces the old session in the same update never leaves a state
-    // where the user is absent, so nothing prunes the record of the previous fetch. The
-    // new session carries no avatar, and the record must not be read as though it does.
-    const fetched = new Map<string, AvatarFetchRecord>([['@broan:x', { attempts: 1, session: 1 }]]);
+  it('does not refetch when a user reconnects onto a new session', () => {
+    // The avatar belongs to the person, not the connection, so it survives a session change.
+    // This is the opposite of the old rule, which was correct only while the avatar lived on
+    // the session-keyed row and a new session therefore genuinely had none.
+    const fetched = new Map<string, AvatarFetchRecord>([['@broan:x', { attempts: 1 }]]);
     const afterReconnect = [{ session: 77, matrixUserId: '@broan:x' }];
 
     pruneFetchedAvatars(fetched, afterReconnect);
 
-    expect(shouldFetchAvatar(afterReconnect[0], fetched)).toBe(true);
+    expect(shouldFetchAvatar(afterReconnect[0], fetched)).toBe(false);
   });
 });

--- a/src/Brmble.Web/src/utils/avatarFetch.ts
+++ b/src/Brmble.Web/src/utils/avatarFetch.ts
@@ -16,8 +16,6 @@ export interface AvatarFetchCandidate {
 /** What is known about a fetch already made for a Matrix user. */
 export interface AvatarFetchRecord {
   attempts: number;
-  /** Voice session the fetch was made for. */
-  session: number;
 }
 
 /**
@@ -34,17 +32,18 @@ export function pruneFetchedAvatars(
   }
 }
 
-/** Whether this user still needs their avatar fetched. */
+/**
+ * Whether this user still needs their avatar fetched.
+ *
+ * The avatar map is keyed by matrixUserId, not by session: an avatar belongs to a person
+ * rather than to a connection. So a reconnect onto a new session is no longer a reason to
+ * fetch again — the avatar already resolved for that identity is still correct. The session
+ * comparison this used to make became wrong when avatars moved out of the user rows.
+ */
 export function shouldFetchAvatar(
   user: AvatarFetchCandidate | undefined,
   fetched: ReadonlyMap<string, AvatarFetchRecord>,
 ): boolean {
   if (!user?.matrixUserId || user.avatarUrl) return false;
-  const record = fetched.get(user.matrixUserId);
-  if (!record) return true;
-  // The fetch on record was made for a different voice session, so its result was applied
-  // to a user this one has since replaced. A reconnect that swaps the session in a single
-  // update never leaves the user absent for the prune to notice, so this is the only thing
-  // standing between the new session and an avatar it does not have.
-  return record.session !== user.session;
+  return !fetched.has(user.matrixUserId);
 }

--- a/src/Brmble.Web/src/utils/avatarFetch.ts
+++ b/src/Brmble.Web/src/utils/avatarFetch.ts
@@ -9,7 +9,8 @@
 
 export interface AvatarFetchCandidate {
   session: number;
-  matrixUserId?: string;
+  /** The projection delivers an explicit null for an identity the server has not resolved. */
+  matrixUserId?: string | null;
   avatarUrl?: string;
 }
 

--- a/src/Brmble.Web/src/utils/parseUserComment.ts
+++ b/src/Brmble.Web/src/utils/parseUserComment.ts
@@ -17,7 +17,7 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&#39;/gi, "'");
 }
 
-export function parseUserComment(comment?: string): ParsedUserComment {
+export function parseUserComment(comment?: string | null): ParsedUserComment {
   if (!comment) {
     return { text: '', hasEmbeddedMedia: false };
   }

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -21,15 +21,32 @@ namespace Brmble.Client.Tests.Services;
 public class MumbleAdapterBridgeTests
 {
     [TestMethod]
-    public void HandleWebSocketMessage_CompanionChanged_EmitsBridgeEvent()
+    public void HandleWebSocketMessage_CompanionChanged_EmitsTheUpdatedRow()
     {
-        var adapter = CreateAdapterWithBridge(out var bridge);
+        // The dedicated voice.companionChanged event is gone: a companion change is just a
+        // change to a server-owned field, so it arrives as the complete row like any other.
+        var bridge = NativeBridgeTestHarness.Create();
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var connection = new MumbleConnection(
+            new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 64738), adapter, voiceSupport: false);
+        adapter.Initialise(connection);
+        adapter.ChannelState(new MumbleProto.ChannelState { ChannelId = 0, Name = "Root" });
+        adapter.UserState(new MumbleProto.UserState { Session = 42, Name = "Alice", ChannelId = 0 });
 
-        InvokePrivate(adapter, "HandleWebSocketMessage", """
-        {"type":"companionChanged","sessionId":42,"matrixUserId":"@alice:test","companionId":"retro"}
+        MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(adapter,
+            """{"type":"sessionMappingSnapshot","instanceId":"i","revision":1,"mappings":{}}""");
+        _ = NativeBridgeTestHarness.DrainMessages(bridge);
+
+        MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(adapter, """
+        {"type":"companionChanged","instanceId":"i","baseRevision":1,"revision":2,"sessionId":42,"matrixUserId":"@alice:test","companionId":"retro"}
         """);
 
-        AssertBridgeSent(bridge, "voice.companionChanged");
+        var row = NativeBridgeTestHarness.DrainMessages(bridge)
+            .Where(m => m.Type == "voice.userJoined")
+            .Select(m => JsonDocument.Parse(m.DataJson).RootElement)
+            .Last(e => e.GetProperty("session").GetUInt32() == 42);
+
+        Assert.AreEqual("retro", row.GetProperty("companionId").GetString());
     }
 
     [TestMethod]

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBridgeTests.cs
@@ -42,8 +42,9 @@ public class MumbleAdapterBridgeTests
         """);
 
         var row = NativeBridgeTestHarness.DrainMessages(bridge)
-            .Where(m => m.Type == "voice.userJoined")
-            .Select(m => JsonDocument.Parse(m.DataJson).RootElement)
+            .Where(m => m.Type == "voice.usersChanged")
+            .SelectMany(m => JsonDocument.Parse(m.DataJson).RootElement
+                .GetProperty("changed").EnumerateArray().ToList())
             .Last(e => e.GetProperty("session").GetUInt32() == 42);
 
         Assert.AreEqual("retro", row.GetProperty("companionId").GetString());

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBrmbleFlagTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBrmbleFlagTests.cs
@@ -1,7 +1,7 @@
-using System.Collections.Concurrent;
 using System.Net;
 using System.Text.Json;
 using Brmble.Client.Services.Voice;
+using Brmble.Client.Services.Voice.Projection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MumbleProto;
 using MumbleSharp;
@@ -9,19 +9,26 @@ using MumbleSharp;
 namespace Brmble.Client.Tests.Services;
 
 /// <summary>
-/// The Brmble flag and the companion both live in the adapter's session mapping cache, and
-/// every later user state re-asserts them to the UI from that cache. An event the cache
-/// cannot absorb is therefore not merely missed once, it is actively contradicted later.
+/// The Brmble flag and the companion are server-owned fields of the user projection, and every
+/// later user state re-emits the whole row. An event the projection cannot absorb is therefore
+/// not merely missed once, it is actively contradicted later.
 /// </summary>
+/// <remarks>
+/// Each test opens with a snapshot because an incremental event with no cursor to sequence
+/// against is discarded by design — the store asks for a snapshot instead of guessing.
+/// </remarks>
 [TestClass]
 public class MumbleAdapterBrmbleFlagTests
 {
+    private const string EmptySnapshot =
+        """{"type":"sessionMappingSnapshot","instanceId":"i","revision":1,"mappings":{}}""";
+
     [TestMethod]
-    public void UserState_AfterActivationForAnUnmappedSession_StillReportsNotBrmble()
+    public void UserState_AfterActivationForAnUnmappedSession_StillReportsBrmble()
     {
         // A client that learns a session is a Brmble client before it learns the session's
-        // mapping has nowhere to record the flag. The next user state for that session --
-        // a mute toggle, a channel move, a comment reply -- then tells the UI the opposite.
+        // mapping must hold the flag. Otherwise the next user state for that session --
+        // a mute toggle, a channel move, a comment reply -- tells the UI the opposite.
         var bridge = NativeBridgeTestHarness.Create();
         var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
         var connection = new MumbleConnection(
@@ -30,8 +37,10 @@ public class MumbleAdapterBrmbleFlagTests
         adapter.ChannelState(new ChannelState { ChannelId = 0, Name = "Root" });
         adapter.ChannelState(new ChannelState { ChannelId = 1, Name = "General", Parent = 0 });
 
+        MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(adapter, EmptySnapshot);
         MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(
-            adapter, """{"type":"brmbleClientActivated","sessionId":42}""");
+            adapter,
+            """{"type":"brmbleClientActivated","instanceId":"i","baseRevision":1,"revision":2,"sessionId":42}""");
         adapter.UserState(new UserState { Session = 42, Name = "Broan", ChannelId = 1 });
 
         var joined = NativeBridgeTestHarness.DrainMessages(bridge)
@@ -52,17 +61,23 @@ public class MumbleAdapterBrmbleFlagTests
         // it is sent for a session the other clients already have a full mapping for.
         var bridge = NativeBridgeTestHarness.Create();
         var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var connection = new MumbleConnection(
+            new IPEndPoint(IPAddress.Loopback, 64738), adapter, voiceSupport: false);
+        adapter.Initialise(connection);
+        adapter.ChannelState(new ChannelState { ChannelId = 0, Name = "Root" });
+        adapter.UserState(new UserState { Session = 42, Name = "Broan", ChannelId = 0 });
 
+        MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(adapter, EmptySnapshot);
         MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(
             adapter,
-            """{"type":"userMappingAdded","sessionId":42,"matrixUserId":"@broan:x","mumbleName":"Broan","companionId":"cat","certHash":"h","isBrmbleClient":true}""");
+            """{"type":"userMappingAdded","instanceId":"i","baseRevision":1,"revision":2,"sessionId":42,"matrixUserId":"@broan:x","mumbleName":"Broan","companionId":"cat","certHash":"h","isBrmbleClient":true}""");
         MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(
             adapter,
-            """{"type":"userMappingAdded","sessionId":42,"matrixUserId":"@broan:x","mumbleName":"Broan","certHash":"h","isBrmbleClient":true}""");
+            """{"type":"userMappingAdded","instanceId":"i","baseRevision":2,"revision":3,"sessionId":42,"matrixUserId":"@broan:x","mumbleName":"Broan","certHash":"h","isBrmbleClient":true}""");
 
-        var mappings = MumbleAdapterTestHarness
-            .GetField<ConcurrentDictionary<uint, MumbleAdapter.SessionMappingEntry>>(adapter, "_sessionMappings");
+        var projection = MumbleAdapterTestHarness
+            .GetField<UserProjectionStore>(adapter, "_projection");
 
-        Assert.AreEqual("cat", mappings[42].CompanionId);
+        Assert.AreEqual("cat", projection.Snapshot()[42].CompanionId);
     }
 }

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterBrmbleFlagTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterBrmbleFlagTests.cs
@@ -43,15 +43,26 @@ public class MumbleAdapterBrmbleFlagTests
             """{"type":"brmbleClientActivated","instanceId":"i","baseRevision":1,"revision":2,"sessionId":42}""");
         adapter.UserState(new UserState { Session = 42, Name = "Broan", ChannelId = 1 });
 
-        var joined = NativeBridgeTestHarness.DrainMessages(bridge)
-            .Where(m => m.Type == "voice.userJoined")
-            .Select(m => JsonDocument.Parse(m.DataJson).RootElement)
-            .Last(e => e.GetProperty("session").GetUInt32() == 42);
+        var joined = LastRowFor(bridge, 42);
 
         Assert.IsTrue(
             joined.GetProperty("isBrmbleClient").GetBoolean(),
             "the activation was dropped, so this user state reverts the badge to a plain Mumble user");
     }
+
+    /// <summary>The latest wire row for a session, from either projection state event.</summary>
+    private static JsonElement LastRowFor(Brmble.Client.Bridge.NativeBridge bridge, uint session)
+        => NativeBridgeTestHarness.DrainMessages(bridge)
+            .Where(m => m.Type is "voice.usersChanged" or "voice.usersReset")
+            .SelectMany(m =>
+            {
+                var root = JsonDocument.Parse(m.DataJson).RootElement;
+                var rows = m.Type == "voice.usersReset"
+                    ? root.GetProperty("users")
+                    : root.GetProperty("changed");
+                return rows.EnumerateArray().ToList();
+            })
+            .Last(e => e.GetProperty("session").GetUInt32() == session);
 
     [TestMethod]
     public void UserMappingAdded_WithoutACompanion_KeepsTheKnownCompanion()

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -82,6 +82,9 @@ internal static class MumbleAdapterTestHarness
         SetField(adapter, "_sessionMappings", new ConcurrentDictionary<uint, MumbleAdapter.SessionMappingEntry>());
         SetField(adapter, "_pendingBrmbleStatus", new ConcurrentDictionary<uint, bool>());
         SetField(adapter, "_channelPasswordRestrictions", new ConcurrentDictionary<uint, bool>());
+        // GetUninitializedObject skips field initialisers, so every field the adapter constructs
+        // inline has to be seeded here or it is null at first use.
+        SetField(adapter, "_projection", new Brmble.Client.Services.Voice.Projection.UserProjectionStore());
         return adapter;
     }
 

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -84,6 +84,7 @@ internal static class MumbleAdapterTestHarness
         // swallows exceptions, so a missing one shows up as a silently dropped message rather
         // than a failure.
         SetField(adapter, "_projection", new Brmble.Client.Services.Voice.Projection.UserProjectionStore());
+        SetField(adapter, "_projectionEmitGate", new object());
         SetField(adapter, "_resync", new Brmble.Client.Services.Voice.ResyncThrottle());
         SetField(adapter, "_resyncClock", System.Diagnostics.Stopwatch.StartNew());
         SetField(adapter, "_wsSendGate", new SemaphoreSlim(1, 1));

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -78,9 +78,6 @@ internal static class MumbleAdapterTestHarness
         SetField(adapter, "_certService", certService);
         SetField(adapter, "_appConfigService", appConfigService);
         SetField(adapter, "_audioManager", audioManager);
-        SetField(adapter, "_userMappings", new Dictionary<string, string>());
-        SetField(adapter, "_sessionMappings", new ConcurrentDictionary<uint, MumbleAdapter.SessionMappingEntry>());
-        SetField(adapter, "_pendingBrmbleStatus", new ConcurrentDictionary<uint, bool>());
         SetField(adapter, "_channelPasswordRestrictions", new ConcurrentDictionary<uint, bool>());
         // GetUninitializedObject skips field initialisers, so every field the adapter constructs
         // inline has to be seeded here or it is null at first use.
@@ -291,26 +288,6 @@ internal sealed class TestTlsHttpServer : IAsyncDisposable
 [TestClass]
 public class MumbleAdapterParseTests
 {
-    [TestMethod]
-    public void ParseSessionMappings_PreservesCertHash()
-    {
-        using var doc = JsonDocument.Parse("""
-        {
-            "42": {
-                "matrixUserId": "@mjg:example.com",
-                "mumbleName": "MJG",
-                "companionId": "bee",
-                "isBrmbleClient": false,
-                "certHash": "cert-mjg"
-            }
-        }
-        """);
-
-        var mappings = MumbleAdapter.ParseSessionMappings(doc.RootElement);
-
-        Assert.AreEqual("cert-mjg", mappings[42].CertHash);
-    }
-
     [TestMethod]
     public void ServerSync_JoinsReconnectTargetAfterAuthenticateTokensApply()
     {
@@ -1029,158 +1006,41 @@ public class MumbleAdapterParseTests
         Assert.AreEqual("https://noscope.it:1912", MumbleAdapter.ParseBrmbleApiUrl(text));
     }
 
-    [TestMethod]
-    public void ParseSessionMappings_WithIsBrmbleClient_RoundTrips()
-    {
-        var json = JsonDocument.Parse("""
-        {
-            "1": { "matrixUserId": "@alice:localhost", "mumbleName": "Alice", "isBrmbleClient": true },
-            "2": { "matrixUserId": "@bob:localhost", "mumbleName": "Bob", "isBrmbleClient": false }
-        }
-        """);
-
-        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
-
-        Assert.AreEqual(2, result.Count);
-        Assert.IsTrue(result[1].IsBrmbleClient, "Alice should be a Brmble client");
-        Assert.IsFalse(result[2].IsBrmbleClient, "Bob should not be a Brmble client");
-        Assert.AreEqual("@alice:localhost", result[1].MatrixUserId);
-        Assert.AreEqual("Bob", result[2].MumbleName);
-    }
-
-    [TestMethod]
-    public void ParseSessionMappings_MissingIsBrmbleClient_DefaultsToFalse()
-    {
-        var json = JsonDocument.Parse("""
-        {
-            "5": { "matrixUserId": "@user:localhost", "mumbleName": "User" }
-        }
-        """);
-
-        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
-
-        Assert.AreEqual(1, result.Count);
-        Assert.IsFalse(result[5].IsBrmbleClient, "Missing isBrmbleClient should default to false");
-    }
-
-    [TestMethod]
-    public void ParseSessionMappings_ExplicitNullIsBrmbleClient_DoesNotThrow()
-    {
-        // TryGetProperty returns true for an explicit JSON null and GetBoolean() throws on it.
-        // This runs inside /auth/token credential handling, so a null would take the client
-        // down on connect. Absent and null must both mean "unknown", rendering as false today.
-        var json = JsonDocument.Parse("""
-        {
-            "5": { "matrixUserId": "@user:localhost", "mumbleName": "User", "isBrmbleClient": null }
-        }
-        """);
-
-        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
-
-        Assert.AreEqual(1, result.Count);
-        Assert.IsFalse(result[5].IsBrmbleClient);
-    }
-
-    [TestMethod]
-    public void ParseSessionMappings_SkipsEntriesWithMissingRequiredFields()
-    {
-        var json = JsonDocument.Parse("""
-        {
-            "1": { "matrixUserId": "@alice:localhost" },
-            "2": { "mumbleName": "Bob" },
-            "3": { "matrixUserId": "@charlie:localhost", "mumbleName": "Charlie" }
-        }
-        """);
-
-        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
-
-        Assert.AreEqual(1, result.Count, "Only the complete entry should be parsed");
-        Assert.IsTrue(result.ContainsKey(3));
-    }
-
-    [TestMethod]
-    public void ParseSessionMappings_SkipsNonNumericKeys()
-    {
-        var json = JsonDocument.Parse("""
-        {
-            "abc": { "matrixUserId": "@x:localhost", "mumbleName": "X" },
-            "42": { "matrixUserId": "@y:localhost", "mumbleName": "Y" }
-        }
-        """);
-
-        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
-
-        Assert.AreEqual(1, result.Count);
-        Assert.IsTrue(result.ContainsKey(42));
-    }
-
-    [TestMethod]
-    public void ParseSessionMappings_EmptyObject_ReturnsEmpty()
-    {
-        var json = JsonDocument.Parse("{}");
-        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
-        Assert.AreEqual(0, result.Count);
-    }
-
-    [TestMethod]
-    public void ParseSessionMappings_WithCompanionId_RoundTrips()
-    {
-        using var json = JsonDocument.Parse("""
-        {
-          "42": {
-            "matrixUserId": "@alice:test",
-            "mumbleName": "Alice",
-            "companionId": "pip",
-            "isBrmbleClient": true
-          }
-        }
-        """);
-
-        var result = MumbleAdapter.ParseSessionMappings(json.RootElement);
-
-        Assert.AreEqual("pip", result[42].CompanionId);
-    }
-
-    [TestMethod]
-    public void ParseWireCompanionId_PrefersCustomCompanionId()
-    {
-        const string json =
-            """{"companionId":"floppy","customCompanionId":"custom:$sprite:test"}""";
-        using var document = JsonDocument.Parse(json);
-
-        Assert.AreEqual(
-            "custom:$sprite:test",
-            MumbleAdapter.ParseWireCompanionId(document.RootElement));
-    }
 
     [TestMethod]
     public void CustomCompanionId_FlowsThroughSnapshotAddedAndChangedMappings()
     {
+        // The legacy wire split sends companionId:"floppy" alongside the real selection in
+        // customCompanionId. The truth must win at every entry point, not just the snapshot.
         var bridge = NativeBridgeTestHarness.Create();
         var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var connection = new MumbleConnection(new IPEndPoint(IPAddress.Loopback, 64738), adapter, voiceSupport: false);
+        adapter.Initialise(connection);
+        adapter.ChannelState(new ChannelState { ChannelId = 0, Name = "Root" });
+        adapter.UserState(new UserState { Session = 42, Name = "Alice", ChannelId = 0 });
+        adapter.UserState(new UserState { Session = 43, Name = "Bob", ChannelId = 0 });
 
         MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(adapter, """
-        {"type":"sessionMappingSnapshot","mappings":{"42":{"matrixUserId":"@alice:test","mumbleName":"Alice","companionId":"floppy","customCompanionId":"custom:$snapshot:test"}}}
+        {"type":"sessionMappingSnapshot","instanceId":"i","revision":1,"mappings":{"42":{"matrixUserId":"@alice:test","mumbleName":"Alice","companionId":"floppy","customCompanionId":"custom:$snapshot:test"}}}
         """);
-        var snapshot = NativeBridgeTestHarness.DrainMessages(bridge).Single(m => m.Type == "voice.sessionMappingSnapshot");
-        using var snapshotDocument = JsonDocument.Parse(snapshot.DataJson);
-        Assert.AreEqual("custom:$snapshot:test", snapshotDocument.RootElement
-            .GetProperty("mappings").GetProperty("42").GetProperty("companionId").GetString());
+        Assert.AreEqual("custom:$snapshot:test", LastRowFor(bridge, 42).GetProperty("companionId").GetString());
 
         MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(adapter, """
-        {"type":"userMappingAdded","sessionId":43,"matrixUserId":"@bob:test","mumbleName":"Bob","companionId":"floppy","customCompanionId":"custom:$joined:test"}
+        {"type":"userMappingAdded","instanceId":"i","baseRevision":1,"revision":2,"sessionId":43,"matrixUserId":"@bob:test","mumbleName":"Bob","companionId":"floppy","customCompanionId":"custom:$joined:test"}
         """);
-        var added = NativeBridgeTestHarness.DrainMessages(bridge).Single(m => m.Type == "voice.userMappingUpdated");
-        using var addedDocument = JsonDocument.Parse(added.DataJson);
-        Assert.AreEqual("custom:$joined:test", addedDocument.RootElement.GetProperty("companionId").GetString());
+        Assert.AreEqual("custom:$joined:test", LastRowFor(bridge, 43).GetProperty("companionId").GetString());
 
         MumbleAdapterTestHarness.InvokeHandleWebSocketMessage(adapter, """
-        {"type":"companionChanged","sessionId":43,"matrixUserId":"@bob:test","companionId":"floppy","customCompanionId":"custom:$changed:test"}
+        {"type":"companionChanged","instanceId":"i","baseRevision":2,"revision":3,"sessionId":43,"matrixUserId":"@bob:test","companionId":"floppy","customCompanionId":"custom:$changed:test"}
         """);
-        var changed = NativeBridgeTestHarness.DrainMessages(bridge).Single(m => m.Type == "voice.companionChanged");
-        using var changedDocument = JsonDocument.Parse(changed.DataJson);
-        Assert.AreEqual("custom:$changed:test", changedDocument.RootElement.GetProperty("companionId").GetString());
+        Assert.AreEqual("custom:$changed:test", LastRowFor(bridge, 43).GetProperty("companionId").GetString());
     }
+
+    private static JsonElement LastRowFor(Brmble.Client.Bridge.NativeBridge bridge, uint session)
+        => NativeBridgeTestHarness.DrainMessages(bridge)
+            .Where(m => m.Type == "voice.userJoined")
+            .Select(m => JsonDocument.Parse(m.DataJson).RootElement)
+            .Last(e => e.GetProperty("session").GetUInt32() == session);
 
     [TestMethod]
     public async Task SetCompanion_ResponsePrefersCustomCompanionId()

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -80,8 +80,13 @@ internal static class MumbleAdapterTestHarness
         SetField(adapter, "_audioManager", audioManager);
         SetField(adapter, "_channelPasswordRestrictions", new ConcurrentDictionary<uint, bool>());
         // GetUninitializedObject skips field initialisers, so every field the adapter constructs
-        // inline has to be seeded here or it is null at first use.
+        // inline has to be seeded here or it is null at first use. HandleWebSocketMessage
+        // swallows exceptions, so a missing one shows up as a silently dropped message rather
+        // than a failure.
         SetField(adapter, "_projection", new Brmble.Client.Services.Voice.Projection.UserProjectionStore());
+        SetField(adapter, "_resync", new Brmble.Client.Services.Voice.ResyncThrottle());
+        SetField(adapter, "_resyncClock", System.Diagnostics.Stopwatch.StartNew());
+        SetField(adapter, "_wsSendGate", new SemaphoreSlim(1, 1));
         return adapter;
     }
 
@@ -1036,10 +1041,20 @@ public class MumbleAdapterParseTests
         Assert.AreEqual("custom:$changed:test", LastRowFor(bridge, 43).GetProperty("companionId").GetString());
     }
 
+    /// <summary>
+    /// The latest wire row for a session, drained from either projection state event.
+    /// </summary>
     private static JsonElement LastRowFor(Brmble.Client.Bridge.NativeBridge bridge, uint session)
         => NativeBridgeTestHarness.DrainMessages(bridge)
-            .Where(m => m.Type == "voice.userJoined")
-            .Select(m => JsonDocument.Parse(m.DataJson).RootElement)
+            .Where(m => m.Type is "voice.usersChanged" or "voice.usersReset")
+            .SelectMany(m =>
+            {
+                var root = JsonDocument.Parse(m.DataJson).RootElement;
+                var rows = m.Type == "voice.usersReset"
+                    ? root.GetProperty("users")
+                    : root.GetProperty("changed");
+                return rows.EnumerateArray().ToList();
+            })
             .Last(e => e.GetProperty("session").GetUInt32() == session);
 
     [TestMethod]

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterParseTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterProjectionTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterProjectionTests.cs
@@ -1,0 +1,47 @@
+using Brmble.Client.Services.Voice;
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+/// <summary>
+/// The ordering guarantees MumbleAdapter relies on when it drives the store from three threads.
+/// </summary>
+[TestClass]
+public class MumbleAdapterProjectionTests
+{
+    [TestMethod]
+    public void AuthTokenSnapshotBeforeUserStateStillEnrichesTheRow()
+    {
+        // The real connect ordering: ServerSync -> FetchAndSendCredentials -> SendVoiceConnected.
+        var store = new UserProjectionStore();
+        var snapshot = ProjectionWire.ReadSnapshot(System.Text.Json.JsonDocument.Parse("""
+        { "instanceId": "inst-a", "revision": 3,
+          "mappings": { "1": { "matrixUserId": "@alice:test", "companionId": "retro",
+                               "isBrmbleClient": true } } }
+        """).RootElement);
+
+        store.ApplyServerSnapshot(snapshot!);
+        var change = store.ApplyMumbleReset([new MumbleUserInput(1, "Alice", 0, false, false, null, null, true)]);
+
+        var row = change.Changed.Single();
+        Assert.AreEqual("@alice:test", row.MatrixUserId);
+        Assert.AreEqual("retro", row.CompanionId);
+        Assert.AreEqual(true, row.IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void AChannelMoveDoesNotDisturbIdentity()
+    {
+        var store = new UserProjectionStore();
+        store.ApplyMumbleUserState(new MumbleUserInput(1, "Alice", 0, false, false, null, null, false));
+        store.ApplyServerSnapshot(new ServerSnapshot("i", 1,
+            new Dictionary<uint, ServerMappingEntry> { [1] = new("@a:t", "retro", true, null) }));
+
+        var change = store.ApplyMumbleUserState(
+            new MumbleUserInput(1, "Alice", 9, false, false, null, null, false));
+
+        Assert.AreEqual(9u, change.Changed.Single().ChannelId);
+        Assert.AreEqual(true, change.Changed.Single().IsBrmbleClient);
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/ProjectionCertHashNormalisationTests.cs
+++ b/tests/Brmble.Client.Tests/Services/ProjectionCertHashNormalisationTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reflection;
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MumbleSharp;
+using MumbleSharp.Model;
+
+namespace Brmble.Client.Tests.Services;
+
+/// <summary>
+/// The seam between MumbleAdapter's translation and the store's reset occupant check.
+/// </summary>
+/// <remarks>
+/// MumbleSharp initialises <c>User.CertificateHash</c> to <see cref="string.Empty"/> and never
+/// nulls it, so "this user has no certificate" only reaches the store as <c>null</c> if the
+/// adapter normalises it. Whether it does decides two things: whether
+/// <c>IsSameOccupant</c> consults the name at all, and whether <c>UserProjection.CertHash</c>
+/// can fall back to the server's recorded copy.
+/// </remarks>
+[TestClass]
+public class ProjectionCertHashNormalisationTests
+{
+    private static MumbleUserInput Translate(User user)
+    {
+        var bridge = NativeBridgeTestHarness.Create();
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var method = typeof(Brmble.Client.Services.Voice.MumbleAdapter)
+            .GetMethod("ToProjectionInput", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (MumbleUserInput)method.Invoke(adapter, [user])!;
+    }
+
+    private static User UserWithoutCertificate(uint session, string name)
+    {
+        var bridge = NativeBridgeTestHarness.Create();
+        var adapter = MumbleAdapterTestHarness.CreateWithBridge(bridge);
+        var connection = new MumbleConnection(
+            new IPEndPoint(IPAddress.Loopback, 64738), adapter, voiceSupport: false);
+        adapter.Initialise(connection);
+        // CertificateHash is deliberately left at its default rather than assigned.
+        return new User(adapter, session) { Name = name };
+    }
+
+    [TestMethod]
+    public void AnUnauthenticatedUserTranslatesToANullCertHash()
+    {
+        var input = Translate(UserWithoutCertificate(5, "Alice"));
+
+        Assert.IsNull(input.CertHash,
+            "an empty hash is an absent certificate, not a certificate whose value is empty");
+    }
+
+    [TestMethod]
+    public void TwoUnauthenticatedUsersAreNotTreatedAsTheSameOccupant()
+    {
+        // Session 5 was Alice. She left unseen and Bob took the recycled id. Neither holds a
+        // certificate. If the empty hash reached the store as "" the equality check would
+        // succeed on two empty strings, the name would never be consulted, and Bob would
+        // inherit Alice's identity — the exact recycling defect the occupant check prevents.
+        var store = new UserProjectionStore();
+        store.ApplyMumbleReset([Translate(UserWithoutCertificate(5, "Alice"))]);
+        store.ApplyServerSnapshot(new ServerSnapshot("i", 1,
+            new Dictionary<uint, ServerMappingEntry> { [5] = new("@alice:test", "retro", true, null) }));
+
+        var change = store.ApplyMumbleReset([Translate(UserWithoutCertificate(5, "Bob"))]);
+
+        var row = change.Changed.Single();
+        Assert.AreEqual("Bob", row.Name);
+        Assert.IsNull(row.MatrixUserId, "Bob must not inherit Alice's matrix id");
+        Assert.IsNull(row.CompanionId, "Bob must not inherit Alice's companion");
+        Assert.IsNull(row.IsBrmbleClient, "Bob must not inherit Alice's Brmble badge");
+    }
+
+    [TestMethod]
+    public void AnUnauthenticatedUserKeepsIdentityWhenTheNameIsUnchanged()
+    {
+        // The other half of the rule: a certificate-less user who reconnects onto the same id
+        // under the same name is the same person and keeps their enrichment.
+        var store = new UserProjectionStore();
+        store.ApplyMumbleReset([Translate(UserWithoutCertificate(5, "Alice"))]);
+        store.ApplyServerSnapshot(new ServerSnapshot("i", 1,
+            new Dictionary<uint, ServerMappingEntry> { [5] = new("@alice:test", "retro", true, null) }));
+
+        var change = store.ApplyMumbleReset([Translate(UserWithoutCertificate(5, "Alice"))]);
+
+        var row = change.Changed.Single();
+        Assert.AreEqual("@alice:test", row.MatrixUserId);
+        Assert.AreEqual("retro", row.CompanionId);
+    }
+
+    [TestMethod]
+    public void AnAbsentLiveCertificateFallsBackToTheServersRecordedCopy()
+    {
+        // CertHash is MumbleCertHash ?? ServerCertHash. An empty live hash is not null, so it
+        // would win the coalesce and blank a hash the server can still supply.
+        var store = new UserProjectionStore();
+        store.ApplyMumbleReset([Translate(UserWithoutCertificate(5, "Alice"))]);
+        store.ApplyServerSnapshot(new ServerSnapshot("i", 1,
+            new Dictionary<uint, ServerMappingEntry> { [5] = new("@alice:test", null, null, "stored-hash") }));
+
+        Assert.AreEqual("stored-hash", store.Snapshot()[5].CertHash);
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
+++ b/tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
@@ -184,6 +184,40 @@ public class ProjectionWireTests
     }
 
     [TestMethod]
+    public void ReadSnapshot_ReadsTheAuthTokenBodyWhichNamesItsMappingsDifferently()
+    {
+        // /auth/token carries the identical data under "sessionMappings"; the WebSocket calls it
+        // "mappings". Reading only one name yields an envelope with no entries, which
+        // ApplyServerSnapshot then applies as "the server knows nobody", wiping every identity
+        // the client holds.
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        {
+          "instanceId": "inst-a",
+          "revision": 4,
+          "sessionMappings": {
+            "3": { "matrixUserId": "@alice:test", "companionId": "retro", "isBrmbleClient": true }
+          }
+        }
+        """));
+
+        Assert.IsNotNull(snapshot);
+        Assert.AreEqual(1, snapshot!.Mappings.Count);
+        Assert.AreEqual("@alice:test", snapshot.Mappings[3].MatrixUserId);
+        Assert.AreEqual("retro", snapshot.Mappings[3].CompanionId);
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_RefusesAPayloadThatNamesNoMappingsBlockAtAll()
+    {
+        // An envelope with no mappings block under either name is a payload we failed to
+        // understand, not a server asserting an empty table. Applying it as authoritative would
+        // reset every row to unknown on the strength of a parsing miss.
+        Assert.IsNull(ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "inst-a", "revision": 4 }
+        """)));
+    }
+
+    [TestMethod]
     public void ToWireRow_EmitsEveryFieldWithNullsExplicit()
     {
         var row = new UserProjection

--- a/tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
+++ b/tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
@@ -139,4 +139,40 @@ public class ProjectionWireTests
         Assert.IsNull(ProjectionWire.ReadEvent("companionChanged",
             Json("""{ "instanceId": "i", "revision": 2 }""")));
     }
+
+    [TestMethod]
+    public void ToWireRow_EmitsEveryFieldWithNullsExplicit()
+    {
+        var row = new UserProjection
+        {
+            SessionId = 3,
+            Name = "Alice",
+            ChannelId = 5,
+            Muted = true,
+            Deafened = false,
+            Comment = "hi",
+            MumbleCertHash = "live",
+            IsSelf = true,
+            MatrixUserId = "@alice:test",
+            CompanionId = null,
+            IsBrmbleClient = null,
+            ServerCertHash = "stored"
+        };
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(ProjectionWire.ToWireRow(row)));
+        var json = doc.RootElement;
+
+        Assert.AreEqual(3, json.GetProperty("session").GetInt32());
+        Assert.AreEqual("Alice", json.GetProperty("name").GetString());
+        Assert.AreEqual(5, json.GetProperty("channelId").GetInt32());
+        Assert.IsTrue(json.GetProperty("muted").GetBoolean());
+        Assert.IsTrue(json.GetProperty("self").GetBoolean());
+        Assert.AreEqual("live", json.GetProperty("certHash").GetString(),
+            "the live certificate wins over the server's recorded copy");
+
+        // Nulls must be present rather than omitted: React replaces rows wholesale, so an
+        // absent key and a null key must not mean different things.
+        Assert.AreEqual(JsonValueKind.Null, json.GetProperty("companionId").ValueKind);
+        Assert.AreEqual(JsonValueKind.Null, json.GetProperty("isBrmbleClient").ValueKind);
+    }
 }

--- a/tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
+++ b/tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
@@ -141,6 +141,49 @@ public class ProjectionWireTests
     }
 
     [TestMethod]
+    public void ReadSnapshot_SkipsNonNumericSessionKeys()
+    {
+        // Ported from ParseSessionMappings_SkipsNonNumericKeys.
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "abc": { "matrixUserId": "@x:t" },
+                        "42":  { "matrixUserId": "@y:t" } } }
+        """));
+
+        Assert.AreEqual(1, snapshot!.Mappings.Count);
+        Assert.IsTrue(snapshot.Mappings.ContainsKey(42));
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_EmptyMappingsIsAnEmptyTableNotAFailure()
+    {
+        // Ported from ParseSessionMappings_EmptyObject_ReturnsEmpty. An empty table is a
+        // legitimate statement: the server knows about nobody.
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1, "mappings": {} }
+        """));
+
+        Assert.IsNotNull(snapshot);
+        Assert.AreEqual(0, snapshot!.Mappings.Count);
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_ExplicitFalseIsBrmbleClientIsKnowledge()
+    {
+        // Ported from ParseSessionMappings_WithIsBrmbleClient_RoundTrips. An explicit false is
+        // a fact and must survive as false, distinct from the absent case above.
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "1": { "matrixUserId": "@alice:t", "isBrmbleClient": true },
+                        "2": { "matrixUserId": "@bob:t",   "isBrmbleClient": false } } }
+        """));
+
+        Assert.AreEqual(true, snapshot!.Mappings[1].IsBrmbleClient);
+        Assert.AreEqual(false, snapshot.Mappings[2].IsBrmbleClient);
+        Assert.AreEqual("@alice:t", snapshot.Mappings[1].MatrixUserId);
+    }
+
+    [TestMethod]
     public void ToWireRow_EmitsEveryFieldWithNullsExplicit()
     {
         var row = new UserProjection

--- a/tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
+++ b/tests/Brmble.Client.Tests/Services/ProjectionWireTests.cs
@@ -1,0 +1,142 @@
+using System.Text.Json;
+using Brmble.Client.Services.Voice;
+using Brmble.Client.Services.Voice.Projection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class ProjectionWireTests
+{
+    private static JsonElement Json(string raw) => JsonDocument.Parse(raw).RootElement.Clone();
+
+    [TestMethod]
+    public void ReadSnapshot_ReadsTheEnvelopeAndEveryMapping()
+    {
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        {
+          "instanceId": "inst-a",
+          "revision": 7,
+          "mappings": {
+            "3": { "matrixUserId": "@alice:test", "mumbleName": "Alice",
+                   "companionId": "retro", "certHash": "abc", "isBrmbleClient": true }
+          }
+        }
+        """));
+
+        Assert.IsNotNull(snapshot);
+        Assert.AreEqual("inst-a", snapshot!.InstanceId);
+        Assert.AreEqual(7L, snapshot.Revision);
+        var entry = snapshot.Mappings[3];
+        Assert.AreEqual("@alice:test", entry.MatrixUserId);
+        Assert.AreEqual("retro", entry.CompanionId);
+        Assert.AreEqual(true, entry.IsBrmbleClient);
+        Assert.AreEqual("abc", entry.CertHash);
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_KeepsAMappingWithNoMumbleName()
+    {
+        // The old ParseSessionMappings dropped these outright, losing the identity entirely.
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "3": { "matrixUserId": "@alice:test" } } }
+        """));
+
+        Assert.AreEqual("@alice:test", snapshot!.Mappings[3].MatrixUserId);
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_AbsentCompanionIsUnknownNotFloppy()
+    {
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "3": { "matrixUserId": "@a:t" } } }
+        """));
+
+        Assert.IsNull(snapshot!.Mappings[3].CompanionId,
+            "a default must never be transmitted as though it were a fact");
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_NullIsBrmbleClientIsUnknownNotFalse()
+    {
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "3": { "matrixUserId": "@a:t", "isBrmbleClient": null } } }
+        """));
+
+        Assert.IsNull(snapshot!.Mappings[3].IsBrmbleClient);
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_PrefersACustomCompanionOverTheLegacyField()
+    {
+        var snapshot = ProjectionWire.ReadSnapshot(Json("""
+        { "instanceId": "i", "revision": 1,
+          "mappings": { "3": { "companionId": "floppy",
+                               "customCompanionId": "custom:$abc" } } }
+        """));
+
+        Assert.AreEqual("custom:$abc", snapshot!.Mappings[3].CompanionId,
+            "the legacy split sends floppy alongside the truth; the truth wins");
+    }
+
+    [TestMethod]
+    public void ReadSnapshot_ReturnsNullWhenTheEnvelopeIsMissing()
+    {
+        Assert.IsNull(ProjectionWire.ReadSnapshot(Json("""{ "mappings": {} }""")));
+    }
+
+    [TestMethod]
+    public void ReadEvent_ReadsAMappingAddedWithItsRange()
+    {
+        var evt = ProjectionWire.ReadEvent("userMappingAdded", Json("""
+        { "instanceId": "inst-a", "baseRevision": 4, "revision": 7, "sessionId": 3,
+          "matrixUserId": "@alice:test", "companionId": "retro", "isBrmbleClient": true }
+        """));
+
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(ServerEventKind.MappingAdded, evt!.Kind);
+        Assert.AreEqual(4L, evt.BaseRevision);
+        Assert.AreEqual(7L, evt.Revision);
+        Assert.AreEqual(3u, evt.SessionId);
+        Assert.AreEqual("retro", evt.Entry!.CompanionId);
+    }
+
+    [TestMethod]
+    public void ReadEvent_ActivationCarriesNoEntry()
+    {
+        var evt = ProjectionWire.ReadEvent("brmbleClientActivated", Json("""
+        { "instanceId": "i", "baseRevision": 1, "revision": 2, "sessionId": 3 }
+        """));
+
+        Assert.AreEqual(ServerEventKind.BrmbleActivated, evt!.Kind);
+        Assert.IsNull(evt.Entry);
+    }
+
+    [TestMethod]
+    public void ReadEvent_DefaultsAMissingBaseRevisionToOneBelowRevision()
+    {
+        // A server predating Phase 1 sends no baseRevision. Assuming a single bump is the
+        // only reading that lets an old server still drive a new client.
+        var evt = ProjectionWire.ReadEvent("companionChanged", Json("""
+        { "instanceId": "i", "revision": 9, "sessionId": 3, "companionId": "bee" }
+        """));
+
+        Assert.AreEqual(8L, evt!.BaseRevision);
+    }
+
+    [TestMethod]
+    public void ReadEvent_ReturnsNullForAnUnknownType()
+    {
+        Assert.IsNull(ProjectionWire.ReadEvent("screenShare.started", Json("{}")));
+    }
+
+    [TestMethod]
+    public void ReadEvent_ReturnsNullWithoutASessionId()
+    {
+        Assert.IsNull(ProjectionWire.ReadEvent("companionChanged",
+            Json("""{ "instanceId": "i", "revision": 2 }""")));
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/ResyncThrottleTests.cs
+++ b/tests/Brmble.Client.Tests/Services/ResyncThrottleTests.cs
@@ -1,0 +1,67 @@
+using Brmble.Client.Services.Voice;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public class ResyncThrottleTests
+{
+    [TestMethod]
+    public void AllowsTheFirstRequestImmediately()
+    {
+        var throttle = new ResyncThrottle();
+        Assert.IsTrue(throttle.TryBegin(TimeSpan.Zero));
+    }
+
+    [TestMethod]
+    public void RefusesASecondRequestWhileOneIsInFlight()
+    {
+        var throttle = new ResyncThrottle();
+        throttle.TryBegin(TimeSpan.Zero);
+
+        Assert.IsFalse(throttle.TryBegin(TimeSpan.FromSeconds(5)),
+            "one in flight at a time, or a burst of events becomes a burst of snapshots");
+    }
+
+    [TestMethod]
+    public void EnforcesMinimumSpacingAfterCompletion()
+    {
+        var throttle = new ResyncThrottle();
+        throttle.TryBegin(TimeSpan.Zero);
+        throttle.Complete(TimeSpan.FromMilliseconds(100));
+
+        Assert.IsFalse(throttle.TryBegin(TimeSpan.FromMilliseconds(200)));
+        Assert.IsTrue(throttle.TryBegin(TimeSpan.FromMilliseconds(1200)));
+    }
+
+    [TestMethod]
+    public void BacksOffExponentiallyToThirtySeconds()
+    {
+        var throttle = new ResyncThrottle();
+        var now = TimeSpan.Zero;
+
+        for (var i = 0; i < 12; i++)
+        {
+            now += TimeSpan.FromMinutes(1);
+            Assert.IsTrue(throttle.TryBegin(now), $"attempt {i} should be allowed after a long wait");
+            throttle.Complete(now);
+        }
+
+        Assert.AreEqual(TimeSpan.FromSeconds(30), throttle.CurrentDelay,
+            "backoff must saturate rather than grow without bound");
+    }
+
+    [TestMethod]
+    public void ResetsBackoffOnceASnapshotArrives()
+    {
+        var throttle = new ResyncThrottle();
+        throttle.TryBegin(TimeSpan.Zero);
+        throttle.Complete(TimeSpan.Zero);
+        throttle.TryBegin(TimeSpan.FromSeconds(10));
+        throttle.Complete(TimeSpan.FromSeconds(10));
+
+        throttle.OnSnapshotApplied();
+
+        Assert.AreEqual(TimeSpan.FromSeconds(1), throttle.CurrentDelay);
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
+++ b/tests/Brmble.Client.Tests/Services/UserProjectionStoreSnapshotTests.cs
@@ -66,6 +66,29 @@ public class UserProjectionStoreSnapshotTests
     }
 
     [TestMethod]
+    public void Reset_ForgetsRowsHoldsAndCursor()
+    {
+        _store.ApplyServerSnapshot(Snapshot(5,
+            (1, new ServerMappingEntry("@alice:test", "retro", true, "cert-a")),
+            (99, new ServerMappingEntry("@ghost:test", null, null, null))));
+
+        _store.Reset();
+
+        Assert.AreEqual(0, _store.Snapshot().Count);
+
+        // The hold for session 99 is gone: a new occupant of that id on the next server gets
+        // no stale enrichment.
+        _store.ApplyMumbleUserState(new MumbleUserInput(99, "Mallory", 0, false, false, null, null, false));
+        Assert.IsNull(_store.Snapshot()[99].MatrixUserId);
+
+        // The cursor is gone too: the next event cannot sequence and must ask for a snapshot.
+        var change = _store.ApplyServerEvent(
+            new ServerEvent(ServerEventKind.CompanionChanged, "inst-a", 5, 6, 99,
+                new ServerMappingEntry(null, "bee", null, null)));
+        Assert.IsTrue(change.NeedsSnapshot);
+    }
+
+    [TestMethod]
     public void ApplyServerSnapshot_ForAnEntryWithNoMumbleRowIsIgnored()
     {
         // The server knows a session Mumble has not shown us. Existence is Mumble's to grant,

--- a/tests/Brmble.Server.Tests/WebSockets/ProjectionVersionTests.cs
+++ b/tests/Brmble.Server.Tests/WebSockets/ProjectionVersionTests.cs
@@ -1,0 +1,68 @@
+using Brmble.Server.Companions;
+using Brmble.Server.WebSockets;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.WebSockets;
+
+[TestClass]
+public class ProjectionVersionTests
+{
+    [TestMethod]
+    public void AbsentQueryParameterIsVersionZero() =>
+        Assert.AreEqual(0, BrmbleWebSocketHandler.ParseProjectionVersion(null));
+
+    [TestMethod]
+    public void ParsesAnExplicitVersion() =>
+        Assert.AreEqual(1, BrmbleWebSocketHandler.ParseProjectionVersion("1"));
+
+    [TestMethod]
+    public void GarbageIsVersionZero()
+    {
+        // A malformed parameter must degrade to the legacy shape, never throw a client off.
+        Assert.AreEqual(0, BrmbleWebSocketHandler.ParseProjectionVersion("banana"));
+        Assert.AreEqual(0, BrmbleWebSocketHandler.ParseProjectionVersion("-3"));
+    }
+
+    [TestMethod]
+    public void Version1SendsTheCustomSelectionInCompanionId()
+    {
+        var wire = CompanionWireSelection.For("custom:$abc", projectionVersion: 1);
+
+        Assert.AreEqual("custom:$abc", wire.CompanionId);
+        Assert.IsNull(wire.CustomCompanionId, "the split exists only for clients that need it");
+    }
+
+    [TestMethod]
+    public void Version0KeepsTheLegacySplit()
+    {
+        var wire = CompanionWireSelection.For("custom:$abc", projectionVersion: 0);
+
+        Assert.AreEqual("floppy", wire.CompanionId);
+        Assert.AreEqual("custom:$abc", wire.CustomCompanionId);
+    }
+
+    [TestMethod]
+    public void AnUnknownCompanionIsNullAtVersion1()
+    {
+        // Absent must not be transmitted as "floppy": that is the defect the design removes.
+        Assert.IsNull(CompanionWireSelection.For(null, projectionVersion: 1).CompanionId);
+    }
+
+    [TestMethod]
+    public void AnUnknownCompanionIsAlsoNullAtVersion0()
+    {
+        // The legacy split is about custom skins, not about inventing a companion for a mapping
+        // that has none. FromPersisted(null) must not manufacture a floppy either.
+        var wire = CompanionWireSelection.For(null, projectionVersion: 0);
+
+        Assert.IsNull(wire.CompanionId);
+        Assert.IsNull(wire.CustomCompanionId);
+    }
+
+    [TestMethod]
+    public void ABuiltInCompanionIsUnchangedByTheVersion()
+    {
+        Assert.AreEqual("retro", CompanionWireSelection.For("retro", projectionVersion: 0).CompanionId);
+        Assert.AreEqual("retro", CompanionWireSelection.For("retro", projectionVersion: 1).CompanionId);
+    }
+}


### PR DESCRIPTION
Phase 3 of the user projection. Stacked on #622 (`feature/user-projection-phase-2`) - **base that branch, not `main`**.

Implements the plan in `docs/superpowers/plans/2026-08-01-user-projection-phase-3-wiring.md` (spec sections 3.4, 4.4, 5, 6, 8, 9, 11) in four independently-green stages.

## What this does

- **Stage A** - the projection becomes the client's only user state. Deletes `_sessionMappings`, `_pendingBrmbleStatus`, `_userMappings`, `SessionMappingEntry`, `ParseSessionMappings` and friends. A new `ProjectionWire` translates wire payloads into store inputs and is the only place that knows both JSON and the projection.
- **Stage B** - the WebSocket stream is hoisted out of the reconnect loop so the client can send, and a `ResyncThrottle` requests a snapshot when the store reports a gap. A credential refresh no longer tears down a live socket.
- **Stage C** - the client announces `pv=1` and the server sends one truthful `companionId` instead of the legacy `floppy` + `customCompanionId` split. Threaded through all three snapshot paths; broadcasts stay on the split because their recipients are at mixed versions.
- **Stage D** - `voice.usersReset` and `voice.usersChanged` replace the old per-field event set, and React state collapses into a `useUserDirectory` hook with avatars keyed by matrix id rather than session.

## Verification

- `dotnet test`: **1342 passing** (Server 799, Client 371, MumbleVoiceEngine 99, Audio 73), up from 1308 at baseline
- `npm run test`: **1490 passing**, up from 1481
- `dotnet build` and `npx tsc --noEmit` clean; `npm run build` succeeds
- All four of the plan's "Done when" greps pass

Manually tested with 4 concurrent clients against a local Docker stack: restart recovery, session-id recycling, and concurrent connect all behave. **Custom companions were not manually verified** - left to @MjG. The failure to watch for there is a custom skin rendering as floppy on other clients, since Stage C is what changed that wire format.

## Three defects this found in live testing

Each was root-caused, reproduced as a failing test, then fixed:

1. **Empty certificate hash defeated the Phase 2 review fix.** MumbleSharp initialises `CertificateHash` to `string.Empty` and never nulls it, so two certificate-less users compared equal and a recycled session id handed the new occupant the previous one's identity. Normalised at the adapter.
2. **`/auth/token` wiped every identity.** Its body names the mappings block `sessionMappings`; the WebSocket calls it `mappings`. `ReadSnapshot` understood only the latter, so every credential fetch produced a valid envelope with zero entries, which `ApplyServerSnapshot` correctly applied as "the server knows nobody". Live symptom: identities restored on reconnect, then wiped seconds later by a credential refresh. A missing block now returns null rather than an empty table.
3. **Self avatar depended on server state.** Keying every avatar on `row.matrixUserId` made a locally-known fact depend on something that can legitimately become unknown. The join now falls back to the client's own matrix id, for the self row only.

## Judgement calls

- **`voice.userLeft` kept**, as presentation only. `moved`, `previousChannelId` and `currentChannelId` are genuinely dead, but `name`, `channelId` and `certHash` drive the "left your channel" TTS line, the overlay event and DM-offline marking. Decisively, a user moving out of your channel is not a removal at all, so `removed: [session]` cannot express it.
- **`TryUpdateCompanionIdIfCurrent` kept.** Spec 4.4 proposed retiring it, but `CustomCompanionEndpoints` computes its reset target inside `PublishAsync`'s gate and carries no client revision, so there is nothing for revision rejection to reject. The CAS also gates the announcement.

## Plan corrections

The plan was wrong in five places, all documented in the relevant commit messages: the test harness needs `_projection` seeded (`GetUninitializedObject` skips field initialisers); `ResyncThrottle` failed its own spacing test; Task C2's null-companion test could not compile because the server had no way to express an unknown companion; and Task D3's "delete handler" would have silently dropped the join TTS, overlay events and avatar fetch.

## Out of scope

Issue #628 (duel does not close after a server restart) was found during this testing but is pre-existing and untouched here.