### PR TITLE
fix: keep Matrix chat compatible with servers that omit the Brmble-client marker

### DIFF
--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -135,6 +135,14 @@ describe('isMatrixChannelChatActive', () => {
   it('uses Matrix credentials when a legacy server omits the Brmble identity marker', () => {
     expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, { session: 1, name: 'Me', self: true }, matrixChannels)).toBe(true);
   });
+
+  it('uses Matrix credentials while the projection reports an unresolved identity', () => {
+    expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: null }, matrixChannels)).toBe(true);
+  });
+
+  it('uses Matrix credentials before the self row has arrived', () => {
+    expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, undefined, matrixChannels)).toBe(true);
+  });
 });
 
 describe('channel chat access helpers', () => {

--- a/src/Brmble.Web/src/App.chatMode.test.ts
+++ b/src/Brmble.Web/src/App.chatMode.test.ts
@@ -131,6 +131,10 @@ describe('isMatrixChannelChatActive', () => {
   it('falls back to Mumble until self is restored as a Brmble client', () => {
     expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, { session: 1, name: 'Me', self: true, isBrmbleClient: false }, matrixChannels)).toBe(false);
   });
+
+  it('uses Matrix credentials when a legacy server omits the Brmble identity marker', () => {
+    expect(isMatrixChannelChatActive('1', credentials, connectedStatuses, { session: 1, name: 'Me', self: true }, matrixChannels)).toBe(true);
+  });
 });
 
 describe('channel chat access helpers', () => {

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -767,7 +767,10 @@ export function isMatrixChannelChatActive(
   if (!channelId || channelId === 'server-root') return false;
   if (!getPermittedMatrixChannelId(channelId, channels)) return false;
   if (statuses.server.state !== 'connected' || statuses.chat.state !== 'connected') return false;
-  if (!selfUser?.isBrmbleClient) return false;
+  // Older Brmble servers do not send the projection's Brmble-client marker.
+  // Successful Matrix credentials already prove this client is Brmble-capable;
+  // only an explicit false marker should keep it on the legacy Mumble path.
+  if (selfUser?.isBrmbleClient === false) return false;
   return credentials?.roomMap[channelId] !== undefined;
 }
 

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -767,9 +767,13 @@ export function isMatrixChannelChatActive(
   if (!channelId || channelId === 'server-root') return false;
   if (!getPermittedMatrixChannelId(channelId, channels)) return false;
   if (statuses.server.state !== 'connected' || statuses.chat.state !== 'connected') return false;
-  // Older Brmble servers do not send the projection's Brmble-client marker.
-  // Successful Matrix credentials already prove this client is Brmble-capable;
-  // only an explicit false marker should keep it on the legacy Mumble path.
+  // Older Brmble servers do not send the projection's Brmble-client marker, and
+  // the projection itself sends null while the identity is unresolved. Successful
+  // Matrix credentials already prove this client is Brmble-capable, so only an
+  // explicit false marker — a confirmed plain Mumble user — keeps it on the legacy
+  // path. An absent selfUser is treated the same way: the row has not arrived yet,
+  // which is not evidence against the credentials we already hold, and refusing it
+  // would flip the panel Matrix -> Mumble -> Matrix during connect.
   if (selfUser?.isBrmbleClient === false) return false;
   return credentials?.roomMap[channelId] !== undefined;
 }

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -804,6 +804,28 @@ describe('useMatrixClient', () => {
     expect(result.current.activeMessages[0].content).toBe('sync-delivered');
   });
 
+  it('loads channel history after PREPARED when the room becomes available during sync', async () => {
+    mockClient.getRoom.mockReturnValue(null);
+
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+    act(() => result.current.setActiveChannel('42'));
+
+    const room = withNoTypingMembers({
+      roomId: '!room:example.com',
+      getMember: () => ({ rawDisplayName: 'Alice', name: 'Alice' }),
+      getLiveTimeline: () => ({ getEvents: () => [] }),
+    });
+    mockClient.getRoom.mockReturnValue(room);
+    mockClient.getRooms.mockReturnValue([room]);
+
+    const onSync = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
+      | ((state: string) => void)
+      | undefined;
+    await act(async () => onSync!('PREPARED'));
+
+    expect(mockClient.scrollback).toHaveBeenCalledWith(room, 50);
+  });
+
   // ── DM activeDmMessages + setActiveDmContact ──
 
   it('setActiveDmContact rebuilds activeDmMessages from SDK timeline', () => {

--- a/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.test.ts
@@ -804,26 +804,80 @@ describe('useMatrixClient', () => {
     expect(result.current.activeMessages[0].content).toBe('sync-delivered');
   });
 
-  it('loads channel history after PREPARED when the room becomes available during sync', async () => {
+  /** The outer `sync` listener the hook registers on mount. */
+  function firstSyncHandler() {
+    return mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
+      (state: string) => void;
+  }
+
+  /**
+   * waitForRoom registers its own `sync` listener while it waits, so the newest
+   * one is the pending wait. Calling it is how a room "arrives" in these tests.
+   */
+  function latestSyncHandler() {
+    const calls = mockClient.on.mock.calls.filter((c: unknown[]) => c[0] === 'sync');
+    return calls[calls.length - 1][1] as () => void;
+  }
+
+  function fakeRoom(roomId: string) {
+    return withNoTypingMembers({
+      roomId,
+      getMember: () => ({ rawDisplayName: 'Alice', name: 'Alice', getAvatarUrl: () => null }),
+      getLiveTimeline: () => ({ getEvents: () => [] }),
+    });
+  }
+
+  it('backfills channel history after PREPARED when the room is already synced', async () => {
+    const room = fakeRoom('!room:example.com');
+    mockClient.getRoom.mockReturnValue(room);
+    mockClient.getRooms.mockReturnValue([room]);
+
+    const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
+    act(() => result.current.setActiveChannel('42'));
+
+    await act(async () => firstSyncHandler()('PREPARED'));
+
+    expect(mockClient.scrollback).toHaveBeenCalledWith(room, 50);
+    expect(mockClient.scrollback).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for the room before backfilling when it is not synced yet at PREPARED', async () => {
     mockClient.getRoom.mockReturnValue(null);
 
     const { result } = renderHook(() => useMatrixClient(creds), { wrapper });
     act(() => result.current.setActiveChannel('42'));
 
-    const room = withNoTypingMembers({
-      roomId: '!room:example.com',
-      getMember: () => ({ rawDisplayName: 'Alice', name: 'Alice' }),
-      getLiveTimeline: () => ({ getEvents: () => [] }),
-    });
+    await act(async () => firstSyncHandler()('PREPARED'));
+
+    // The room is still absent, so the wait is pending and nothing was fetched.
+    expect(mockClient.scrollback).not.toHaveBeenCalled();
+
+    const room = fakeRoom('!room:example.com');
     mockClient.getRoom.mockReturnValue(room);
     mockClient.getRooms.mockReturnValue([room]);
-
-    const onSync = mockClient.on.mock.calls.find((c: unknown[]) => c[0] === 'sync')?.[1] as
-      | ((state: string) => void)
-      | undefined;
-    await act(async () => onSync!('PREPARED'));
+    await act(async () => { latestSyncHandler()(); });
 
     expect(mockClient.scrollback).toHaveBeenCalledWith(room, 50);
+    expect(mockClient.scrollback).toHaveBeenCalledTimes(1);
+  });
+
+  it('backfills DM history after PREPARED', async () => {
+    const dmRoom = fakeRoom('!dm-bob:example.com');
+    mockClient.getRoom.mockReturnValue(dmRoom);
+    mockClient.getRooms.mockReturnValue([dmRoom]);
+
+    const credsWithDm: MatrixCredentials = {
+      ...creds,
+      roomMap: {},
+      dmRoomMap: { '@bob:example.com': '!dm-bob:example.com' },
+    };
+    const { result } = renderHook(() => useMatrixClient(credsWithDm), { wrapper });
+    act(() => result.current.setActiveDmContact('@bob:example.com'));
+
+    await act(async () => firstSyncHandler()('PREPARED'));
+
+    expect(mockClient.scrollback).toHaveBeenCalledWith(dmRoom, 50);
+    expect(mockClient.scrollback).toHaveBeenCalledTimes(1);
   });
 
   // ── DM activeDmMessages + setActiveDmContact ──

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -846,8 +846,9 @@ export function useMatrixClient(
                 setActiveMessages(messages);
               }
 
-              const roomPromise = client.getRoom(roomId)
-                ? Promise.resolve(client.getRoom(roomId)!)
+              const knownRoom = client.getRoom(roomId);
+              const roomPromise = knownRoom
+                ? Promise.resolve(knownRoom)
                 : waitForRoomRef.current?.(roomId);
               roomPromise?.then(room => client.scrollback(room, 50)).catch(error => {
                 console.warn(`[Matrix] Failed to load channel history for ${roomId}:`, error);
@@ -865,8 +866,9 @@ export function useMatrixClient(
                 setActiveDmMessages(messages);
               }
 
-              const roomPromise = client.getRoom(dmRoomId)
-                ? Promise.resolve(client.getRoom(dmRoomId)!)
+              const knownDmRoom = client.getRoom(dmRoomId);
+              const roomPromise = knownDmRoom
+                ? Promise.resolve(knownDmRoom)
                 : waitForRoomRef.current?.(dmRoomId);
               roomPromise?.then(room => client.scrollback(room, 50)).catch(error => {
                 console.warn(`[Matrix] Failed to load DM history for ${dmRoomId}:`, error);

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -846,13 +846,21 @@ export function useMatrixClient(
                 setActiveMessages(messages);
               }
 
-              const knownRoom = client.getRoom(roomId);
-              const roomPromise = knownRoom
-                ? Promise.resolve(knownRoom)
-                : waitForRoomRef.current?.(roomId);
-              roomPromise?.then(room => client.scrollback(room, 50)).catch(error => {
-                console.warn(`[Matrix] Failed to load channel history for ${roomId}:`, error);
-              });
+              // waitForRoom resolves immediately when the SDK already has the room,
+              // so it covers both the known and the still-syncing case.
+              waitForRoomRef.current?.(roomId)
+                .then(room => client.scrollback(room, 50))
+                .then(() => {
+                  // Rebuild rather than rely on the timeline events scrollback emits:
+                  // a backfill batch delivers reactions before the messages they
+                  // target, and onTimeline drops a reaction whose target it has not
+                  // seen. loadMessagesFromTimeline collects them order-independently.
+                  if (activeRoomVersionRef.current !== myVersion) return;
+                  setActiveMessages(loadMessagesFromTimeline(client, roomId, channelId, credentials.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit));
+                })
+                .catch(error => {
+                  console.warn(`[Matrix] Failed to load channel history for ${roomId}:`, error);
+                });
             }
           }
           if (activeDmContactIdRef.current) {
@@ -866,13 +874,15 @@ export function useMatrixClient(
                 setActiveDmMessages(messages);
               }
 
-              const knownDmRoom = client.getRoom(dmRoomId);
-              const roomPromise = knownDmRoom
-                ? Promise.resolve(knownDmRoom)
-                : waitForRoomRef.current?.(dmRoomId);
-              roomPromise?.then(room => client.scrollback(room, 50)).catch(error => {
-                console.warn(`[Matrix] Failed to load DM history for ${dmRoomId}:`, error);
-              });
+              waitForRoomRef.current?.(dmRoomId)
+                .then(room => client.scrollback(room, 50))
+                .then(() => {
+                  if (activeDmVersionRef.current !== myVersion) return;
+                  setActiveDmMessages(loadMessagesFromTimeline(client, dmRoomId, dmContactId, credentials.userId, reactionEventsRef, ownReactionEventIdsRef, rememberReplacementEdit));
+                })
+                .catch(error => {
+                  console.warn(`[Matrix] Failed to load DM history for ${dmRoomId}:`, error);
+                });
             }
           }
         }

--- a/src/Brmble.Web/src/hooks/useMatrixClient.ts
+++ b/src/Brmble.Web/src/hooks/useMatrixClient.ts
@@ -845,6 +845,13 @@ export function useMatrixClient(
               if (activeRoomVersionRef.current === myVersion) {
                 setActiveMessages(messages);
               }
+
+              const roomPromise = client.getRoom(roomId)
+                ? Promise.resolve(client.getRoom(roomId)!)
+                : waitForRoomRef.current?.(roomId);
+              roomPromise?.then(room => client.scrollback(room, 50)).catch(error => {
+                console.warn(`[Matrix] Failed to load channel history for ${roomId}:`, error);
+              });
             }
           }
           if (activeDmContactIdRef.current) {
@@ -857,6 +864,13 @@ export function useMatrixClient(
               if (activeDmVersionRef.current === myVersion) {
                 setActiveDmMessages(messages);
               }
+
+              const roomPromise = client.getRoom(dmRoomId)
+                ? Promise.resolve(client.getRoom(dmRoomId)!)
+                : waitForRoomRef.current?.(dmRoomId);
+              roomPromise?.then(room => client.scrollback(room, 50)).catch(error => {
+                console.warn(`[Matrix] Failed to load DM history for ${dmRoomId}:`, error);
+              });
             }
           }
         }


### PR DESCRIPTION
## Problem

Channel chat and DM history stopped rendering for clients whose server does not
state the projection's Brmble-client marker.

`isBrmbleClient` became tri-state in PR #629 (user projection phase 3): the server
omits the field entirely when it does not know yet, rather than asserting `false`
(`SessionMappingWire.cs:10`, `SessionMappingHandler.cs:78`). That distinction is
the whole point of the projection's "null means unknown" rule.

The chat gate never learned it:

```ts
// App.tsx:770
if (!selfUser?.isBrmbleClient) return false;
```

`null` and `false` are indistinguishable there, so an unresolved identity disabled
Matrix chat and fell the client back to the legacy Mumble text path.

Separately, opening a room set the message list from cache but never asked the
homeserver to backfill, so a room the client had not synced showed up empty.

## Fix

- Only an explicit `false` keeps a client on the legacy path. Successful Matrix
  credentials already prove the client is Brmble-capable.
- `client.scrollback(room, 50)` when a channel or DM becomes active, resolving the
  room through the existing `waitForRoomRef` when it is not in the client yet.
  Failures log and are swallowed — missing backfill should not break the panel.

## Notes

Both changes were originally written on `Matrix-token` (#637). They are
cherry-picked here so the chat regression can land without waiting on that
branch's Matrix token security work.

## Verification

- `npx tsc --noEmit` — clean
- `App.chatMode.test.ts` + `useMatrixClient.test.ts` — 99 passed
- Full frontend suite — 1543 passed, 1 failed

The single failure is `VerticalSplitPane.test.tsx > supports keyboard resizing and
stores the split size`. It fails identically on a clean `main`, so it is unrelated
to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
