### PR TITLE
Delete messages

### DIFF
--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -1394,3 +1394,11 @@ See `src/Brmble.Web/src/themes/_template.css` for guidance values per token.
 | `UpdateNotification` | `info` | `top-right` | No | `Update available` | `Press Update to install v{version}.` |
 | `BrokenCertNotification` | `warning` | `top-right` | No | `Certificate missing` | Profile name, switched-to info, recovery instructions |
 | `game-command-error` (App) | `error` | `top-right` | No | `Ready check failed` / `Rematch response failed` / `Rematch request failed` | Server `reason` for the rejected duel command |
+#### Chat context action failures
+
+A rejected message context-menu mutation (for example, server-authorized
+message deletion) renders one localized `role="alert"` row directly above the
+chat composer. Use `.chat-action-error`, danger tokens, a labeled dismiss
+button, and the server-provided human-readable message. Clear the row before
+retrying and after success. Do not use `window.alert`, add a feature-specific
+modal, or create a second toast system.

--- a/docs/superpowers/plans/2026-08-06-message-deletion-actor-routing.md
+++ b/docs/superpowers/plans/2026-08-06-message-deletion-actor-routing.md
@@ -1,0 +1,203 @@
+# Message Deletion Actor Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore recent-message deletion for Brmble users by routing Matrix redactions through the correct actor for channels and direct messages.
+
+**Architecture:** `MessageDeletionService` remains the authorization boundary and first classifies the registered room as a channel or DM. Channel redactions use the existing default Brmble bot actor so administrators can moderate other users; DM redactions use the authenticated requester, with DM room creation explicitly allowing participant redactions. The existing optional actor parameter on `IMatrixAppService.RedactRoomEvent` is retained.
+
+**Tech Stack:** .NET 10, ASP.NET Core minimal APIs, MSTest, Moq, Dapper, Matrix Client-Server API, TypeScript/React existing deletion client.
+
+## Global Constraints
+
+- Non-admins may delete only their own channel or DM message within 24 hours.
+- Admins may delete any channel or DM message within 24 hours.
+- Brmble server authorization remains authoritative; Matrix room permissions must not replace it.
+- Channel redactions use the bot default; DM redactions use the authenticated requester.
+- Do not add the Brmble bot to private DMs or use a Matrix admin token.
+- Preserve unrelated bot-owned redaction callers and existing error/status mappings.
+
+---
+
+### Task 1: Add failing actor-routing coverage
+
+**Files:**
+- Modify: `tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs`
+- Modify: `tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs` only if the existing fixture needs a DM mapping helper
+
+**Interfaces:**
+- Consumes: `MessageDeletionService.DeleteAsync(User requester, string roomId, string eventId, CancellationToken cancellationToken)`.
+- Produces: assertions that channel deletion calls `RedactRoomEvent(room, event, reason)` with the default bot actor and DM deletion calls the four-argument overload with the requester Matrix ID.
+
+- [ ] **Step 1: Add a registered-DM fixture helper and four focused tests**
+
+Use the existing `FactoryAsync` setup and add a DM mapping for the authenticated user. Add tests named:
+
+```csharp
+[TestMethod]
+public async Task Administrator_DeletesOtherUsersChannelMessage_AsBot()
+
+[TestMethod]
+public async Task Author_DeletesOwnDmMessage_AsRequester()
+
+[TestMethod]
+public async Task Administrator_DeletesOtherUsersDmMessage_AsRequester()
+
+[TestMethod]
+public async Task NonAdministrator_CannotDeleteOtherUsersDmMessage()
+```
+
+For channel moderation, verify:
+
+```csharp
+factory.MatrixAppMock.Verify(matrix => matrix.RedactRoomEvent(
+    RoomId, EventId, "Deleted through Brmble", null), Times.Once);
+```
+
+For DM deletion, verify the requester actor:
+
+```csharp
+factory.MatrixAppMock.Verify(matrix => matrix.RedactRoomEvent(
+    DmRoomId, EventId, "Deleted through Brmble", "@alice:test"), Times.Once);
+```
+
+The non-admin test must assert `403`, code `not_authorized`, and no redaction.
+
+- [ ] **Step 2: Run the focused tests and confirm the expected failures**
+
+Run:
+
+```text
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter FullyQualifiedName~MessageDeletionEndpointTests
+```
+
+Expected: the new channel moderation assertion fails because the service currently passes `@alice:test`; DM setup/assertions fail because the service does not distinguish room types.
+
+### Task 2: Route channel and DM redaction actors
+
+**Files:**
+- Modify: `src/Brmble.Server/Messages/MessageDeletionService.cs`
+- Modify: `tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs`
+
+**Interfaces:**
+- Consumes: channel and DM room repositories already injected into `MessageDeletionService`.
+- Produces: a private room-classification result and actor selection that calls `RedactRoomEvent(roomId, eventId, reason, actor)`.
+
+- [ ] **Step 1: Add a private room classifier without changing authorization behavior**
+
+Refactor `IsRequesterConversationAsync` into a method that returns a room kind, for example:
+
+```csharp
+private enum ConversationKind { Channel, DirectMessage, Unknown }
+```
+
+Check channel mappings first, then the requester’s DM mappings. Return `Unknown` when neither contains the requested room. Return `Forbidden` before Matrix access for `Unknown`, preserving the existing security behavior.
+
+- [ ] **Step 2: Implement the minimal actor selection**
+
+After the existing policy returns `Allowed`, call:
+
+```csharp
+var redactionActor = conversationKind == ConversationKind.DirectMessage
+    ? requester.MatrixUserId
+    : null;
+
+await _matrix.RedactRoomEvent(
+    roomId,
+    eventId,
+    "Deleted through Brmble",
+    redactionActor);
+```
+
+Do not use `effectiveAuthor` as the redaction actor. Keep the current trusted-author parsing and policy evaluation unchanged.
+
+- [ ] **Step 3: Run the focused server tests**
+
+Run the same `MessageDeletionEndpointTests` command. Expected: all actor-routing tests and all existing deletion tests pass.
+
+- [ ] **Step 4: Commit the implementation unit**
+
+```text
+git add src/Brmble.Server/Messages/MessageDeletionService.cs tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
+git commit -m "fix: route message deletion by room type"
+```
+
+### Task 3: Permit participant redaction in newly created DMs
+
+**Files:**
+- Modify: `src/Brmble.Server/Matrix/MatrixAppService.cs` in `CreateDMRoom`
+- Modify: `tests/Brmble.Server.Tests/Matrix/MatrixAppServiceTests.cs`
+
+**Interfaces:**
+- Consumes: existing `CreateDMRoom(string localpartA, string localpartB)`.
+- Produces: DM rooms whose initial `m.room.power_levels` state permits joined participants to submit redactions, while the server endpoint still controls who may request deletion.
+
+- [ ] **Step 1: Add a failing request-shape test**
+
+Capture the `createRoom` JSON in the existing Matrix HTTP test handler, call `CreateDMRoom("alice", "bob")`, and assert the initial state includes:
+
+```json
+{
+  "type": "m.room.power_levels",
+  "content": { "redact": 0 }
+}
+```
+
+The test should fail because the current `trusted_private_chat` request has no explicit power-level state.
+
+- [ ] **Step 2: Add explicit DM power levels**
+
+Change the `CreateDMRoom` body to include an `initial_state` entry for `m.room.power_levels` with `users_default: 0`, `events_default: 0`, `state_default: 50`, and `redact: 0`. Preserve the private trusted invite behavior and the two participant IDs.
+
+- [ ] **Step 3: Run Matrix-focused tests**
+
+Run:
+
+```text
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj --filter FullyQualifiedName~MatrixAppServiceTests
+```
+
+Expected: all Matrix service tests pass, including the new DM power-level assertion and existing bot-default redaction tests.
+
+- [ ] **Step 4: Commit the DM room change**
+
+```text
+git add src/Brmble.Server/Matrix/MatrixAppService.cs tests/Brmble.Server.Tests/Matrix/MatrixAppServiceTests.cs
+git commit -m "fix: allow participant redaction in new DMs"
+```
+
+### Task 4: Full verification and final review
+
+**Files:**
+- Verify only: all files changed by Tasks 1–3
+
+- [ ] **Step 1: Run the complete server test suite**
+
+```text
+dotnet test tests/Brmble.Server.Tests/Brmble.Server.Tests.csproj
+```
+
+Expected: zero failed tests.
+
+- [ ] **Step 2: Run the relevant web regression tests**
+
+```text
+npm run test -- --run src/utils/replyHelpers.test.ts
+npm run test -- --run src/components/ChatPanel/ChatPanel.test.tsx
+npm run test -- --run src/components/ChatPanel/MessageBubble.test.tsx
+```
+
+Expected: all existing deletion UI tests pass; no frontend behavior changes are required.
+
+- [ ] **Step 3: Inspect formatting and scope**
+
+Run `git diff --check`, inspect the scoped diff, and confirm no untracked user files were staged. Confirm the final behavior matrix matches the requirement for channel/DM and author/admin combinations.
+
+- [ ] **Step 4: Commit verification-only adjustments if needed**
+
+Only commit if a test-only correction was required:
+
+```text
+git add <scoped-test-files>
+git commit -m "test: cover message deletion actor routing"
+```

