### PR TITLE
fix: correct companion selection and connection visibility

### DIFF
--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1542,7 +1542,7 @@ function App() {
     requestCompanionAtlas,
     users,
   ]);
-  useCompanionOverlayPublisher(overlaySettings, overlaySnapshot);
+  useCompanionOverlayPublisher(overlaySettings, overlaySnapshot, connected);
   useServerHealth();
 
   // Avatar state and management

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -5092,6 +5092,7 @@ const handleConnect = (serverData: SavedServer) => {
         customCompanionGallery={customCompanionGallery}
         customCompanionMatrixClient={matrixClient.client ?? undefined}
         onCustomCompanionAtlasRequest={requestSettingsCompanionAtlas}
+        selectedCompanion={requestedLocalCompanion}
         liveUsers={users}
         channels={channels}
         onChannelsChange={setChannels}

--- a/src/Brmble.Web/src/components/SettingsModal/InterfaceSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/InterfaceSettingsTab.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { InterfaceSettingsTab } from './InterfaceSettingsTab';
 import { DEFAULT_BRMBLEGOTCHI, DEFAULT_OVERLAY } from './InterfaceSettingsTypes';
 import type { CustomCompanionGalleryController } from '../../hooks/useCustomCompanionGallery';
+import type { CustomCompanionEntry } from '../../customCompanions/customCompanionTypes';
 
 const disabledGallery: CustomCompanionGalleryController = {
   status: 'disabled',
@@ -19,6 +20,19 @@ const disabledGallery: CustomCompanionGalleryController = {
 };
 
 describe('InterfaceSettingsTab', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', class {
+      constructor() {}
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('does not render plain inline overlay help text', () => {
     render(
       <InterfaceSettingsTab
@@ -55,5 +69,43 @@ describe('InterfaceSettingsTab', () => {
     expect(screen.getByRole('heading', { name: 'Custom' })).toBeVisible();
     await user.click(screen.getAllByRole('button', { name: /Upload custom sprite/ })[0]);
     expect(screen.getByRole('dialog', { name: 'Upload custom companion' })).toBeVisible();
+  });
+
+  it('highlights the effective custom selection instead of the built-in fallback', () => {
+    const customEntry: CustomCompanionEntry = {
+      id: 'custom:$orbit:test',
+      eventId: '$orbit:test',
+      roomId: '!gallery:test',
+      name: 'Orbit',
+      mediaUri: 'mxc://test/orbit',
+      mimeType: 'image/png',
+      width: 1536,
+      height: 1872,
+      frameCount: 1,
+      byteSize: 1024,
+      uploaderMatrixUserId: '@alice:test',
+      uploaderDisplayName: 'Alice',
+      createdAt: 1,
+      atlasCacheKey: '!gallery:test\u0000$orbit:test',
+    };
+
+    render(
+      <InterfaceSettingsTab
+        appearanceSettings={{ theme: 'classic' }}
+        overlaySettings={{ ...DEFAULT_OVERLAY, mode: 'full', myCompanion: 'floppy' }}
+        brmblegotchiSettings={DEFAULT_BRMBLEGOTCHI}
+        customCompanionGallery={{ ...disabledGallery, status: 'ready', entries: [customEntry] }}
+        selectedCompanion={customEntry.id}
+        onAppearanceChange={vi.fn()}
+        onOverlayChange={vi.fn()}
+        onBrmblegotchiChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /Orbit, uploaded by Alice/ }))
+      .toHaveAttribute('aria-pressed', 'true');
+    for (const label of ['Bee', 'Engineer', 'Floppy', 'Patch', 'Pip', 'Retro']) {
+      expect(screen.getByRole('button', { name: label })).toHaveAttribute('aria-pressed', 'false');
+    }
   });
 });

--- a/src/Brmble.Web/src/components/SettingsModal/InterfaceSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/InterfaceSettingsTab.tsx
@@ -24,6 +24,7 @@ interface InterfaceSettingsTabProps {
   customCompanionMatrixClient?: MatrixUploadClient;
   onCustomCompanionAtlasRequest?: (selection: CompanionSelection) => void;
   onCustomCompanionUploadActivityChange?: (active: boolean) => void;
+  selectedCompanion?: CompanionSelection;
 }
 
 export function InterfaceSettingsTab({ 
@@ -35,6 +36,7 @@ export function InterfaceSettingsTab({
   customCompanionMatrixClient,
   onCustomCompanionAtlasRequest,
   onCustomCompanionUploadActivityChange,
+  selectedCompanion,
 }: InterfaceSettingsTabProps) {
   
   const [localAppearance, setLocalAppearance] = useState<AppearanceSettings>(appearanceSettings);
@@ -126,7 +128,7 @@ export function InterfaceSettingsTab({
             <label>My Companion</label>
             {customCompanionGallery ? (
               <CompanionPicker
-                value={overlaySettings.myCompanion}
+                value={selectedCompanion ?? overlaySettings.myCompanion}
                 gallery={customCompanionGallery}
                 onChange={handleMyCompanionChange}
                 onRequestCustomAtlas={onCustomCompanionAtlasRequest}

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -70,6 +70,7 @@ interface SettingsModalProps {
   customCompanionGallery?: CustomCompanionGalleryController;
   customCompanionMatrixClient?: MatrixUploadClient;
   onCustomCompanionAtlasRequest?: (selection: CompanionSelection) => void;
+  selectedCompanion?: CompanionSelection;
 }
 
 export interface ScreenShareSettings {
@@ -549,6 +550,7 @@ export function SettingsModal(props: SettingsModalProps) {
         customCompanionGallery={props.customCompanionGallery}
         customCompanionMatrixClient={props.customCompanionMatrixClient}
         onCustomCompanionAtlasRequest={props.onCustomCompanionAtlasRequest}
+        selectedCompanion={props.selectedCompanion}
         onCustomCompanionUploadActivityChange={setCustomCompanionUploadActive}
       />
           )}

--- a/src/Brmble.Web/src/hooks/useCompanionOverlayPublisher.test.ts
+++ b/src/Brmble.Web/src/hooks/useCompanionOverlayPublisher.test.ts
@@ -16,7 +16,7 @@ vi.mock('../bridge', () => ({
 describe('useCompanionOverlayPublisher', () => {
   it('publishes overlay.sync payload', () => {
     const snapshot = createOverlaySnapshot('7', 'Raid');
-    renderHook(() => useCompanionOverlayPublisher({ ...DEFAULT_OVERLAY, overlayEnabled: true }, snapshot));
+    renderHook(() => useCompanionOverlayPublisher({ ...DEFAULT_OVERLAY, overlayEnabled: true }, snapshot, true));
 
     expect(bridge.send).toHaveBeenCalledWith('overlay.sync', expect.objectContaining({
       enabled: true,
@@ -43,7 +43,7 @@ describe('useCompanionOverlayPublisher', () => {
       liveUserSessions: [42],
     });
 
-    renderHook(() => useCompanionOverlayPublisher({ ...DEFAULT_OVERLAY, overlayEnabled: true }, snapshot));
+    renderHook(() => useCompanionOverlayPublisher({ ...DEFAULT_OVERLAY, overlayEnabled: true }, snapshot, true));
 
     expect(bridge.send).toHaveBeenCalledWith('overlay.sync', expect.objectContaining({
       snapshot: expect.objectContaining({
@@ -52,6 +52,22 @@ describe('useCompanionOverlayPublisher', () => {
           flags: expect.objectContaining({ localMuted: true, liveUserSessions: [42] }),
         }),
       }),
+    }));
+  });
+
+  it('hides the overlay while disconnected even when the setting is enabled', () => {
+    const snapshot = createOverlaySnapshot('7', 'Raid');
+
+    renderHook(() => useCompanionOverlayPublisher(
+      { ...DEFAULT_OVERLAY, overlayEnabled: true },
+      snapshot,
+      false,
+    ));
+
+    expect(bridge.send).toHaveBeenCalledWith('overlay.sync', expect.objectContaining({
+      enabled: false,
+      settings: null,
+      snapshot: null,
     }));
   });
 });

--- a/src/Brmble.Web/src/hooks/useCompanionOverlayPublisher.ts
+++ b/src/Brmble.Web/src/hooks/useCompanionOverlayPublisher.ts
@@ -13,13 +13,15 @@ export interface OverlaySyncPayload {
 export function useCompanionOverlayPublisher(
   overlaySettings: OverlaySettings,
   snapshot: CompanionOverlaySnapshot | null,
+  connected: boolean,
 ) {
+  const visible = overlaySettings.overlayEnabled && connected;
   const payload = useMemo<OverlaySyncPayload>(() => ({
-    enabled: overlaySettings.overlayEnabled,
+    enabled: visible,
     mode: overlaySettings.mode,
-    settings: overlaySettings,
-    snapshot,
-  }), [overlaySettings, snapshot]);
+    settings: visible ? overlaySettings : null,
+    snapshot: visible ? snapshot : null,
+  }), [overlaySettings, snapshot, visible]);
 
   useEffect(() => {
     bridge.send('overlay.sync', payload);


### PR DESCRIPTION
## Summary

- Highlight the effective custom companion selection instead of the previous built-in fallback.
- Hide the companion overlay whenever the client is not connected to a server.

## Root cause

The settings picker received the global built-in fallback instead of the current server-specific companion selection. Separately, overlay publication was gated only by the persisted enabled setting, allowing an idle companion snapshot to be published before connection.

## Validation

- Focused regression tests: 6 passed
- Type-check: passed
- Full web suite: 123 test files, 1,525 tests passed