### PR TITLE
fix: allow channel members to join paint rooms

### DIFF
--- a/src/Brmble.Client/Services/Paint/PaintService.cs
+++ b/src/Brmble.Client/Services/Paint/PaintService.cs
@@ -33,6 +33,7 @@ internal sealed class PaintService : IService
         bridge.RegisterHandler("paint.create", data => PostAsync("paint/sessions", data));
         bridge.RegisterHandler("paint.attachSource", data => PostSessionAsync(data, "source"));
         bridge.RegisterHandler("paint.join", data => PostSessionAsync(data, "join"));
+        bridge.RegisterHandler("paint.prepareJoin", data => PostSessionAsync(data, "prepare-join"));
         bridge.RegisterHandler("paint.leave", data => PostSessionAsync(data, "leave"));
         bridge.RegisterHandler("paint.commitStroke", data => PostSessionAsync(data, "stroke"));
         bridge.RegisterHandler("paint.sendPreview", data => PostSessionAsync(data, "preview"));

--- a/src/Brmble.Server/Paint/PaintEndpoints.cs
+++ b/src/Brmble.Server/Paint/PaintEndpoints.cs
@@ -74,6 +74,10 @@ public static class PaintEndpoints
             UserRepository users, PaintSessionManager manager, CancellationToken cancellationToken) =>
             await ExecuteAsync(async user => Results.Ok(await manager.JoinAsync(id, user.UserId, cancellationToken)), context, certificates, users));
 
+        app.MapPost("/paint/sessions/{id:guid}/prepare-join", async (Guid id, HttpContext context, ICertificateHashExtractor certificates,
+            UserRepository users, PaintSessionManager manager, CancellationToken cancellationToken) =>
+            await ExecuteAsync(async user => Results.Ok(await manager.PrepareJoinAsync(id, user.UserId, cancellationToken)), context, certificates, users));
+
         app.MapPost("/paint/sessions/{id:guid}/leave", async (Guid id, HttpContext context, ICertificateHashExtractor certificates,
             UserRepository users, PaintSessionManager manager) =>
             await ExecuteAsync(async user => Results.Ok(await manager.LeaveAsync(id, user.UserId)), context, certificates, users));

--- a/src/Brmble.Server/Paint/PaintSessionManager.cs
+++ b/src/Brmble.Server/Paint/PaintSessionManager.cs
@@ -7,6 +7,7 @@ public sealed class PaintConflictException(string message) : Exception(message);
 public sealed class PaintNotFoundException(string message) : Exception(message);
 
 public sealed record CreatePaintSessionResult(Guid SessionId, string MatrixRoomId);
+public sealed record PaintJoinPreparationResult(Guid SessionId, string MatrixRoomId, bool AlreadyJoined);
 public sealed record PaintSourceAttachedResult(PaintSource Source, long Revision, long Generation);
 public sealed record PaintParticipantChangeResult(PaintParticipant Participant, long Revision, long Generation);
 public sealed record PaintStrokeCommittedResult(PaintStroke Stroke, long Revision, long Generation);
@@ -170,6 +171,35 @@ public sealed class PaintSessionManager(
         return new PaintParticipantChangeResult(participant, revision, generation);
     }
 