--- a/docs/superpowers/plans/2026-08-06-trusted-author-metadata.md
+++ b/docs/superpowers/plans/2026-08-06-trusted-author-metadata.md
@@ -1,0 +1,54 @@
+# Trusted Author Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Trust bridged author metadata only when the Matrix event sender is the exact configured Brmble bot.
+
+**Architecture:** Derive the bot identity once from `MatrixSettings.ServerDomain`, expose it in the authenticated web Matrix credentials, and pass it explicitly into both server parsing and web event transformation. Invalid sender/metadata combinations fall back to the actual Matrix sender.
+
+**Tech Stack:** ASP.NET Core/C#, MSTest, React/TypeScript, Vitest.
+
+## Global Constraints
+
+- Preserve existing bridged message formatting and deletion-window behavior.
+- Use exact ordinal Matrix user-ID comparisons.
+- Add regression coverage before production changes.
+
+---
+
+### Task 1: Server trust validation
+
+**Files:**
+- Modify: `src/Brmble.Server/Messages/MessageDeletionPolicy.cs`
+- Modify: `src/Brmble.Server/Messages/MessageDeletionService.cs`
+- Modify: `src/Brmble.Server/Auth/AuthEndpoints.cs`
+- Modify: `tests/Brmble.Server.Tests/Messages/MessageDeletionPolicyTests.cs`
+
+- [ ] Write a failing test that parses forged metadata from `@alice:test` with trusted bot `@brmble:test` and expects `AuthorMatrixUserId` to be null.
+- [ ] Run the server policy test and confirm it fails because parsing currently accepts the field.
+- [ ] Add `trustedBotUserId` to parsing, retaining metadata only on an exact sender match; pass the configured bot ID from deletion service and expose the same ID in the auth Matrix payload.
+- [ ] Add/retain the positive bot-authored parsing test.
+- [ ] Run the server policy tests and confirm they pass.
+
+### Task 2: Web trust validation
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.ts`
+- Modify: `src/Brmble.Web/src/utils/matrixCredentials.ts`
+- Modify: `src/Brmble.Web/src/hooks/useMatrixClient.test.ts`
+- Modify: `src/Brmble.Web/src/utils/matrixCredentials.test.ts`
+
+- [ ] Write a failing transformer test where a non-bot sender forges the author field and expect the sender ID to remain the event sender.
+- [ ] Run the focused Vitest test and confirm it fails because metadata is currently trusted unconditionally.
+- [ ] Add `botUserId` to credentials and transformer inputs, and honor metadata only when the actual sender exactly equals that ID.
+- [ ] Include `botUserId` in credential equality.
+- [ ] Run focused web tests and confirm they pass.
+
+### Task 3: Full verification
+
+**Files:**
+- No additional files.
+
+- [ ] Run the full server test project.
+- [ ] Run the full web test suite.
+- [ ] Review the diff for scope, exact comparisons, and absence of forged-metadata paths.

--- a/docs/superpowers/specs/2026-08-06-message-deletion-actor-routing-design.md
+++ b/docs/superpowers/specs/2026-08-06-message-deletion-actor-routing-design.md
@@ -1,0 +1,38 @@
+# Message Deletion Actor Routing Design
+
+## Goal
+
+Restore message deletion for Brmble users while preserving the server-side policy: non-admins may delete only their own channel or DM messages within 24 hours, and admins may delete any channel or DM message within 24 hours.
+
+## Root Cause
+
+The Matrix redaction actor was changed to the authenticated requester for every room. That allows a user to redact their own event, but it prevents a Brmble administrator from deleting another user's channel message because the requester does not have sufficient Matrix power. Direct-message rooms also reject participant redactions under their current Matrix power-level defaults, so both own and other-user DM deletions fail.
+
+## Design
+
+1. Keep `MessageDeletionService` as the source of truth for Brmble authorization and the 24-hour deletion window.
+2. Identify whether the requested room is a registered channel or a registered DM room.
+3. For channel messages, redact through the Brmble bot, preserving the pre-requester behavior that permits server administrators to moderate other users' messages.
+4. For DM messages, redact as the authenticated requester. Update DM room creation to define participant redaction permission explicitly so a joined participant can redact through Matrix. Brmble authorization still prevents non-admins from deleting another participant's message.
+5. Preserve the existing optional actor parameter on `IMatrixAppService.RedactRoomEvent`; callers unrelated to message deletion continue to use the bot default.
+
+## Error Handling
+
+Authorization failures remain `403 not_authorized`, expired messages remain `410 expired`, and Matrix transport or authorization failures continue to be surfaced by the existing endpoint mapping. The service must not fall back from a DM requester to the bot, because the bot is not a participant in existing two-person DMs.
+
+## Testing
+
+Add policy/service coverage proving actor selection for registered channels and DMs. Extend integration coverage to verify:
+
+- an ordinary user can delete their own recent channel message;
+- an administrator can delete another user's recent channel message through the bot actor;
+- an ordinary user can delete their own recent DM message through their own Matrix identity;
+- an administrator can delete another user's recent DM message through their own Matrix identity;
+- an ordinary user cannot delete another user's recent message;
+- the 24-hour limit and existing invalid/already-deleted behavior remain unchanged.
+
+Add Matrix app-service coverage proving the channel path retains the bot default and the DM path includes the requester actor. Keep the test changes scoped to message deletion and DM room power-level construction.
+
+## Scope
+
+This change does not alter message display, frontend eligibility, Matrix user identity validation, room membership, or unrelated bot-owned redactions.

--- a/docs/superpowers/specs/2026-08-06-message-deletion-bridge-author-design.md
+++ b/docs/superpowers/specs/2026-08-06-message-deletion-bridge-author-design.md
@@ -1,0 +1,36 @@
+# Message Deletion for Mumble-Relayed Messages
+
+## Goal
+
+Allow a user to delete their own recent messages even when the message was relayed from Mumble by the Brmble Matrix bot. Preserve the existing authorization rules: authors may delete their own messages within 24 hours, administrators may delete any recent message, and other non-administrators may not delete someone else’s message.
+
+## Root cause
+
+Direct Matrix messages are authored by the user’s Matrix ID. Mumble-relayed messages are authored by the Brmble bot and currently put the Mumble display name only in the visible body prefix. The client and server therefore cannot safely determine the actual author. Admins can delete these messages through the moderation path, but non-admin authors cannot.
+
+## Chosen design
+
+When the authenticated server-side Mumble relay sends a message, it adds a dedicated event-content field containing the authenticated Matrix user ID. The visible body remains unchanged. The field is not accepted from the browser as an authorization claim; it is written only by the server relay using the authenticated sender mapping.
+
+The server parses this field as the effective author and evaluates deletion against it. For direct Matrix messages, or older relayed messages without the field, the Matrix event sender remains the author. The browser uses the same effective-author field when deciding whether to show the Delete action. Admin capability remains a server-issued hint for UI visibility, with the server remaining authoritative.
+
+## Data flow
+
+1. The Mumble event handler receives an authenticated sender and calls the Matrix relay.
+2. The relay writes `com.brmble.author_matrix_user_id` alongside the normal message content.
+3. The Matrix client reads the field into `ChatMessage.senderMatrixUserId` for bridged messages.
+4. The deletion endpoint parses the field and passes the effective author to the existing 24-hour policy.
+5. Direct messages and legacy bridged events continue to use the Matrix event sender.
+
+The metadata is an ownership hint only when produced by the trusted server relay. It is never accepted as a request-body override and cannot grant moderation rights.
+
+## Testing
+
+- Matrix deletion policy: a recent bridged message is allowed for its effective author and forbidden for another non-admin.
+- Server integration: the relay writes the authenticated author metadata; the deletion endpoint permits that author and rejects another non-admin.
+- Web transformation/eligibility: the metadata is exposed as the message sender identity and the Delete action appears for the author.
+- Existing direct-message, administrator, expiry, redaction, and non-author tests remain passing.
+
+## Scope
+
+Keep the 24-hour window, redaction behavior, room authorization, and admin permission checks unchanged. Do not infer ownership from display names or visible body prefixes. No migration is required; old events use their actual Matrix sender.

--- a/docs/superpowers/specs/2026-08-06-trusted-author-metadata-design.md
+++ b/docs/superpowers/specs/2026-08-06-trusted-author-metadata-design.md
@@ -1,0 +1,19 @@
+# Trusted Author Metadata Design
+
+## Goal
+
+Prevent arbitrary Matrix users from asserting `com.brmble.author_matrix_user_id` as trusted authorship metadata.
+
+## Design
+
+The server will expose one exact trusted bot Matrix ID, derived from `MatrixSettings.ServerDomain` using the same `@brmble:<domain>` identity used by `MatrixAppService`. `MatrixMessageMetadata.Parse` will only retain the custom author field when the event's actual `sender` exactly matches that trusted bot ID. The deletion service will pass the configured ID into parsing, so forged metadata falls back to the event sender before authorization.
+
+The web credential payload will include the same `botUserId`. `transformEventToChatMessage` will accept that trusted ID and apply custom author metadata only when the event sender exactly matches it. Existing bridge display-name parsing remains unchanged.
+
+## Testing
+
+Server policy tests will verify that bot-authored metadata is retained and non-bot forged metadata is ignored. Web transformer tests will verify the same positive and negative cases. Credential equality tests will include the bot ID so a configuration change refreshes the client state.
+
+## Scope
+
+No changes to Matrix message format, deletion permissions, moderation rules, or existing author metadata producers are required.

--- a/src/Brmble.Client/Program.cs
+++ b/src/Brmble.Client/Program.cs
@@ -13,6 +13,7 @@ using Brmble.Client.Services.Games;
 using Brmble.Client.Services.Paint;
 using Brmble.Client.Services.Update;
 using Brmble.Client.Services.Idle;
+using Brmble.Client.Services.Messages;
 using Brmble.Client.Overlay;
 using System.Text.Json;
 
@@ -30,6 +31,7 @@ static class Program
     private static MumbleAdapter? _mumbleClient;
     private static GameService? _gameService;
     private static PaintService? _paintService;
+    private static MessageService? _messageService;
     private static UpdateService? _updateService;
     private static IdleService? _idleService;
     private static CompanionOverlayRelay? _overlayRelay;
@@ -383,6 +385,14 @@ static class Program
                 MumbleAdapter.GetChannelRequestViaBcTls);
             _gameService.Initialize(_bridge);
             _gameService.RegisterHandlers(_bridge);
+
+            _messageService = new MessageService(
+                _bridge,
+                () => _certService?.GetExportableCertificate(),
+                () => _mumbleClient?.ApiUrl,
+                MumbleAdapter.PostChannelRequestViaBcTls);
+            _messageService.Initialize(_bridge);
+            _messageService.RegisterHandlers(_bridge);
 
             _paintService = new PaintService(
                 _bridge,

--- a/src/Brmble.Client/Services/Messages/MessageService.cs
+++ b/src/Brmble.Client/Services/Messages/MessageService.cs
@@ -1,0 +1,130 @@
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using Brmble.Client.Bridge;
+using Brmble.Client.Services.Voice;
+
+namespace Brmble.Client.Services.Messages;
+
+internal sealed class MessageService : IService
+{
+    private readonly Func<X509Certificate2?> _getCertificate;
+    private readonly Func<string?> _getApiUrl;
+    private readonly Func<
+        X509Certificate2,
+        Uri,
+        string,
+        Task<ChannelRequestBridgeHandler.TlsCallResult>> _postJsonAsync;
+    private NativeBridge? _bridge;
+
+    public MessageService(
+        NativeBridge? bridge,
+        Func<X509Certificate2?> getCertificate,
+        Func<string?> getApiUrl,
+        Func<
+            X509Certificate2,
+            Uri,
+            string,
+            Task<ChannelRequestBridgeHandler.TlsCallResult>> postJsonAsync)
+    {
+        _bridge = bridge;
+        _getCertificate = getCertificate;
+        _getApiUrl = getApiUrl;
+        _postJsonAsync = postJsonAsync;
+    }
+
+    public string ServiceName => "messages";
+
+    public void Initialize(NativeBridge bridge) => _bridge = bridge;
+
+    public void RegisterHandlers(NativeBridge bridge)
+    {
+        bridge.RegisterHandler("messages.delete", DeleteAsync);
+    }
+
+    private async Task DeleteAsync(JsonElement data)
+    {
+        var requestId =
+            data.TryGetProperty("requestId", out var requestIdElement)
+            && requestIdElement.TryGetInt32(out var parsedRequestId)
+                ? parsedRequestId
+                : (int?)null;
+
+        try
+        {
+            var roomId = data.TryGetProperty(
+                "roomId", out var roomElement)
+                ? roomElement.GetString()
+                : null;
+            var eventId = data.TryGetProperty(
+                "eventId", out var eventElement)
+                ? eventElement.GetString()
+                : null;
+            var apiUrl = _getApiUrl();
+
+            if (string.IsNullOrWhiteSpace(apiUrl)
+                || string.IsNullOrWhiteSpace(roomId)
+                || string.IsNullOrWhiteSpace(eventId))
+            {
+                SendResponse(
+                    requestId,
+                    success: false,
+                    body: null,
+                    statusCode: 0,
+                    error: "Not connected or invalid message deletion request.");
+                return;
+            }
+
+            using var cert = _getCertificate();
+            if (cert is null)
+            {
+                SendResponse(
+                    requestId,
+                    success: false,
+                    body: null,
+                    statusCode: 0,
+                    error: "No client certificate.");
+                return;
+            }
+
+            var body = JsonSerializer.Serialize(new { roomId, eventId });
+            var result = await _postJsonAsync(
+                cert,
+                new Uri(new Uri(apiUrl, UriKind.Absolute), "messages/delete"),
+                body);
+
+            SendResponse(
+                requestId,
+                result.Success,
+                result.Body,
+                result.StatusCode,
+                result.Error);
+        }
+        catch (Exception ex)
+        {
+            SendResponse(
+                requestId,
+                success: false,
+                body: null,
+                statusCode: 0,
+                error: ex.Message);
+        }
+    }
+
+    private void SendResponse(
+        int? requestId,
+        bool success,
+        string? body,
+        int statusCode,
+        string? error)
+    {
+        _bridge?.Send("messages.response", new
+        {
+            requestId,
+            success,
+            body,
+            statusCode,
+            error
+        });
+        _bridge?.NotifyUiThread();
+    }
+}

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -4,6 +4,7 @@ using Brmble.Server.Companions;
 using Brmble.Server.Events;
 using Brmble.Server.Matrix;
 using Brmble.Server.Mumble;
+using Brmble.Server.Messages;
 using Microsoft.Extensions.Options;
 
 namespace Brmble.Server.Auth;
@@ -165,6 +166,8 @@ public static class AuthEndpoints
 
             // Ensure user is in all rooms, then sync display name
             await matrixAppService.EnsureUserInRooms(result.Localpart, roomMap.Values);
+            var canModerateServer =
+                await aclAuthorization.CanModerateServerAsync(result.UserId);
             CustomCompanionCapability? customCompanions = null;
             try
             {
@@ -177,7 +180,7 @@ public static class AuthEndpoints
                         SchemaVersion: 1,
                         GalleryRoomId: galleryRoomId,
                         TrustedSender: $"@brmble:{matrixSettings.Value.ServerDomain}",
-                        CanModerate: await aclAuthorization.CanModerateServerAsync(result.UserId),
+                        CanModerate: canModerateServer,
                         SelectedCompanionId: await userRepository.GetCompanionId(result.UserId),
                         MaxActivePerUser: customCompanionOptions.Value.MaxActivePerUser,
                         MaxActiveTotal: customCompanionOptions.Value.MaxActiveTotal);
@@ -215,7 +218,12 @@ public static class AuthEndpoints
                 ["accessToken"] = result.MatrixAccessToken,
                 ["userId"] = result.MatrixUserId,
                 ["roomMap"] = roomMap,
-                ["dmRoomMap"] = dmRoomMap
+                ["dmRoomMap"] = dmRoomMap,
+                ["messageDeletion"] = new
+                {
+                    canModerate = canModerateServer,
+                    maxAgeMs = (long)MessageDeletionPolicy.DeletionWindow.TotalMilliseconds
+                }
             };
             if (customCompanions is not null)
                 matrixPayload["customCompanions"] = customCompanions;

--- a/src/Brmble.Server/Auth/AuthEndpoints.cs
+++ b/src/Brmble.Server/Auth/AuthEndpoints.cs
@@ -217,6 +217,7 @@ public static class AuthEndpoints
                 ["homeserverUrl"] = publicHomeserverUrl,
                 ["accessToken"] = result.MatrixAccessToken,
                 ["userId"] = result.MatrixUserId,
+                ["botUserId"] = $"@brmble:{matrixSettings.Value.ServerDomain}",
                 ["roomMap"] = roomMap,
                 ["dmRoomMap"] = dmRoomMap,
                 ["messageDeletion"] = new

--- a/src/Brmble.Server/DM/DmRoomRepository.cs
+++ b/src/Brmble.Server/DM/DmRoomRepository.cs
@@ -54,4 +54,13 @@ public class DmRoomRepository
             new { id = userId });
         return rows.Select(r => new DmRoomForUser((string)r.other_matrix_user_id, (string)r.matrix_room_id)).ToList();
     }
+
+    public async Task<bool> IsRoomForUserAsync(long userId, string matrixRoomId)
+    {
+        using var conn = _db.CreateConnection();
+        var match = await conn.QuerySingleOrDefaultAsync<string>(
+            "SELECT matrix_room_id FROM dm_room_map WHERE (user_id_low = @userId OR user_id_high = @userId) AND matrix_room_id = @roomId LIMIT 1",
+            new { userId, roomId = matrixRoomId });
+        return match is not null;
+    }
 }

--- a/src/Brmble.Server/Matrix/ChannelRepository.cs
+++ b/src/Brmble.Server/Matrix/ChannelRepository.cs
@@ -46,4 +46,13 @@ public class ChannelRepository
             "SELECT mumble_channel_id, matrix_room_id FROM channel_room_map");
         return rows.Select(r => new ChannelRoomMapping((int)(long)r.mumble_channel_id, (string)r.matrix_room_id)).ToList();
     }
+
+    public async Task<bool> IsRoomRegisteredAsync(string matrixRoomId)
+    {
+        using var conn = _db.CreateConnection();
+        var match = await conn.QuerySingleOrDefaultAsync<string>(
+            "SELECT matrix_room_id FROM channel_room_map WHERE matrix_room_id = @roomId LIMIT 1",
+            new { roomId = matrixRoomId });
+        return match is not null;
+    }
 }

--- a/src/Brmble.Server/Matrix/MatrixAppService.cs
+++ b/src/Brmble.Server/Matrix/MatrixAppService.cs
@@ -26,7 +26,7 @@ public interface IMatrixAppService
     Task SetAccountData(string localpart, string eventType, string jsonContent);
     Task<string?> GetAccountData(string localpart, string eventType);
     Task<string> SendStateEvent(string roomId, string eventType, string stateKey, string jsonContent);
-    Task RedactRoomEvent(string roomId, string eventId, string reason);
+    Task RedactRoomEvent(string roomId, string eventId, string reason, string? actAsMatrixUserId = null);
     Task InvitePaintUser(string roomId, string matrixUserId);
     Task<JsonElement> GetRoomEvent(string roomId, string eventId);
     Task<string?> GetRoomMembership(string roomId, string matrixUserId);
@@ -404,12 +404,16 @@ public class MatrixAppService : IMatrixAppService
             ?? throw new InvalidOperationException("Matrix did not return an event_id");
     }
 
-    public Task RedactRoomEvent(string roomId, string eventId, string reason)
+    public Task RedactRoomEvent(
+        string roomId,
+        string eventId,
+        string reason,
+        string? actAsMatrixUserId = null)
     {
         var txnId = Guid.NewGuid().ToString("N");
         var url = $"{_homeserverUrl}/_matrix/client/v3/rooms/{Uri.EscapeDataString(roomId)}/redact/{Uri.EscapeDataString(eventId)}/{txnId}";
         var body = JsonSerializer.Serialize(new { reason });
-        return SendRequest(HttpMethod.Put, url, body);
+        return SendRequest(HttpMethod.Put, url, body, actAs: actAsMatrixUserId);
     }
 
     public Task InvitePaintUser(string roomId, string matrixUserId)

--- a/src/Brmble.Server/Matrix/MatrixAppService.cs
+++ b/src/Brmble.Server/Matrix/MatrixAppService.cs
@@ -9,7 +9,7 @@ namespace Brmble.Server.Matrix;
 
 public interface IMatrixAppService
 {
-    Task SendMessage(string roomId, string displayName, string text);
+    Task SendMessage(string roomId, string displayName, string text, string? authorMatrixUserId = null);
     Task<string> CreateRoom(string name);
     Task<string> CreatePaintRoom(string name, IReadOnlyList<string> invitedMatrixUserIds);
     Task<string> CreateCustomCompanionGalleryRoom();
@@ -22,7 +22,7 @@ public interface IMatrixAppService
     Task SetDisplayName(string localpart, string displayName);
     Task SetAvatarUrl(string localpart, string avatarUrl);
     Task<string> UploadMedia(byte[] data, string contentType, string fileName);
-    Task SendImageMessage(string roomId, string displayName, string mxcUrl, string fileName, string mimetype, int size);
+    Task SendImageMessage(string roomId, string displayName, string mxcUrl, string fileName, string mimetype, int size, string? authorMatrixUserId = null);
     Task SetAccountData(string localpart, string eventType, string jsonContent);
     Task<string?> GetAccountData(string localpart, string eventType);
     Task<string> SendStateEvent(string roomId, string eventType, string stateKey, string jsonContent);
@@ -61,15 +61,19 @@ public class MatrixAppService : IMatrixAppService
         }
     }
 
-    public async Task SendMessage(string roomId, string displayName, string text)
+    public async Task SendMessage(string roomId, string displayName, string text, string? authorMatrixUserId = null)
     {
         var txnId = Guid.NewGuid().ToString("N");
         var url = $"{_homeserverUrl}/_matrix/client/v3/rooms/{roomId}/send/m.room.message/{txnId}";
-        var body = JsonSerializer.Serialize(new
+        var content = new Dictionary<string, object?>
         {
-            msgtype = "m.text",
-            body = $"[{displayName}]: {text}",
-        });
+            ["msgtype"] = "m.text",
+            ["body"] = $"[{displayName}]: {text}",
+        };
+        if (!string.IsNullOrWhiteSpace(authorMatrixUserId))
+            content["com.brmble.author_matrix_user_id"] = authorMatrixUserId;
+
+        var body = JsonSerializer.Serialize(content);
         await SendRequest(HttpMethod.Put, url, body);
     }
 
@@ -322,17 +326,21 @@ public class MatrixAppService : IMatrixAppService
             ?? throw new InvalidOperationException("Matrix did not return a content_uri");
     }
 
-    public async Task SendImageMessage(string roomId, string displayName, string mxcUrl, string fileName, string mimetype, int size)
+    public async Task SendImageMessage(string roomId, string displayName, string mxcUrl, string fileName, string mimetype, int size, string? authorMatrixUserId = null)
     {
         var txnId = Guid.NewGuid().ToString("N");
         var url = $"{_homeserverUrl}/_matrix/client/v3/rooms/{roomId}/send/m.room.message/{txnId}";
-        var body = JsonSerializer.Serialize(new
+        var content = new Dictionary<string, object?>
         {
-            msgtype = "m.image",
-            body = $"[{displayName}]: {fileName}",
-            url = mxcUrl,
-            info = new { mimetype, size },
-        });
+            ["msgtype"] = "m.image",
+            ["body"] = $"[{displayName}]: {fileName}",
+            ["url"] = mxcUrl,
+            ["info"] = new { mimetype, size },
+        };
+        if (!string.IsNullOrWhiteSpace(authorMatrixUserId))
+            content["com.brmble.author_matrix_user_id"] = authorMatrixUserId;
+
+        var body = JsonSerializer.Serialize(content);
         await SendRequest(HttpMethod.Put, url, body);
     }
 

--- a/src/Brmble.Server/Matrix/MatrixAppService.cs
+++ b/src/Brmble.Server/Matrix/MatrixAppService.cs
@@ -28,7 +28,7 @@ public interface IMatrixAppService
     Task<string> SendStateEvent(string roomId, string eventType, string stateKey, string jsonContent);
     Task RedactRoomEvent(string roomId, string eventId, string reason, string? actAsMatrixUserId = null);
     Task InvitePaintUser(string roomId, string matrixUserId);
-    Task<JsonElement> GetRoomEvent(string roomId, string eventId);
+    Task<JsonElement> GetRoomEvent(string roomId, string eventId, string? actAsMatrixUserId = null);
     Task<string?> GetRoomMembership(string roomId, string matrixUserId);
     Task<byte[]> DownloadMedia(string mxcUrl, CancellationToken cancellationToken);
     Task<byte[]> DownloadMedia(string mxcUrl, long maxBytes, CancellationToken cancellationToken)
@@ -355,6 +355,20 @@ public class MatrixAppService : IMatrixAppService
             is_direct = true,
             preset = "trusted_private_chat",
             invite = new[] { userIdB },
+            initial_state = new object[]
+            {
+                new
+                {
+                    type = "m.room.power_levels",
+                    content = new
+                    {
+                        users_default = 0,
+                        events_default = 0,
+                        state_default = 50,
+                        redact = 0,
+                    }
+                }
+            }
         });
         var response = await SendRequest(HttpMethod.Post, url, body, actAs: userIdA);
         var json = JsonSerializer.Deserialize<JsonElement>(response);
@@ -421,10 +435,13 @@ public class MatrixAppService : IMatrixAppService
         return InviteUserToRoom(roomId, matrixUserId);
     }
 
-    public async Task<JsonElement> GetRoomEvent(string roomId, string eventId)
+    public async Task<JsonElement> GetRoomEvent(
+        string roomId,
+        string eventId,
+        string? actAsMatrixUserId = null)
     {
         var url = $"{_homeserverUrl}/_matrix/client/v3/rooms/{Uri.EscapeDataString(roomId)}/event/{Uri.EscapeDataString(eventId)}";
-        var response = await SendRequest(HttpMethod.Get, url, "{}");
+        var response = await SendRequest(HttpMethod.Get, url, "{}", actAs: actAsMatrixUserId);
         return JsonSerializer.Deserialize<JsonElement>(response);
     }
 

--- a/src/Brmble.Server/Matrix/MatrixService.cs
+++ b/src/Brmble.Server/Matrix/MatrixService.cs
@@ -27,6 +27,7 @@ public class MatrixService
     };
 
     private readonly ChannelRepository _channelRepository;
+    private readonly UserRepository? _userRepository;
     private readonly IMatrixAppService _appService;
     private readonly IActiveBrmbleSessions _activeSessions;
     private readonly ILogger<MatrixService> _logger;
@@ -35,12 +36,14 @@ public class MatrixService
         ChannelRepository channelRepository,
         IMatrixAppService appService,
         IActiveBrmbleSessions activeSessions,
-        ILogger<MatrixService> logger)
+        ILogger<MatrixService> logger,
+        UserRepository? userRepository = null)
     {
         _channelRepository = channelRepository;
         _appService = appService;
         _activeSessions = activeSessions;
         _logger = logger;
+        _userRepository = userRepository;
     }
 
     public async Task RelayMessage(MumbleUser sender, string text, int channelId)
@@ -57,6 +60,13 @@ public class MatrixService
             _logger.LogWarning("No Matrix room mapped for Mumble channel {ChannelId} — message from {User} dropped", channelId, sender.Name);
             return;
         }
+
+        var user = _userRepository is null
+            ? null
+            : await _userRepository.GetByCertHash(sender.CertHash);
+        var authorMatrixUserId = string.IsNullOrWhiteSpace(user?.MatrixUserId)
+            ? null
+            : user.MatrixUserId;
 
         // Extract and upload base64 images
         var remaining = text;
@@ -99,7 +109,7 @@ public class MatrixService
             try
             {
                 var mxcUrl = await _appService.UploadMedia(imageData, mimetype, fileName);
-                await _appService.SendImageMessage(roomId, sender.Name, mxcUrl, fileName, mimetype, imageData.Length);
+                await _appService.SendImageMessage(roomId, sender.Name, mxcUrl, fileName, mimetype, imageData.Length, authorMatrixUserId);
                 remaining = remaining.Remove(match.Index - offset, match.Length);
                 offset += match.Length;
             }
@@ -114,7 +124,7 @@ public class MatrixService
         if (!string.IsNullOrWhiteSpace(plainText))
         {
             _logger.LogInformation("Relaying message from {User} in channel {ChannelId} to {RoomId}", sender.Name, channelId, roomId);
-            await _appService.SendMessage(roomId, sender.Name, plainText);
+            await _appService.SendMessage(roomId, sender.Name, plainText, authorMatrixUserId);
         }
     }
 

--- a/src/Brmble.Server/Messages/MessageDeletionPolicy.cs
+++ b/src/Brmble.Server/Messages/MessageDeletionPolicy.cs
@@ -15,7 +15,8 @@ public sealed record MatrixMessageMetadata(
     string EventType,
     string Sender,
     DateTimeOffset OriginServerTimestamp,
-    bool IsRedacted)
+    bool IsRedacted,
+    string? AuthorMatrixUserId = null)
 {
     public static MatrixMessageMetadata Parse(JsonElement eventJson)
     {
@@ -37,11 +38,22 @@ public sealed record MatrixMessageMetadata(
                 "redacted_because", out var redactedBecause)
             && redactedBecause.ValueKind == JsonValueKind.Object;
 
+        string? authorMatrixUserId = null;
+        if (eventJson.TryGetProperty("content", out var contentElement)
+            && contentElement.ValueKind == JsonValueKind.Object
+            && contentElement.TryGetProperty("com.brmble.author_matrix_user_id", out var authorElement)
+            && authorElement.ValueKind == JsonValueKind.String
+            && authorElement.GetString() is { Length: > 0 } author)
+        {
+            authorMatrixUserId = author;
+        }
+
         return new(
             eventType,
             sender,
             DateTimeOffset.FromUnixTimeMilliseconds(timestampMs),
-            isRedacted);
+            isRedacted,
+            authorMatrixUserId);
     }
 }
 
@@ -80,7 +92,7 @@ public static class MessageDeletionPolicy
         }
 
         if (string.Equals(
-                message.Sender,
+                message.AuthorMatrixUserId ?? message.Sender,
                 requesterMatrixUserId,
                 StringComparison.Ordinal)
             || canModerate)

--- a/src/Brmble.Server/Messages/MessageDeletionPolicy.cs
+++ b/src/Brmble.Server/Messages/MessageDeletionPolicy.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+
+namespace Brmble.Server.Messages;
+
+public enum MessageDeletionDecision
+{
+    Allowed,
+    Forbidden,
+    Expired,
+    AlreadyDeleted,
+    InvalidEvent,
+}
+
+public sealed record MatrixMessageMetadata(
+    string EventType,
+    string Sender,
+    DateTimeOffset OriginServerTimestamp,
+    bool IsRedacted)
+{
+    public static MatrixMessageMetadata Parse(JsonElement eventJson)
+    {
+        if (!eventJson.TryGetProperty("type", out var typeElement)
+            || typeElement.GetString() is not { Length: > 0 } eventType
+            || !eventJson.TryGetProperty("sender", out var senderElement)
+            || senderElement.GetString() is not { Length: > 0 } sender
+            || !eventJson.TryGetProperty("origin_server_ts", out var timestampElement)
+            || !timestampElement.TryGetInt64(out var timestampMs))
+        {
+            throw new JsonException(
+                "Matrix event is missing type, sender, or origin_server_ts.");
+        }
+
+        var isRedacted =
+            eventJson.TryGetProperty("unsigned", out var unsignedElement)
+            && unsignedElement.ValueKind == JsonValueKind.Object
+            && unsignedElement.TryGetProperty(
+                "redacted_because", out var redactedBecause)
+            && redactedBecause.ValueKind == JsonValueKind.Object;
+
+        return new(
+            eventType,
+            sender,
+            DateTimeOffset.FromUnixTimeMilliseconds(timestampMs),
+            isRedacted);
+    }
+}
+
+public static class MessageDeletionPolicy
+{
+    public static readonly TimeSpan DeletionWindow = TimeSpan.FromHours(24);
+
+    public static MessageDeletionDecision Evaluate(
+        MatrixMessageMetadata message,
+        string requesterMatrixUserId,
+        bool canModerate,
+        DateTimeOffset now)
+    {
+        if (!string.Equals(
+                message.EventType,
+                "m.room.message",
+                StringComparison.Ordinal))
+        {
+            return MessageDeletionDecision.InvalidEvent;
+        }
+
+        if (message.IsRedacted)
+        {
+            return MessageDeletionDecision.AlreadyDeleted;
+        }
+
+        var age = now - message.OriginServerTimestamp;
+        if (age < TimeSpan.Zero)
+        {
+            return MessageDeletionDecision.InvalidEvent;
+        }
+
+        if (age >= DeletionWindow)
+        {
+            return MessageDeletionDecision.Expired;
+        }
+
+        if (string.Equals(
+                message.Sender,
+                requesterMatrixUserId,
+                StringComparison.Ordinal)
+            || canModerate)
+        {
+            return MessageDeletionDecision.Allowed;
+        }
+
+        return MessageDeletionDecision.Forbidden;
+    }
+}

--- a/src/Brmble.Server/Messages/MessageDeletionPolicy.cs
+++ b/src/Brmble.Server/Messages/MessageDeletionPolicy.cs
@@ -18,7 +18,7 @@ public sealed record MatrixMessageMetadata(
     bool IsRedacted,
     string? AuthorMatrixUserId = null)
 {
-    public static MatrixMessageMetadata Parse(JsonElement eventJson)
+    public static MatrixMessageMetadata Parse(JsonElement eventJson, string? trustedBotUserId = null)
     {
         if (!eventJson.TryGetProperty("type", out var typeElement)
             || typeElement.GetString() is not { Length: > 0 } eventType
@@ -39,7 +39,8 @@ public sealed record MatrixMessageMetadata(
             && redactedBecause.ValueKind == JsonValueKind.Object;
 
         string? authorMatrixUserId = null;
-        if (eventJson.TryGetProperty("content", out var contentElement)
+        if (string.Equals(sender, trustedBotUserId, StringComparison.Ordinal)
+            && eventJson.TryGetProperty("content", out var contentElement)
             && contentElement.ValueKind == JsonValueKind.Object
             && contentElement.TryGetProperty("com.brmble.author_matrix_user_id", out var authorElement)
             && authorElement.ValueKind == JsonValueKind.String

--- a/src/Brmble.Server/Messages/MessageDeletionService.cs
+++ b/src/Brmble.Server/Messages/MessageDeletionService.cs
@@ -1,0 +1,137 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Brmble.Server.Auth;
+using Brmble.Server.DM;
+using Brmble.Server.Matrix;
+using Brmble.Server.Mumble;
+
+namespace Brmble.Server.Messages;
+
+public enum MessageDeletionOutcome
+{
+    Deleted,
+    Forbidden,
+    Expired,
+    AlreadyDeleted,
+    InvalidEvent,
+}
+
+public sealed record MessageDeletionResult(MessageDeletionOutcome Outcome);
+
+public sealed class MessageDeletionService
+{
+    private readonly IMatrixAppService _matrix;
+    private readonly ChannelRepository _channels;
+    private readonly DmRoomRepository _directMessages;
+    private readonly IAclAuthorizationService _authorization;
+    private readonly TimeProvider _timeProvider;
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _eventLocks = new();
+
+    public MessageDeletionService(
+        IMatrixAppService matrix,
+        ChannelRepository channels,
+        DmRoomRepository directMessages,
+        IAclAuthorizationService authorization,
+        TimeProvider timeProvider)
+    {
+        _matrix = matrix;
+        _channels = channels;
+        _directMessages = directMessages;
+        _authorization = authorization;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<MessageDeletionResult> DeleteAsync(
+        User requester,
+        string roomId,
+        string eventId,
+        CancellationToken cancellationToken)
+    {
+        if (!await IsRequesterConversationAsync(requester.Id, roomId))
+        {
+            return new(MessageDeletionOutcome.Forbidden);
+        }
+
+        var lockKey = $"{roomId}\n{eventId}";
+        var gate = _eventLocks.GetOrAdd(lockKey, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken);
+
+        try
+        {
+            var eventJson = await _matrix.GetRoomEvent(roomId, eventId);
+            MatrixMessageMetadata message;
+            try
+            {
+                message = MatrixMessageMetadata.Parse(eventJson);
+            }
+            catch (JsonException)
+            {
+                return new(MessageDeletionOutcome.InvalidEvent);
+            }
+
+            var isAuthor = string.Equals(
+                message.Sender,
+                requester.MatrixUserId,
+                StringComparison.Ordinal);
+            var canModerate = !isAuthor
+                && await _authorization.CanModerateServerAsync(requester.Id);
+
+            var decision = MessageDeletionPolicy.Evaluate(
+                message,
+                requester.MatrixUserId,
+                canModerate,
+                _timeProvider.GetUtcNow());
+
+            if (decision != MessageDeletionDecision.Allowed)
+            {
+                return new(decision switch
+                {
+                    MessageDeletionDecision.Forbidden =>
+                        MessageDeletionOutcome.Forbidden,
+                    MessageDeletionDecision.Expired =>
+                        MessageDeletionOutcome.Expired,
+                    MessageDeletionDecision.AlreadyDeleted =>
+                        MessageDeletionOutcome.AlreadyDeleted,
+                    _ => MessageDeletionOutcome.InvalidEvent,
+                });
+            }
+
+            await _matrix.RedactRoomEvent(
+                roomId,
+                eventId,
+                "Deleted through Brmble");
+            return new(MessageDeletionOutcome.Deleted);
+        }
+        finally
+        {
+            gate.Release();
+            if (gate.CurrentCount == 1)
+            {
+                _eventLocks.TryRemove(
+                    new KeyValuePair<string, SemaphoreSlim>(lockKey, gate));
+            }
+        }
+    }
+
+    private async Task<bool> IsRequesterConversationAsync(
+        long requesterId,
+        string roomId)
+    {
+        var channelRooms = await _channels.GetAllAsync();
+        if (channelRooms.Any(mapping =>
+                string.Equals(
+                    mapping.MatrixRoomId,
+                    roomId,
+                    StringComparison.Ordinal)))
+        {
+            return true;
+        }
+
+        var dmRooms = await _directMessages.GetAllForUserAsync(requesterId);
+        return dmRooms.Any(mapping =>
+            string.Equals(
+                mapping.MatrixRoomId,
+                roomId,
+                StringComparison.Ordinal));
+    }
+}

--- a/src/Brmble.Server/Messages/MessageDeletionService.cs
+++ b/src/Brmble.Server/Messages/MessageDeletionService.cs
@@ -21,6 +21,13 @@ public sealed record MessageDeletionResult(MessageDeletionOutcome Outcome);
 
 public sealed class MessageDeletionService
 {
+    private enum ConversationKind
+    {
+        Unknown,
+        Channel,
+        DirectMessage,
+    }
+
     private readonly IMatrixAppService _matrix;
     private readonly ChannelRepository _channels;
     private readonly DmRoomRepository _directMessages;
@@ -51,10 +58,15 @@ public sealed class MessageDeletionService
         string eventId,
         CancellationToken cancellationToken)
     {
-        if (!await IsRequesterConversationAsync(requester.Id, roomId))
+        var conversationKind = await GetConversationKindAsync(requester.Id, roomId);
+        if (conversationKind == ConversationKind.Unknown)
         {
             return new(MessageDeletionOutcome.Forbidden);
         }
+
+        var redactionActor = conversationKind == ConversationKind.DirectMessage
+            ? requester.MatrixUserId
+            : null;
 
         var lockKey = $"{roomId}\n{eventId}";
         var gate = _eventLocks.GetOrAdd(lockKey, _ => new SemaphoreSlim(1, 1));
@@ -62,7 +74,7 @@ public sealed class MessageDeletionService
 
         try
         {
-            var eventJson = await _matrix.GetRoomEvent(roomId, eventId);
+            var eventJson = await _matrix.GetRoomEvent(roomId, eventId, redactionActor);
             MatrixMessageMetadata message;
             try
             {
@@ -105,7 +117,7 @@ public sealed class MessageDeletionService
                 roomId,
                 eventId,
                 "Deleted through Brmble",
-                requester.MatrixUserId);
+                redactionActor);
             return new(MessageDeletionOutcome.Deleted);
         }
         finally
@@ -119,7 +131,7 @@ public sealed class MessageDeletionService
         }
     }
 
-    private async Task<bool> IsRequesterConversationAsync(
+    private async Task<ConversationKind> GetConversationKindAsync(
         long requesterId,
         string roomId)
     {
@@ -130,14 +142,16 @@ public sealed class MessageDeletionService
                     roomId,
                     StringComparison.Ordinal)))
         {
-            return true;
+            return ConversationKind.Channel;
         }
 
         var dmRooms = await _directMessages.GetAllForUserAsync(requesterId);
         return dmRooms.Any(mapping =>
-            string.Equals(
-                mapping.MatrixRoomId,
-                roomId,
-                StringComparison.Ordinal));
+                string.Equals(
+                    mapping.MatrixRoomId,
+                    roomId,
+                    StringComparison.Ordinal))
+            ? ConversationKind.DirectMessage
+            : ConversationKind.Unknown;
     }
 }

--- a/src/Brmble.Server/Messages/MessageDeletionService.cs
+++ b/src/Brmble.Server/Messages/MessageDeletionService.cs
@@ -69,15 +69,16 @@ public sealed class MessageDeletionService
                 return new(MessageDeletionOutcome.InvalidEvent);
             }
 
+            var effectiveAuthor = message.AuthorMatrixUserId ?? message.Sender;
             var isAuthor = string.Equals(
-                message.Sender,
+                effectiveAuthor,
                 requester.MatrixUserId,
                 StringComparison.Ordinal);
             var canModerate = !isAuthor
                 && await _authorization.CanModerateServerAsync(requester.Id);
 
             var decision = MessageDeletionPolicy.Evaluate(
-                message,
+                message with { Sender = effectiveAuthor },
                 requester.MatrixUserId,
                 canModerate,
                 _timeProvider.GetUtcNow());

--- a/src/Brmble.Server/Messages/MessageDeletionService.cs
+++ b/src/Brmble.Server/Messages/MessageDeletionService.cs
@@ -100,7 +100,8 @@ public sealed class MessageDeletionService
             await _matrix.RedactRoomEvent(
                 roomId,
                 eventId,
-                "Deleted through Brmble");
+                "Deleted through Brmble",
+                requester.MatrixUserId);
             return new(MessageDeletionOutcome.Deleted);
         }
         finally

--- a/src/Brmble.Server/Messages/MessageDeletionService.cs
+++ b/src/Brmble.Server/Messages/MessageDeletionService.cs
@@ -135,22 +135,12 @@ public sealed class MessageDeletionService
         long requesterId,
         string roomId)
     {
-        var channelRooms = await _channels.GetAllAsync();
-        if (channelRooms.Any(mapping =>
-                string.Equals(
-                    mapping.MatrixRoomId,
-                    roomId,
-                    StringComparison.Ordinal)))
+        if (await _channels.IsRoomRegisteredAsync(roomId))
         {
             return ConversationKind.Channel;
         }
 
-        var dmRooms = await _directMessages.GetAllForUserAsync(requesterId);
-        return dmRooms.Any(mapping =>
-                string.Equals(
-                    mapping.MatrixRoomId,
-                    roomId,
-                    StringComparison.Ordinal))
+        return await _directMessages.IsRoomForUserAsync(requesterId, roomId)
             ? ConversationKind.DirectMessage
             : ConversationKind.Unknown;
     }

--- a/src/Brmble.Server/Messages/MessageDeletionService.cs
+++ b/src/Brmble.Server/Messages/MessageDeletionService.cs
@@ -4,6 +4,7 @@ using Brmble.Server.Auth;
 using Brmble.Server.DM;
 using Brmble.Server.Matrix;
 using Brmble.Server.Mumble;
+using Microsoft.Extensions.Options;
 
 namespace Brmble.Server.Messages;
 
@@ -25,6 +26,7 @@ public sealed class MessageDeletionService
     private readonly DmRoomRepository _directMessages;
     private readonly IAclAuthorizationService _authorization;
     private readonly TimeProvider _timeProvider;
+    private readonly string _trustedBotUserId;
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _eventLocks = new();
 
     public MessageDeletionService(
@@ -32,13 +34,15 @@ public sealed class MessageDeletionService
         ChannelRepository channels,
         DmRoomRepository directMessages,
         IAclAuthorizationService authorization,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        IOptions<MatrixSettings> matrixSettings)
     {
         _matrix = matrix;
         _channels = channels;
         _directMessages = directMessages;
         _authorization = authorization;
         _timeProvider = timeProvider;
+        _trustedBotUserId = $"@brmble:{matrixSettings.Value.ServerDomain}";
     }
 
     public async Task<MessageDeletionResult> DeleteAsync(
@@ -62,7 +66,7 @@ public sealed class MessageDeletionService
             MatrixMessageMetadata message;
             try
             {
-                message = MatrixMessageMetadata.Parse(eventJson);
+                message = MatrixMessageMetadata.Parse(eventJson, _trustedBotUserId);
             }
             catch (JsonException)
             {

--- a/src/Brmble.Server/Messages/MessageEndpoints.cs
+++ b/src/Brmble.Server/Messages/MessageEndpoints.cs
@@ -1,0 +1,97 @@
+using Brmble.Server.Auth;
+
+namespace Brmble.Server.Messages;
+
+public sealed record DeleteMessageRequest(string RoomId, string EventId);
+
+public static class MessageEndpoints
+{
+    public static IEndpointRouteBuilder MapMessageEndpoints(
+        this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/messages/delete", DeleteMessageAsync);
+        return app;
+    }
+
+    private static async Task<IResult> DeleteMessageAsync(
+        DeleteMessageRequest request,
+        HttpContext httpContext,
+        ICertificateHashExtractor certHashExtractor,
+        UserRepository users,
+        MessageDeletionService deletionService)
+    {
+        if (string.IsNullOrWhiteSpace(request.RoomId)
+            || string.IsNullOrWhiteSpace(request.EventId))
+        {
+            return Error(
+                StatusCodes.Status400BadRequest,
+                "invalid_request",
+                "roomId and eventId are required.");
+        }
+
+        var certHash = certHashExtractor.GetCertHash(httpContext);
+        if (string.IsNullOrWhiteSpace(certHash))
+        {
+            return Results.Unauthorized();
+        }
+
+        var requester = await users.GetByCertHash(certHash);
+        if (requester is null)
+        {
+            return Results.Unauthorized();
+        }
+
+        try
+        {
+            var result = await deletionService.DeleteAsync(
+                requester,
+                request.RoomId,
+                request.EventId,
+                httpContext.RequestAborted);
+
+            return result.Outcome switch
+            {
+                MessageDeletionOutcome.Deleted =>
+                    Results.Ok(new { status = "deleted" }),
+                MessageDeletionOutcome.Forbidden =>
+                    Error(
+                        StatusCodes.Status403Forbidden,
+                        "not_authorized",
+                        "You do not have permission to delete this message."),
+                MessageDeletionOutcome.Expired =>
+                    Error(
+                        StatusCodes.Status410Gone,
+                        "expired",
+                        "Messages can only be deleted within 24 hours."),
+                MessageDeletionOutcome.AlreadyDeleted =>
+                    Error(
+                        StatusCodes.Status409Conflict,
+                        "already_deleted",
+                        "This message has already been deleted."),
+                _ =>
+                    Error(
+                        StatusCodes.Status400BadRequest,
+                        "invalid_event",
+                        "Only Matrix room messages can be deleted."),
+            };
+        }
+        catch (OperationCanceledException)
+            when (httpContext.RequestAborted.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (HttpRequestException)
+        {
+            return Error(
+                StatusCodes.Status503ServiceUnavailable,
+                "matrix_unavailable",
+                "Message deletion is temporarily unavailable.");
+        }
+    }
+
+    private static IResult Error(
+        int statusCode,
+        string code,
+        string error) =>
+        Results.Json(new { code, error }, statusCode: statusCode);
+}

--- a/src/Brmble.Server/Program.cs
+++ b/src/Brmble.Server/Program.cs
@@ -14,6 +14,7 @@ using Brmble.Server.ServerInfo;
 using Brmble.Server.WebSockets;
 using Brmble.Server.Paint;
 using Brmble.Server.Companions;
+using Brmble.Server.Messages;
 using Microsoft.AspNetCore.RateLimiting;
 using System.Threading.RateLimiting;
 
@@ -43,6 +44,8 @@ builder.Services.AddMatrix();
 builder.Services.AddLiveKit();
 builder.Services.AddGames();
 builder.Services.AddCustomCompanions();
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<MessageDeletionService>();
 builder.Services.AddSingleton<IMatrixPaintService, MatrixPaintService>();
 builder.Services.AddSingleton<MatrixPaintSourceResolver>();
 builder.Services.AddSingleton<IPaintPresence, SessionMappingPaintPresence>();
@@ -138,6 +141,7 @@ app.Map("/ws", BrmbleWebSocketHandler.HandleAsync);
 app.MapServerInfoEndpoints();
 app.MapLiveKitEndpoints();
 app.MapCustomCompanionEndpoints();
+app.MapMessageEndpoints();
 app.MapReverseProxy();
 
 app.Run();

--- a/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
+++ b/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
@@ -33,7 +33,7 @@ const mockValues = vi.hoisted(() => {
     sendMessage: vi.fn(),
     sendImageMessage: vi.fn(),
     uploadContent: vi.fn(),
-    fetchHistory: vi.fn(),
+    fetchHistory: vi.fn().mockResolvedValue(undefined),
     sendReaction: vi.fn(),
     removeReaction: vi.fn(),
     dmLastMessages: new Map(),
@@ -49,6 +49,7 @@ const mockValues = vi.hoisted(() => {
     activeTypingText: 'Val is typing',
     startTyping: vi.fn(),
     stopTyping: vi.fn(),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
   };
   const dmStore = {
     contacts: [],
@@ -176,7 +177,7 @@ function renderConnectedApp() {
   const view = render(<ServiceStatusProvider><App /></ServiceStatusProvider>);
   act(() => {
     (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('server.credentials', {
-      matrix: { homeserverUrl: 'https://example.com', accessToken: 'token', userId: '@me:example.com', roomMap: {} },
+      matrix: { homeserverUrl: 'https://example.com', accessToken: 'token', userId: '@me:example.com', roomMap: { '1': '!general:example.com' }, messageDeletion: { canModerate: true, maxAgeMs: 86_400_000 } },
     });
     (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('voice.connected', {
       username: 'Me', channelId: 1, channels: [{ id: 1, name: 'General' }], users: [],
@@ -200,6 +201,7 @@ function renderPaintReadyApp() {
         accessToken: 'token',
         userId: '@me:example.com',
         roomMap: { '1': '!general:example.com' },
+        messageDeletion: { canModerate: true, maxAgeMs: 86_400_000 },
       },
     });
     (bridge as unknown as {
@@ -541,6 +543,54 @@ describe('DM route Matrix isolation', () => {
       onTypingStart: mockValues.matrixClient.startTyping, onTypingStop: mockValues.matrixClient.stopTyping,
       onToggleReaction: expect.any(Function), currentUserMatrixId: '@me:example.com',
     }));
+  });
+
+  it('passes deletion capability and operation to Matrix channel chat', async () => {
+    renderPaintReadyApp();
+    act(() => {
+      (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('brmble.serviceStatus', {
+        service: 'server', state: 'connected',
+      });
+      (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('chat.channelAccess', {
+        channels: { '1': { canRead: true, canSend: true } },
+      });
+    });
+
+    await waitFor(() => expect(mockValues.channelChatPanelProps).toEqual(expect.objectContaining({
+      onDeleteMessage: mockValues.matrixClient.deleteMessage,
+      canModerateRecentMessages: true,
+      messageDeletionWindowMs: 86_400_000,
+    })));
+
+    await (mockValues.channelChatPanelProps?.onDeleteMessage as (
+      roomId: string, eventId: string,
+    ) => Promise<void>)('!general:example.com', '$message:test');
+    expect(mockValues.matrixClient.deleteMessage).toHaveBeenCalledWith(
+      '!general:example.com', '$message:test',
+    );
+  });
+
+  it('passes deletion to a Matrix-backed DM', () => {
+    mockValues.dmStore.selectedContact = {
+      id: '@val:example.com', displayName: 'Vanilla Val', unreadCount: 0,
+    };
+    mockValues.matrixClient.dmRoomMap.set('@val:example.com', '!val:example.com');
+    renderConnectedApp();
+
+    act(() => {
+      (mockValues.dmContactListProps?.onSelectContact as (id: string) => void)('@val:example.com');
+    });
+    expect(mockValues.dmChatPanelProps?.onDeleteMessage)
+      .toBe(mockValues.matrixClient.deleteMessage);
+  });
+
+  it('omits deletion from a Mumble-only DM', () => {
+    mockValues.dmStore.selectedContact = {
+      id: 'cert-val', displayName: 'Vanilla Val', unreadCount: 0,
+      isEphemeral: true, mumbleSessionId: 42,
+    };
+    renderConnectedApp();
+    expect(mockValues.dmChatPanelProps?.onDeleteMessage).toBeUndefined();
   });
 
   it('reports an unread foreground only when the workspace and selected contact match', () => {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -25,6 +25,7 @@ import { PaintSessionView } from './components/Paint/PaintSessionView';
 import { VerticalSplitPane } from './components/VerticalSplitPane/VerticalSplitPane';
 import { Sidebar } from './components/Sidebar/Sidebar';
 import { ChatPanel } from './components/ChatPanel/ChatPanel';
+import { DEFAULT_MESSAGE_DELETION_WINDOW_MS } from './utils/messageDeletion';
 import { ConnectModal } from './components/ConnectModal/ConnectModal';
 import { ServerList } from './components/ServerList/ServerList';
 import { ConnectionState } from './components/ConnectionState/ConnectionState';
@@ -4982,6 +4983,9 @@ const handleConnect = (serverData: SavedServer) => {
                         onMessageContextMenu={handleChatMessageContextMenu}
                         onCopyToClipboard={handleCopyToClipboard}
                         currentUserMatrixId={matrixCredentials?.userId}
+                        onDeleteMessage={channelMatrixRoomId ? matrixClient.deleteMessage : undefined}
+                        canModerateRecentMessages={matrixCredentials?.messageDeletion?.canModerate ?? false}
+                        messageDeletionWindowMs={matrixCredentials?.messageDeletion?.maxAgeMs ?? DEFAULT_MESSAGE_DELETION_WINDOW_MS}
                         onToggleReaction={handleToggleChannelReaction}
                         typingIndicatorText={isDmMode ? undefined : matrixClient.activeTypingText}
                         typingTargetId={activeChannelId ?? undefined}
@@ -5017,6 +5021,9 @@ const handleConnect = (serverData: SavedServer) => {
                     onMessageContextMenu={handleChatMessageContextMenu}
                     onCopyToClipboard={handleCopyToClipboard}
                     currentUserMatrixId={foregroundDmContact && !selectedDmIsMumble ? matrixCredentials?.userId : undefined}
+                    onDeleteMessage={foregroundDmContact && !selectedDmIsMumble && dmMatrixRoomId ? matrixClient.deleteMessage : undefined}
+                    canModerateRecentMessages={foregroundDmContact && !selectedDmIsMumble ? (matrixCredentials?.messageDeletion?.canModerate ?? false) : false}
+                    messageDeletionWindowMs={matrixCredentials?.messageDeletion?.maxAgeMs ?? DEFAULT_MESSAGE_DELETION_WINDOW_MS}
                     onToggleReaction={foregroundDmContact && !selectedDmIsMumble ? handleToggleDmReaction : undefined}
                     typingIndicatorText={foregroundDmContact && !selectedDmIsMumble && isDmMode ? matrixClient.activeTypingText : undefined}
                     typingTargetId={foregroundDmContact && !selectedDmIsMumble ? (activeDmMatrixContactId ?? undefined) : undefined}

--- a/src/Brmble.Web/src/api/messages.test.ts
+++ b/src/Brmble.Web/src/api/messages.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import bridge from '../bridge';
+import {
+  MessageDeletionError,
+  messageApi,
+} from './messages';
+
+vi.mock('../bridge', () => ({
+  default: {
+    on: vi.fn(),
+    off: vi.fn(),
+    send: vi.fn(),
+  },
+}));
+
+describe('messageApi.delete', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('correlates a successful WebView bridge response', async () => {
+    vi.stubGlobal('chrome', { webview: {} });
+    vi.mocked(bridge.send).mockImplementation((_type, data) => {
+      const requestId = (data as { requestId: number }).requestId;
+      const handler = vi.mocked(bridge.on).mock.calls
+        .find(([type]) => type === 'messages.response')?.[1];
+      handler?.({ requestId, success: true, body: '{"status":"deleted"}', statusCode: 200 });
+    });
+
+    await expect(messageApi.delete('!general:test', '$message:test')).resolves.toBeUndefined();
+    expect(bridge.send).toHaveBeenCalledWith('messages.delete', expect.objectContaining({
+      roomId: '!general:test', eventId: '$message:test',
+    }));
+    expect(bridge.off).toHaveBeenCalledWith('messages.response', expect.any(Function));
+  });
+
+  it('preserves a structured expired error', async () => {
+    vi.stubGlobal('chrome', { webview: {} });
+    vi.mocked(bridge.send).mockImplementation((_type, data) => {
+      const requestId = (data as { requestId: number }).requestId;
+      const handler = vi.mocked(bridge.on).mock.calls
+        .find(([type]) => type === 'messages.response')?.[1];
+      handler?.({
+        requestId, success: false,
+        body: JSON.stringify({ code: 'expired', error: 'Messages can only be deleted within 24 hours.' }),
+        statusCode: 410, error: 'Gone',
+      });
+    });
+
+    await expect(messageApi.delete('!general:test', '$message:test')).rejects.toEqual(expect.objectContaining({
+      code: 'expired', statusCode: 410,
+      message: 'Messages can only be deleted within 24 hours.',
+    } satisfies Partial<MessageDeletionError>));
+  });
+
+  it('uses direct fetch outside WebView', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ status: 'deleted' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+
+    await messageApi.delete('!general:test', '$message:test');
+    expect(fetch).toHaveBeenCalledWith('/messages/delete', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ roomId: '!general:test', eventId: '$message:test' }),
+    }));
+  });
+
+  it('maps an unknown server code to request_failed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      '{"code":"new_server_code","error":"Rejected"}', { status: 400 },
+    )));
+
+    await expect(messageApi.delete('!general:test', '$message:test')).rejects.toEqual(expect.objectContaining({
+      code: 'request_failed', message: 'Rejected',
+    }));
+  });
+
+  it('times out and removes the bridge listener', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('chrome', { webview: {} });
+
+    const pending = messageApi.delete('!general:test', '$message:test');
+    const rejection = expect(pending).rejects.toEqual(expect.objectContaining({
+      code: 'request_failed', message: 'Message deletion timed out. Try again.',
+    }));
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    await rejection;
+    expect(bridge.off).toHaveBeenCalledWith('messages.response', expect.any(Function));
+    vi.useRealTimers();
+  });
+});

--- a/src/Brmble.Web/src/api/messages.ts
+++ b/src/Brmble.Web/src/api/messages.ts
@@ -1,0 +1,123 @@
+import bridge from '../bridge';
+
+const REQUEST_TIMEOUT_MS = 15_000;
+let nextRequestId = 1;
+
+export type MessageDeletionErrorCode =
+  | 'invalid_request'
+  | 'not_authorized'
+  | 'expired'
+  | 'already_deleted'
+  | 'invalid_event'
+  | 'matrix_unavailable'
+  | 'request_failed';
+
+const MESSAGE_DELETION_ERROR_CODES = new Set<MessageDeletionErrorCode>([
+  'invalid_request', 'not_authorized', 'expired', 'already_deleted',
+  'invalid_event', 'matrix_unavailable', 'request_failed',
+]);
+
+function isMessageDeletionErrorCode(value: unknown): value is MessageDeletionErrorCode {
+  return typeof value === 'string' && MESSAGE_DELETION_ERROR_CODES.has(value as MessageDeletionErrorCode);
+}
+
+export class MessageDeletionError extends Error {
+  readonly code: MessageDeletionErrorCode;
+  readonly statusCode: number;
+
+  constructor(
+    message: string,
+    code: MessageDeletionErrorCode,
+    statusCode: number,
+  ) {
+    super(message);
+    this.name = 'MessageDeletionError';
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+interface BridgeResponse {
+  requestId?: number;
+  success?: boolean;
+  body?: string;
+  statusCode?: number;
+  error?: string;
+}
+
+function parseError(body: string | undefined, fallback: string | undefined, statusCode: number): MessageDeletionError {
+  let parsed: { code?: string; error?: string } = {};
+  if (body) {
+    try { parsed = JSON.parse(body) as typeof parsed; } catch { parsed = {}; }
+  }
+  return new MessageDeletionError(
+    parsed.error ?? fallback ?? 'Message could not be deleted. Try again.',
+    isMessageDeletionErrorCode(parsed.code) ? parsed.code : 'request_failed',
+    statusCode,
+  );
+}
+
+function isWebViewBridgeAvailable(): boolean {
+  return !!(window as Window & { chrome?: { webview?: unknown } }).chrome?.webview;
+}
+
+function deleteThroughBridge(roomId: string, eventId: string): Promise<void> {
+  const requestId = nextRequestId++;
+  return new Promise<void>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const cleanup = () => {
+      bridge.off('messages.response', handleResponse);
+      if (timer !== undefined) clearTimeout(timer);
+    };
+    const handleResponse = (data: unknown) => {
+      const response = data as BridgeResponse;
+      if (response.requestId !== requestId) return;
+      cleanup();
+      if (response.success) {
+        resolve();
+      } else {
+        reject(parseError(response.body, response.error, response.statusCode ?? 0));
+      }
+    };
+    bridge.on('messages.response', handleResponse);
+    timer = setTimeout(() => {
+      cleanup();
+      reject(new MessageDeletionError('Message deletion timed out. Try again.', 'request_failed', 0));
+    }, REQUEST_TIMEOUT_MS);
+    try {
+      bridge.send('messages.delete', { requestId, roomId, eventId });
+    } catch (error) {
+      cleanup();
+      reject(new MessageDeletionError(
+        error instanceof Error ? error.message : 'Message could not be deleted. Try again.',
+        'request_failed',
+        0,
+      ));
+    }
+  });
+}
+
+async function deleteThroughFetch(roomId: string, eventId: string): Promise<void> {
+  try {
+    const response = await fetch('/messages/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ roomId, eventId }),
+    });
+    if (response.ok) return;
+    throw parseError(await response.text(), response.statusText, response.status);
+  } catch (error) {
+    if (error instanceof MessageDeletionError) throw error;
+    throw new MessageDeletionError(
+      error instanceof Error ? error.message : 'Message could not be deleted. Try again.',
+      'request_failed',
+      0,
+    );
+  }
+}
+
+export const messageApi = {
+  delete(roomId: string, eventId: string): Promise<void> {
+    return isWebViewBridgeAvailable() ? deleteThroughBridge(roomId, eventId) : deleteThroughFetch(roomId, eventId);
+  },
+};

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.css
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.css
@@ -402,6 +402,23 @@
   padding: 0 var(--space-lg) var(--space-md);
 }
 
+.chat-action-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  margin: 0 var(--space-md) var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--accent-danger-border);
+  border-radius: var(--radius-md);
+  background: var(--accent-danger-subtle);
+  color: var(--accent-danger-text);
+}
+
+.chat-action-error__dismiss {
+  flex: 0 0 auto;
+}
+
 .chat-typing-indicator {
   --chat-typing-indicator-min-height: calc(var(--space-lg) - var(--space-2xs));
   min-height: var(--chat-typing-indicator-min-height);

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -2,6 +2,13 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { ChatPanel } from './ChatPanel';
+import { confirm } from '../../hooks/usePrompt';
+import { MessageDeletionError } from '../../api/messages';
+
+vi.mock('../../hooks/usePrompt', async () => {
+  const actual = await vi.importActual<typeof import('../../hooks/usePrompt')>('../../hooks/usePrompt');
+  return { ...actual, confirm: vi.fn() };
+});
 
 beforeAll(() => {
   class ResizeObserverMock {
@@ -195,6 +202,95 @@ describe('ChatPanel image paint background menu', () => {
     expect(screen.queryByRole('button', {
       name: 'Use as paint background',
     })).not.toBeInTheDocument();
+  });
+});
+
+const recentOwnMessage = {
+  id: '$message', channelId: '42', sender: 'Alice', senderMatrixUserId: '@alice:test',
+  content: 'delete me', timestamp: new Date(Date.now() - 3_600_000), msgType: 'm.text' as const,
+};
+
+describe('ChatPanel message deletion', () => {
+  beforeEach(() => vi.mocked(confirm).mockReset());
+
+  it('shows Delete message for an eligible author', () => {
+    render(<ChatPanel channelId="42" channelName="general" matrixRoomId="!general:test" messages={[recentOwnMessage]} currentUserMatrixId="@alice:test" onSendMessage={() => {}} onDeleteMessage={vi.fn()} />);
+    fireEvent.contextMenu(screen.getByText('delete me'), { clientX: 50, clientY: 60 });
+    expect(screen.getByRole('button', { name: 'Delete message' })).toBeInTheDocument();
+  });
+
+  it('hides Delete message for another user without admin permission', () => {
+    render(<ChatPanel channelId="42" channelName="general" matrixRoomId="!general:test" messages={[{ ...recentOwnMessage, sender: 'Bob', senderMatrixUserId: '@bob:test' }]} currentUserMatrixId="@alice:test" canModerateRecentMessages={false} onSendMessage={() => {}} onDeleteMessage={vi.fn()} />);
+    fireEvent.contextMenu(screen.getByText('delete me'), { clientX: 50, clientY: 60 });
+    expect(screen.queryByRole('button', { name: 'Delete message' })).not.toBeInTheDocument();
+  });
+
+  it('shows Delete message to an administrator for another author', () => {
+    render(<ChatPanel channelId="42" channelName="general" matrixRoomId="!general:test" messages={[{ ...recentOwnMessage, sender: 'Bob', senderMatrixUserId: '@bob:test' }]} currentUserMatrixId="@alice:test" canModerateRecentMessages onSendMessage={() => {}} onDeleteMessage={vi.fn()} />);
+    fireEvent.contextMenu(screen.getByText('delete me'), { clientX: 50, clientY: 60 });
+    expect(screen.getByRole('button', { name: 'Delete message' })).toBeInTheDocument();
+  });
+
+  it('confirms before invoking the delete callback', async () => {
+    const user = userEvent.setup();
+    const onDeleteMessage = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(confirm).mockResolvedValue(true);
+    render(<ChatPanel channelId="42" channelName="general" matrixRoomId="!general:test" messages={[recentOwnMessage]} currentUserMatrixId="@alice:test" onSendMessage={() => {}} onDeleteMessage={onDeleteMessage} />);
+    fireEvent.contextMenu(screen.getByText('delete me'), { clientX: 50, clientY: 60 });
+    await user.click(screen.getByRole('button', { name: 'Delete message' }));
+    expect(confirm).toHaveBeenCalledWith({
+      title: 'Delete message?',
+      message: 'This message will be replaced with “Message deleted” for everyone.',
+      confirmLabel: 'Delete message', cancelLabel: 'Cancel', destructive: true,
+    });
+    await waitFor(() => expect(onDeleteMessage).toHaveBeenCalledWith('!general:test', '$message'));
+  });
+
+  it('does not invoke deletion when confirmation is canceled', async () => {
+    const user = userEvent.setup();
+    const onDeleteMessage = vi.fn();
+    vi.mocked(confirm).mockResolvedValue(false);
+    render(<ChatPanel channelId="42" channelName="general" matrixRoomId="!general:test" messages={[recentOwnMessage]} currentUserMatrixId="@alice:test" onSendMessage={() => {}} onDeleteMessage={onDeleteMessage} />);
+    fireEvent.contextMenu(screen.getByText('delete me'));
+    await user.click(screen.getByRole('button', { name: 'Delete message' }));
+    expect(onDeleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows a clear server failure and locks duplicate clicks', async () => {
+    const user = userEvent.setup();
+    let rejectDelete!: (error: Error) => void;
+    const onDeleteMessage = vi.fn(() => new Promise<void>((_, reject) => { rejectDelete = reject; }));
+    vi.mocked(confirm).mockResolvedValue(true);
+    render(<ChatPanel channelId="42" channelName="general" matrixRoomId="!general:test" messages={[recentOwnMessage]} currentUserMatrixId="@alice:test" onSendMessage={() => {}} onDeleteMessage={onDeleteMessage} />);
+    fireEvent.contextMenu(screen.getByText('delete me'));
+    await user.click(screen.getByRole('button', { name: 'Delete message' }));
+    expect(onDeleteMessage).toHaveBeenCalledTimes(1);
+    fireEvent.contextMenu(screen.getByText('delete me'));
+    const lockedAction = screen.getByRole('button', { name: 'Deleting message…' });
+    expect(lockedAction).toBeDisabled();
+    await user.click(lockedAction);
+    expect(onDeleteMessage).toHaveBeenCalledTimes(1);
+    rejectDelete(new MessageDeletionError('Messages can only be deleted within 24 hours.', 'expired', 410));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Messages can only be deleted within 24 hours.');
+  });
+
+  it('uses the room captured before confirmation when navigation changes', async () => {
+    const user = userEvent.setup();
+    let resolveConfirm!: (accepted: boolean) => void;
+    vi.mocked(confirm).mockReturnValue(new Promise(resolve => { resolveConfirm = resolve; }));
+    const onDeleteMessage = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = render(<ChatPanel channelId="42" channelName="room A" matrixRoomId="!room-a:test" messages={[recentOwnMessage]} currentUserMatrixId="@alice:test" onSendMessage={() => {}} onDeleteMessage={onDeleteMessage} />);
+    fireEvent.contextMenu(screen.getByText('delete me'));
+    void user.click(screen.getByRole('button', { name: 'Delete message' }));
+    await waitFor(() => expect(confirm).toHaveBeenCalled());
+    rerender(<ChatPanel channelId="43" channelName="room B" matrixRoomId="!room-b:test" messages={[recentOwnMessage]} currentUserMatrixId="@alice:test" onSendMessage={() => {}} onDeleteMessage={onDeleteMessage} />);
+    resolveConfirm(true);
+    await waitFor(() => expect(onDeleteMessage).toHaveBeenCalledWith('!room-a:test', '$message'));
+  });
+
+  it('shows Message deleted in a reply strip when its target is redacted', () => {
+    render(<ChatPanel channelId="42" channelName="general" messages={[{ ...recentOwnMessage, redacted: true, content: '' }, { ...recentOwnMessage, id: '$reply', content: 'reply body', replyToEventId: '$message' }]} onSendMessage={() => {}} />);
+    expect(screen.getAllByText('Message deleted')).toHaveLength(2);
   });
 });
 

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -225,6 +225,12 @@ describe('ChatPanel message deletion', () => {
     expect(screen.queryByRole('button', { name: 'Delete message' })).not.toBeInTheDocument();
   });
 
+  it('hides Delete message when a bridged bot sender is not the effective author', () => {
+    render(<ChatPanel channelId="42" channelName="general" matrixRoomId="!general:test" messages={[{ ...recentOwnMessage, senderMatrixUserId: '@brmble:test' }]} currentUserMatrixId="@alice:test" canModerateRecentMessages={false} onSendMessage={() => {}} onDeleteMessage={vi.fn()} />);
+    fireEvent.contextMenu(screen.getByText('delete me'), { clientX: 50, clientY: 60 });
+    expect(screen.queryByRole('button', { name: 'Delete message' })).not.toBeInTheDocument();
+  });
+
   it('shows Delete message to an administrator for another author', () => {
     render(<ChatPanel channelId="42" channelName="general" matrixRoomId="!general:test" messages={[{ ...recentOwnMessage, sender: 'Bob', senderMatrixUserId: '@bob:test' }]} currentUserMatrixId="@alice:test" canModerateRecentMessages onSendMessage={() => {}} onDeleteMessage={vi.fn()} />);
     fireEvent.contextMenu(screen.getByText('delete me'), { clientX: 50, clientY: 60 });

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -1182,7 +1182,7 @@ const [replyState, setReplyState] = useState<{
         {messageDeletionError && (
           <div className="chat-action-error" role="alert">
             <span>{messageDeletionError}</span>
-            <button type="button" className="btn btn-ghost btn-icon chat-action-error__dismiss" aria-label="Dismiss message deletion error" onClick={() => setMessageDeletionError(null)}>×</button>
+            <button type="button" className="btn btn-ghost btn-icon chat-action-error__dismiss" aria-label="Dismiss message deletion error" onClick={() => setMessageDeletionError(null)}><Icon name="x" size={14} /></button>
           </div>
         )}
         {showScrollButton && (

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -17,6 +17,9 @@ import Avatar from '../Avatar/Avatar';
 import { SUPPORTED_REACTIONS } from '../../utils/chatReactions';
 import { buildMessageEditContent, canEditMessage } from '../../utils/matrixMessageEditing';
 import { isPaintSourceAttachment } from '../../utils/chatImagePaintSource';
+import { confirm } from '../../hooks/usePrompt';
+import { MessageDeletionError } from '../../api/messages';
+import { canDeleteMessage, DEFAULT_MESSAGE_DELETION_WINDOW_MS } from '../../utils/messageDeletion';
 import type { PaintSessionStatus } from '../../types/paint';
 import './ChatPanel.css';
 
@@ -59,6 +62,9 @@ interface ChatPanelProps {
   onJoinPaint?: (sessionId: string) => Promise<void> | void;
   onOpenPaint?: (sessionId: string) => void;
   onUseAsPaintBackground?: (attachment: MediaAttachment) => void | Promise<void>;
+  canModerateRecentMessages?: boolean;
+  messageDeletionWindowMs?: number;
+  onDeleteMessage?: (roomId: string, eventId: string) => Promise<void>;
 }
 
 const SCROLL_THRESHOLD = 150;
@@ -66,7 +72,7 @@ const SPLIT_STORAGE_KEY = 'brmble-screenshare-split';
 const DEFAULT_SPLIT = 50;
 const REPLY_TARGET_HIGHLIGHT_MS = 1600;
 
-export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, focusedShare, remoteVideoEls, roomQuality, shareQualities, viewerQualities, onFocusShare, onCloseShare, onViewerQualityChange, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard, currentUserMatrixId, onToggleReaction, typingIndicatorText, typingTargetId, onTypingStart, onTypingStop, currentUserId, paintSessionStatuses, onJoinPaint, onOpenPaint, onUseAsPaintBackground }: ChatPanelProps) {
+export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, focusedShare, remoteVideoEls, roomQuality, shareQualities, viewerQualities, onFocusShare, onCloseShare, onViewerQualityChange, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard, currentUserMatrixId, onToggleReaction, typingIndicatorText, typingTargetId, onTypingStart, onTypingStop, currentUserId, paintSessionStatuses, onJoinPaint, onOpenPaint, onUseAsPaintBackground, canModerateRecentMessages = false, messageDeletionWindowMs = DEFAULT_MESSAGE_DELETION_WINDOW_MS, onDeleteMessage }: ChatPanelProps) {
   // Build lookup maps from sender name and matrixUserId → avatar data for MessageBubble.
   // Name-based lookup works when Mumble name matches message sender.
   // MatrixUserId-based lookup handles cases where the user connected with a different
@@ -184,6 +190,8 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
   const hiddenSetRef = useRef<Set<string>>(new Set());
   const replyHighlightTimeoutRef = useRef<number | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; sender: string; senderMatrixUserId?: string; content?: string; messageId?: string; msgType?: string; reactions?: Record<string, string[]>; attachment?: MediaAttachment } | null>(null);
+  const [deletingMessageId, setDeletingMessageId] = useState<string | null>(null);
+  const [messageDeletionError, setMessageDeletionError] = useState<string | null>(null);
 const [replyState, setReplyState] = useState<{
   eventId: string;
   sender: string;
@@ -987,7 +995,7 @@ const [replyState, setReplyState] = useState<{
                     isActiveMatch={isActiveMatch}
                     messageIndex={msgIndex}
                     senderAvatarUrl={lookupAvatar(item.message.sender, item.message.senderMatrixUserId)?.avatarUrl}
-                    senderMatrixUserId={lookupAvatar(item.message.sender, item.message.senderMatrixUserId)?.matrixUserId}
+                    senderMatrixUserId={item.message.senderMatrixUserId}
                     currentUsername={currentUsername}
                     knownUsernames={knownUsernames}
                     messageId={item.message.id}
@@ -996,11 +1004,13 @@ const [replyState, setReplyState] = useState<{
                     mumbleDelivery={item.message.mumbleDelivery}
                     replyToEventId={item.message.replyToEventId}
                     replyToSender={(item.message.replyToSender) || (item.message.replyToEventId ? lookupMessageById(item.message.replyToEventId)?.sender : undefined)}
-                    replyToContent={(item.message.replyToContent) || (item.message.replyToEventId ? lookupMessageById(item.message.replyToEventId)?.content : undefined)}
+                    replyToContent={item.message.replyToEventId && lookupMessageById(item.message.replyToEventId)?.redacted
+                      ? 'Message deleted'
+                      : (item.message.replyToContent) || (item.message.replyToEventId ? lookupMessageById(item.message.replyToEventId)?.content : undefined)}
                     isReplyTargetHighlighted={highlightedMessageId === item.message.id}
                     onReplyClick={scrollToMessage}
                     onDismiss={onDismissMessage}
-                    onOpenContextMenu={(onMessageContextMenu || onUseAsPaintBackground) ? (x, y, s, m, c, msgId, msgType = 'm.text', reactions, redacted, attachment) => {
+                    onOpenContextMenu={(onMessageContextMenu || onUseAsPaintBackground || onDeleteMessage) ? (x, y, s, m, c, msgId, msgType = 'm.text', reactions, redacted, attachment) => {
                       if (!redacted) {
                         setContextMenu({ x, y, sender: s, senderMatrixUserId: m, content: c, messageId: msgId, msgType, reactions, attachment });
                       }
@@ -1090,6 +1100,46 @@ const [replyState, setReplyState] = useState<{
                   },
                 });
               }
+              const canDeleteSelectedMessage = Boolean(
+                contextMessage && onDeleteMessage && canDeleteMessage(
+                  contextMessage,
+                  matrixRoomId,
+                  currentUserMatrixId,
+                  canModerateRecentMessages,
+                  messageDeletionWindowMs,
+                ),
+              );
+              if (canDeleteSelectedMessage && contextMenu) {
+                items.push({
+                  type: 'item',
+                  label: deletingMessageId === contextMenu.messageId ? 'Deleting message…' : 'Delete message',
+                  disabled: deletingMessageId === contextMenu.messageId,
+                  onClick: async () => {
+                    const eventId = contextMenu.messageId;
+                    const roomId = matrixRoomId;
+                    setContextMenu(null);
+                    setMessageDeletionError(null);
+                    if (!roomId || !eventId || deletingMessageId !== null) return;
+                    const accepted = await confirm({
+                      title: 'Delete message?',
+                      message: 'This message will be replaced with “Message deleted” for everyone.',
+                      confirmLabel: 'Delete message', cancelLabel: 'Cancel', destructive: true,
+                    });
+                    if (!accepted || deletingMessageId !== null) return;
+                    if (!onDeleteMessage) return;
+                    setDeletingMessageId(eventId);
+                    try {
+                      await onDeleteMessage(roomId, eventId);
+                    } catch (error) {
+                      setMessageDeletionError(error instanceof MessageDeletionError
+                        ? error.message
+                        : 'Message could not be deleted. Try again.');
+                    } finally {
+                      setDeletingMessageId(null);
+                    }
+                  },
+                });
+              }
               items.push({
                 type: 'item',
                 label: 'Reply',
@@ -1129,6 +1179,12 @@ const [replyState, setReplyState] = useState<{
       </div>
 
       <div className="chat-input-area">
+        {messageDeletionError && (
+          <div className="chat-action-error" role="alert">
+            <span>{messageDeletionError}</span>
+            <button type="button" className="btn btn-ghost btn-icon chat-action-error__dismiss" aria-label="Dismiss message deletion error" onClick={() => setMessageDeletionError(null)}>×</button>
+          </div>
+        )}
         {showScrollButton && (
           <Tooltip content="Scroll to bottom">
           <button

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -191,6 +191,7 @@ export function ChatPanel({ channelId, channelName, messages, currentUsername, o
   const replyHighlightTimeoutRef = useRef<number | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; sender: string; senderMatrixUserId?: string; content?: string; messageId?: string; msgType?: string; reactions?: Record<string, string[]>; attachment?: MediaAttachment } | null>(null);
   const [deletingMessageId, setDeletingMessageId] = useState<string | null>(null);
+  const deletingMessageIdRef = useRef<string | null>(null);
   const [messageDeletionError, setMessageDeletionError] = useState<string | null>(null);
 const [replyState, setReplyState] = useState<{
   eventId: string;
@@ -1112,21 +1113,24 @@ const [replyState, setReplyState] = useState<{
               if (canDeleteSelectedMessage && contextMenu) {
                 items.push({
                   type: 'item',
-                  label: deletingMessageId === contextMenu.messageId ? 'Deleting message…' : 'Delete message',
-                  disabled: deletingMessageId === contextMenu.messageId,
+                  label: deletingMessageId !== null ? 'Deleting message…' : 'Delete message',
+                  disabled: deletingMessageId !== null,
                   onClick: async () => {
                     const eventId = contextMenu.messageId;
                     const roomId = matrixRoomId;
                     setContextMenu(null);
                     setMessageDeletionError(null);
-                    if (!roomId || !eventId || deletingMessageId !== null) return;
+                    if (!roomId || !eventId || deletingMessageIdRef.current !== null) return;
+                    deletingMessageIdRef.current = eventId;
                     const accepted = await confirm({
                       title: 'Delete message?',
                       message: 'This message will be replaced with “Message deleted” for everyone.',
                       confirmLabel: 'Delete message', cancelLabel: 'Cancel', destructive: true,
                     });
-                    if (!accepted || deletingMessageId !== null) return;
-                    if (!onDeleteMessage) return;
+                    if (!accepted || !onDeleteMessage) {
+                      deletingMessageIdRef.current = null;
+                      return;
+                    }
                     setDeletingMessageId(eventId);
                     try {
                       await onDeleteMessage(roomId, eventId);
@@ -1135,6 +1139,7 @@ const [replyState, setReplyState] = useState<{
                         ? error.message
                         : 'Message could not be deleted. Try again.');
                     } finally {
+                      deletingMessageIdRef.current = null;
                       setDeletingMessageId(null);
                     }
                   },

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -215,6 +215,45 @@ describe('useMatrixClient', () => {
 
     expect(deleteMessageRequest).toHaveBeenCalledWith('!dm:test', '$dm-message');
   });
+
+  it('reconciles a DM local echo to its canonical event ID without reloading', async () => {
+    const room = withNoTypingMembers({
+      roomId: '!dm:test',
+      getMember: () => undefined,
+      getLiveTimeline: () => ({ getEvents: () => [] }),
+    });
+    const dmCredentials: MatrixCredentials = {
+      ...creds,
+      dmRoomMap: { '@bob:test': '!dm:test' },
+    };
+    mockClient.getRoom.mockReturnValue(room);
+    const { result } = renderHook(() => useMatrixClient(dmCredentials), { wrapper });
+    const onTimeline = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'Room.timeline')?.[1] as
+      | ((event: unknown, timelineRoom: unknown) => void)
+      | undefined;
+
+    const onSync = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
+      | ((state: string) => void)
+      | undefined;
+    act(() => onSync?.('PREPARED'));
+    act(() => result.current.setActiveDmContact('@bob:test'));
+    mockClient.sendMessage.mockImplementationOnce(async (_roomId: string, _content: unknown, txnId: string) => {
+      onTimeline?.(fakeRoomMessage(undefined, '@1:example.com', 'hello', 1_000, undefined, txnId), room);
+      return { event_id: '$dm-sent' };
+    });
+
+    await act(async () => { await result.current.sendDMMessage('@bob:test', 'hello'); });
+
+    expect(mockClient.sendMessage).toHaveBeenCalledWith(
+      '!dm:test',
+      { msgtype: 'm.text', body: 'hello' },
+      'txn-1',
+    );
+    expect(result.current.activeDmMessages).toEqual([
+      expect.objectContaining({ id: '$dm-sent', transactionId: 'txn-1', content: 'hello' }),
+    ]);
+  });
+
   it('calls onDirectMessage only for incoming DM messages', () => {
     mockClient.getRoom.mockReturnValue(null);
     const onDirectMessage = vi.fn();

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -36,19 +36,21 @@ const mockClient = {
   createRoom: vi.fn().mockResolvedValue({ room_id: '!new:example.com' }),
   scrollback: vi.fn().mockResolvedValue(undefined),
   sendMessage: vi.fn().mockResolvedValue({ event_id: '$sent-event' }),
+  makeTxnId: vi.fn().mockReturnValue('txn-1'),
   sendEvent: vi.fn().mockResolvedValue({ event_id: '$sent-event' }),
   sendTyping: vi.fn().mockResolvedValue(undefined),
   redactEvent: vi.fn().mockResolvedValue(undefined),
   mxcUrlToHttp: vi.fn((url: string) => url.replace('mxc://', 'https://matrix.example.com/_matrix/media/v3/download/')),
 };
 
-function fakeRoomMessage(id: string, sender: string, body: string, ts: number, content?: Record<string, unknown>) {
+function fakeRoomMessage(id: string | undefined, sender: string, body: string, ts: number, content?: Record<string, unknown>, txnId?: string) {
   return {
     getType: () => 'm.room.message',
     getId: () => id,
     getSender: () => sender,
     getContent: () => ({ body, ...content }),
     getTs: () => ts,
+    getTxnId: () => txnId,
     isRedacted: () => false,
   };
 }
@@ -118,6 +120,58 @@ describe('useMatrixClient', () => {
     const message = transformEventToChatMessage(event as never, room as never, '42', mockClient as never);
 
     expect(message?.senderMatrixUserId).toBe('@brmble:test');
+  });
+
+  it('replaces a local echo with its canonical event instead of duplicating it', () => {
+    const room = {
+      roomId: '!room:example.com',
+      getMember: () => undefined,
+      getMembers: () => [],
+      getLiveTimeline: () => ({ getEvents: () => [] }),
+    };
+    mockClient.getRoom.mockReturnValue(room);
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+    const onTimeline = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'Room.timeline')?.[1] as
+      | ((event: unknown, timelineRoom: unknown) => void)
+      | undefined;
+
+    act(() => result.current.setActiveChannel('42'));
+    act(() => onTimeline?.(
+      fakeRoomMessage(undefined, '@1:example.com', 'hello', 1_000, undefined, 'txn-1'),
+      room,
+    ));
+    expect(result.current.activeMessages[0]?.id).not.toMatch(/^\$/);
+
+    act(() => onTimeline?.(
+      fakeRoomMessage('$sent', '@1:example.com', 'hello', 1_000, undefined, 'txn-1'),
+      room,
+    ));
+
+    expect(result.current.activeMessages).toEqual([expect.objectContaining({ id: '$sent', content: 'hello' })]);
+  });
+
+  it('updates a local echo with the canonical ID returned by sendMessage', async () => {
+    const room = {
+      roomId: '!room:example.com',
+      getMember: () => undefined,
+      getMembers: () => [],
+      getLiveTimeline: () => ({ getEvents: () => [] }),
+    };
+    mockClient.getRoom.mockReturnValue(room);
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+    const onTimeline = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'Room.timeline')?.[1] as
+      | ((event: unknown, timelineRoom: unknown) => void)
+      | undefined;
+
+    act(() => result.current.setActiveChannel('42'));
+    act(() => onTimeline?.(
+      fakeRoomMessage(undefined, '@1:example.com', 'hello', 1_000, undefined, 'txn-1'),
+      room,
+    ));
+
+    await act(async () => { await result.current.sendMessage('42', 'hello'); });
+
+    expect(result.current.activeMessages).toEqual([expect.objectContaining({ id: '$sent-event', content: 'hello' })]);
   });
 
   it('deletes from the active channel room and redacts local content after success', async () => {
@@ -470,7 +524,7 @@ describe('useMatrixClient', () => {
     expect(mockClient.sendMessage).toHaveBeenCalledWith('!room:example.com', {
       msgtype: 'm.text',
       body: 'hello',
-    });
+    }, expect.any(String));
     expect(mockClient.sendTyping).toHaveBeenLastCalledWith('!room:example.com', false, 0);
   });
 

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, renderHook, screen, act } from '@testing-library/react';
 import React from 'react';
-import { useMatrixClient } from './useMatrixClient';
+import { transformEventToChatMessage, useMatrixClient } from './useMatrixClient';
 import type { MatrixCredentials } from './useMatrixClient';
 import { ServiceStatusProvider, useServiceStatus } from './useServiceStatus';
 
@@ -42,12 +42,12 @@ const mockClient = {
   mxcUrlToHttp: vi.fn((url: string) => url.replace('mxc://', 'https://matrix.example.com/_matrix/media/v3/download/')),
 };
 
-function fakeRoomMessage(id: string, sender: string, body: string, ts: number) {
+function fakeRoomMessage(id: string, sender: string, body: string, ts: number, content?: Record<string, unknown>) {
   return {
     getType: () => 'm.room.message',
     getId: () => id,
     getSender: () => sender,
-    getContent: () => ({ body }),
+    getContent: () => ({ body, ...content }),
     getTs: () => ts,
     isRedacted: () => false,
   };
@@ -93,6 +93,33 @@ beforeEach(() => {
 });
 
 describe('useMatrixClient', () => {
+  it('uses trusted bridged author metadata as the effective sender ID', () => {
+    const event = fakeRoomMessage(
+      '$bridged',
+      '@brmble:test',
+      '[Alice]: hello',
+      Date.now(),
+      { 'com.brmble.author_matrix_user_id': '@alice:test' },
+    );
+    const room = { getMember: () => undefined };
+
+    const message = transformEventToChatMessage(event as never, room as never, '42', mockClient as never);
+
+    expect(message).toEqual(expect.objectContaining({
+      sender: 'Alice',
+      senderMatrixUserId: '@alice:test',
+    }));
+  });
+
+  it('falls back to the Matrix sender when bridged author metadata is absent', () => {
+    const event = fakeRoomMessage('$legacy', '@brmble:test', '[Alice]: hello', Date.now());
+    const room = { getMember: () => undefined };
+
+    const message = transformEventToChatMessage(event as never, room as never, '42', mockClient as never);
+
+    expect(message?.senderMatrixUserId).toBe('@brmble:test');
+  });
+
   it('deletes from the active channel room and redacts local content after success', async () => {
     deleteMessageRequest.mockResolvedValue(undefined);
     const room = {

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -76,6 +76,7 @@ const creds: MatrixCredentials = {
   homeserverUrl: 'https://matrix.example.com',
   accessToken: 'tok_abc',
   userId: '@1:example.com',
+  botUserId: '@brmble:test',
   roomMap: { '42': '!room:example.com' },
 };
 
@@ -105,12 +106,27 @@ describe('useMatrixClient', () => {
     );
     const room = { getMember: () => undefined };
 
-    const message = transformEventToChatMessage(event as never, room as never, '42', mockClient as never);
+    const message = transformEventToChatMessage(event as never, room as never, '42', mockClient as never, '@brmble:test');
 
     expect(message).toEqual(expect.objectContaining({
       sender: 'Alice',
       senderMatrixUserId: '@alice:test',
     }));
+  });
+
+  it('ignores forged bridged author metadata from a non-bot sender', () => {
+    const event = fakeRoomMessage(
+      '$forged',
+      '@mallory:test',
+      'forged',
+      Date.now(),
+      { 'com.brmble.author_matrix_user_id': '@alice:test' },
+    );
+    const room = { getMember: () => undefined };
+
+    const message = transformEventToChatMessage(event as never, room as never, '42', mockClient as never, '@brmble:test');
+
+    expect(message?.senderMatrixUserId).toBe('@mallory:test');
   });
 
   it('falls back to the Matrix sender when bridged author metadata is absent', () => {

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -14,6 +14,14 @@ vi.mock('../bridge', () => ({
   },
 }));
 
+const deleteMessageRequest = vi.hoisted(() => vi.fn());
+
+vi.mock('../api/messages', () => ({
+  messageApi: {
+    delete: deleteMessageRequest,
+  },
+}));
+
 // --- mock matrix-js-sdk ---
 const mockClient = {
   startClient: vi.fn(),
@@ -85,6 +93,47 @@ beforeEach(() => {
 });
 
 describe('useMatrixClient', () => {
+  it('deletes from the active channel room and redacts local content after success', async () => {
+    deleteMessageRequest.mockResolvedValue(undefined);
+    const room = {
+      roomId: '!room:example.com',
+      getMember: () => undefined,
+      getMembers: () => [],
+      getLiveTimeline: () => ({
+        getEvents: () => [fakeRoomMessage('$message', '@1:example.com', 'delete me', Date.now())],
+      }),
+    };
+    mockClient.getRoom.mockReturnValue(room);
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+
+    await act(async () => { await result.current.setActiveChannel('42'); });
+    await act(async () => { await result.current.deleteMessage('!room:example.com', '$message'); });
+
+    expect(deleteMessageRequest).toHaveBeenCalledWith('!room:example.com', '$message');
+    expect(result.current.activeMessages).toEqual([expect.objectContaining({
+      id: '$message', redacted: true, content: '', media: undefined,
+    })]);
+  });
+
+  it('deletes from the active DM room', async () => {
+    deleteMessageRequest.mockResolvedValue(undefined);
+    const dmCredentials: MatrixCredentials = { ...creds, dmRoomMap: { '@bob:test': '!dm:test' } };
+    const room = {
+      roomId: '!dm:test',
+      getMember: () => undefined,
+      getMembers: () => [],
+      getLiveTimeline: () => ({
+        getEvents: () => [fakeRoomMessage('$dm-message', '@1:example.com', 'delete me', Date.now())],
+      }),
+    };
+    mockClient.getRoom.mockReturnValue(room);
+    const { result } = renderHook(() => useMatrixClient(dmCredentials), { wrapper });
+
+    await act(async () => { result.current.setActiveDmContact('@bob:test'); });
+    await act(async () => { await result.current.deleteMessage('!dm:test', '$dm-message'); });
+
+    expect(deleteMessageRequest).toHaveBeenCalledWith('!dm:test', '$dm-message');
+  });
   it('calls onDirectMessage only for incoming DM messages', () => {
     mockClient.getRoom.mockReturnValue(null);
     const onDirectMessage = vi.fn();
@@ -666,6 +715,7 @@ describe('useMatrixClient', () => {
     act(() => onTimeline!(fakeEvent, mockRoom));
 
     expect(result.current.lastMessages.get('42')).toEqual({
+      eventId: '$evt-1',
       content: 'hi there',
       ts: 1_700_000_000_000,
       sender: 'Alice',
@@ -959,6 +1009,7 @@ describe('useMatrixClient', () => {
     act(() => onTimeline!(fakeEvent, dmMockRoom));
 
     expect(result.current.dmLastMessages.get('@bob:example.com')).toEqual({
+      eventId: '$dm-ev-1',
       content: 'dm preview text',
       ts: 1_700_000_000_000,
       sender: 'Bob',
@@ -992,6 +1043,7 @@ describe('useMatrixClient', () => {
     act(() => onSync!('PREPARED'));
 
     expect(result.current.dmLastMessages.get('@bob:example.com')).toEqual({
+      eventId: '$e2',
       content: 'last one',
       ts: 2000,
       sender: 'Bob',
@@ -1041,6 +1093,7 @@ describe('useMatrixClient', () => {
       reactions: { '👍': ['@bob:example.com'] },
     }));
     expect(result.current.lastMessages.get('42')).toEqual({
+      eventId: '$message',
       content: 'react to me',
       ts: 1000,
       sender: 'Alice',

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -298,12 +298,6 @@ function loadMessagesFromTimeline(
   }
 
   for (const ev of room.getLiveTimeline().getEvents()) {
-    // Track redaction events
-    if (ev.getType() === 'm.room.redaction') {
-      const redactedId = getRedactedEventId(ev);
-      if (redactedId) redactedEventIds.add(redactedId);
-    }
-
     const m = transformEventToChatMessage(ev, room, targetId, client, trustedBotUserId);
     if (m) {
       const bundled = parseBundledReplacementFromUnsigned(ev as never);

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -13,6 +13,7 @@ import {
 } from '../utils/matrixMessageEditing';
 import { useServiceStatus } from './useServiceStatus';
 import bridge from '../bridge';
+import { messageApi } from '../api/messages';
 
 const TYPING_TIMEOUT_MS = 10_000;
 const TYPING_REFRESH_MS = 5_000;
@@ -193,6 +194,23 @@ function getRedactedEventId(event: RedactionLikeEvent): string | undefined {
   return content?.redacts;
 }
 
+function sanitizeRedactedMessage(message: ChatMessage): ChatMessage {
+  return {
+    ...message,
+    redacted: true,
+    content: '',
+    media: undefined,
+    replyToEventId: undefined,
+    replyToSender: undefined,
+    replyToContent: undefined,
+    edited: false,
+    originalContent: undefined,
+    latestEditTimestamp: undefined,
+    latestEditEventId: undefined,
+    reactions: undefined,
+  };
+}
+
 function markMessageRedacted(
   existing: ChatMessage[],
   redactedEventId: string | undefined,
@@ -200,9 +218,9 @@ function markMessageRedacted(
   if (!redactedEventId) return existing;
   let changed = false;
   const updated = existing.map((message) => {
-    if (message.id !== redactedEventId) return message;
+    if (message.id !== redactedEventId || message.redacted) return message;
     changed = true;
-    return { ...message, redacted: true, content: '', media: undefined };
+    return sanitizeRedactedMessage(message);
   });
   return changed ? updated : existing;
 }
@@ -255,6 +273,13 @@ function loadMessagesFromTimeline(
   const redactedEventIds = new Set<string>();
 
   for (const ev of room.getLiveTimeline().getEvents()) {
+    if (ev.getType() === 'm.room.redaction') {
+      const redactedId = getRedactedEventId(ev);
+      if (redactedId) redactedEventIds.add(redactedId);
+    }
+  }
+
+  for (const ev of room.getLiveTimeline().getEvents()) {
     // Track redaction events
     if (ev.getType() === 'm.room.redaction') {
       const redactedId = getRedactedEventId(ev);
@@ -271,7 +296,7 @@ function loadMessagesFromTimeline(
       // Mark message as redacted if already redacted or has redaction event
       const isEventRedacted = typeof ev.isRedacted === 'function' && ev.isRedacted();
       if (isEventRedacted || redactedEventIds.has(m.id)) {
-        out.push({ ...m, redacted: true, content: '', media: undefined });
+        out.push(sanitizeRedactedMessage(m));
       } else {
         out.push(m);
       }
@@ -323,6 +348,7 @@ export interface MatrixCredentials {
 }
 
 export interface MessagePreview {
+  eventId: string;
   content: string;
   ts: number;
   sender: string;
@@ -416,6 +442,42 @@ export function useMatrixClient(
       Object.entries(credentials.roomMap).map(([channelId, roomId]) => [roomId, channelId])
     );
   }, [credentials]);
+
+  const reconcileRedaction = useCallback((roomId: string, eventId: string) => {
+    const channelId = roomIdToChannelId.get(roomId);
+    const dmUserId = roomIdToDMUserIdRef.current.get(roomId);
+
+    if (channelId && activeChannelIdRef.current === channelId) {
+      setActiveMessages(messages => markMessageRedacted(messages, eventId));
+    }
+    if (channelId) {
+      setLastMessages(previews => {
+        const preview = previews.get(channelId);
+        if (preview?.eventId !== eventId) return previews;
+        const next = new Map(previews);
+        next.set(channelId, { ...preview, content: 'Message deleted' });
+        return next;
+      });
+    }
+
+    if (dmUserId && activeDmContactIdRef.current === dmUserId) {
+      setActiveDmMessages(messages => markMessageRedacted(messages, eventId));
+    }
+    if (dmUserId) {
+      setDmLastMessages(previews => {
+        const preview = previews.get(dmUserId);
+        if (preview?.eventId !== eventId) return previews;
+        const next = new Map(previews);
+        next.set(dmUserId, { ...preview, content: 'Message deleted' });
+        return next;
+      });
+    }
+  }, [roomIdToChannelId]);
+
+  const deleteMessage = useCallback(async (roomId: string, eventId: string) => {
+    await messageApi.delete(roomId, eventId);
+    reconcileRedaction(roomId, eventId);
+  }, [reconcileRedaction]);
 
   const getActiveMatrixRoomId = useCallback((): string | null => {
     if (activeChannelIdRef.current && credentials?.roomMap[activeChannelIdRef.current]) {
@@ -670,16 +732,7 @@ export function useMatrixClient(
           return;
         }
 
-        const channelId2 = roomIdToChannelId.get(room?.roomId ?? '');
-        if (channelId2 && activeChannelIdRef.current === channelId2) {
-          setActiveMessages(prev => markMessageRedacted(prev, redactedEventId));
-          return;
-        }
-
-        const dmUserId2 = roomIdToDMUserIdRef.current.get(room?.roomId ?? '');
-        if (dmUserId2 && activeDmContactIdRef.current === dmUserId2) {
-          setActiveDmMessages(prev => markMessageRedacted(prev, redactedEventId));
-        }
+        if (redactedEventId && room?.roomId) reconcileRedaction(room.roomId, redactedEventId);
         return;
       }
 
@@ -708,6 +761,7 @@ export function useMatrixClient(
           if (existing && existing.ts >= message.timestamp.getTime()) return prev;
           const next = new Map(prev);
           next.set(channelId, {
+            eventId: message.id,
             content: message.content,
             ts: message.timestamp.getTime(),
             sender: message.sender,
@@ -754,6 +808,7 @@ export function useMatrixClient(
         if (existing && existing.ts >= dmMessage.timestamp.getTime()) return prev;
         const next = new Map(prev);
         next.set(dmUserId, {
+          eventId: dmMessage.id,
           content: dmMessage.content,
           ts: dmMessage.timestamp.getTime(),
           sender: dmMessage.sender,
@@ -817,13 +872,23 @@ export function useMatrixClient(
             if (!target) continue;
 
             const events = room.getLiveTimeline().getEvents();
+            const redactedEventIds = new Set<string>();
+            for (const ev of events) {
+              if (ev.getType() === EventType.RoomRedaction) {
+                const redactedId = getRedactedEventId(ev as unknown as RedactionLikeEvent);
+                if (redactedId) redactedEventIds.add(redactedId);
+              }
+            }
             for (let i = events.length - 1; i >= 0; i--) {
               const ev = events[i];
               if (ev.getType() !== EventType.RoomMessage) continue;
               const msg = transformEventToChatMessage(ev, room, target, clientRef.current);
               if (!msg) continue;
+              const isRedacted = redactedEventIds.has(msg.id)
+                || (typeof ev.isRedacted === 'function' && ev.isRedacted());
               const preview: MessagePreview = {
-                content: msg.content,
+                eventId: msg.id,
+                content: isRedacted ? 'Message deleted' : msg.content,
                 ts: msg.timestamp.getTime(),
                 sender: msg.sender,
               };
@@ -909,7 +974,7 @@ export function useMatrixClient(
           const existing = prev.get(otherUserId);
           if (existing && existing.ts >= msg.timestamp.getTime()) return prev;
           const next = new Map(prev);
-          next.set(otherUserId, { content: msg.content, ts: msg.timestamp.getTime(), sender: msg.sender });
+          next.set(otherUserId, { eventId: msg.id, content: msg.content, ts: msg.timestamp.getTime(), sender: msg.sender });
           return next;
         });
         break;
@@ -1028,7 +1093,7 @@ export function useMatrixClient(
       setClient(null);
       updateStatus('chat', { state: 'idle', error: undefined });
     };
-  }, [clearLocalTypingState, credentials, forgetReplacementEdit, rememberReplacementEdit, replaceRoomTypingFromMembers, roomIdToChannelId, stopTypingForRoom, updateStatus]);
+  }, [clearLocalTypingState, credentials, forgetReplacementEdit, reconcileRedaction, rememberReplacementEdit, replaceRoomTypingFromMembers, roomIdToChannelId, stopTypingForRoom, updateStatus]);
 
   const sendMessage = useCallback(async (channelId: string, text: string) => {
     if (!credentials || !clientRef.current) return;
@@ -1405,7 +1470,7 @@ export function useMatrixClient(
     }
   }, [credentials]);
 
-  return { lastMessages, activeMessages, setActiveChannel,
+  return { lastMessages, activeMessages, setActiveChannel, deleteMessage,
            sendMessage, sendImageMessage, uploadContent, fetchHistory,
            sendReaction, removeReaction,
            dmLastMessages, activeDmMessages, setActiveDmContact, dmRoomMap,

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -29,6 +29,15 @@ type TypingEntry = {
 
 /** Insert a message into a chronologically sorted array, deduplicating by id. Returns the same array if already present. */
 function insertMessage(existing: ChatMessage[], msg: ChatMessage): ChatMessage[] {
+  const transactionIndex = msg.transactionId
+    ? existing.findIndex(item => item.transactionId === msg.transactionId)
+    : -1;
+  if (transactionIndex >= 0) {
+    if (existing[transactionIndex].id === msg.id) return existing;
+    const updated = [...existing];
+    updated[transactionIndex] = msg;
+    return updated;
+  }
   if (existing.some(m => m.id === msg.id)) return existing;
   const last = existing[existing.length - 1];
   if (!last || msg.timestamp.getTime() >= last.timestamp.getTime()) {
@@ -110,6 +119,7 @@ export function transformEventToChatMessage(
 
   return {
     id: event.getId() ?? crypto.randomUUID(),
+    ...(event.getTxnId?.() && { transactionId: event.getTxnId() }),
     channelId,
     sender: messageSender,
     senderMatrixUserId: effectiveSenderId,
@@ -1104,7 +1114,17 @@ export function useMatrixClient(
     if (!credentials || !clientRef.current) return;
     const roomId = credentials.roomMap[channelId];
     if (!roomId) return;
-    await clientRef.current.sendMessage(roomId, { msgtype: MsgType.Text, body: text });
+    const txnId = clientRef.current.makeTxnId();
+    const response = await clientRef.current.sendMessage(roomId, { msgtype: MsgType.Text, body: text }, txnId);
+    if (response.event_id) {
+      setActiveMessages(prev => {
+        const index = prev.findIndex(message => message.transactionId === txnId);
+        if (index < 0 || prev[index].id === response.event_id) return prev;
+        const updated = [...prev];
+        updated[index] = { ...updated[index], id: response.event_id };
+        return updated;
+      });
+    }
     await stopTypingForRoom(roomId);
     clearLocalTypingState();
   }, [clearLocalTypingState, credentials, stopTypingForRoom]);

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -1240,7 +1240,21 @@ export function useMatrixClient(
       }
     }
 
-    await client.sendMessage(roomId, { msgtype: MsgType.Text, body: text });
+    const txnId = client.makeTxnId();
+    const response = await client.sendMessage(
+      roomId,
+      { msgtype: MsgType.Text, body: text },
+      txnId,
+    );
+    if (response.event_id) {
+      setActiveDmMessages(prev => {
+        const index = prev.findIndex(message => message.transactionId === txnId);
+        if (index < 0 || prev[index].id === response.event_id) return prev;
+        const updated = [...prev];
+        updated[index] = { ...updated[index], id: response.event_id };
+        return updated;
+      });
+    }
   }, [credentials]);
 
   const fetchDMHistory = useCallback(async (targetMatrixUserId: string) => {

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -311,6 +311,10 @@ function loadMessagesFromTimeline(
 
 export interface MatrixCredentials {
   customCompanions?: CustomCompanionCapability;
+  messageDeletion?: {
+    canModerate: boolean;
+    maxAgeMs: number;
+  };
   homeserverUrl: string;
   accessToken: string;
   userId: string;

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -67,6 +67,7 @@ export function transformEventToChatMessage(
   room: Room | undefined,
   channelId: string,
   client: MatrixClient | null,
+  trustedBotUserId?: string,
 ): ChatMessage | null {
   if (event.getType() !== EventType.RoomMessage) return null;
 
@@ -102,7 +103,8 @@ export function transformEventToChatMessage(
   const isBridgeBotSender = /^@brmble[_-]?/.test(senderId);
   const bridgeMatch = isBridgeBotSender ? rawBody.match(/^\[(.+?)\]:\s*/) : null;
   const messageSender = bridgeMatch ? bridgeMatch[1] : displayName;
-  const effectiveSenderId = typeof content['com.brmble.author_matrix_user_id'] === 'string'
+  const effectiveSenderId = senderId === trustedBotUserId
+    && typeof content['com.brmble.author_matrix_user_id'] === 'string'
     && content['com.brmble.author_matrix_user_id'].length > 0
     ? content['com.brmble.author_matrix_user_id']
     : senderId;
@@ -279,6 +281,7 @@ function loadMessagesFromTimeline(
   reactionEventsRef?: React.MutableRefObject<Map<string, ReactionEventRecord>>,
   ownReactionEventIdsRef?: React.MutableRefObject<Map<string, Map<string, string>>>,
   onReplacementEdit?: (replacement: ReplacementEventRecord) => void,
+  trustedBotUserId?: string,
 ): ChatMessage[] {
   const room = client.getRoom(roomId);
   if (!room) return [];
@@ -301,7 +304,7 @@ function loadMessagesFromTimeline(
       if (redactedId) redactedEventIds.add(redactedId);
     }
 
-    const m = transformEventToChatMessage(ev, room, targetId, client);
+    const m = transformEventToChatMessage(ev, room, targetId, client, trustedBotUserId);
     if (m) {
       const bundled = parseBundledReplacementFromUnsigned(ev as never);
       if (bundled && !redactedEventIds.has(bundled.editEventId)) {
@@ -350,6 +353,7 @@ function loadMessagesFromTimeline(
 }
 
 export interface MatrixCredentials {
+  botUserId?: string;
   customCompanions?: CustomCompanionCapability;
   messageDeletion?: {
     canModerate: boolean;
@@ -754,7 +758,7 @@ export function useMatrixClient(
       if (eventType !== EventType.RoomMessage) return;
       const channelId = roomIdToChannelId.get(room?.roomId ?? '');
       if (channelId) {
-        const message = transformEventToChatMessage(event, room, channelId, clientRef.current);
+        const message = transformEventToChatMessage(event, room, channelId, clientRef.current, credentials.botUserId);
         if (!message) return;
         
         // Apply cached replacement edits if any exist for this message
@@ -801,7 +805,7 @@ export function useMatrixClient(
         return;
       }
 
-      const dmMessage = transformEventToChatMessage(event, room, dmUserId, clientRef.current);
+      const dmMessage = transformEventToChatMessage(event, room, dmUserId, clientRef.current, credentials.botUserId);
       if (!dmMessage) return;
       
       // Apply cached replacement edits if any exist for this message
@@ -897,7 +901,7 @@ export function useMatrixClient(
             for (let i = events.length - 1; i >= 0; i--) {
               const ev = events[i];
               if (ev.getType() !== EventType.RoomMessage) continue;
-              const msg = transformEventToChatMessage(ev, room, target, clientRef.current);
+              const msg = transformEventToChatMessage(ev, room, target, clientRef.current, credentials.botUserId);
               if (!msg) continue;
               const isRedacted = redactedEventIds.has(msg.id)
                 || (typeof ev.isRedacted === 'function' && ev.isRedacted());
@@ -925,7 +929,7 @@ export function useMatrixClient(
             if (roomId) {
               activeRoomVersionRef.current += 1;
               const myVersion = activeRoomVersionRef.current;
-              const messages = loadMessagesFromTimeline(client, roomId, channelId, credentials.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit);
+              const messages = loadMessagesFromTimeline(client, roomId, channelId, credentials.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit, credentials.botUserId);
               if (activeRoomVersionRef.current === myVersion) {
                 setActiveMessages(messages);
               }
@@ -937,7 +941,7 @@ export function useMatrixClient(
             if (dmRoomId) {
               activeDmVersionRef.current += 1;
               const myVersion = activeDmVersionRef.current;
-              const messages = loadMessagesFromTimeline(client, dmRoomId, dmContactId, credentials.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit);
+              const messages = loadMessagesFromTimeline(client, dmRoomId, dmContactId, credentials.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit, credentials.botUserId);
               if (activeDmVersionRef.current === myVersion) {
                 setActiveDmMessages(messages);
               }
@@ -983,7 +987,7 @@ export function useMatrixClient(
       for (let i = timelineEvents.length - 1; i >= 0; i--) {
         const ev = timelineEvents[i];
         if (ev.getType() !== EventType.RoomMessage) continue;
-        const msg = transformEventToChatMessage(ev, room, otherUserId, clientRef.current);
+        const msg = transformEventToChatMessage(ev, room, otherUserId, clientRef.current, credentials.botUserId);
         if (!msg) continue;
         setDmLastMessages(prev => {
           const existing = prev.get(otherUserId);
@@ -1000,7 +1004,7 @@ export function useMatrixClient(
         const myVersion = activeDmVersionRef.current;
         const messages: ChatMessage[] = [];
         for (const ev of timelineEvents) {
-          const m = transformEventToChatMessage(ev, room, otherUserId, clientRef.current);
+          const m = transformEventToChatMessage(ev, room, otherUserId, clientRef.current, credentials.botUserId);
           if (m) messages.push(m);
         }
         if (activeDmVersionRef.current === myVersion) {
@@ -1343,7 +1347,7 @@ export function useMatrixClient(
       hydrateRoomTypingFromCurrentMembers(nextRoomId);
       return;
     }
-    const messages = loadMessagesFromTimeline(client, roomId, channelId, credentials.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit);
+    const messages = loadMessagesFromTimeline(client, roomId, channelId, credentials.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit, credentials.botUserId);
 
     if (activeRoomVersionRef.current === myVersion) {
       setActiveMessages(messages);
@@ -1380,7 +1384,7 @@ export function useMatrixClient(
       hydrateRoomTypingFromCurrentMembers(nextRoomId);
       return;
     }
-    const messages = loadMessagesFromTimeline(client, roomId, matrixUserId, credentials?.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit);
+    const messages = loadMessagesFromTimeline(client, roomId, matrixUserId, credentials?.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit, credentials?.botUserId);
 
     if (activeDmVersionRef.current === myVersion) {
       setActiveDmMessages(messages);

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -53,7 +53,7 @@ function insertMessage(existing: ChatMessage[], msg: ChatMessage): ChatMessage[]
  *
  * Returns null for non-message events.
  */
-function transformEventToChatMessage(
+export function transformEventToChatMessage(
   event: MatrixEvent,
   room: Room | undefined,
   channelId: string,
@@ -72,6 +72,7 @@ function transformEventToChatMessage(
     info?: { thumbnail_url?: string; w?: number; h?: number; mimetype?: string; size?: number };
     'm.relates_to'?: { 'm.in_reply_to'?: { event_id: string } };
     'com.brmble.mumble_delivery'?: MumbleDeliveryState;
+    'com.brmble.author_matrix_user_id'?: unknown;
   };
 
   let media: MediaAttachment[] | undefined;
@@ -92,6 +93,10 @@ function transformEventToChatMessage(
   const isBridgeBotSender = /^@brmble[_-]?/.test(senderId);
   const bridgeMatch = isBridgeBotSender ? rawBody.match(/^\[(.+?)\]:\s*/) : null;
   const messageSender = bridgeMatch ? bridgeMatch[1] : displayName;
+  const effectiveSenderId = typeof content['com.brmble.author_matrix_user_id'] === 'string'
+    && content['com.brmble.author_matrix_user_id'].length > 0
+    ? content['com.brmble.author_matrix_user_id']
+    : senderId;
   let messageContent = bridgeMatch ? rawBody.slice(bridgeMatch[0].length) : rawBody;
 
   // Strip reply fallback from body (lines starting with > )
@@ -107,7 +112,7 @@ function transformEventToChatMessage(
     id: event.getId() ?? crypto.randomUUID(),
     channelId,
     sender: messageSender,
-    senderMatrixUserId: senderId,
+    senderMatrixUserId: effectiveSenderId,
     content: displayContent,
     timestamp: new Date(event.getTs()),
     msgType: content.msgtype,

--- a/src/Brmble.Web/src/types/index.ts
+++ b/src/Brmble.Web/src/types/index.ts
@@ -55,6 +55,8 @@ export interface MediaAttachment {
 
 export interface ChatMessage {
   id: string;
+  /** Matrix transaction ID used to reconcile a local echo with its server event ID. */
+  transactionId?: string;
   channelId: string;
   sender: string;
   senderMatrixUserId?: string;

--- a/src/Brmble.Web/src/utils/matrixCredentials.test.ts
+++ b/src/Brmble.Web/src/utils/matrixCredentials.test.ts
@@ -55,4 +55,25 @@ describe('areMatrixCredentialsEqual', () => {
     })).toBe(false);
     expect(areMatrixCredentialsEqual(base, { ...base, customCompanions: undefined })).toBe(false);
   });
+
+  it('detects a message deletion capability change', () => {
+    const credentials = {
+      ...base,
+      messageDeletion: {
+        canModerate: false,
+        maxAgeMs: 86_400_000,
+      },
+    };
+
+    expect(areMatrixCredentialsEqual(
+      credentials,
+      {
+        ...credentials,
+        messageDeletion: {
+          ...credentials.messageDeletion,
+          canModerate: true,
+        },
+      },
+    )).toBe(false);
+  });
 });

--- a/src/Brmble.Web/src/utils/matrixCredentials.ts
+++ b/src/Brmble.Web/src/utils/matrixCredentials.ts
@@ -23,6 +23,16 @@ function customCompanionsEqual(
     && a.maxActiveTotal === b.maxActiveTotal;
 }
 
+function messageDeletionEqual(
+  a: MatrixCredentials['messageDeletion'],
+  b: MatrixCredentials['messageDeletion'],
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.canModerate === b.canModerate
+    && a.maxAgeMs === b.maxAgeMs;
+}
+
 export function areMatrixCredentialsEqual(a: MatrixCredentials | null, b: MatrixCredentials | null): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
@@ -31,5 +41,6 @@ export function areMatrixCredentialsEqual(a: MatrixCredentials | null, b: Matrix
     && a.userId === b.userId
     && recordEqual(a.roomMap, b.roomMap)
     && recordEqual(a.dmRoomMap, b.dmRoomMap)
-    && customCompanionsEqual(a.customCompanions, b.customCompanions);
+    && customCompanionsEqual(a.customCompanions, b.customCompanions)
+    && messageDeletionEqual(a.messageDeletion, b.messageDeletion);
 }

--- a/src/Brmble.Web/src/utils/matrixCredentials.ts
+++ b/src/Brmble.Web/src/utils/matrixCredentials.ts
@@ -39,6 +39,7 @@ export function areMatrixCredentialsEqual(a: MatrixCredentials | null, b: Matrix
   return a.homeserverUrl === b.homeserverUrl
     && a.accessToken === b.accessToken
     && a.userId === b.userId
+    && a.botUserId === b.botUserId
     && recordEqual(a.roomMap, b.roomMap)
     && recordEqual(a.dmRoomMap, b.dmRoomMap)
     && customCompanionsEqual(a.customCompanions, b.customCompanions)

--- a/src/Brmble.Web/src/utils/messageDeletion.test.ts
+++ b/src/Brmble.Web/src/utils/messageDeletion.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { canDeleteMessage } from './messageDeletion';
+
+const NOW = Date.parse('2026-08-06T12:00:00Z');
+const WINDOW = 86_400_000;
+
+function message(senderMatrixUserId: string, ageMs: number, redacted = false) {
+  return {
+    id: '$message:test', channelId: '42', sender: 'Alice', content: 'hello',
+    senderMatrixUserId, timestamp: new Date(NOW - ageMs), redacted,
+  };
+}
+
+describe('canDeleteMessage', () => {
+  it('allows the author one millisecond inside the window', () => {
+    expect(canDeleteMessage(message('@alice:test', WINDOW - 1), '!general:test', '@alice:test', false, WINDOW, NOW)).toBe(true);
+  });
+
+  it('rejects the author at exactly twenty-four hours', () => {
+    expect(canDeleteMessage(message('@alice:test', WINDOW), '!general:test', '@alice:test', false, WINDOW, NOW)).toBe(false);
+  });
+
+  it('allows an administrator to target another author', () => {
+    expect(canDeleteMessage(message('@bob:test', 1_000), '!general:test', '@alice:test', true, WINDOW, NOW)).toBe(true);
+  });
+
+  it('rejects another user and a redacted message', () => {
+    expect(canDeleteMessage(message('@bob:test', 1_000), '!general:test', '@alice:test', false, WINDOW, NOW)).toBe(false);
+    expect(canDeleteMessage(message('@alice:test', 1_000, true), '!general:test', '@alice:test', true, WINDOW, NOW)).toBe(false);
+  });
+
+  it.each([
+    ['missing Matrix room', message('@alice:test', 1_000), null],
+    ['temporary id', { ...message('@alice:test', 1_000), id: 'temp-1' }, '!general:test'],
+    ['pending', { ...message('@alice:test', 1_000), pending: true }, '!general:test'],
+    ['failed', { ...message('@alice:test', 1_000), error: true }, '!general:test'],
+    ['system', { ...message('@alice:test', 1_000), type: 'system' as const }, '!general:test'],
+    ['game', { ...message('@alice:test', 1_000), gameType: 'deathroll' }, '!general:test'],
+  ])('rejects %s messages', (_label, candidate, roomId) => {
+    expect(canDeleteMessage(candidate, roomId, '@alice:test', true, WINDOW, NOW)).toBe(false);
+  });
+
+  it('rejects invalid and future timestamps', () => {
+    expect(canDeleteMessage({ ...message('@alice:test', 1_000), timestamp: new Date(Number.NaN) }, '!general:test', '@alice:test', false, WINDOW, NOW)).toBe(false);
+    expect(canDeleteMessage(message('@alice:test', -1), '!general:test', '@alice:test', false, WINDOW, NOW)).toBe(false);
+  });
+});

--- a/src/Brmble.Web/src/utils/messageDeletion.test.ts
+++ b/src/Brmble.Web/src/utils/messageDeletion.test.ts
@@ -24,6 +24,10 @@ describe('canDeleteMessage', () => {
     expect(canDeleteMessage(message('@bob:test', 1_000), '!general:test', '@alice:test', true, WINDOW, NOW)).toBe(true);
   });
 
+  it('allows a bridged author using the effective sender ID', () => {
+    expect(canDeleteMessage(message('@alice:test', 1_000), '!general:test', '@alice:test', false, WINDOW, NOW)).toBe(true);
+  });
+
   it('rejects another user and a redacted message', () => {
     expect(canDeleteMessage(message('@bob:test', 1_000), '!general:test', '@alice:test', false, WINDOW, NOW)).toBe(false);
     expect(canDeleteMessage(message('@alice:test', 1_000, true), '!general:test', '@alice:test', true, WINDOW, NOW)).toBe(false);

--- a/src/Brmble.Web/src/utils/messageDeletion.ts
+++ b/src/Brmble.Web/src/utils/messageDeletion.ts
@@ -1,0 +1,22 @@
+import type { ChatMessage } from '../types';
+
+export const DEFAULT_MESSAGE_DELETION_WINDOW_MS = 86_400_000;
+
+export function canDeleteMessage(
+  message: ChatMessage,
+  matrixRoomId: string | null | undefined,
+  currentUserMatrixId: string | undefined,
+  canModerate: boolean,
+  maxAgeMs: number,
+  nowMs = Date.now(),
+): boolean {
+  if (!matrixRoomId || !currentUserMatrixId || !message.id.startsWith('$')
+    || message.type === 'system' || Boolean(message.gameType)
+    || message.pending || message.error || message.redacted) return false;
+
+  const ageMs = nowMs - message.timestamp.getTime();
+  if (!Number.isFinite(ageMs) || !Number.isFinite(maxAgeMs) || maxAgeMs <= 0
+    || ageMs < 0 || ageMs >= maxAgeMs) return false;
+
+  return message.senderMatrixUserId === currentUserMatrixId || canModerate;
+}

--- a/tests/Brmble.Client.Tests/Services/MessageServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MessageServiceTests.cs
@@ -1,0 +1,156 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using Brmble.Client.Services.Messages;
+using Brmble.Client.Services.Voice;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public sealed class MessageServiceTests
+{
+    [TestMethod]
+    public async Task Delete_ForwardsExactPathAndBody()
+    {
+        Uri? calledUri = null;
+        string? calledBody = null;
+        using var cert = CreateCertificate();
+        var bridge = NativeBridgeTestHarness.Create();
+        var service = CreateService(
+            bridge,
+            cert,
+            (uri, body) =>
+            {
+                calledUri = uri;
+                calledBody = body;
+                return new(true, "{\"status\":\"deleted\"}", 200, null);
+            });
+        service.RegisterHandlers(bridge);
+
+        await NativeBridgeTestHarness.InvokeAsync(
+            bridge,
+            "messages.delete",
+            JsonSerializer.SerializeToElement(new
+            {
+                requestId = 17,
+                roomId = "!general:test",
+                eventId = "$message:test"
+            }));
+
+        Assert.AreEqual(
+            new Uri("https://api.example/messages/delete"),
+            calledUri);
+        using var bodyDocument = JsonDocument.Parse(calledBody!);
+        Assert.AreEqual(
+            "!general:test",
+            bodyDocument.RootElement.GetProperty("roomId").GetString());
+        Assert.AreEqual(
+            "$message:test",
+            bodyDocument.RootElement.GetProperty("eventId").GetString());
+    }
+
+    [TestMethod]
+    public async Task Delete_ReturnsCorrelatedStructuredFailure()
+    {
+        using var cert = CreateCertificate();
+        var bridge = NativeBridgeTestHarness.Create();
+        var service = CreateService(
+            bridge,
+            cert,
+            (_, _) => new(
+                false,
+                "{\"code\":\"expired\",\"error\":\"Messages can only be deleted within 24 hours.\"}",
+                410,
+                "Gone"));
+        service.RegisterHandlers(bridge);
+
+        await NativeBridgeTestHarness.InvokeAsync(
+            bridge,
+            "messages.delete",
+            JsonSerializer.SerializeToElement(new
+            {
+                requestId = 73,
+                roomId = "!general:test",
+                eventId = "$message:test"
+            }));
+
+        var response = NativeBridgeTestHarness
+            .DrainMessages(bridge)
+            .Single(message => message.Type == "messages.response");
+        using var document = JsonDocument.Parse(response.DataJson);
+
+        Assert.AreEqual(
+            73,
+            document.RootElement.GetProperty("requestId").GetInt32());
+        Assert.IsFalse(
+            document.RootElement.GetProperty("success").GetBoolean());
+        Assert.AreEqual(
+            410,
+            document.RootElement.GetProperty("statusCode").GetInt32());
+        Assert.AreEqual(
+            "expired",
+            JsonDocument.Parse(
+                    document.RootElement.GetProperty("body").GetString()!)
+                .RootElement.GetProperty("code").GetString());
+    }
+
+    [TestMethod]
+    public async Task Delete_WithoutApiUrl_ReturnsCorrelatedFailure()
+    {
+        using var cert = CreateCertificate();
+        var bridge = NativeBridgeTestHarness.Create();
+        var service = new MessageService(
+            bridge,
+            getCertificate: () => cert,
+            getApiUrl: () => null,
+            postJsonAsync: (_, _, _) =>
+                Task.FromResult(
+                    new ChannelRequestBridgeHandler.TlsCallResult(
+                        true, "{}", 200, null)));
+        service.RegisterHandlers(bridge);
+
+        await NativeBridgeTestHarness.InvokeAsync(
+            bridge,
+            "messages.delete",
+            JsonSerializer.SerializeToElement(new
+            {
+                requestId = 5,
+                roomId = "!general:test",
+                eventId = "$message:test"
+            }));
+
+        var response = NativeBridgeTestHarness
+            .DrainMessages(bridge)
+            .Single(message => message.Type == "messages.response");
+        using var document = JsonDocument.Parse(response.DataJson);
+        Assert.IsFalse(
+            document.RootElement.GetProperty("success").GetBoolean());
+        StringAssert.Contains(
+            document.RootElement.GetProperty("error").GetString(),
+            "Not connected");
+    }
+
+    private static MessageService CreateService(
+        Brmble.Client.Bridge.NativeBridge bridge,
+        X509Certificate2 certificate,
+        Func<Uri, string, ChannelRequestBridgeHandler.TlsCallResult> post) =>
+        new(
+            bridge,
+            () => certificate,
+            () => "https://api.example/",
+            (_, uri, body) => Task.FromResult(post(uri, body)));
+
+    private static X509Certificate2 CreateCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=MessageServiceTests",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-1),
+            DateTimeOffset.UtcNow.AddMinutes(5));
+    }
+}

--- a/tests/Brmble.Client.Tests/Services/MumbleAdapterCredentialTests.cs
+++ b/tests/Brmble.Client.Tests/Services/MumbleAdapterCredentialTests.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using Brmble.Client.Services.Voice;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Client.Tests.Services;
+
+[TestClass]
+public sealed class MumbleAdapterCredentialTests
+{
+    [TestMethod]
+    public void RewriteMatrixHomeserverUrl_PreservesMessageDeletionCapability()
+    {
+        var credentials = JsonSerializer.SerializeToElement(new
+        {
+            matrix = new
+            {
+                homeserverUrl = "http://localhost:8008",
+                accessToken = "token",
+                userId = "@alice:test",
+                roomMap = new Dictionary<string, string>(),
+                messageDeletion = new
+                {
+                    canModerate = true,
+                    maxAgeMs = 86_400_000
+                }
+            }
+        });
+
+        var rewritten = MumbleAdapter.RewriteMatrixHomeserverUrl(
+            credentials,
+            "https://api.example/");
+
+        var matrix = rewritten.GetProperty("matrix");
+        Assert.AreEqual(
+            "https://api.example",
+            matrix.GetProperty("homeserverUrl").GetString());
+        Assert.IsTrue(
+            matrix.GetProperty("messageDeletion")
+                .GetProperty("canModerate")
+                .GetBoolean());
+        Assert.AreEqual(
+            86_400_000,
+            matrix.GetProperty("messageDeletion")
+                .GetProperty("maxAgeMs")
+                .GetInt64());
+    }
+}

--- a/tests/Brmble.Server.Tests/Auth/AuthMessageDeletionCapabilityTests.cs
+++ b/tests/Brmble.Server.Tests/Auth/AuthMessageDeletionCapabilityTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Brmble.Server.Tests.Auth;
+
+[TestClass]
+public sealed class AuthMessageDeletionCapabilityTests
+{
+    [TestMethod]
+    public async Task AuthToken_ReturnsCurrentMessageModerationHint()
+    {
+        using var factory = new Integration.BrmbleServerFactory();
+        using var client = factory.CreateClient();
+        factory.AclAuthorizationMock
+            .Setup(acl => acl.CanModerateServerAsync(factory.AliceUserId))
+            .ReturnsAsync(true);
+
+        var response = await client.PostAsJsonAsync(
+            "/auth/token",
+            new { mumbleUsername = "Alice" });
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        using var document = await JsonDocument.ParseAsync(
+            await response.Content.ReadAsStreamAsync());
+        var capability = document.RootElement
+            .GetProperty("matrix")
+            .GetProperty("messageDeletion");
+
+        Assert.IsTrue(capability.GetProperty("canModerate").GetBoolean());
+        Assert.AreEqual(
+            86_400_000,
+            capability.GetProperty("maxAgeMs").GetInt64());
+    }
+}

--- a/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
+++ b/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
@@ -24,6 +24,7 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
     private readonly SqliteConnection _keepAlive;
     private readonly string _cs;
     private readonly string? _certHash;
+    private readonly TimeProvider _timeProvider;
     public Mock<IAclAuthorizationService> AclAuthorizationMock { get; } = new();
     public Mock<IAclSyncCoordinator> AclCoordinatorMock { get; } = new();
     public Mock<IMumbleAclService> MumbleAclMock { get; } = new();
@@ -37,9 +38,12 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
         Services.GetRequiredService<CustomCompanionRepository>();
     public long AliceUserId { get; private set; }
 
-    public BrmbleServerFactory(string? certHash = "testcerthash123")
+    public BrmbleServerFactory(
+        string? certHash = "testcerthash123",
+        TimeProvider? timeProvider = null)
     {
         _certHash = certHash;
+        _timeProvider = timeProvider ?? TimeProvider.System;
         var dbName = "brmble_server_" + Guid.NewGuid().ToString("N");
         _cs = $"Data Source={dbName};Mode=Memory;Cache=Shared";
         _keepAlive = new SqliteConnection(_cs);
@@ -130,6 +134,11 @@ internal class BrmbleServerFactory : WebApplicationFactory<Program>, IDisposable
                     """, new { CertHash = _certHash });
             }
             services.AddSingleton(db);
+
+            var timeProvider = services.FirstOrDefault(d =>
+                d.ServiceType == typeof(TimeProvider));
+            if (timeProvider != null) services.Remove(timeProvider);
+            services.AddSingleton(_timeProvider);
 
             var mumbleIceHostedService = services.FirstOrDefault(d =>
                 d.ServiceType == typeof(IHostedService) &&

--- a/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
+++ b/tests/Brmble.Server.Tests/Integration/BrmbleServerFactory.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text.Json;
 using Brmble.Server.Auth;
 using Brmble.Server.ChannelRequests;
 using Brmble.Server.Companions;
@@ -189,6 +190,15 @@ internal sealed class ControllableMatrixAppService
 
     public ControllableMatrixAppService()
     {
+        Mock.Setup(service => service.GetRoomEvent(
+                It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(JsonSerializer.SerializeToElement(new
+            {
+                type = "m.room.message",
+                sender = "@alice:test",
+                origin_server_ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                content = new { msgtype = "m.text", body = "test" }
+            }));
         Mock.Setup(service => service.RegisterUser(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync("stub_matrix_token");
         Mock.Setup(service => service.LoginUser(It.IsAny<string>()))

--- a/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
@@ -1,0 +1,215 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Brmble.Server.Matrix;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Brmble.Server.Tests.Integration;
+
+[TestClass]
+public sealed class MessageDeletionEndpointTests
+{
+    private const string RoomId = "!general:test";
+    private const string EventId = "$message:test";
+    private static readonly DateTimeOffset Now =
+        new(2026, 8, 6, 12, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public async Task Author_CanDeleteRecentMessage()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@alice:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: false);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.RedactRoomEvent(
+                RoomId, EventId, "Deleted through Brmble"),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Administrator_CanDeleteOtherUsersRecentMessage()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@bob:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: true);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        factory.AclAuthorizationMock.Verify(
+            acl => acl.CanModerateServerAsync(factory.AliceUserId),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task NonAdministrator_CannotDeleteOtherUsersMessage()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@bob:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: false);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client);
+        var body = await response.Content.ReadFromJsonAsync<ErrorBody>();
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.AreEqual("not_authorized", body!.Code);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.RedactRoomEvent(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ExactlyTwentyFourHoursOld_IsRejected()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@alice:test",
+            timestamp: Now - TimeSpan.FromHours(24),
+            canModerate: false);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client);
+        var body = await response.Content.ReadFromJsonAsync<ErrorBody>();
+
+        Assert.AreEqual(HttpStatusCode.Gone, response.StatusCode);
+        Assert.AreEqual("expired", body!.Code);
+    }
+
+    [TestMethod]
+    public async Task AlreadyRedactedMessage_ReturnsConflict()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@alice:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: false,
+            isRedacted: true);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client);
+        var body = await response.Content.ReadFromJsonAsync<ErrorBody>();
+
+        Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
+        Assert.AreEqual("already_deleted", body!.Code);
+    }
+
+    [TestMethod]
+    public async Task UnknownRoom_IsRejectedBeforeMatrixRedaction()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@alice:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: false,
+            registerRoom: false);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client);
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.GetRoomEvent(
+                It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ConcurrentDuplicateRequests_ReturnOkAndConflict()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@alice:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: false);
+        factory.MatrixAppMock
+            .SetupSequence(matrix => matrix.GetRoomEvent(RoomId, EventId))
+            .ReturnsAsync(Event("@alice:test", Now - TimeSpan.FromMinutes(10)))
+            .ReturnsAsync(Event(
+                "@alice:test",
+                Now - TimeSpan.FromMinutes(10),
+                isRedacted: true));
+        using var client = factory.CreateClient();
+
+        var responses = await Task.WhenAll(
+            DeleteAsync(client),
+            DeleteAsync(client));
+
+        CollectionAssert.AreEquivalent(
+            new[] { HttpStatusCode.OK, HttpStatusCode.Conflict },
+            responses.Select(response => response.StatusCode).ToArray());
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.RedactRoomEvent(
+                RoomId, EventId, "Deleted through Brmble"),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task MissingCertificate_IsUnauthorized()
+    {
+        using var factory = new BrmbleServerFactory(certHash: null);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client);
+
+        Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private static async Task<BrmbleServerFactory> FactoryAsync(
+        string sender,
+        DateTimeOffset timestamp,
+        bool canModerate,
+        bool isRedacted = false,
+        bool registerRoom = true)
+    {
+        var factory = new BrmbleServerFactory();
+        factory.MatrixAppMock
+            .Setup(matrix => matrix.GetRoomEvent(RoomId, EventId))
+            .ReturnsAsync(Event(sender, timestamp, isRedacted));
+        if (registerRoom)
+        {
+            await factory.Services
+                .GetRequiredService<ChannelRepository>()
+                .InsertAsync(42, RoomId);
+        }
+        _ = factory.Services;
+        factory.AclAuthorizationMock
+            .Setup(acl => acl.CanModerateServerAsync(factory.AliceUserId))
+            .ReturnsAsync(canModerate);
+        return factory;
+    }
+
+    private static JsonElement Event(
+        string sender,
+        DateTimeOffset timestamp,
+        bool isRedacted = false) =>
+        JsonSerializer.SerializeToElement(new
+        {
+            type = "m.room.message",
+            sender,
+            origin_server_ts = timestamp.ToUnixTimeMilliseconds(),
+            content = new { msgtype = "m.text", body = "hello" },
+            unsigned = isRedacted
+                ? new { redacted_because = new { type = "m.room.redaction" } }
+                : null
+        });
+
+    private static Task<HttpResponseMessage> DeleteAsync(HttpClient client) =>
+        client.PostAsJsonAsync("/messages/delete", new
+        {
+            roomId = RoomId,
+            eventId = EventId
+        });
+
+    private sealed record ErrorBody(string Code, string Error);
+}

--- a/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
@@ -291,7 +291,8 @@ public sealed class MessageDeletionEndpointTests
         string roomId = RoomId,
         bool registerDm = false)
     {
-        var factory = new BrmbleServerFactory();
+        var factory = new BrmbleServerFactory(
+            timeProvider: new FixedTimeProvider(Now));
         factory.MatrixAppMock
             .Setup(matrix => matrix.GetRoomEvent(roomId, EventId, It.IsAny<string?>()))
             .ReturnsAsync(Event(sender, timestamp, isRedacted, authorMatrixUserId));
@@ -351,4 +352,9 @@ public sealed class MessageDeletionEndpointTests
         });
 
     private sealed record ErrorBody(string Code, string Error);
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
 }

--- a/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Brmble.Server.DM;
 using Brmble.Server.Matrix;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,6 +14,7 @@ namespace Brmble.Server.Tests.Integration;
 public sealed class MessageDeletionEndpointTests
 {
     private const string RoomId = "!general:test";
+    private const string DmRoomId = "!dm:test";
     private const string EventId = "$message:test";
     private static readonly DateTimeOffset Now =
         new(2026, 8, 6, 12, 0, 0, TimeSpan.Zero);
@@ -31,7 +33,7 @@ public sealed class MessageDeletionEndpointTests
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         factory.MatrixAppMock.Verify(
             matrix => matrix.RedactRoomEvent(
-                RoomId, EventId, "Deleted through Brmble", "@alice:test"),
+                RoomId, EventId, "Deleted through Brmble", null),
             Times.Once);
     }
 
@@ -47,6 +49,10 @@ public sealed class MessageDeletionEndpointTests
         var response = await DeleteAsync(client);
 
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.RedactRoomEvent(
+                RoomId, EventId, "Deleted through Brmble", null),
+            Times.Once);
         factory.AclAuthorizationMock.Verify(
             acl => acl.CanModerateServerAsync(factory.AliceUserId),
             Times.Once);
@@ -89,7 +95,7 @@ public sealed class MessageDeletionEndpointTests
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         factory.MatrixAppMock.Verify(
             matrix => matrix.RedactRoomEvent(
-                RoomId, EventId, "Deleted through Brmble", "@alice:test"),
+                RoomId, EventId, "Deleted through Brmble", null),
             Times.Once);
     }
 
@@ -189,7 +195,7 @@ public sealed class MessageDeletionEndpointTests
             responses.Select(response => response.StatusCode).ToArray());
         factory.MatrixAppMock.Verify(
             matrix => matrix.RedactRoomEvent(
-                RoomId, EventId, "Deleted through Brmble", "@alice:test"),
+                RoomId, EventId, "Deleted through Brmble", null),
             Times.Once);
     }
 
@@ -204,23 +210,103 @@ public sealed class MessageDeletionEndpointTests
         Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
+    [TestMethod]
+    public async Task Author_CanDeleteOwnDmMessage_AsRequester()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@alice:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: false,
+            registerRoom: false,
+            roomId: DmRoomId,
+            registerDm: true);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client, DmRoomId);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.GetRoomEvent(DmRoomId, EventId, "@alice:test"),
+            Times.Once);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.RedactRoomEvent(
+                DmRoomId, EventId, "Deleted through Brmble", "@alice:test"),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Administrator_CanDeleteOtherUsersDmMessage_AsRequester()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@bob:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: true,
+            registerRoom: false,
+            roomId: DmRoomId,
+            registerDm: true);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client, DmRoomId);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.GetRoomEvent(DmRoomId, EventId, "@alice:test"),
+            Times.Once);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.RedactRoomEvent(
+                DmRoomId, EventId, "Deleted through Brmble", "@alice:test"),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task NonAdministrator_CannotDeleteOtherUsersDmMessage()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@bob:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: false,
+            registerRoom: false,
+            roomId: DmRoomId,
+            registerDm: true);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client, DmRoomId);
+        var body = await response.Content.ReadFromJsonAsync<ErrorBody>();
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.AreEqual("not_authorized", body!.Code);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.RedactRoomEvent(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()),
+            Times.Never);
+    }
+
     private static async Task<BrmbleServerFactory> FactoryAsync(
         string sender,
         DateTimeOffset timestamp,
         bool canModerate,
         bool isRedacted = false,
         bool registerRoom = true,
-        string? authorMatrixUserId = null)
+        string? authorMatrixUserId = null,
+        string roomId = RoomId,
+        bool registerDm = false)
     {
         var factory = new BrmbleServerFactory();
         factory.MatrixAppMock
-            .Setup(matrix => matrix.GetRoomEvent(RoomId, EventId))
+            .Setup(matrix => matrix.GetRoomEvent(roomId, EventId, It.IsAny<string?>()))
             .ReturnsAsync(Event(sender, timestamp, isRedacted, authorMatrixUserId));
         if (registerRoom)
         {
             await factory.Services
                 .GetRequiredService<ChannelRepository>()
                 .InsertAsync(42, RoomId);
+        }
+        if (registerDm)
+        {
+            var bob = await factory.Users.Insert("bob-cert", "Bob");
+            await factory.Services
+                .GetRequiredService<DmRoomRepository>()
+                .InsertAsync(factory.AliceUserId, bob.Id, DmRoomId);
         }
         _ = factory.Services;
         factory.AclAuthorizationMock
@@ -255,10 +341,12 @@ public sealed class MessageDeletionEndpointTests
         });
     }
 
-    private static Task<HttpResponseMessage> DeleteAsync(HttpClient client) =>
+    private static Task<HttpResponseMessage> DeleteAsync(
+        HttpClient client,
+        string roomId = RoomId) =>
         client.PostAsJsonAsync("/messages/delete", new
         {
-            roomId = RoomId,
+            roomId,
             eventId = EventId
         });
 

--- a/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
@@ -31,7 +31,7 @@ public sealed class MessageDeletionEndpointTests
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         factory.MatrixAppMock.Verify(
             matrix => matrix.RedactRoomEvent(
-                RoomId, EventId, "Deleted through Brmble"),
+                RoomId, EventId, "Deleted through Brmble", "@alice:test"),
             Times.Once);
     }
 
@@ -89,7 +89,7 @@ public sealed class MessageDeletionEndpointTests
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         factory.MatrixAppMock.Verify(
             matrix => matrix.RedactRoomEvent(
-                RoomId, EventId, "Deleted through Brmble"),
+                RoomId, EventId, "Deleted through Brmble", "@alice:test"),
             Times.Once);
     }
 
@@ -189,7 +189,7 @@ public sealed class MessageDeletionEndpointTests
             responses.Select(response => response.StatusCode).ToArray());
         factory.MatrixAppMock.Verify(
             matrix => matrix.RedactRoomEvent(
-                RoomId, EventId, "Deleted through Brmble"),
+                RoomId, EventId, "Deleted through Brmble", "@alice:test"),
             Times.Once);
     }
 

--- a/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
+++ b/tests/Brmble.Server.Tests/Integration/MessageDeletionEndpointTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Brmble.Server.Matrix;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -70,6 +71,44 @@ public sealed class MessageDeletionEndpointTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [TestMethod]
+    public async Task BridgedAuthor_CanDeleteRecentMessage()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@brmble:test",
+            authorMatrixUserId: "@alice:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: false);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.RedactRoomEvent(
+                RoomId, EventId, "Deleted through Brmble"),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task NonAdministrator_CannotDeleteBridgedMessageOwnedByAnotherUser()
+    {
+        using var factory = await FactoryAsync(
+            sender: "@brmble:test",
+            authorMatrixUserId: "@bob:test",
+            timestamp: Now - TimeSpan.FromMinutes(10),
+            canModerate: false);
+        using var client = factory.CreateClient();
+
+        var response = await DeleteAsync(client);
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
+        factory.MatrixAppMock.Verify(
+            matrix => matrix.RedactRoomEvent(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
             Times.Never);
     }
 
@@ -170,12 +209,13 @@ public sealed class MessageDeletionEndpointTests
         DateTimeOffset timestamp,
         bool canModerate,
         bool isRedacted = false,
-        bool registerRoom = true)
+        bool registerRoom = true,
+        string? authorMatrixUserId = null)
     {
         var factory = new BrmbleServerFactory();
         factory.MatrixAppMock
             .Setup(matrix => matrix.GetRoomEvent(RoomId, EventId))
-            .ReturnsAsync(Event(sender, timestamp, isRedacted));
+            .ReturnsAsync(Event(sender, timestamp, isRedacted, authorMatrixUserId));
         if (registerRoom)
         {
             await factory.Services
@@ -192,17 +232,28 @@ public sealed class MessageDeletionEndpointTests
     private static JsonElement Event(
         string sender,
         DateTimeOffset timestamp,
-        bool isRedacted = false) =>
-        JsonSerializer.SerializeToElement(new
+        bool isRedacted = false,
+        string? authorMatrixUserId = null)
+    {
+        var content = new JsonObject
+        {
+            ["msgtype"] = "m.text",
+            ["body"] = authorMatrixUserId is null ? "hello" : "[Alice]: hello"
+        };
+        if (authorMatrixUserId is not null)
+            content["com.brmble.author_matrix_user_id"] = authorMatrixUserId;
+
+        return JsonSerializer.SerializeToElement(new
         {
             type = "m.room.message",
             sender,
             origin_server_ts = timestamp.ToUnixTimeMilliseconds(),
-            content = new { msgtype = "m.text", body = "hello" },
+            content,
             unsigned = isRedacted
                 ? new { redacted_because = new { type = "m.room.redaction" } }
                 : null
         });
+    }
 
     private static Task<HttpResponseMessage> DeleteAsync(HttpClient client) =>
         client.PostAsJsonAsync("/messages/delete", new

--- a/tests/Brmble.Server.Tests/Matrix/MatrixAppServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Matrix/MatrixAppServiceTests.cs
@@ -377,6 +377,48 @@ public class MatrixAppServiceTests
     }
 
     [TestMethod]
+    public async Task RedactRoomEvent_UsesCallerSuppliedActor()
+    {
+        SetupHttpResponse(HttpStatusCode.OK, """{"event_id":"$redaction:test"}""");
+
+        await _svc.RedactRoomEvent(
+            "!dm:server", "$message:server", "Deleted through Brmble", "@alice:server");
+
+        StringAssert.Contains(
+            _capturedRequests.Single().RequestUri!.Query,
+            "user_id=%40alice%3Aserver");
+    }
+
+    [TestMethod]
+    public async Task DmRedactionRequiresJoinedParticipant()
+    {
+        var homeserver = new MatrixPermissionTestServer();
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient(homeserver));
+        var service = new MatrixAppService(
+            factory.Object,
+            Options.Create(new MatrixSettings
+            {
+                HomeserverUrl = "http://matrix.test",
+                AppServiceToken = "test-token",
+                ServerDomain = "server"
+            }),
+            NullLogger<MatrixAppService>.Instance);
+
+        var roomId = await service.CreateDMRoom("alice", "bob");
+
+        await Assert.ThrowsExceptionAsync<HttpRequestException>(() =>
+            service.RedactRoomEvent(
+                roomId, "$message:server", "Deleted through Brmble", "@brmble:server"));
+
+        await service.RedactRoomEvent(
+            roomId, "$message:server", "Deleted through Brmble", "@alice:server");
+
+        Assert.AreEqual("@alice:server", homeserver.LastRedactionActor);
+    }
+
+    [TestMethod]
     public async Task EnsureUserInRoom_ReturnsFalseWhenJoinFails()
     {
         SetupHttpResponse(

--- a/tests/Brmble.Server.Tests/Matrix/MatrixAppServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Matrix/MatrixAppServiceTests.cs
@@ -390,6 +390,18 @@ public class MatrixAppServiceTests
     }
 
     [TestMethod]
+    public async Task GetRoomEvent_UsesCallerSuppliedActor()
+    {
+        SetupHttpResponse(HttpStatusCode.OK, """{"type":"m.room.message"}""");
+
+        await _svc.GetRoomEvent("!dm:server", "$message:server", "@alice:server");
+
+        StringAssert.Contains(
+            _capturedRequests.Single().RequestUri!.Query,
+            "user_id=%40alice%3Aserver");
+    }
+
+    [TestMethod]
     public async Task DmRedactionRequiresJoinedParticipant()
     {
         var homeserver = new MatrixPermissionTestServer();

--- a/tests/Brmble.Server.Tests/Matrix/MatrixAppServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Matrix/MatrixAppServiceTests.cs
@@ -116,6 +116,18 @@ public class MatrixAppServiceTests
     }
 
     [TestMethod]
+    public async Task SendMessage_WithAuthor_IncludesTrustedAuthorMetadata()
+    {
+        SetupHttpResponse(HttpStatusCode.OK);
+
+        await _svc.SendMessage("!room:server", "Alice", "hello", "@alice:test");
+
+        using var json = JsonDocument.Parse(await _capturedRequests.Single().Content!.ReadAsStringAsync());
+        Assert.AreEqual("[Alice]: hello", json.RootElement.GetProperty("body").GetString());
+        Assert.AreEqual("@alice:test", json.RootElement.GetProperty("com.brmble.author_matrix_user_id").GetString());
+    }
+
+    [TestMethod]
     public async Task CreateRoom_ReturnsRoomId()
     {
         SetupHttpResponse(HttpStatusCode.OK,

--- a/tests/Brmble.Server.Tests/Matrix/MatrixPermissionTestServer.cs
+++ b/tests/Brmble.Server.Tests/Matrix/MatrixPermissionTestServer.cs
@@ -54,6 +54,12 @@ internal sealed class MatrixPermissionTestServer : HttpMessageHandler
     {
         if (content.GetProperty("preset").GetString() != "trusted_private_chat")
             throw new InvalidOperationException("DM test did not create a trusted private chat");
+
+        var powerLevels = content.GetProperty("initial_state")
+            .EnumerateArray()
+            .Single(state => state.GetProperty("type").GetString() == "m.room.power_levels")
+            .GetProperty("content");
+        Assert.AreEqual(0, powerLevels.GetProperty("redact").GetInt32());
     }
 
     private static string? QueryValue(Uri? uri, string name)

--- a/tests/Brmble.Server.Tests/Matrix/MatrixPermissionTestServer.cs
+++ b/tests/Brmble.Server.Tests/Matrix/MatrixPermissionTestServer.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.Matrix;
+
+internal sealed class MatrixPermissionTestServer : HttpMessageHandler
+{
+    private const string RoomId = "!dm:server";
+    private readonly HashSet<string> _joinedUsers = [];
+
+    public string? LastRedactionActor { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var path = request.RequestUri?.AbsolutePath ?? string.Empty;
+        var actor = QueryValue(request.RequestUri, "user_id");
+
+        if (path.EndsWith("/createRoom", StringComparison.Ordinal))
+        {
+            using var document = JsonDocument.Parse(await request.Content!.ReadAsStringAsync(cancellationToken));
+            AssertTrustedPrivateChat(document.RootElement);
+            _joinedUsers.Add(actor ?? throw new InvalidOperationException("createRoom actor missing"));
+
+            return JsonResponse(HttpStatusCode.OK, $$"""{"room_id":"{{RoomId}}"}""");
+        }
+
+        if (path.Contains("/join/", StringComparison.Ordinal))
+        {
+            _joinedUsers.Add(actor ?? throw new InvalidOperationException("join actor missing"));
+            return JsonResponse(HttpStatusCode.OK, "{}");
+        }
+
+        if (path.Contains("/redact/", StringComparison.Ordinal))
+        {
+            if (actor is null || !_joinedUsers.Contains(actor))
+            {
+                return JsonResponse(
+                    HttpStatusCode.Forbidden,
+                    """{"errcode":"M_FORBIDDEN","error":"User is not joined to the room"}""");
+            }
+
+            LastRedactionActor = actor;
+            return JsonResponse(HttpStatusCode.OK, """{"event_id":"$redaction:server"}""");
+        }
+
+        return JsonResponse(HttpStatusCode.OK, "{}");
+    }
+
+    private static void AssertTrustedPrivateChat(JsonElement content)
+    {
+        if (content.GetProperty("preset").GetString() != "trusted_private_chat")
+            throw new InvalidOperationException("DM test did not create a trusted private chat");
+    }
+
+    private static string? QueryValue(Uri? uri, string name)
+    {
+        if (uri is null)
+            return null;
+
+        var pair = uri.Query.TrimStart('?')
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(value => value.Split('=', 2))
+            .FirstOrDefault(value => value.Length == 2 && value[0] == name);
+        return pair is null ? null : Uri.UnescapeDataString(pair[1]);
+    }
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode status, string json) =>
+        new(status)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+}

--- a/tests/Brmble.Server.Tests/Matrix/MatrixServiceTests.cs
+++ b/tests/Brmble.Server.Tests/Matrix/MatrixServiceTests.cs
@@ -4,6 +4,7 @@ using Brmble.Server.Matrix;
 using Brmble.Server.Mumble;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -15,6 +16,7 @@ public class MatrixServiceTests
     private SqliteConnection? _keepAlive;
     private ChannelRepository _channelRepo = null!;
     private Mock<IMatrixAppService> _appService = null!;
+    private Mock<UserRepository> _users = null!;
     private Mock<IActiveBrmbleSessions> _sessions = null!;
     private MatrixService _svc = null!;
 
@@ -30,8 +32,11 @@ public class MatrixServiceTests
         _channelRepo = new ChannelRepository(db);
 
         _appService = new Mock<IMatrixAppService>();
+        _users = new Mock<UserRepository>(db, Options.Create(new MatrixSettings { ServerDomain = "localhost" }));
+        _users.Setup(r => r.GetByCertHash("og-hash"))
+            .ReturnsAsync(new User(1, "og-hash", "Bob", "@bob:localhost", null));
         _sessions = new Mock<IActiveBrmbleSessions>();
-        _svc = new MatrixService(_channelRepo, _appService.Object, _sessions.Object, NullLogger<MatrixService>.Instance);
+        _svc = new MatrixService(_channelRepo, _appService.Object, _sessions.Object, NullLogger<MatrixService>.Instance, _users.Object);
     }
 
     [TestCleanup]
@@ -81,7 +86,7 @@ public class MatrixServiceTests
 
         await _svc.RelayMessage(new MumbleUser("Bob", "og-hash", 2), "hello", 42);
 
-        _appService.Verify(a => a.SendMessage("!room:server", "Bob", "hello"), Times.Once);
+        _appService.Verify(a => a.SendMessage("!room:server", "Bob", "hello", "@bob:localhost"), Times.Once);
     }
 
     [TestMethod]
@@ -96,7 +101,7 @@ public class MatrixServiceTests
             1);
 
         _appService.Verify(
-            a => a.SendMessage("!room:server", "Bob", "bold and italic"),
+            a => a.SendMessage("!room:server", "Bob", "bold and italic", "@bob:localhost"),
             Times.Once);
     }
 
@@ -112,7 +117,7 @@ public class MatrixServiceTests
             1);
 
         _appService.Verify(
-            a => a.SendMessage("!room:server", "Bob", "hello & world"),
+            a => a.SendMessage("!room:server", "Bob", "hello & world", "@bob:localhost"),
             Times.Once);
     }
 
@@ -143,7 +148,7 @@ public class MatrixServiceTests
         await _svc.RelayMessage(new MumbleUser("Bob", "og-hash", 1), msg, 1);
 
         _appService.Verify(a => a.UploadMedia(It.IsAny<byte[]>(), "image/png", "image.png"), Times.Once);
-        _appService.Verify(a => a.SendImageMessage("!room:server", "Bob", "mxc://server/uploaded123", "image.png", "image/png", 4), Times.Once);
+        _appService.Verify(a => a.SendImageMessage("!room:server", "Bob", "mxc://server/uploaded123", "image.png", "image/png", 4, "@bob:localhost"), Times.Once);
         _appService.Verify(a => a.SendMessage(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
@@ -161,8 +166,8 @@ public class MatrixServiceTests
 
         await _svc.RelayMessage(new MumbleUser("Bob", "og-hash", 1), msg, 1);
 
-        _appService.Verify(a => a.SendImageMessage("!room:server", "Bob", "mxc://server/uploaded123", "image.png", "image/png", 4), Times.Once);
-        _appService.Verify(a => a.SendMessage("!room:server", "Bob", "Check this out:"), Times.Once);
+        _appService.Verify(a => a.SendImageMessage("!room:server", "Bob", "mxc://server/uploaded123", "image.png", "image/png", 4, "@bob:localhost"), Times.Once);
+        _appService.Verify(a => a.SendMessage("!room:server", "Bob", "Check this out:", "@bob:localhost"), Times.Once);
     }
 
     [TestMethod]
@@ -208,6 +213,6 @@ public class MatrixServiceTests
         await _svc.RelayMessage(new MumbleUser("Bob", "og-hash", 1), msg, 1);
 
         _appService.Verify(a => a.UploadMedia(It.IsAny<byte[]>(), "image/JPEG", "image.jpg"), Times.Once);
-        _appService.Verify(a => a.SendImageMessage("!room:server", "Bob", "mxc://server/uploaded456", "image.jpg", "image/JPEG", 4), Times.Once);
+        _appService.Verify(a => a.SendImageMessage("!room:server", "Bob", "mxc://server/uploaded456", "image.jpg", "image/JPEG", 4, "@bob:localhost"), Times.Once);
     }
 }

--- a/tests/Brmble.Server.Tests/Messages/MessageDeletionPolicyTests.cs
+++ b/tests/Brmble.Server.Tests/Messages/MessageDeletionPolicyTests.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Brmble.Server.Messages;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Brmble.Server.Tests.Messages;
+
+[TestClass]
+public sealed class MessageDeletionPolicyTests
+{
+    private static readonly DateTimeOffset Now =
+        new(2026, 8, 6, 12, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public void AuthorMessage_OneMillisecondInsideWindow_IsAllowed()
+    {
+        var message = Message(
+            sender: "@alice:test",
+            timestamp: Now - TimeSpan.FromHours(24) + TimeSpan.FromMilliseconds(1));
+
+        var result = MessageDeletionPolicy.Evaluate(
+            message, "@alice:test", canModerate: false, Now);
+
+        Assert.AreEqual(MessageDeletionDecision.Allowed, result);
+    }
+
+    [TestMethod]
+    public void AuthorMessage_ExactlyTwentyFourHoursOld_IsExpired()
+    {
+        var message = Message("@alice:test", Now - TimeSpan.FromHours(24));
+
+        var result = MessageDeletionPolicy.Evaluate(
+            message, "@alice:test", canModerate: false, Now);
+
+        Assert.AreEqual(MessageDeletionDecision.Expired, result);
+    }
+
+    [TestMethod]
+    public void OtherUsersMessage_WithoutAdminPermission_IsForbidden()
+    {
+        var message = Message("@bob:test", Now - TimeSpan.FromMinutes(10));
+
+        var result = MessageDeletionPolicy.Evaluate(
+            message, "@alice:test", canModerate: false, Now);
+
+        Assert.AreEqual(MessageDeletionDecision.Forbidden, result);
+    }
+
+    [TestMethod]
+    public void OtherUsersRecentMessage_WithAdminPermission_IsAllowed()
+    {
+        var message = Message("@bob:test", Now - TimeSpan.FromMinutes(10));
+
+        var result = MessageDeletionPolicy.Evaluate(
+            message, "@alice:test", canModerate: true, Now);
+
+        Assert.AreEqual(MessageDeletionDecision.Allowed, result);
+    }
+
+    [TestMethod]
+    public void RedactedMessage_IsAlreadyDeleted()
+    {
+        var message = Message(
+            "@alice:test",
+            Now - TimeSpan.FromMinutes(10),
+            isRedacted: true);
+
+        var result = MessageDeletionPolicy.Evaluate(
+            message, "@alice:test", canModerate: false, Now);
+
+        Assert.AreEqual(MessageDeletionDecision.AlreadyDeleted, result);
+    }
+
+    [TestMethod]
+    public void FutureDatedMessage_IsInvalid()
+    {
+        var message = Message(
+            "@alice:test",
+            Now + TimeSpan.FromMilliseconds(1));
+
+        var result = MessageDeletionPolicy.Evaluate(
+            message, "@alice:test", canModerate: false, Now);
+
+        Assert.AreEqual(MessageDeletionDecision.InvalidEvent, result);
+    }
+
+    [TestMethod]
+    public void Parse_ReadsSenderTimestampTypeAndRedactionState()
+    {
+        var json = JsonSerializer.SerializeToElement(new
+        {
+            type = "m.room.message",
+            sender = "@alice:test",
+            origin_server_ts = Now.ToUnixTimeMilliseconds(),
+            content = new { msgtype = "m.text", body = "hello" },
+            unsigned = new
+            {
+                redacted_because = new { type = "m.room.redaction" }
+            }
+        });
+
+        var parsed = MatrixMessageMetadata.Parse(json);
+
+        Assert.AreEqual("m.room.message", parsed.EventType);
+        Assert.AreEqual("@alice:test", parsed.Sender);
+        Assert.AreEqual(Now, parsed.OriginServerTimestamp);
+        Assert.IsTrue(parsed.IsRedacted);
+    }
+
+    private static MatrixMessageMetadata Message(
+        string sender,
+        DateTimeOffset timestamp,
+        bool isRedacted = false) =>
+        new("m.room.message", sender, timestamp, isRedacted);
+}

--- a/tests/Brmble.Server.Tests/Messages/MessageDeletionPolicyTests.cs
+++ b/tests/Brmble.Server.Tests/Messages/MessageDeletionPolicyTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Brmble.Server.Messages;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -57,6 +58,18 @@ public sealed class MessageDeletionPolicyTests
     }
 
     [TestMethod]
+    public void BridgedMessage_EffectiveAuthor_IsAllowed()
+    {
+        var message = new MatrixMessageMetadata(
+            "m.room.message", "@brmble:test", Now - TimeSpan.FromMinutes(10), false,
+            "@alice:test");
+
+        Assert.AreEqual(
+            MessageDeletionDecision.Allowed,
+            MessageDeletionPolicy.Evaluate(message, "@alice:test", false, Now));
+    }
+
+    [TestMethod]
     public void RedactedMessage_IsAlreadyDeleted()
     {
         var message = Message(
@@ -104,6 +117,28 @@ public sealed class MessageDeletionPolicyTests
         Assert.AreEqual("@alice:test", parsed.Sender);
         Assert.AreEqual(Now, parsed.OriginServerTimestamp);
         Assert.IsTrue(parsed.IsRedacted);
+    }
+
+    [TestMethod]
+    public void Parse_ReadsNonEmptyBridgedAuthorMetadata()
+    {
+        var content = new JsonObject
+        {
+            ["msgtype"] = "m.text",
+            ["body"] = "[Alice]: hello",
+            ["com.brmble.author_matrix_user_id"] = "@alice:test"
+        };
+        var json = JsonSerializer.SerializeToElement(new
+        {
+            type = "m.room.message",
+            sender = "@brmble:test",
+            origin_server_ts = Now.ToUnixTimeMilliseconds(),
+            content
+        });
+
+        var parsed = MatrixMessageMetadata.Parse(json);
+
+        Assert.AreEqual("@alice:test", parsed.AuthorMatrixUserId);
     }
 
     private static MatrixMessageMetadata Message(

--- a/tests/Brmble.Server.Tests/Messages/MessageDeletionPolicyTests.cs
+++ b/tests/Brmble.Server.Tests/Messages/MessageDeletionPolicyTests.cs
@@ -111,7 +111,7 @@ public sealed class MessageDeletionPolicyTests
             }
         });
 
-        var parsed = MatrixMessageMetadata.Parse(json);
+        var parsed = MatrixMessageMetadata.Parse(json, "@brmble:test");
 
         Assert.AreEqual("m.room.message", parsed.EventType);
         Assert.AreEqual("@alice:test", parsed.Sender);
@@ -136,9 +136,31 @@ public sealed class MessageDeletionPolicyTests
             content
         });
 
-        var parsed = MatrixMessageMetadata.Parse(json);
+        var parsed = MatrixMessageMetadata.Parse(json, "@brmble:test");
 
         Assert.AreEqual("@alice:test", parsed.AuthorMatrixUserId);
+    }
+
+    [TestMethod]
+    public void Parse_IgnoresAuthorMetadataFromNonBotSender()
+    {
+        var content = new JsonObject
+        {
+            ["msgtype"] = "m.text",
+            ["body"] = "forged",
+            ["com.brmble.author_matrix_user_id"] = "@alice:test"
+        };
+        var json = JsonSerializer.SerializeToElement(new
+        {
+            type = "m.room.message",
+            sender = "@mallory:test",
+            origin_server_ts = Now.ToUnixTimeMilliseconds(),
+            content
+        });
+
+        var parsed = MatrixMessageMetadata.Parse(json, "@brmble:test");
+
+        Assert.IsNull(parsed.AuthorMatrixUserId);
     }
 
     private static MatrixMessageMetadata Message(


### PR DESCRIPTION
## Summary

Adds end-to-end message deletion for Matrix-backed channel and direct-message conversations.

## What changed

- Added server-side deletion policy with a 24-hour deletion window.
- Allowed message authors and authorized moderators to delete messages.
- Added `/messages/delete` API endpoint with clear error responses.
- Added mTLS bridge support for desktop clients.
- Added author metadata to bridged messages so ownership is preserved.
- Added “Delete message” context-menu action with confirmation and error handling.
- Added immediate Matrix redaction and local UI updates.
- Added support for deleting both native and bridged messages.
- Added comprehensive client, server, bridge, policy, and integration tests.
- Updated the UI guide and documented bridged-message deletion ownership.

## Notes

Messages are replaced with “Message deleted” for all users after successful deletion.