+    public async Task<PaintJoinPreparationResult> PrepareJoinAsync(Guid sessionId, long userId, CancellationToken cancellationToken = default)
+    {
+        var session = GetSession(sessionId);
+        if (!presence.TryGetParticipant(userId, out var current) || current.ChannelId != session.ChannelId)
+            throw new PaintAuthorizationException("You must be in the paint channel.");
+
+        PaintInvitee invitee;
+        string roomId;
+        lock (session.Lock)
+        {
+            RequireOpen(session);
+            invitee = GetInvitee(session, userId);
+            roomId = session.MatrixRoomId;
+        }
+
+        var membership = await matrixPaintService.GetMembershipAsync(roomId, invitee.MatrixUserId, cancellationToken);
+        var alreadyJoined = string.Equals(membership, "join", StringComparison.OrdinalIgnoreCase);
+        if (!alreadyJoined)
+        {
+            await matrixPaintService.InvitePaintUserAsync(roomId, invitee.MatrixUserId, cancellationToken);
+            lock (session.Lock)
+            {
+                session.Invitees[userId] = invitee;
+            }
+        }
+
+        return new PaintJoinPreparationResult(session.SessionId, roomId, alreadyJoined);
+    }
+
     public async Task<PaintParticipantChangeResult> LeaveAsync(Guid sessionId, long userId)
     {
         var session = GetSession(sessionId); PaintParticipant participant; long revision, generation; Task publish;
@@ -308,7 +338,8 @@ public sealed class PaintSessionManager(
 
         lock (session.Lock)
         {
-            var canJoin = session.Invitees.ContainsKey(userId);
+            var canJoin = session.Status is not (PaintSessionStatus.Ended or PaintSessionStatus.Expired)
+                && current.ChannelId == session.ChannelId;
             var isParticipant = canJoin && IsCurrentParticipant(session, userId, out _);
             return Task.FromResult(new PaintSessionSummary(
                 session.SessionId,
@@ -500,7 +531,15 @@ public sealed class PaintSessionManager(
             else _openSessionCounts[userId] = count - 1;
         }
     }
-    private static PaintInvitee GetInvitee(LivePaintSession session, long userId) => session.Invitees.TryGetValue(userId, out var invitee) ? invitee : throw new PaintAuthorizationException("You are not selected for this paint session.");
+    private PaintInvitee GetInvitee(LivePaintSession session, long userId)
+    {
+        if (session.Invitees.TryGetValue(userId, out var invitee)) return invitee;
+        if (!presence.TryGetParticipant(userId, out var current) || current.ChannelId != session.ChannelId)
+            throw new PaintAuthorizationException("You must be in the paint channel.");
+        invitee = new PaintInvitee(userId, current.MatrixUserId);
+        session.Invitees[userId] = invitee;
+        return invitee;
+    }
     private bool IsCurrentParticipant(LivePaintSession session, long userId, out PaintParticipant participant)
     {
         participant = null!;

--- a/src/Brmble.Web/src/App.paintFlow.test.tsx
+++ b/src/Brmble.Web/src/App.paintFlow.test.tsx
@@ -12,7 +12,7 @@ import type { ChatMessage } from './types';
 import type { PaintSessionSnapshot, PaintSessionStatus } from './types/paint';
 
 const paint = vi.hoisted(() => ({
-  createSession: vi.fn(), attachSource: vi.fn(), getSnapshot: vi.fn(), getSummary: vi.fn(), join: vi.fn(), end: vi.fn(),
+  createSession: vi.fn(), attachSource: vi.fn(), getSnapshot: vi.fn(), getSummary: vi.fn(), prepareJoin: vi.fn(), join: vi.fn(), end: vi.fn(),
 }));
 
 type TestBridge = typeof bridge & {
@@ -150,7 +150,7 @@ function PaintFlowApp({ matrixClient, initialUsers = [{ session: 7, name: 'Alice
   const currentUserId = users.find(user => user.self)?.session;
 
   return <><header><button onClick={() => setSetup(true)}>Start paint</button></header>
-    {setup && <PaintSessionSetupModal channelId={5} channelRoomId="!channel:test" candidates={[{ userId: 2, name: 'Bob' }]} hostUserId={7} paintApi={paintApi} matrixClient={matrixClient} onAttachSource={paint.attachSource} onComplete={id => { setSessionId(id); setSetup(false); }} />}
+    {setup && <PaintSessionSetupModal channelId={5} channelRoomId="!channel:test" paintApi={paintApi} matrixClient={matrixClient} onAttachSource={paint.attachSource} onComplete={id => { setSessionId(id); setSetup(false); }} />}
     <VerticalSplitPane
       top={sessionId ? <PaintSessionView sessionId={sessionId} matrixClient={matrixClient} channelRoomMap={{ '5': '!channel:test' }} onClose={() => setSessionId(null)} /> : null}
       storageKey="paint-flow-split"
@@ -166,7 +166,11 @@ function PaintFlowApp({ matrixClient, initialUsers = [{ session: 7, name: 'Alice
         users={users}
         currentUserId={currentUserId}
         paintSessionStatuses={paintSessionStatuses}
-        onJoinPaint={async id => { await paintApi.join(id); }}
+        onJoinPaint={async id => {
+          const preparation = await paintApi.prepareJoin(id);
+          if (!preparation.alreadyJoined) await matrixClient.joinRoom(preparation.matrixRoomId);
+          await paintApi.join(id);
+        }}
         onOpenPaint={id => setSessionId(id)}
       />
     </VerticalSplitPane>
@@ -208,7 +212,6 @@ async function openActivePaintSession(user: ReturnType<typeof userEvent.setup>, 
   paint.getSnapshot.mockResolvedValue(initial);
 
   await user.click(screen.getByRole('button', { name: 'Start paint' }));
-  await user.click(screen.getByLabelText('Bob'));
   await user.upload(screen.getByLabelText('Source image'), new File(['source'], 'source.png', { type: 'image/png' }));
   expect(await screen.findByText('source.png')).toBeInTheDocument();
   await user.click(within(screen.getByRole('dialog', { name: 'Start collaborative paint' })).getByRole('button', { name: 'Start paint' }));
@@ -242,7 +245,6 @@ describe('collaborative paint app flow', () => {
     render(<PaintFlowApp matrixClient={matrixClient} />);
 
     await user.click(screen.getByRole('button', { name: 'Start paint' }));
-    await user.click(screen.getByLabelText('Bob'));
     await user.upload(screen.getByLabelText('Source image'), new File(['source'], 'source.png', { type: 'image/png' }));
     expect(await screen.findByText('source.png')).toBeInTheDocument();
     await user.click(within(screen.getByRole('dialog', { name: 'Start collaborative paint' })).getByRole('button', { name: 'Start paint' }));
@@ -463,6 +465,7 @@ describe('collaborative paint app flow', () => {
         canJoin: true,
         isParticipant: true,
       });
+    paint.prepareJoin.mockResolvedValue({ sessionId: 'session-1', matrixRoomId: '!paint:test', alreadyJoined: false });
     paint.join.mockResolvedValue(undefined);
     paint.getSnapshot.mockResolvedValue({
       ...initial,
@@ -476,6 +479,8 @@ describe('collaborative paint app flow', () => {
 
     await user.click(screen.getByRole('button', { name: 'Join paint' }));
 
+    expect(paint.prepareJoin).toHaveBeenCalledWith('session-1');
+    expect(matrixClient.joinRoom).toHaveBeenCalledWith('!paint:test');
     expect(paint.join).toHaveBeenCalledWith('session-1');
     expect(screen.queryByLabelText('Collaborative paint')).toBeNull();
     expect(composer).toHaveValue('draft survives');

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4806,14 +4806,14 @@ const handleConnect = (serverData: SavedServer) => {
     },
     [isCurrentPaintPreparation, notifQueue],
   );
-  const paintCandidates = paintChannelId === null
-    ? []
-    : users
-      .filter(user => user.channelId === paintChannelId && !user.self)
-      .map(user => ({ userId: user.session, name: user.name }));
   const handleJoinPaint = useCallback(async (sessionId: string) => {
+    if (!matrixClient.client) throw new Error('Matrix is not connected.');
+    const preparation = await paintApi.prepareJoin(sessionId);
+    if (!preparation.alreadyJoined) {
+      await matrixClient.client.joinRoom(preparation.matrixRoomId);
+    }
     await paintApi.join(sessionId);
-  }, []);
+  }, [matrixClient.client]);
   const handleOpenPaint = useCallback((sessionId: string) => {
     invalidatePaintPreparation();
     activePaintChannelIdRef.current = currentChannelId;
@@ -4870,8 +4870,6 @@ const handleConnect = (serverData: SavedServer) => {
         <PaintSessionSetupModal
           channelId={paintChannelId}
           channelRoomId={paintChannelRoomId}
-          candidates={paintCandidates}
-          hostUserId={selfSession}
           paintApi={paintApi}
           matrixClient={matrixClient.client}
           onAttachSource={paintApi.attachSource}

--- a/src/Brmble.Web/src/api/paint.test.ts
+++ b/src/Brmble.Web/src/api/paint.test.ts
@@ -18,6 +18,7 @@ describe('paintApi browser fallback', () => {
     ['createSession', () => paintApi.createSession({ channelId: 7, participantSessionIds: [2] }), '/paint/sessions', 'POST'],
     ['attachSource', () => paintApi.attachSource(sessionId, '$source'), '/paint/sessions/session-1/source', 'POST'],
     ['join', () => paintApi.join(sessionId), '/paint/sessions/session-1/join', 'POST'],
+    ['prepareJoin', () => paintApi.prepareJoin(sessionId), '/paint/sessions/session-1/prepare-join', 'POST'],
     ['leave', () => paintApi.leave(sessionId), '/paint/sessions/session-1/leave', 'POST'],
     ['commitStroke', () => paintApi.commitStroke(sessionId, { correlationId: 'stroke-1', generation: 0, tool: 'pen', width: 6, points: [] }), '/paint/sessions/session-1/stroke', 'POST'],
     ['sendPreview', () => paintApi.sendPreview(sessionId, { correlationId: 'stroke-1', generation: 0, tool: 'pen', width: 6, points: [] }), '/paint/sessions/session-1/preview', 'POST'],
@@ -132,6 +133,30 @@ describe('paintApi WebView bridge', () => {
     });
 
     await expect(result).resolves.toBeUndefined();
+  });
+
+  it('returns the prepared Matrix room from the bridge', async () => {
+    const result = paintApi.prepareJoin(sessionId);
+    const postMessage = window.chrome!.webview!.postMessage as ReturnType<typeof vi.fn>;
+    const request = postMessage.mock.calls[0][0];
+
+    expect(request).toEqual({
+      type: 'paint.prepareJoin',
+      data: { sessionId, requestId: expect.any(Number) },
+    });
+
+    bridge._handleMessage({
+      data: {
+        type: 'paint.response',
+        data: {
+          requestId: request.data.requestId,
+          success: true,
+          body: JSON.stringify({ sessionId, matrixRoomId: '!paint:test', alreadyJoined: false }),
+        },
+      },
+    });
+
+    await expect(result).resolves.toEqual({ sessionId, matrixRoomId: '!paint:test', alreadyJoined: false });
   });
 
   it('keeps end pending until its correlated response arrives', async () => {

--- a/src/Brmble.Web/src/api/paint.ts
+++ b/src/Brmble.Web/src/api/paint.ts
@@ -10,6 +10,12 @@ export interface CreatedPaintSession {
   channelId: number;
 }
 
+export interface PaintJoinPreparation {
+  sessionId: string;
+  matrixRoomId: string;
+  alreadyJoined: boolean;
+}
+
 interface BridgeResponse {
   requestId?: number;
   success?: boolean;
@@ -76,6 +82,11 @@ async function mutate(event: string, path: string, payload: Record<string, unkno
   await post<unknown>(path, payload);
 }
 
+async function mutateWithResponse<T>(event: string, path: string, payload: Record<string, unknown>): Promise<T> {
+  if (isWebViewBridgeAvailable()) return bridgeRequest<T>(event, payload);
+  return post<T>(path, payload);
+}
+
 function normalizedStroke(stroke: PaintStrokeInput): PaintStrokeInput {
   return {
     correlationId: stroke.correlationId,
@@ -97,6 +108,7 @@ export const paintApi = {
   },
   attachSource: (sessionId: string, sourceEventId: string) => mutate('paint.attachSource', `/paint/sessions/${encodeURIComponent(sessionId)}/source`, { sessionId, sourceEventId }),
   join: (sessionId: string) => mutate('paint.join', `/paint/sessions/${encodeURIComponent(sessionId)}/join`, { sessionId }),
+  prepareJoin: (sessionId: string) => mutateWithResponse<PaintJoinPreparation>('paint.prepareJoin', `/paint/sessions/${encodeURIComponent(sessionId)}/prepare-join`, { sessionId }),
   leave: (sessionId: string) => mutate('paint.leave', `/paint/sessions/${encodeURIComponent(sessionId)}/leave`, { sessionId }),
   commitStroke: (sessionId: string, stroke: PaintStrokeInput) => mutate('paint.commitStroke', `/paint/sessions/${encodeURIComponent(sessionId)}/stroke`, { sessionId, ...normalizedStroke(stroke) }),
   sendPreview: (sessionId: string, stroke: PaintStrokeInput) => mutate('paint.sendPreview', `/paint/sessions/${encodeURIComponent(sessionId)}/preview`, { sessionId, ...normalizedStroke(stroke) }),

--- a/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.test.tsx
+++ b/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.test.tsx
@@ -85,12 +85,11 @@ describe('PaintSessionSetupModal', () => {
       onAttachSource={attachSource}
     />);
 
-    await user.click(screen.getByLabelText('Bob'));
     await user.upload(screen.getByLabelText('Source image'), new File(['image'], 'source.png', { type: 'image/png' }));
     expect(await screen.findByText('source.png')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /start paint/i }));
 
-    expect(paintApi.createSession).toHaveBeenCalledWith({ channelId: 5, participantSessionIds: [2] });
+    expect(paintApi.createSession).toHaveBeenCalledWith({ channelId: 5, participantSessionIds: [] });
     expect(matrixClient.joinRoom).toHaveBeenCalledWith('!paint:server');
     expect(matrixClient.sendMessage).toHaveBeenCalledWith('!paint:server', expect.objectContaining({ msgtype: 'm.image' }));
     expect(attachSource).toHaveBeenCalledWith('session-1', '$source');
@@ -321,7 +320,6 @@ describe('PaintSessionSetupModal', () => {
         onAttachSource={attachSource}
       />,
     );
-    await user.click(screen.getByLabelText('Bob'));
     screen.getByRole('button', { name: 'Cancel' }).focus();
     const pasted = new File(['clipboard-pixels'], 'image.png', {
       type: 'image/png',
@@ -337,7 +335,6 @@ describe('PaintSessionSetupModal', () => {
     expect(screen.getByAltText(
       'Selected paint source: Pasted screenshot.png',
     )).toHaveAttribute('src', 'blob:source-preview');
-    expect(screen.getByLabelText('Bob')).toBeChecked();
     expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
     expect(paintApi.createSession).not.toHaveBeenCalled();
 
@@ -349,7 +346,7 @@ describe('PaintSessionSetupModal', () => {
     expect(paintApi.createSession).toHaveBeenCalledOnce();
   });
 
-  it('replaces a selected file with a valid paste without changing participants', async () => {
+  it('replaces a selected file with a valid paste', async () => {
     const user = userEvent.setup();
     const { paintApi, matrixClient, attachSource } = createHarness();
     render(
@@ -363,7 +360,6 @@ describe('PaintSessionSetupModal', () => {
         onAttachSource={attachSource}
       />,
     );
-    await user.click(screen.getByLabelText('Bob'));
     await user.upload(
       screen.getByLabelText('Source image'),
       new File(['first'], 'first.webp', { type: 'image/webp' }),
@@ -378,7 +374,6 @@ describe('PaintSessionSetupModal', () => {
     expect(await screen.findByText('Pasted screenshot.jpg'))
       .toBeInTheDocument();
     expect(screen.queryByText('first.webp')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Bob')).toBeChecked();
     expect(screen.getByLabelText('Source image')).toHaveValue('');
   });
 

--- a/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.tsx
+++ b/src/Brmble.Web/src/components/Paint/PaintSessionSetupModal.tsx
@@ -14,7 +14,6 @@ import {
 } from '../../utils/paintSourceFile';
 import './PaintSessionSetupModal.css';
 
-type Candidate = { userId: number; name: string };
 type Created = { sessionId: string; matrixRoomId: string; channelId: number };
 type Matrix = Pick<
   MatrixClient,
@@ -24,8 +23,10 @@ type Matrix = Pick<
 type PaintSessionSetupModalProps = {
   channelId: number;
   channelRoomId: string;
-  candidates: Candidate[];
-  hostUserId: number;
+  /** @deprecated Participant selection is no longer used; channel members can join later. */
+  candidates?: unknown;
+  /** @deprecated Kept for compatibility with older callers. */
+  hostUserId?: number;
   paintApi: {
     createSession(input: {
       channelId: number;
@@ -46,7 +47,6 @@ type PaintSessionSetupModalProps = {
 export function PaintSessionSetupModal({
   channelId,
   channelRoomId,
-  candidates,
   paintApi,
   matrixClient,
   onAttachSource,
@@ -59,7 +59,6 @@ export function PaintSessionSetupModal({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const sourceRevisionRef = useRef(0);
   const uploadLimitPromiseRef = useRef<Promise<number | undefined> | null>(null);
-  const [selected, setSelected] = useState<number[]>([]);
   const [file, setFile] = useState<File | null>(
     () => initialSourceFile ?? null,
   );
@@ -174,7 +173,7 @@ export function PaintSessionSetupModal({
       }
       created = await paintApi.createSession({
         channelId,
-        participantSessionIds: selected,
+        participantSessionIds: [],
       });
       await matrixClient.joinRoom(created.matrixRoomId);
       const uploaded = await matrixClient.uploadContent(file, {
@@ -252,21 +251,6 @@ export function PaintSessionSetupModal({
             Start collaborative paint
           </h2>
         </div>
-        {candidates.map((candidate) => (
-          <label key={candidate.userId}>
-            <input
-              aria-label={candidate.name}
-              type="checkbox"
-              checked={selected.includes(candidate.userId)}
-              onChange={() => setSelected((value) => (
-                value.includes(candidate.userId)
-                  ? value.filter((id) => id !== candidate.userId)
-                  : [...value, candidate.userId]
-              ))}
-            />
-            {candidate.name}
-          </label>
-        ))}
         <label>
           Source image
           <input

--- a/tests/Brmble.Client.Tests/Services/PaintServiceTests.cs
+++ b/tests/Brmble.Client.Tests/Services/PaintServiceTests.cs
@@ -94,6 +94,34 @@ public sealed class PaintServiceTests
     }
 
     [TestMethod]
+    public async Task PaintPrepareJoin_ForwardsRoomPreparationResult()
+    {
+        var bridge = NativeBridgeTestHarness.Create();
+        using var key = RSA.Create(2048);
+        var certificateRequest = new CertificateRequest("CN=paint-test", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = certificateRequest.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddMinutes(1));
+        Uri? calledUri = null;
+        var service = new PaintService(bridge, () => certificate, () => "https://api.example.com",
+            (_, _) => Task.FromResult(new ChannelRequestBridgeHandler.TlsCallResult(true, null, 200, null)),
+            (_, uri, _) =>
+            {
+                calledUri = uri;
+                return Task.FromResult(new ChannelRequestBridgeHandler.TlsCallResult(true,
+                    "{\"sessionId\":\"11111111-1111-1111-1111-111111111111\",\"matrixRoomId\":\"!paint:test\",\"alreadyJoined\":false}", 200, null));
+            });
+        service.RegisterHandlers(bridge);
+
+        using var request = JsonDocument.Parse("{ \"sessionId\": \"11111111-1111-1111-1111-111111111111\", \"requestId\": 13 }");
+        await NativeBridgeTestHarness.InvokeAsync(bridge, "paint.prepareJoin", request.RootElement.Clone());
+
+        Assert.AreEqual("https://api.example.com/paint/sessions/11111111-1111-1111-1111-111111111111/prepare-join", calledUri?.ToString());
+        var response = NativeBridgeTestHarness.DrainMessages(bridge).Single(message => message.Type == "paint.response");
+        StringAssert.Contains(response.DataJson, "alreadyJoined");
+        StringAssert.Contains(response.DataJson, "false");
+        StringAssert.Contains(response.DataJson, "\"requestId\":13");
+    }
+
+    [TestMethod]
     public async Task PaintMutationFailure_ReturnsCorrelatedFailure()
     {
         var bridge = NativeBridgeTestHarness.Create();

--- a/tests/Brmble.Server.Tests/Paint/PaintEndpointsTests.cs
+++ b/tests/Brmble.Server.Tests/Paint/PaintEndpointsTests.cs
@@ -40,7 +40,7 @@ public sealed class PaintEndpointsTests
         CollectionAssert.IsSubsetOf(new[]
         {
             "/paint/sessions", "/paint/sessions/{id:guid}/source", "/paint/sessions/{id:guid}/summary",
-            "/paint/sessions/{id:guid}", "/paint/sessions/{id:guid}/join", "/paint/sessions/{id:guid}/leave",
+            "/paint/sessions/{id:guid}", "/paint/sessions/{id:guid}/prepare-join", "/paint/sessions/{id:guid}/join", "/paint/sessions/{id:guid}/leave",
             "/paint/sessions/{id:guid}/stroke", "/paint/sessions/{id:guid}/preview", "/paint/sessions/{id:guid}/undo",
             "/paint/sessions/{id:guid}/clear", "/paint/sessions/{id:guid}/end",
         }, endpoints.ToArray());
@@ -82,6 +82,22 @@ public sealed class PaintEndpointsTests
         var body = await response.Content
             .ReadFromJsonAsync<PaintErrorDto>();
         Assert.AreEqual("MATRIX_MEMBERSHIP_REQUIRED", body!.Code);
+    }
+
+    [TestMethod]
+    public async Task PrepareJoin_InvitesAnyChannelMemberAndReturnsRoom()
+    {
+        await using var app = await EndpointFixture.StartActiveInviteeAsync();
+
+        var response = await app.Client.PostAsync(
+            $"/paint/sessions/{app.SessionId}/prepare-join",
+            null);
+
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.AreEqual("!paint:test", body.GetProperty("matrixRoomId").GetString());
+        Assert.IsFalse(body.GetProperty("alreadyJoined").GetBoolean());
+        Assert.AreEqual(1, app.InvitedMatrixUserIds.Count);
     }
 
     [TestMethod]
@@ -248,6 +264,7 @@ public sealed class PaintEndpointsTests
         private readonly TestCertificate _certificate;
         public HttpClient Client { get; }
         public Guid SessionId { get; private set; }
+        public List<string> InvitedMatrixUserIds => _matrix.InvitedMatrixUserIds;
 
         private EndpointFixture(WebApplication app, Database database, TestPresence presence, TestMatrix matrix, TestCertificate certificate)
         {
@@ -283,7 +300,7 @@ public sealed class PaintEndpointsTests
             var invitee = await users.Insert("alice-cert", "alice");
             presence.Participants[host.Id] = new(host.Id, 9, 101, host.MatrixUserId);
             presence.Participants[invitee.Id] = new(invitee.Id, 9, 102, invitee.MatrixUserId);
-            fixture.SessionId = (await app.Services.GetRequiredService<PaintSessionManager>().CreateAsync(host.Id, [102])).SessionId;
+            fixture.SessionId = (await app.Services.GetRequiredService<PaintSessionManager>().CreateAsync(host.Id, [])).SessionId;
             return fixture;
         }
 
@@ -351,8 +368,13 @@ public sealed class PaintEndpointsTests
         private static readonly byte[] ValidPng = Convert.FromBase64String(
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
         public Dictionary<string, string?> Memberships { get; } = [];
+        public List<string> InvitedMatrixUserIds { get; } = [];
         public Task<string> CreatePaintRoomAsync(string name, IReadOnlyList<string> ids, CancellationToken token) => Task.FromResult("!paint:test");
-        public Task InvitePaintUserAsync(string roomId, string id, CancellationToken token) => Task.CompletedTask;
+        public Task InvitePaintUserAsync(string roomId, string id, CancellationToken token)
+        {
+            InvitedMatrixUserIds.Add(id);
+            return Task.CompletedTask;
+        }
         public Task<JsonElement> GetRoomEventAsync(string roomId, string eventId, CancellationToken token) => Task.FromResult(JsonDocument.Parse($"{{\"room_id\":\"!paint:test\",\"sender\":\"@1:test\",\"type\":\"m.room.message\",\"content\":{{\"msgtype\":\"m.image\",\"url\":\"mxc://test/image\",\"info\":{{\"mimetype\":\"image/png\",\"size\":{ValidPng.Length}}}}}}}").RootElement.Clone());
         public Task<string?> GetMembershipAsync(string roomId, string id, CancellationToken token) => Task.FromResult(Memberships.GetValueOrDefault(id));
         public Task<byte[]> DownloadMediaAsync(string mxcUrl, CancellationToken token) => Task.FromResult(ValidPng);


### PR DESCRIPTION
## Summary

Fixes collaborative paint access for users who were receiving `MATRIX_MEMBERSHIP_REQUIRED` errors.

### What changed

- Added a prepare-join flow that invites eligible channel members to the private Matrix paint room.
- The client now joins the Matrix room before requesting canvas access.
- Users who join the voice channel after the paint session starts can participate.
- Removed the preselected participant requirement from the paint setup UI.
- Preserved server-side validation for voice-channel membership and Matrix-room membership.
- Added regression tests for the server, native bridge, API, and frontend join flow.

### Root cause

The server sent a Matrix invitation but immediately rejected the canvas join because the client had not yet joined the private Matrix room. The frontend also had no flow to accept that invitation automatically after the user clicked **Join paint**.

### Validation

- Server tests passed
- Client tests passed
- Frontend tests passed
- Production web build succeeded