### PR TITLE
feat: main panel regions and conversation tabs

### DIFF
--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -759,6 +759,27 @@ Rules:
 7. Password input prompts must use the same icon-only reveal pattern as `ServerList`: `Icon name="eye"` for hidden, `Icon name="eye-off"` for visible, shown only while the input or reveal button has focus
 8. Rich preview confirmations still use the single App-owned prompt host; never mount a second host for feature-specific content
 
+### Screen-Reader-Only Text (`.sr-only`)
+
+Reference: `src/Brmble.Web/src/index.css`
+
+Use the global `.sr-only` utility for text that must reach assistive technology but not the
+screen — for example marking which item is the current one. Prefer it over `aria-label` on any
+element that also carries visible dynamic content (unread counts, mention badges, status
+chips): `aria-label` **replaces** the whole accessible name and silences those badges.
+
+Because the accessible name is the concatenation of inline children **without separators**, do
+not rely on a leading space inside the `.sr-only` span (it is trimmed). Instead repeat the label
+inside the `.sr-only` span and mark the visible copy `aria-hidden="true"`:
+
+```tsx
+<span className={styles.text} aria-hidden="true">{label}</span>
+<span className="sr-only">{`${label} (you are here)`}</span>
+```
+
+Do not add per-component visually-hidden helpers, and never use `display: none` or
+`visibility: hidden` for this — both remove the text from the accessibility tree.
+
 ### Form Inputs
 
 | Element | Class / Component | Notes |

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -102,6 +102,29 @@ All visual properties must come from CSS custom properties. Two layers exist:
 | `padding: 1rem` | `padding: var(--space-md)` |
 | `box-shadow: 0 8px 32px rgba(0,0,0,0.4)` | `box-shadow: var(--shadow-elevated)` |
 
+### Text On An Accent Fill
+
+When text or an icon sits on a filled accent background (`--accent-primary`,
+`--accent-success`, unread/mention badges, the active conversation tab), its colour is
+**`var(--bg-deep)`**. This is the established convention across `ChatPanel.css`,
+`ChannelTree.css`, `ConversationTabStrip.module.css` and `NeonD.module.css`. There is no
+`--text-on-accent` token — do not invent one, and do not hardcode white.
+
+### Phantom Tokens (do not copy)
+
+These names appear in older code and in AI-generated CSS but are **defined nowhere**. A
+`var()` on them resolves to nothing, so the declaration silently does nothing:
+
+| Phantom (not real) | Use instead |
+|---|---|
+| `--radius-pill` | `--radius-lg` (or `--radius-full` for a true circle) |
+| `--bg-subtle` | `--bg-surface` |
+| `--text-on-accent` | `--bg-deep` (see above) |
+| `--font-size-xs` | `--text-xs` |
+
+Before using any token, confirm it exists in `index.css` (`:root`) or
+`themes/_template.css`. Font-size tokens are `--text-*`, never `--font-size-*`.
+
 ---
 
 ## 3. Heading System
@@ -203,6 +226,53 @@ stable `storageKey` so the 20-80% split persists locally.
 The divider supports ArrowUp / ArrowDown keyboard resizing in 5% steps. Pointer drags must release
 their document listeners on pointerup, pointercancel, window blur, and component unmount; do not
 duplicate this listener lifecycle in a consumer.
+
+The main panel has **exactly one** split, keyed `brmble-main-split` (channel activity above,
+conversation below). No component may introduce a second splitter inside the main panel. See the
+Main Panel Region Pattern.
+
+### Main Panel Region Pattern
+
+Reference: `src/Brmble.Web/src/components/MainPanel/MainPanel.tsx`,
+`workspace/mainPanelMode.ts`, `components/ChannelActivityRegion/ChannelActivityRegion.tsx`,
+`App.tsx`
+
+Rules:
+1. The main panel has exactly two modes. In `game` mode a single game surface fills it
+   entirely — no activity chips, no tab strip, no chat. In `split` mode the channel
+   activity region sits above the conversation region, separated by one
+   `VerticalSplitPane` keyed `brmble-main-split`.
+2. Game mode is entered by **participating** in a game, never by spectating one. Opening
+   the solo idle game is participation.
+3. The channel activity region is bound to the joined voice channel and to nothing else.
+   It never renders at server root, and never renders when the channel has no activity —
+   in that case the panel has no upper pane and no divider.
+4. The activity region stages exactly one activity. Chips list everything live; the first
+   activity to appear takes the stage, later arrivals never steal it, and an explicit chip
+   click always wins.
+5. A backgrounded screen share stays subscribed for a 10-second grace period, then
+   unsubscribes. Watched list, order, focus, receive quality, room membership and local
+   publishing are never changed by staging.
+6. No component may introduce a second splitter inside the main panel.
+
+### Conversation Tab Strip Pattern
+
+Reference: `src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx`,
+`ConversationTabStrip.module.css`, `workspace/` conversation tab state
+
+Rules:
+1. The strip is a single `role="tablist"`. The home tab is first, is derived from the
+   joined voice channel, has no close control, and is pinned outside the scroll container.
+2. Moving voice channel **replaces** the home tab. A browsed tab for the new channel is
+   absorbed rather than duplicated. Presence never creates history.
+3. Only an explicit click to read a channel or a user creates a tab, and every such click
+   creates a permanent tab. There are no preview tabs.
+4. Overflow shrinks labels to `--conversation-tab-min-width` with ellipsis, then scrolls
+   horizontally.
+5. An open conversation's unread badge lives on its tab; its sidebar row or contact entry
+   shows nothing. Aggregate counts are computed **before** suppression.
+6. Tabs persist per server and are validated on restore. The home tab is never restored
+   from storage.
 
 ### Conversation Region Pattern
 

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -204,6 +204,28 @@ The divider supports ArrowUp / ArrowDown keyboard resizing in 5% steps. Pointer 
 their document listeners on pointerup, pointercancel, window blur, and component unmount; do not
 duplicate this listener lifecycle in a consumer.
 
+### Conversation Region Pattern
+
+Reference: `src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx`,
+`App.tsx` (`.conversation-region`), `App.css`
+
+The main panel's conversation slot is a single `.conversation-region` column: a
+`ConversationTabStrip` above **one** `ChatPanel`. There is no second, hidden chat panel and
+no sliding transform — the active tab decides which conversation the one panel renders.
+
+Rules:
+1. Never render more than one `ChatPanel`. Channel and DM prop sets are selected by the
+   active conversation's kind, not rendered side by side.
+2. Do not reintroduce `aria-hidden` / `inert` conversation slides or a transform-based
+   route transition. Nothing is mounted-but-hidden, so there is nothing to mark inert.
+3. Every tab must have a visible label. A channel whose name cannot be resolved falls back
+   to its channel id.
+4. The "you are here" (home) tab is the joined voice channel and follows presence; it is
+   not closeable and is never persisted. Use the `.sr-only` pattern for its suffix.
+5. Root chat (`'server-root'`) is not Matrix-backed and therefore has no unread source. It
+   must render **no** badge, not a zero.
+6. Presence and unread signals live on the tab, not in the `.chat-header`.
+
 ### Minigame Panel Pattern
 
 Reference: `components/Games/DeathrollModal.tsx`, `DeathrollModal.module.css`,

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -204,23 +204,32 @@ The divider supports ArrowUp / ArrowDown keyboard resizing in 5% steps. Pointer 
 their document listeners on pointerup, pointercancel, window blur, and component unmount; do not
 duplicate this listener lifecycle in a consumer.
 
-### Minigame Modal Pattern
+### Minigame Panel Pattern
 
 Reference: `components/Games/DeathrollModal.tsx`, `DeathrollModal.module.css`,
-`components/Games/RpsModal.tsx`, `RpsModal.module.css`
+`components/Games/RpsModal.tsx`, `RpsModal.module.css`, `components/Games/GameSurface.tsx`
 
-Real-time minigame modals (e.g. Deathroll, Rock Paper Scissors) reuse the shared modal shell —
-global `div.modal-overlay`, `.glass-panel.animate-slide-up`, `.modal-close`, `.modal-header`,
-`h2.heading-title.modal-title` — and add game-specific content styling via a colocated
-CSS module (`*.module.css`). Do not build a bespoke overlay/positioning system.
+A minigame the local player is participating in — and the result of the one that just
+finished — **owns the whole main panel**. It is not a dialog: there is no
+`div.modal-overlay`, no click-outside dismissal, no focus trap and no `role="dialog"`.
+App composes the panel with `<MainPanel>` (`components/MainPanel/MainPanel.tsx`), whose
+mode comes from `selectMainPanelMode` (`workspace/mainPanelMode.ts`); the board is
+centered in the panel by the `<GameSurface>` wrapper. The idle Neon-D game uses the same
+main-panel slot and is closed by its own close control. Chat, paint and screen share stay
+mounted underneath and simply reappear when the panel returns to `split`.
 
-Each game gets its **own** modal component (Deathroll and RPS do not share a body). The
-`view` prop is the generic `GameView` union from `useGameState`; each modal narrows it to its
+The board itself still reuses the shared card shell — `.glass-panel.animate-slide-up`,
+`.modal-close`, `.modal-header`, `h2.heading-title.modal-title` — and adds game-specific
+content styling via a colocated CSS module (`*.module.css`). Do not build a bespoke
+positioning system, and do not put a live match back behind an overlay.
+
+Each game gets its **own** board component (Deathroll and RPS do not share a body). The
+`view` prop is the generic `GameView` union from `useGameState`; each one narrows it to its
 own shape with the `isRpsView` guard and ignores views it doesn't understand. App picks which
-modal to render from `activeMatch?.gameType ?? ended?.gameType`.
+board to render from `activeMatch?.gameType ?? ended?.gameType`.
 
 Rules:
-1. Reuse the shared modal shell classes above; only game-board content (player rows,
+1. Reuse the shared card shell classes above; only game-board content (player rows,
    stat tiles, countdown bar, pick buttons, result banner) lives in the CSS module.
 2. All module CSS uses tokens (`--bg-surface`, `--glass-border`, `--accent-primary`,
    `--radius-*`, `--space-*`, `--text-*`, `--font-*`) — no hardcoded visual values.
@@ -248,9 +257,10 @@ Rules:
    short token-styled `3…2…1` countdown in the status area, then reveal the updated
    score, `lastRound`, and — only after the countdown — the end result banner. Gate this
    with local state (the raw `view` prop is the source of truth; a `display` copy lags
-   during the reveal). Key the modal on the match id in App so this reveal state resets
-   between matches.
-7. A modal may show a **Head-to-head** panel (see the Head-to-head pattern) below the
+   during the reveal). Key the board on the match id in App so this reveal state resets
+   between matches — and keep the live match and its result in the **same** mount site, or
+   the reveal state is destroyed by a remount the moment `game.ended` nulls the view.
+7. A board may show a **Head-to-head** panel (see the Head-to-head pattern) below the
    result, scoped to the current opponent.
 
 ### Minigame Invite Pattern
@@ -352,9 +362,9 @@ Rematch **requests** from the result modal are locked client-side on `sourceMatc
 Ready/Accept are locked, because `outgoingRematch` only arrives after the server answers. The lock
 releases on a correlated `requestRematch` error or when the completed match changes.
 
-Completed Deathroll and Rock Paper Scissors participant result modals place a secondary
-**Rematch** action beside **Close**. A pending request disables that action and leaves the result
-modal open.
+Completed Deathroll and Rock Paper Scissors participant result panels place a secondary
+**Rematch** action beside **Close**. A pending request disables that action and leaves the
+result panel open.
 
 #### Duel queue confirmation
 

--- a/docs/UI_GUIDE.md
+++ b/docs/UI_GUIDE.md
@@ -781,6 +781,32 @@ Rules:
 7. Password input prompts must use the same icon-only reveal pattern as `ServerList`: `Icon name="eye"` for hidden, `Icon name="eye-off"` for visible, shown only while the input or reveal button has focus
 8. Rich preview confirmations still use the single App-owned prompt host; never mount a second host for feature-specific content
 
+### Permanently Visible User Panel Pattern
+
+Reference: `src/Brmble.Web/src/components/DMContactList/DMContactList.tsx`,
+`DMContactList.css`, `App.tsx` (`.app-body`), `App.css`
+
+`.app-body` is a static three-column workspace: sidebar | main content | user panel
+(`DMContactList`). The user panel is **permanently visible** whenever the client is
+connected. It is not a reading surface — clicking a contact opens a conversation tab.
+
+Rules:
+1. There is no visibility state, no toggle control, and no `visible` prop. Do not
+   reintroduce `messagesPanelExpanded`, a Header/UserPanel DM toggle button, or any
+   activity-driven auto-collapse (screen share, game, remote watching).
+2. Below `60rem` the panel narrows to a compact rail. That collapse is **presentation
+   only**: driven by a CSS media query on viewport width alone. No reducer state, no
+   JavaScript, not user-toggleable.
+3. Widths come from `--dm-panel-width` and `--dm-rail-width` in `:root` (`index.css`).
+4. Unread counts render unconditionally and stay visible in the rail (absolutely
+   positioned on the contact entry). Never gate a badge on panel width.
+5. Text that is the accessible name of a control must be visually hidden with the
+   `.sr-only` technique in the rail, never `display: none`. Do not use `aria-label`
+   on a contact entry — it would replace the accessible name and silence the unread
+   badge (see the `.sr-only` section).
+6. The panel is rendered only while connected, so it never appears on the
+   server-list, onboarding, connecting, or disconnected screens.
+
 ### Screen-Reader-Only Text (`.sr-only`)
 
 Reference: `src/Brmble.Web/src/index.css`

--- a/docs/superpowers/plans/2026-08-19-main-panel-regions-and-conversation-tabs.md
+++ b/docs/superpowers/plans/2026-08-19-main-panel-regions-and-conversation-tabs.md
@@ -1,0 +1,2706 @@
+# Main Panel Regions And Conversation Tabs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Brmble main panel a single owner: participating in a game fills the whole panel, and otherwise the panel splits into a channel activity region on top and a tabbed conversation region below.
+
+**Architecture:** Replace the single overloaded `currentChannelId` with two named concepts — presence (`joinedChannelId`) and conversation (an explicit tab list in the workspace reducer). Every presence-bound feature rebinds to `joinedChannelId`, which fixes four live defects. The two nested splitters collapse into one `VerticalSplitPane`, the two-slide `.content-slider` collapses into one `ChatPanel` driven by the active tab, and `DMContactList` becomes a permanently visible directory.
+
+**Tech Stack:** React 19, TypeScript 5.9, Vitest + Testing Library, CSS custom-property design tokens, Vite.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-main-panel-regions-and-conversation-tabs-design.md`
+
+## Global Constraints
+
+- Working directory for all frontend commands is `src/Brmble.Web`. Run tests with `npm test -- --run <path>`.
+- Read `docs/UI_GUIDE.md` before touching any UI. Never hardcode colours, font sizes, font families, spacing, border radius, shadows, or transition values — use existing CSS custom-property tokens. Add new tokens rather than literals.
+- Never commit directly to `main`. All work lands on branch `feature/main-panel-regions`.
+- TDD throughout: write the failing test, watch it fail, write the minimal implementation, watch it pass, commit.
+- Strict ordering constraint from the spec: Tasks 1–7 (state model and rebinds) must be complete and green before any layout task (8 onward) begins.
+- Split bounds are 20–80% with a 50% default and a 5% keyboard step — these already exist in `VerticalSplitPane` and must not be redefined.
+- Backgrounded screen-share grace period is exactly 10 seconds, expressed as one named constant.
+- Existing icon names are available from `components/Icon/Icon.tsx`; `x` already exists. Do not add duplicate icon definitions.
+- Do not create a toast system. Notifications use the existing top-right `<Notification>` with `useNotificationQueue`.
+
+---
+
+## File Structure
+
+### New modules
+
+- `src/Brmble.Web/src/workspace/conversation.ts` — the `Conversation` type plus key and equality helpers. No React, no storage.
+- `src/Brmble.Web/src/workspace/presence.ts` — `selectJoinedChannelId`, the single derivation of the joined voice channel.
+- `src/Brmble.Web/src/workspace/conversationStorage.ts` — per-server persistence and validated restore of open tabs.
+- `src/Brmble.Web/src/workspace/mainPanelMode.ts` — `'game' | 'split'` selection.
+- `src/Brmble.Web/src/workspace/channelActivity.ts` — activity list and stage selection rules.
+- `src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.tsx` + `.module.css` — chip header and single stage.
+- `src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx` + `.module.css` — the tab strip.
+
+### Rewritten
+
+- `src/Brmble.Web/src/workspace/workspaceState.ts` — conversation tab model replaces `foreground` / `messagesPanelExpanded` / `remoteWatchCount`.
+
+### Modified
+
+- `src/Brmble.Web/src/App.tsx` — the bulk of the wiring.
+- `src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx` + `ChatPanel.css` — bespoke splitter and screen-share slot removed.
+- `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx` — presence marker, challenge gate, badge ownership.
+- `src/Brmble.Web/src/components/DMContactList/DMContactList.tsx` + `.css` — always visible, narrow rail, badge ownership.
+- `src/Brmble.Web/src/hooks/useScreenShare.ts` — grace-period hide/restore.
+- `src/Brmble.Web/src/index.css` — new layout tokens.
+- `docs/UI_GUIDE.md` — three new patterns, two rewritten.
+
+### Deleted
+
+- `.chat-split-video`, `.chat-split-divider` and their handlers in `ChatPanel.tsx`; the `.chat-split-*` CSS block.
+- `.content-slider` / `.content-slide` markup in `App.tsx` and their CSS in `App.css`.
+- `DMContactList`'s `visible` prop and expand/collapse control.
+
+---
+
+## Task 1: Conversation Identity
+
+**Files:**
+- Create: `src/Brmble.Web/src/workspace/conversation.ts`
+- Test: `src/Brmble.Web/src/workspace/conversation.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Conversation`, `conversationKey(c: Conversation): string`, `sameConversation(a: Conversation, b: Conversation): boolean`, `isChannelConversation(c: Conversation): c is { kind: 'channel'; channelId: string }`. Every later task uses these; tabs are identified by key strings, never by object reference.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/Brmble.Web/src/workspace/conversation.test.ts
+import { describe, expect, it } from 'vitest';
+import { conversationKey, isChannelConversation, sameConversation, type Conversation } from './conversation';
+
+describe('conversation identity', () => {
+  it('keys channels and dms into disjoint namespaces', () => {
+    expect(conversationKey({ kind: 'channel', channelId: '7' })).toBe('channel:7');
+    expect(conversationKey({ kind: 'dm', contactId: '@val:example.com' })).toBe('dm:@val:example.com');
+    expect(conversationKey({ kind: 'channel', channelId: 'server-root' })).toBe('channel:server-root');
+  });
+
+  it('never collides a channel id with a contact id', () => {
+    const channel: Conversation = { kind: 'channel', channelId: '7' };
+    const dm: Conversation = { kind: 'dm', contactId: '7' };
+    expect(conversationKey(channel)).not.toBe(conversationKey(dm));
+    expect(sameConversation(channel, dm)).toBe(false);
+  });
+
+  it('compares by value, not reference', () => {
+    expect(sameConversation({ kind: 'channel', channelId: '7' }, { kind: 'channel', channelId: '7' })).toBe(true);
+    expect(sameConversation({ kind: 'channel', channelId: '7' }, { kind: 'channel', channelId: '8' })).toBe(false);
+  });
+
+  it('narrows channel conversations', () => {
+    const c: Conversation = { kind: 'channel', channelId: '7' };
+    expect(isChannelConversation(c)).toBe(true);
+    expect(isChannelConversation({ kind: 'dm', contactId: 'a' })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/workspace/conversation.test.ts`
+Working directory: `src/Brmble.Web`
+Expected: FAIL — cannot resolve `./conversation`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/Brmble.Web/src/workspace/conversation.ts
+export type Conversation =
+  | { kind: 'channel'; channelId: string }
+  | { kind: 'dm'; contactId: string };
+
+export function conversationKey(conversation: Conversation): string {
+  return conversation.kind === 'channel'
+    ? `channel:${conversation.channelId}`
+    : `dm:${conversation.contactId}`;
+}
+
+export function sameConversation(a: Conversation, b: Conversation): boolean {
+  return conversationKey(a) === conversationKey(b);
+}
+
+export function isChannelConversation(
+  conversation: Conversation,
+): conversation is { kind: 'channel'; channelId: string } {
+  return conversation.kind === 'channel';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run src/workspace/conversation.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/workspace/conversation.ts src/Brmble.Web/src/workspace/conversation.test.ts
+git commit -m "feat: add conversation identity helpers"
+```
+
+---
+
+## Task 2: Presence Selector
+
+The joined voice channel is currently re-derived ad hoc in at least three places (`App.tsx:4340`, `App.tsx:3370`, `App.tsx:4468-4470`). This task gives it one name.
+
+**Files:**
+- Create: `src/Brmble.Web/src/workspace/presence.ts`
+- Test: `src/Brmble.Web/src/workspace/presence.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `selectJoinedChannelId(users: PresenceUser[]): string | null` where `PresenceUser = { self?: boolean; channelId?: number }`. Returns `'server-root'` for channel `0`, the stringified id otherwise, and `null` when no self user exists. This string is directly comparable with the existing `currentChannelId` string values.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/Brmble.Web/src/workspace/presence.test.ts
+import { describe, expect, it } from 'vitest';
+import { selectJoinedChannelId } from './presence';
+
+describe('selectJoinedChannelId', () => {
+  it('returns the stringified channel of the self user', () => {
+    expect(selectJoinedChannelId([
+      { channelId: 3 },
+      { self: true, channelId: 7 },
+    ])).toBe('7');
+  });
+
+  it('maps the root channel to server-root', () => {
+    expect(selectJoinedChannelId([{ self: true, channelId: 0 }])).toBe('server-root');
+  });
+
+  it('returns null when there is no self user', () => {
+    expect(selectJoinedChannelId([{ channelId: 7 }])).toBeNull();
+    expect(selectJoinedChannelId([])).toBeNull();
+  });
+
+  it('returns null when the self user has no channel', () => {
+    expect(selectJoinedChannelId([{ self: true }])).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/workspace/presence.test.ts`
+Expected: FAIL — cannot resolve `./presence`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/Brmble.Web/src/workspace/presence.ts
+export interface PresenceUser {
+  self?: boolean;
+  channelId?: number;
+}
+
+export const SERVER_ROOT_CHANNEL_ID = 'server-root';
+
+export function selectJoinedChannelId(users: PresenceUser[]): string | null {
+  const self = users.find(user => user.self);
+  if (!self || self.channelId == null) return null;
+  return self.channelId === 0 ? SERVER_ROOT_CHANNEL_ID : String(self.channelId);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run src/workspace/presence.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/workspace/presence.ts src/Brmble.Web/src/workspace/presence.test.ts
+git commit -m "feat: add joined channel presence selector"
+```
+
+---
+
+## Task 3: Conversation Tab Reducer
+
+This replaces `workspaceState.ts` wholesale. The old file's `foreground`, `messagesPanelExpanded`, `previousContent` and `remoteWatchCount` all disappear, along with the events `REMOTE_WATCH_COUNT_CHANGED`, `TOGGLE_MESSAGES_PANEL`, `OPEN_MESSAGES_PANEL`, `SELECT_CHANNEL`, `SELECT_DM` and `SELECTED_DM_INVALIDATED`. The existing `workspaceState.test.ts` is replaced entirely — do not try to preserve its cases, they test behaviour that is being deleted on purpose.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/workspace/workspaceState.ts` (full rewrite, currently 114 lines)
+- Test: `src/Brmble.Web/src/workspace/workspaceState.test.ts` (full rewrite)
+
+**Interfaces:**
+- Consumes: `Conversation`, `conversationKey` from Task 1.
+- Produces:
+  - `WorkspaceState { joinedChannelId: string | null; tabs: Conversation[]; activeKey: string | null }`
+  - `createWorkspaceState(): WorkspaceState`
+  - `workspaceReducer(state, event): WorkspaceState`
+  - Events: `{ type: 'JOINED_CHANNEL_CHANGED'; channelId: string | null }`, `{ type: 'OPEN_CONVERSATION'; conversation: Conversation }`, `{ type: 'CLOSE_CONVERSATION'; key: string }`, `{ type: 'ACTIVATE_CONVERSATION'; key: string }`, `{ type: 'CONVERSATION_INVALIDATED'; key: string }`, `{ type: 'RESTORE_CONVERSATIONS'; conversations: Conversation[] }`, `{ type: 'WORKSPACE_RESET' }`
+  - Selectors: `selectHomeKey(state): string | null`, `selectActiveConversation(state): Conversation | null`, `isHomeKey(state, key): boolean`
+
+Behaviour contract, in prose so the implementer does not have to infer it from tests:
+
+- `tabs[0]` is the home tab whenever `joinedChannelId` is non-null. Home is never closable.
+- `JOINED_CHANNEL_CHANGED` drops the previous home, absorbs any existing tab matching the new home so it cannot appear twice, and prepends the new home. Non-home tabs keep their relative order. If the active tab was the old home, or was the tab that got absorbed, active becomes the new home.
+- `OPEN_CONVERSATION` activates an existing tab rather than duplicating it; otherwise appends and activates.
+- `CLOSE_CONVERSATION` and `CONVERSATION_INVALIDATED` are the same operation. Both are ignored for the home key. If the closed tab was active, activation moves to the right neighbour, else the left, else home.
+- `RESTORE_CONVERSATIONS` replaces the non-home tabs and activates home.
+- `WORKSPACE_RESET` reduces to home only, or to an empty strip when disconnected.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/Brmble.Web/src/workspace/workspaceState.test.ts
+import { describe, expect, it } from 'vitest';
+import { conversationKey, type Conversation } from './conversation';
+import {
+  createWorkspaceState,
+  isHomeKey,
+  selectActiveConversation,
+  selectHomeKey,
+  workspaceReducer,
+  type WorkspaceState,
+} from './workspaceState';
+
+const channel = (id: string): Conversation => ({ kind: 'channel', channelId: id });
+const dm = (id: string): Conversation => ({ kind: 'dm', contactId: id });
+const keys = (state: WorkspaceState) => state.tabs.map(conversationKey);
+
+const joined = (id: string | null, base = createWorkspaceState()) =>
+  workspaceReducer(base, { type: 'JOINED_CHANNEL_CHANGED', channelId: id });
+
+describe('workspace conversation tabs', () => {
+  it('starts empty and disconnected', () => {
+    const state = createWorkspaceState();
+    expect(state).toEqual({ joinedChannelId: null, tabs: [], activeKey: null });
+    expect(selectHomeKey(state)).toBeNull();
+    expect(selectActiveConversation(state)).toBeNull();
+  });
+
+  it('creates a pinned home tab when joining a channel', () => {
+    const state = joined('7');
+    expect(keys(state)).toEqual(['channel:7']);
+    expect(state.activeKey).toBe('channel:7');
+    expect(isHomeKey(state, 'channel:7')).toBe(true);
+  });
+
+  it('keeps a home tab at server root', () => {
+    const state = joined('server-root');
+    expect(keys(state)).toEqual(['channel:server-root']);
+    expect(selectHomeKey(state)).toBe('channel:server-root');
+  });
+
+  it('appends and activates an opened conversation', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('@val:example.com') });
+    expect(keys(state)).toEqual(['channel:7', 'channel:9', 'dm:@val:example.com']);
+    expect(state.activeKey).toBe('dm:@val:example.com');
+  });
+
+  it('activates rather than duplicating an already open conversation', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    expect(keys(state)).toEqual(['channel:7', 'channel:9', 'dm:a']);
+    expect(state.activeKey).toBe('channel:9');
+  });
+
+  it('replaces the home tab when the joined channel changes and leaves browsed tabs alone', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '12' });
+    expect(keys(state)).toEqual(['channel:12', 'channel:9']);
+    expect(selectHomeKey(state)).toBe('channel:12');
+  });
+
+  it('absorbs a browsed tab that becomes the new home instead of showing it twice', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '9' });
+    expect(keys(state)).toEqual(['channel:9', 'dm:a']);
+    expect(state.activeKey).toBe('channel:9');
+  });
+
+  it('moves activation to the new home when the old home was active', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'ACTIVATE_CONVERSATION', key: 'channel:7' });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '12' });
+    expect(state.activeKey).toBe('channel:12');
+  });
+
+  it('keeps activation on a browsed tab across a channel move', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '12' });
+    expect(state.activeKey).toBe('channel:9');
+  });
+
+  it('refuses to close the home tab', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'channel:7' });
+    expect(keys(state)).toEqual(['channel:7']);
+  });
+
+  it('activates the right neighbour when closing the active tab', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'ACTIVATE_CONVERSATION', key: 'channel:9' });
+    state = workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'channel:9' });
+    expect(keys(state)).toEqual(['channel:7', 'dm:a']);
+    expect(state.activeKey).toBe('dm:a');
+  });
+
+  it('falls back to the left neighbour when closing the last tab', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'dm:a' });
+    expect(state.activeKey).toBe('channel:9');
+  });
+
+  it('leaves activation alone when closing an inactive tab', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'channel:9' });
+    expect(state.activeKey).toBe('dm:a');
+  });
+
+  it('treats invalidation as a close', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'CONVERSATION_INVALIDATED', key: 'dm:a' });
+    expect(keys(state)).toEqual(['channel:7']);
+    expect(state.activeKey).toBe('channel:7');
+  });
+
+  it('restores non-home tabs and activates home', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, {
+      type: 'RESTORE_CONVERSATIONS',
+      conversations: [channel('9'), dm('a'), channel('7')],
+    });
+    expect(keys(state)).toEqual(['channel:7', 'channel:9', 'dm:a']);
+    expect(state.activeKey).toBe('channel:7');
+  });
+
+  it('drops every tab and the home tab on disconnect', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: null });
+    expect(selectHomeKey(state)).toBeNull();
+    expect(keys(state)).toEqual(['dm:a']);
+    state = workspaceReducer(state, { type: 'WORKSPACE_RESET' });
+    expect(keys(state)).toEqual([]);
+    expect(state.activeKey).toBeNull();
+  });
+
+  it('returns the same state object when nothing changes', () => {
+    const state = joined('7');
+    expect(workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '7' })).toBe(state);
+    expect(workspaceReducer(state, { type: 'ACTIVATE_CONVERSATION', key: 'channel:7' })).toBe(state);
+    expect(workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'channel:404' })).toBe(state);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/workspace/workspaceState.test.ts`
+Expected: FAIL — `createWorkspaceState` returns the old shape and none of the new events exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/Brmble.Web/src/workspace/workspaceState.ts
+import { conversationKey, type Conversation } from './conversation';
+
+export interface WorkspaceState {
+  joinedChannelId: string | null;
+  tabs: Conversation[];
+  activeKey: string | null;
+}
+
+export type WorkspaceEvent =
+  | { type: 'JOINED_CHANNEL_CHANGED'; channelId: string | null }
+  | { type: 'OPEN_CONVERSATION'; conversation: Conversation }
+  | { type: 'CLOSE_CONVERSATION'; key: string }
+  | { type: 'ACTIVATE_CONVERSATION'; key: string }
+  | { type: 'CONVERSATION_INVALIDATED'; key: string }
+  | { type: 'RESTORE_CONVERSATIONS'; conversations: Conversation[] }
+  | { type: 'WORKSPACE_RESET' };
+
+export const createWorkspaceState = (): WorkspaceState => ({
+  joinedChannelId: null,
+  tabs: [],
+  activeKey: null,
+});
+
+export const selectHomeKey = (state: WorkspaceState): string | null =>
+  state.joinedChannelId === null ? null : `channel:${state.joinedChannelId}`;
+
+export const isHomeKey = (state: WorkspaceState, key: string): boolean =>
+  selectHomeKey(state) === key;
+
+export const selectActiveConversation = (state: WorkspaceState): Conversation | null =>
+  state.tabs.find(tab => conversationKey(tab) === state.activeKey) ?? null;
+
+function withoutKey(tabs: Conversation[], key: string | null): Conversation[] {
+  if (key === null) return tabs;
+  return tabs.filter(tab => conversationKey(tab) !== key);
+}
+
+function closeTab(state: WorkspaceState, key: string): WorkspaceState {
+  if (isHomeKey(state, key)) return state;
+  const index = state.tabs.findIndex(tab => conversationKey(tab) === key);
+  if (index === -1) return state;
+
+  const tabs = state.tabs.filter((_, position) => position !== index);
+  if (state.activeKey !== key) return { ...state, tabs };
+
+  const neighbour = tabs[index] ?? tabs[index - 1] ?? null;
+  const fallback = neighbour ? conversationKey(neighbour) : selectHomeKey(state);
+  return { ...state, tabs, activeKey: fallback };
+}
+
+export const workspaceReducer = (
+  state: WorkspaceState,
+  event: WorkspaceEvent,
+): WorkspaceState => {
+  switch (event.type) {
+    case 'JOINED_CHANNEL_CHANGED': {
+      if (event.channelId === state.joinedChannelId) return state;
+
+      const previousHomeKey = selectHomeKey(state);
+      const rest = withoutKey(state.tabs, previousHomeKey);
+
+      if (event.channelId === null) {
+        const activeKey = state.activeKey === previousHomeKey
+          ? (rest[0] ? conversationKey(rest[0]) : null)
+          : state.activeKey;
+        return { joinedChannelId: null, tabs: rest, activeKey };
+      }
+
+      const home: Conversation = { kind: 'channel', channelId: event.channelId };
+      const homeKey = conversationKey(home);
+      const absorbed = rest.some(tab => conversationKey(tab) === homeKey);
+      const tabs = [home, ...withoutKey(rest, homeKey)];
+      const activeKey = state.activeKey === previousHomeKey || state.activeKey === null || absorbed && state.activeKey === homeKey
+        ? homeKey
+        : tabs.some(tab => conversationKey(tab) === state.activeKey)
+          ? state.activeKey
+          : homeKey;
+
+      return { joinedChannelId: event.channelId, tabs, activeKey };
+    }
+
+    case 'OPEN_CONVERSATION': {
+      const key = conversationKey(event.conversation);
+      if (state.tabs.some(tab => conversationKey(tab) === key)) {
+        return state.activeKey === key ? state : { ...state, activeKey: key };
+      }
+      return { ...state, tabs: [...state.tabs, event.conversation], activeKey: key };
+    }
+
+    case 'ACTIVATE_CONVERSATION': {
+      if (state.activeKey === event.key) return state;
+      if (!state.tabs.some(tab => conversationKey(tab) === event.key)) return state;
+      return { ...state, activeKey: event.key };
+    }
+
+    case 'CLOSE_CONVERSATION':
+    case 'CONVERSATION_INVALIDATED':
+      return closeTab(state, event.key);
+
+    case 'RESTORE_CONVERSATIONS': {
+      const homeKey = selectHomeKey(state);
+      const home = state.tabs.find(tab => conversationKey(tab) === homeKey);
+      const seen = new Set<string>(homeKey ? [homeKey] : []);
+      const restored: Conversation[] = [];
+      for (const conversation of event.conversations) {
+        const key = conversationKey(conversation);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        restored.push(conversation);
+      }
+      const tabs = home ? [home, ...restored] : restored;
+      return { ...state, tabs, activeKey: homeKey ?? (tabs[0] ? conversationKey(tabs[0]) : null) };
+    }
+
+    case 'WORKSPACE_RESET': {
+      const homeKey = selectHomeKey(state);
+      const home = state.tabs.find(tab => conversationKey(tab) === homeKey);
+      return { ...state, tabs: home ? [home] : [], activeKey: home ? homeKey : null };
+    }
+  }
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run src/workspace/workspaceState.test.ts`
+Expected: PASS, 17 tests.
+
+- [ ] **Step 5: Confirm the scale of the breakage before proceeding**
+
+Run: `npx tsc -b --noEmit`
+Expected: FAIL, with errors in `App.tsx` for every removed field and event. This is the expected blast radius — record the error count, it is the checklist for Task 7.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/workspace/workspaceState.ts src/Brmble.Web/src/workspace/workspaceState.test.ts
+git commit -m "feat: replace workspace foreground state with conversation tabs"
+```
+
+---
+
+## Task 4: Validated Per-Server Tab Persistence
+
+Stored tabs are never trusted. A channel may have been deleted, chat permission revoked, or a DM contact may no longer resolve. The home tab is always recomputed from live presence and is never restored from storage.
+
+**Files:**
+- Create: `src/Brmble.Web/src/workspace/conversationStorage.ts`
+- Test: `src/Brmble.Web/src/workspace/conversationStorage.test.ts`
+
+**Interfaces:**
+- Consumes: `Conversation`, `conversationKey` from Task 1.
+- Produces: `saveConversationTabs(serverId: string, tabs: Conversation[]): void`, `loadConversationTabs(serverId: string, isValid: (c: Conversation) => boolean): Conversation[]`, `conversationStorageKey(serverId: string): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/Brmble.Web/src/workspace/conversationStorage.test.ts
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Conversation } from './conversation';
+import {
+  conversationStorageKey,
+  loadConversationTabs,
+  saveConversationTabs,
+} from './conversationStorage';
+
+const channel = (id: string): Conversation => ({ kind: 'channel', channelId: id });
+const dm = (id: string): Conversation => ({ kind: 'dm', contactId: id });
+const always = () => true;
+
+describe('conversation tab persistence', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('round-trips tabs for a server', () => {
+    saveConversationTabs('server-a', [channel('9'), dm('@val:example.com')]);
+    expect(loadConversationTabs('server-a', always)).toEqual([channel('9'), dm('@val:example.com')]);
+  });
+
+  it('scopes storage per server', () => {
+    saveConversationTabs('server-a', [channel('9')]);
+    saveConversationTabs('server-b', [channel('4')]);
+    expect(loadConversationTabs('server-a', always)).toEqual([channel('9')]);
+    expect(loadConversationTabs('server-b', always)).toEqual([channel('4')]);
+    expect(conversationStorageKey('server-a')).not.toBe(conversationStorageKey('server-b'));
+  });
+
+  it('returns an empty list when nothing is stored', () => {
+    expect(loadConversationTabs('server-a', always)).toEqual([]);
+  });
+
+  it('drops conversations the validator rejects', () => {
+    saveConversationTabs('server-a', [channel('9'), channel('404'), dm('gone')]);
+    const restored = loadConversationTabs('server-a', c =>
+      c.kind === 'channel' ? c.channelId === '9' : false);
+    expect(restored).toEqual([channel('9')]);
+  });
+
+  it('resets to empty on malformed json', () => {
+    localStorage.setItem(conversationStorageKey('server-a'), '{not json');
+    expect(loadConversationTabs('server-a', always)).toEqual([]);
+  });
+
+  it('resets to empty on an unexpected version', () => {
+    localStorage.setItem(conversationStorageKey('server-a'), JSON.stringify({ version: 99, tabs: [channel('9')] }));
+    expect(loadConversationTabs('server-a', always)).toEqual([]);
+  });
+
+  it('discards structurally invalid entries without discarding valid ones', () => {
+    localStorage.setItem(conversationStorageKey('server-a'), JSON.stringify({
+      version: 1,
+      tabs: [channel('9'), { kind: 'channel' }, { kind: 'wormhole', id: 1 }, null, dm('a')],
+    }));
+    expect(loadConversationTabs('server-a', always)).toEqual([channel('9'), dm('a')]);
+  });
+
+  it('deduplicates repeated keys', () => {
+    saveConversationTabs('server-a', [channel('9'), channel('9'), dm('a')]);
+    expect(loadConversationTabs('server-a', always)).toEqual([channel('9'), dm('a')]);
+  });
+
+  it('survives a storage write failure without throwing', () => {
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => { throw new Error('quota'); };
+    expect(() => saveConversationTabs('server-a', [channel('9')])).not.toThrow();
+    Storage.prototype.setItem = original;
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/workspace/conversationStorage.test.ts`
+Expected: FAIL — cannot resolve `./conversationStorage`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/Brmble.Web/src/workspace/conversationStorage.ts
+import { conversationKey, type Conversation } from './conversation';
+
+const STORAGE_VERSION = 1;
+const STORAGE_PREFIX = 'brmble-conversation-tabs';
+
+export function conversationStorageKey(serverId: string): string {
+  return `${STORAGE_PREFIX}:${serverId}`;
+}
+
+function isConversation(value: unknown): value is Conversation {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as { kind?: unknown; channelId?: unknown; contactId?: unknown };
+  if (candidate.kind === 'channel') return typeof candidate.channelId === 'string';
+  if (candidate.kind === 'dm') return typeof candidate.contactId === 'string';
+  return false;
+}
+
+function dedupe(conversations: Conversation[]): Conversation[] {
+  const seen = new Set<string>();
+  const result: Conversation[] = [];
+  for (const conversation of conversations) {
+    const key = conversationKey(conversation);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(conversation);
+  }
+  return result;
+}
+
+export function saveConversationTabs(serverId: string, tabs: Conversation[]): void {
+  try {
+    localStorage.setItem(
+      conversationStorageKey(serverId),
+      JSON.stringify({ version: STORAGE_VERSION, tabs: dedupe(tabs) }),
+    );
+  } catch {
+    // Persistence is best-effort; a full or unavailable store must never break the UI.
+  }
+}
+
+export function loadConversationTabs(
+  serverId: string,
+  isValid: (conversation: Conversation) => boolean,
+): Conversation[] {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(conversationStorageKey(serverId));
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return [];
+  const payload = parsed as { version?: unknown; tabs?: unknown };
+  if (payload.version !== STORAGE_VERSION || !Array.isArray(payload.tabs)) return [];
+
+  return dedupe(payload.tabs.filter(isConversation)).filter(isValid);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run src/workspace/conversationStorage.test.ts`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/workspace/conversationStorage.ts src/Brmble.Web/src/workspace/conversationStorage.test.ts
+git commit -m "feat: persist conversation tabs per server with validated restore"
+```
+
+---
+
+## Task 5: Wire App To Presence And Tabs
+
+Task 3 deliberately broke the build. This task makes it compile again by replacing every consumer of the deleted workspace fields. The visible layout is intentionally **unchanged** at the end of this task — the old `.content-slider` and both old splitters are still in place. Only the state underneath is new.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Modify: `src/Brmble.Web/src/components/DMContactList/DMContactList.tsx` (call sites only)
+- Test: `src/Brmble.Web/src/App.conversationTabs.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: everything produced by Tasks 1–4.
+- Produces: in `App.tsx`, `joinedChannelId: string | null`, `activeConversation: Conversation | null`, and `activeChannelChatId: string | undefined` (the channel id the `ChatPanel` should render, or `undefined` when the active conversation is a DM). Later layout tasks consume these three names.
+
+Replacements, one per broken reference:
+
+| Deleted | Replacement |
+|---|---|
+| `workspace.foreground.kind === 'dm'` | `activeConversation?.kind === 'dm'` |
+| `showChannelConversation` | `activeConversation?.kind === 'channel'` |
+| `foregroundDmContactId` | `activeConversation?.kind === 'dm' ? activeConversation.contactId : null` |
+| `messagesPanelExpanded` | literal `true` for now; removed entirely in Task 14 |
+| `dispatchWorkspace({ type: 'SELECT_CHANNEL' })` | `dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'channel', channelId } })` |
+| `dispatchWorkspace({ type: 'SELECT_DM', contactId })` | `dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId } })` |
+| `dispatchWorkspace({ type: 'SELECTED_DM_INVALIDATED' })` | `dispatchWorkspace({ type: 'CONVERSATION_INVALIDATED', key: conversationKey({ kind: 'dm', contactId }) })` |
+| `dispatchWorkspace({ type: 'REMOTE_WATCH_COUNT_CHANGED', count })` | delete the dispatch and the effect that raised it |
+| `dispatchWorkspace({ type: 'TOGGLE_MESSAGES_PANEL' })` / `OPEN_MESSAGES_PANEL` | delete; `toggleMessagesPanel` keeps only its `setShowGame(false)` behaviour until Task 14 removes it |
+| `dispatchWorkspace({ type: 'CONNECTION_WORKSPACE_READY' })` | `dispatchWorkspace({ type: 'WORKSPACE_RESET' })` |
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/Brmble.Web/src/App.conversationTabs.test.tsx
+import { describe, expect, it } from 'vitest';
+import { conversationKey } from './workspace/conversation';
+import { selectJoinedChannelId } from './workspace/presence';
+import {
+  createWorkspaceState,
+  selectActiveConversation,
+  selectHomeKey,
+  workspaceReducer,
+} from './workspace/workspaceState';
+
+// Presence and tabs must agree: whatever selectJoinedChannelId reports is the home tab.
+describe('App presence and tab wiring contract', () => {
+  it('derives the home tab from the self user channel', () => {
+    const joinedChannelId = selectJoinedChannelId([{ channelId: 3 }, { self: true, channelId: 7 }]);
+    const state = workspaceReducer(createWorkspaceState(), { type: 'JOINED_CHANNEL_CHANGED', channelId: joinedChannelId });
+    expect(selectHomeKey(state)).toBe('channel:7');
+  });
+
+  it('opens a browsed channel without disturbing presence', () => {
+    let state = workspaceReducer(createWorkspaceState(), { type: 'JOINED_CHANNEL_CHANGED', channelId: '7' });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: { kind: 'channel', channelId: '9' } });
+    expect(state.joinedChannelId).toBe('7');
+    expect(selectHomeKey(state)).toBe('channel:7');
+    expect(conversationKey(selectActiveConversation(state)!)).toBe('channel:9');
+  });
+
+  it('invalidates a dm by key', () => {
+    let state = workspaceReducer(createWorkspaceState(), { type: 'JOINED_CHANNEL_CHANGED', channelId: '7' });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: 'a' } });
+    state = workspaceReducer(state, { type: 'CONVERSATION_INVALIDATED', key: conversationKey({ kind: 'dm', contactId: 'a' }) });
+    expect(state.tabs.map(conversationKey)).toEqual(['channel:7']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/App.conversationTabs.test.tsx`
+Expected: FAIL — the suite cannot compile while `App.tsx` still references deleted workspace fields.
+
+- [ ] **Step 3: Derive presence and the active conversation in App**
+
+Replace the ad-hoc derivation at `App.tsx:4340` and add the new derived values near the workspace reducer usage (around `App.tsx:1687`):
+
+```tsx
+import { conversationKey, type Conversation } from './workspace/conversation';
+import { selectJoinedChannelId } from './workspace/presence';
+import { loadConversationTabs, saveConversationTabs } from './workspace/conversationStorage';
+import { selectActiveConversation, selectHomeKey } from './workspace/workspaceState';
+
+const joinedChannelId = selectJoinedChannelId(users);
+const activeConversation = selectActiveConversation(workspace);
+const activeChannelChatId = activeConversation?.kind === 'channel'
+  ? activeConversation.channelId
+  : undefined;
+```
+
+Keep `selfVoiceChannelId` as a thin alias during this task so unrelated call sites keep compiling:
+
+```tsx
+const selfVoiceChannelId = joinedChannelId === null || joinedChannelId === 'server-root'
+  ? undefined
+  : Number(joinedChannelId);
+```
+
+- [ ] **Step 4: Feed presence changes into the reducer**
+
+```tsx
+useEffect(() => {
+  dispatchWorkspace({ type: 'JOINED_CHANNEL_CHANGED', channelId: joinedChannelId });
+}, [joinedChannelId]);
+```
+
+Delete the two `setCurrentChannelId('server-root')` side effects at `App.tsx:2156` and `App.tsx:2716` that exist only to make the viewed channel follow a voice move — presence now drives the home tab directly. Keep `setCurrentChannelName` updates; the name is still needed for display.
+
+- [ ] **Step 5: Restore and persist tabs**
+
+```tsx
+useEffect(() => {
+  if (!connected || !serverId) return;
+  const restored = loadConversationTabs(serverId, conversation =>
+    conversation.kind === 'dm'
+      ? true
+      : canOpenChannelChat(conversation.channelId, channels));
+  dispatchWorkspace({ type: 'RESTORE_CONVERSATIONS', conversations: restored });
+}, [connected, serverId]);
+```
+
+Restore must run once the channel list has arrived, otherwise every channel tab is rejected as unknown. Guard on the channel list being non-empty, and keep the effect's dependency array free of `channels` so a later roster update cannot re-trigger a restore that would discard tabs the user opened since connecting.
+
+```tsx
+useEffect(() => {
+  if (!connected || !serverId) return;
+  const homeKey = selectHomeKey(workspace);
+  saveConversationTabs(serverId, workspace.tabs.filter(tab => conversationKey(tab) !== homeKey));
+}, [connected, serverId, workspace.tabs, workspace.joinedChannelId]);
+```
+
+`serverId` is the stable identifier of the connected server already available in App's connection state. If no such stable value exists, use the server host and port joined by a colon — it must not be the user-editable label.
+
+- [ ] **Step 6: Replace every remaining broken reference**
+
+Work through the table above. `handleSelectChannel` (`App.tsx:3428-3440`) keeps its permission check via `getChannelSelectionOutcome` and its `setShowGame(false)`, but its terminal action becomes an `OPEN_CONVERSATION` dispatch rather than `setCurrentChannelId` plus `SELECT_CHANNEL`. Leave `currentChannelId` in place for now as a derived alias so untouched call sites still work:
+
+```tsx
+const currentChannelId = activeChannelChatId;
+```
+
+- [ ] **Step 7: Verify the build and the whole suite**
+
+Run: `npx tsc -b --noEmit`
+Expected: PASS, zero errors.
+
+Run: `npm test -- --run`
+Expected: PASS. Tests asserting the deleted Messages-panel auto-collapse behaviour will fail; delete those cases — the behaviour is intentionally gone. Tests asserting DM slide transitions still pass because the layout is unchanged.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Brmble.Web/src
+git commit -m "refactor: drive App from presence and conversation tabs"
+```
+
+---
+
+## Task 6: Bug Fix — Paint No Longer Closes When Browsing
+
+Paint sessions are created against the joined channel (`App.tsx:4650`) but kept alive against the viewed channel (`App.tsx:1371-1379`), so clicking any other channel silently destroys a live canvas.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx:1371-1379`, and the two assignments to `activePaintChannelIdRef` at `App.tsx:4740` and `App.tsx:4802`
+- Test: `src/Brmble.Web/src/App.paintPresence.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `joinedChannelId` from Task 5.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/Brmble.Web/src/App.paintPresence.test.tsx
+import { describe, expect, it } from 'vitest';
+import { shouldKeepPaintSession } from './App';
+
+describe('paint session survival', () => {
+  it('survives while the user stays in the channel that owns the session', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: '7', joinedChannelId: '7' })).toBe(true);
+  });
+
+  it('survives while the user browses another channel', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: '7', joinedChannelId: '7' })).toBe(true);
+  });
+
+  it('ends when the user moves to a different voice channel', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: '7', joinedChannelId: '12' })).toBe(false);
+  });
+
+  it('ends when the user leaves voice entirely', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: '7', joinedChannelId: null })).toBe(false);
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: '7', joinedChannelId: 'server-root' })).toBe(false);
+  });
+
+  it('ends when the connection drops', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'disconnected', sessionChannelId: '7', joinedChannelId: '7' })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/App.paintPresence.test.tsx`
+Expected: FAIL — `shouldKeepPaintSession` is not exported from `App.tsx`.
+
+- [ ] **Step 3: Extract and rebind the guard**
+
+Export a pure predicate from `App.tsx`, alongside the other exported pure helpers such as `canOpenChannelChat` at `App.tsx:694`:
+
+```tsx
+export function shouldKeepPaintSession(input: {
+  connectionStatus: string;
+  sessionChannelId: string | undefined;
+  joinedChannelId: string | null;
+}): boolean {
+  if (input.connectionStatus !== 'connected') return false;
+  if (input.joinedChannelId === null || input.joinedChannelId === 'server-root') return false;
+  return input.sessionChannelId === input.joinedChannelId;
+}
+```
+
+Rewrite the effect at `App.tsx:1371-1379` to use it:
+
+```tsx
+if (!shouldKeepPaintSession({
+  connectionStatus,
+  sessionChannelId: activePaintChannelIdRef.current,
+  joinedChannelId,
+})) {
+  activePaintSessionIdRef.current = null;
+  setActivePaintSessionId(null);
+  activePaintChannelIdRef.current = undefined;
+}
+```
+
+Change both writers so the ref records the channel that actually owns the session. At `App.tsx:4740` and `App.tsx:4802`, replace `activePaintChannelIdRef.current = currentChannelId` with `activePaintChannelIdRef.current = joinedChannelId ?? undefined`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run src/App.paintPresence.test.tsx`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx src/Brmble.Web/src/App.paintPresence.test.tsx
+git commit -m "fix: keep paint sessions alive while browsing another channel"
+```
+
+---
+
+## Task 7: Bug Fix — Screen Share Follows Presence
+
+Publishing is gated on the joined channel (`App.tsx:4340-4341`) but watching and discovery are gated on the viewed channel (`App.tsx:477-480`, `App.tsx:4432-4437`). The asymmetry means clicking another channel makes your own channel's share unwatchable.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx:477-480` (`canWatchShareFromChannel`), `App.tsx:4432-4437` (discovery effect), `App.tsx:4526` (call site)
+- Test: `src/Brmble.Web/src/App.sharePresence.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `joinedChannelId` from Task 5.
+- Produces: `canWatchShareFromChannel(joinedChannelId: string | null, shareRoomName: string): boolean` — the first parameter changes meaning from viewed to joined. The signature shape is unchanged, so update the existing tests rather than adding a parallel helper.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/Brmble.Web/src/App.sharePresence.test.tsx
+import { describe, expect, it } from 'vitest';
+import { canWatchShareFromChannel } from './App';
+
+describe('canWatchShareFromChannel', () => {
+  it('allows watching a share published into the joined channel', () => {
+    expect(canWatchShareFromChannel('7', 'channel-7')).toBe(true);
+  });
+
+  it('still allows it while the user browses a different channel', () => {
+    // The viewed channel is irrelevant now; only presence matters.
+    expect(canWatchShareFromChannel('7', 'channel-7')).toBe(true);
+  });
+
+  it('rejects a share from any other channel', () => {
+    expect(canWatchShareFromChannel('7', 'channel-9')).toBe(false);
+  });
+
+  it('rejects when not in a channel', () => {
+    expect(canWatchShareFromChannel(null, 'channel-7')).toBe(false);
+    expect(canWatchShareFromChannel('server-root', 'channel-7')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/App.sharePresence.test.tsx`
+Expected: FAIL — the third case passes by accident but the null/`server-root` case and the parameter meaning do not match; the existing `App.test.tsx` cases for this helper also fail once rebound.
+
+- [ ] **Step 3: Rebind the helper and its callers**
+
+```tsx
+export function canWatchShareFromChannel(
+  joinedChannelId: string | null,
+  shareRoomName: string,
+): boolean {
+  if (!joinedChannelId || joinedChannelId === 'server-root') return false;
+  return shareRoomName === `channel-${joinedChannelId}`;
+}
+```
+
+Update the call site at `App.tsx:4526` to pass `joinedChannelId`. Change the discovery effect at `App.tsx:4432-4437` to depend on presence rather than selection:
+
+```tsx
+useEffect(() => {
+  setScreenShareNotification(null);
+  notifQueueRef.current.unregister('screen-share');
+  requestActiveShareDiscoveryRef.current?.(joinedChannelId ?? undefined);
+}, [joinedChannelId]);
+```
+
+`requestActiveShareDiscovery` at `App.tsx:4406-4422` keeps its existing `'server-root'` branch, which now means "not in a channel" and correctly yields the `{ scope: 'all' }` target.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --run src/App.sharePresence.test.tsx src/App.test.tsx`
+Expected: PASS. Update any existing case in `App.test.tsx` that passed a viewed channel id — the argument is now the joined channel.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/App.tsx src/Brmble.Web/src/App.sharePresence.test.tsx src/Brmble.Web/src/App.test.tsx
+git commit -m "fix: bind screen share watching and discovery to the joined channel"
+```
+
+---
+
+## Task 8: Bug Fix — Challenge Gate And Sidebar Presence Marker
+
+The challenge context item is gated on the viewed channel (`ChannelTree.tsx:635-651`) while the server requires the same voice channel (`DuelOrchestrator.cs:121-125`), so it is offered where it will be rejected and hidden where it would succeed. Separately, the sidebar `current` highlight follows the viewed channel (`ChannelTree.tsx:285`), leaving no indication anywhere of which channel the user is in.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx`
+- Modify: `src/Brmble.Web/src/components/Sidebar/Sidebar.tsx` (prop threading)
+- Modify: `src/Brmble.Web/src/App.tsx` (prop wiring at `App.tsx:4816`, `App.tsx:4837`)
+- Modify: `src/Brmble.Web/src/components/Sidebar/ChannelTree.css`
+- Test: `src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx`
+
+**Interfaces:**
+- Consumes: `joinedChannelId` from Task 5.
+- Produces: `ChannelTree` gains `joinedChannelId?: number` alongside the existing `currentChannelId?: number`. `currentChannelId` keeps its meaning — the active conversation — and gains no new responsibility.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// added to src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+it('marks the joined channel separately from the active conversation', () => {
+  render(<ChannelTree {...props} currentChannelId={9} joinedChannelId={7} />);
+  expect(screen.getByRole('treeitem', { name: /General/ })).toHaveClass('channel-row--joined');
+  expect(screen.getByRole('treeitem', { name: /Random/ })).toHaveClass('current');
+  expect(screen.getByRole('treeitem', { name: /Random/ })).not.toHaveClass('channel-row--joined');
+});
+
+it('offers Challenge only for users in the joined channel', () => {
+  const { rerender } = render(
+    <ChannelTree {...props} currentChannelId={9} joinedChannelId={7} users={[brmbleUserInChannel(7)]} />,
+  );
+  fireEvent.contextMenu(screen.getByText('Alice'));
+  expect(screen.getByRole('menuitem', { name: /Challenge/ })).toBeInTheDocument();
+
+  rerender(<ChannelTree {...props} currentChannelId={9} joinedChannelId={12} users={[brmbleUserInChannel(7)]} />);
+  fireEvent.contextMenu(screen.getByText('Alice'));
+  expect(screen.queryByRole('menuitem', { name: /Challenge/ })).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/components/Sidebar/ChannelTree.test.tsx`
+Expected: FAIL — `joinedChannelId` is not a prop and `channel-row--joined` does not exist.
+
+- [ ] **Step 3: Add the prop, the marker, and the corrected gate**
+
+Add `joinedChannelId?: number` to `ChannelTreeProps`. At the channel row (`ChannelTree.tsx:285`, `:303`) keep `isCurrentChannel` bound to `currentChannelId` and add a second, independent flag:
+
+```tsx
+const isJoinedChannel = joinedChannelId === channel.id;
+// className: [..., isCurrentChannel && 'current', isJoinedChannel && 'channel-row--joined']
+```
+
+Replace the eligibility check at `ChannelTree.tsx:635-651`:
+
+```tsx
+const eligible = !!target?.isBrmbleClient
+  && contextMenu.channelId != null
+  && contextMenu.channelId === joinedChannelId;
+```
+
+In `ChannelTree.css`, style `.channel-row--joined` using existing tokens only — a left accent border drawn with `var(--accent-primary)` and no new colour literals. The marker must be distinguishable from `.current` without relying on colour alone; add a visually hidden suffix to the row's accessible name, for example `<span className="sr-only"> (you are here)</span>`.
+
+Thread `joinedChannelId` through `Sidebar.tsx` and pass it from `App.tsx` next to the existing `currentChannelId` prop at `App.tsx:4816`:
+
+```tsx
+joinedChannelId={joinedChannelId && joinedChannelId !== 'server-root' ? Number(joinedChannelId) : undefined}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --run src/components/Sidebar/ChannelTree.test.tsx`
+Expected: PASS, including the pre-existing cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/Sidebar src/Brmble.Web/src/App.tsx
+git commit -m "fix: gate duel challenges on presence and mark the joined channel"
+```
+
+- [ ] **Step 6: Gate — state phase complete**
+
+Run: `npx tsc -b --noEmit` and `npm test -- --run`
+Expected: both PASS. Do not begin Task 9 until this gate is green; the spec's ordering constraint exists to keep the layout work off unstable state.
+
+---
+
+## Task 9: Main Panel Mode Selection
+
+**Files:**
+- Create: `src/Brmble.Web/src/workspace/mainPanelMode.ts`
+- Test: `src/Brmble.Web/src/workspace/mainPanelMode.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `type MainPanelMode = 'game' | 'split'` and `selectMainPanelMode(input: { idleGameOpen: boolean; participatingMatchId: string | null }): MainPanelMode`. Note the input is *participation*, not spectating — watching a duel never takes the panel.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/Brmble.Web/src/workspace/mainPanelMode.test.ts
+import { describe, expect, it } from 'vitest';
+import { selectMainPanelMode } from './mainPanelMode';
+
+describe('selectMainPanelMode', () => {
+  it('splits when nothing is being played', () => {
+    expect(selectMainPanelMode({ idleGameOpen: false, participatingMatchId: null })).toBe('split');
+  });
+
+  it('takes the panel for the idle game', () => {
+    expect(selectMainPanelMode({ idleGameOpen: true, participatingMatchId: null })).toBe('game');
+  });
+
+  it('takes the panel while participating in a match', () => {
+    expect(selectMainPanelMode({ idleGameOpen: false, participatingMatchId: 'match-1' })).toBe('game');
+  });
+
+  it('prefers the match when both are somehow set', () => {
+    expect(selectMainPanelMode({ idleGameOpen: true, participatingMatchId: 'match-1' })).toBe('game');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/workspace/mainPanelMode.test.ts`
+Expected: FAIL — cannot resolve `./mainPanelMode`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/Brmble.Web/src/workspace/mainPanelMode.ts
+export type MainPanelMode = 'game' | 'split';
+
+export function selectMainPanelMode(input: {
+  idleGameOpen: boolean;
+  participatingMatchId: string | null;
+}): MainPanelMode {
+  return input.participatingMatchId !== null || input.idleGameOpen ? 'game' : 'split';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run src/workspace/mainPanelMode.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/workspace/mainPanelMode.ts src/Brmble.Web/src/workspace/mainPanelMode.test.ts
+git commit -m "feat: add main panel mode selection"
+```
+
+---
+
+## Task 10: Game Mode Takes The Whole Panel
+
+`NeonDGame` already replaces `<main>` (`App.tsx:4870`) but as a special case suppressed by paint. `DeathrollModal` and `RpsModal` are modal overlays. All three become the same thing: the sole content of the main panel.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx` (render block `App.tsx:4869-4951`, and the modal render sites for Deathroll and RPS)
+- Test: `src/Brmble.Web/src/App.gameMode.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `selectMainPanelMode` from Task 9, `useGameState`'s existing active-match value.
+- Produces: `mainPanelMode` in `App.tsx`, consumed by Tasks 14 and 17.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/Brmble.Web/src/App.gameMode.test.tsx
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MainPanel } from './components/MainPanel/MainPanel';
+
+// MainPanel is the extracted render decision; App composes it.
+describe('main panel game mode', () => {
+  const base = {
+    activityRegion: <div>activity</div>,
+    conversationRegion: <div>conversation</div>,
+    gameSurface: <div>game surface</div>,
+  };
+
+  it('renders the split layout when not playing', () => {
+    render(<MainPanel {...base} mode="split" />);
+    expect(screen.getByText('activity')).toBeInTheDocument();
+    expect(screen.getByText('conversation')).toBeInTheDocument();
+    expect(screen.queryByText('game surface')).not.toBeInTheDocument();
+  });
+
+  it('renders only the game surface when playing', () => {
+    render(<MainPanel {...base} mode="game" />);
+    expect(screen.getByText('game surface')).toBeInTheDocument();
+    expect(screen.queryByText('activity')).not.toBeInTheDocument();
+    expect(screen.queryByText('conversation')).not.toBeInTheDocument();
+  });
+
+  it('omits the activity region entirely when there is no activity', () => {
+    render(<MainPanel {...base} mode="split" activityRegion={null} />);
+    expect(screen.queryByText('activity')).not.toBeInTheDocument();
+    expect(screen.getByText('conversation')).toBeInTheDocument();
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/App.gameMode.test.tsx`
+Expected: FAIL — `components/MainPanel/MainPanel` does not exist.
+
+- [ ] **Step 3: Create the MainPanel component**
+
+```tsx
+// src/Brmble.Web/src/components/MainPanel/MainPanel.tsx
+import type { ReactNode } from 'react';
+import { VerticalSplitPane } from '../VerticalSplitPane/VerticalSplitPane';
+import type { MainPanelMode } from '../../workspace/mainPanelMode';
+
+export const MAIN_PANEL_SPLIT_STORAGE_KEY = 'brmble-main-split';
+
+interface MainPanelProps {
+  mode: MainPanelMode;
+  activityRegion: ReactNode | null;
+  conversationRegion: ReactNode;
+  gameSurface: ReactNode;
+}
+
+export function MainPanel({ mode, activityRegion, conversationRegion, gameSurface }: MainPanelProps) {
+  if (mode === 'game') return <>{gameSurface}</>;
+
+  return (
+    <VerticalSplitPane
+      top={activityRegion}
+      storageKey={MAIN_PANEL_SPLIT_STORAGE_KEY}
+      label="Resize channel activity and conversation"
+    >
+      {conversationRegion}
+    </VerticalSplitPane>
+  );
+}
+```
+
+`VerticalSplitPane` already renders neither the top pane nor the divider when `top` is `null`, which satisfies the third test without extra code.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run src/App.gameMode.test.tsx`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Wire App to MainPanel and retire the game special cases**
+
+Replace the `showGame && !activePaintSessionId ? <NeonDGame/> : <div className="content-slider">…` block at `App.tsx:4869-4951` with a `<MainPanel>`. Compute the mode:
+
+```tsx
+const participatingMatchId = activeGameMatch?.matchId ?? null;
+const mainPanelMode = selectMainPanelMode({ idleGameOpen: showGame, participatingMatchId });
+```
+
+`gameSurface` renders `NeonDGame` when `showGame` is set, otherwise the participant surface for the active match — the existing `DeathrollModal` and `RpsModal` bodies, rendered inline rather than inside `div.modal-overlay`. Remove `role="dialog"`, `aria-modal`, the overlay click-to-close, and the focus trap from both; a full-panel surface is not a dialog. Keep their close and forfeit controls.
+
+Delete the paint suppression: the condition becomes `mainPanelMode === 'game'`, with no `!activePaintSessionId` term. Delete the `setShowGame(false)` calls at `App.tsx:3434` and `App.tsx:1715`; leaving game mode is now driven by closing the game or the match ending, not by unrelated navigation.
+
+Add the exit effect so a finished match returns to split mode:
+
+```tsx
+useEffect(() => {
+  if (participatingMatchId === null) return;
+  if (activeGameMatch?.state === 'complete') setShowGame(false);
+}, [participatingMatchId, activeGameMatch?.state]);
+```
+
+Paint and screen share continue running underneath and are simply re-rendered when the mode returns to `split`; nothing tears them down.
+
+- [ ] **Step 6: Verify**
+
+Run: `npx tsc -b --noEmit` and `npm test -- --run`
+Expected: PASS. Delete cases in existing Deathroll/RPS modal tests that assert `role="dialog"` or overlay dismissal; keep every case covering game behaviour.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Web/src
+git commit -m "feat: give active games the whole main panel"
+```
+
+---
+
+## Task 11: Activity Stage Selection Rules
+
+The stage shows exactly one activity. First to appear wins, later arrivals never steal it, an explicit choice always wins, and a departing activity hands over rather than leaving the region blank.
+
+**Files:**
+- Create: `src/Brmble.Web/src/workspace/channelActivity.ts`
+- Test: `src/Brmble.Web/src/workspace/channelActivity.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `type ChannelActivityKind = 'screen-share' | 'paint'` and `selectStage(input: { available: ChannelActivityKind[]; explicit: ChannelActivityKind | null; previous: ChannelActivityKind | null }): ChannelActivityKind | null`. Task 17 adds `'duel'` to the union in the follow-up project; the function must not special-case any member.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/Brmble.Web/src/workspace/channelActivity.test.ts
+import { describe, expect, it } from 'vitest';
+import { selectStage } from './channelActivity';
+
+describe('selectStage', () => {
+  it('returns nothing when the channel is quiet', () => {
+    expect(selectStage({ available: [], explicit: null, previous: null })).toBeNull();
+  });
+
+  it('stages the first activity to appear', () => {
+    expect(selectStage({ available: ['screen-share'], explicit: null, previous: null })).toBe('screen-share');
+  });
+
+  it('does not let a later activity steal the stage', () => {
+    expect(selectStage({ available: ['screen-share', 'paint'], explicit: null, previous: 'screen-share' })).toBe('screen-share');
+  });
+
+  it('honours an explicit choice', () => {
+    expect(selectStage({ available: ['screen-share', 'paint'], explicit: 'paint', previous: 'screen-share' })).toBe('paint');
+  });
+
+  it('ignores an explicit choice that is no longer available', () => {
+    expect(selectStage({ available: ['screen-share'], explicit: 'paint', previous: null })).toBe('screen-share');
+  });
+
+  it('hands over when the staged activity ends', () => {
+    expect(selectStage({ available: ['paint'], explicit: null, previous: 'screen-share' })).toBe('paint');
+  });
+
+  it('returns nothing when the last activity ends', () => {
+    expect(selectStage({ available: [], explicit: 'paint', previous: 'paint' })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/workspace/channelActivity.test.ts`
+Expected: FAIL — cannot resolve `./channelActivity`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/Brmble.Web/src/workspace/channelActivity.ts
+export type ChannelActivityKind = 'screen-share' | 'paint';
+
+export function selectStage(input: {
+  available: ChannelActivityKind[];
+  explicit: ChannelActivityKind | null;
+  previous: ChannelActivityKind | null;
+}): ChannelActivityKind | null {
+  if (input.available.length === 0) return null;
+  if (input.explicit && input.available.includes(input.explicit)) return input.explicit;
+  if (input.previous && input.available.includes(input.previous)) return input.previous;
+  return input.available[0];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run src/workspace/channelActivity.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/workspace/channelActivity.ts src/Brmble.Web/src/workspace/channelActivity.test.ts
+git commit -m "feat: add channel activity stage selection"
+```
+
+---
+
+## Task 12: Channel Activity Region
+
+**Files:**
+- Create: `src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.tsx`
+- Create: `src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.module.css`
+- Modify: `src/Brmble.Web/src/index.css` (add `--activity-stage-min-height`)
+- Test: `src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.test.tsx`
+
+**Interfaces:**
+- Consumes: `ChannelActivityKind` from Task 11.
+- Produces: `ChannelActivityRegion` with props `{ channelName: string; activities: { kind: ChannelActivityKind; label: string }[]; stage: ChannelActivityKind | null; onSelect: (kind: ChannelActivityKind) => void; children: ReactNode }`. `children` is the staged surface, chosen by the caller.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.test.tsx
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ChannelActivityRegion } from './ChannelActivityRegion';
+
+const activities = [
+  { kind: 'screen-share' as const, label: 'Screen share' },
+  { kind: 'paint' as const, label: 'Paint' },
+];
+
+describe('ChannelActivityRegion', () => {
+  it('names the channel and lists every live activity', () => {
+    render(
+      <ChannelActivityRegion channelName="General" activities={activities} stage="screen-share" onSelect={vi.fn()}>
+        <div>stage content</div>
+      </ChannelActivityRegion>,
+    );
+    expect(screen.getByRole('region', { name: 'General activity' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Screen share' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Paint' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByText('stage content')).toBeInTheDocument();
+  });
+
+  it('reports an explicit selection', () => {
+    const onSelect = vi.fn();
+    render(
+      <ChannelActivityRegion channelName="General" activities={activities} stage="screen-share" onSelect={onSelect}>
+        <div>stage content</div>
+      </ChannelActivityRegion>,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Paint' }));
+    expect(onSelect).toHaveBeenCalledWith('paint');
+  });
+
+  it('renders a single chip without a switcher affordance disappearing', () => {
+    render(
+      <ChannelActivityRegion channelName="General" activities={[activities[0]]} stage="screen-share" onSelect={vi.fn()}>
+        <div>stage content</div>
+      </ChannelActivityRegion>,
+    );
+    expect(screen.getAllByRole('tab')).toHaveLength(1);
+  });
+
+  it('moves between chips with the arrow keys', () => {
+    const onSelect = vi.fn();
+    render(
+      <ChannelActivityRegion channelName="General" activities={activities} stage="screen-share" onSelect={onSelect}>
+        <div>stage content</div>
+      </ChannelActivityRegion>,
+    );
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Screen share' }), { key: 'ArrowRight' });
+    expect(onSelect).toHaveBeenCalledWith('paint');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/components/ChannelActivityRegion/ChannelActivityRegion.test.tsx`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Write the component**
+
+```tsx
+// src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.tsx
+import type { ReactNode } from 'react';
+import type { ChannelActivityKind } from '../../workspace/channelActivity';
+import styles from './ChannelActivityRegion.module.css';
+
+interface ChannelActivityRegionProps {
+  channelName: string;
+  activities: { kind: ChannelActivityKind; label: string }[];
+  stage: ChannelActivityKind | null;
+  onSelect: (kind: ChannelActivityKind) => void;
+  children: ReactNode;
+}
+
+export function ChannelActivityRegion({
+  channelName,
+  activities,
+  stage,
+  onSelect,
+  children,
+}: ChannelActivityRegionProps) {
+  const move = (index: number, delta: number) => {
+    const next = activities[(index + delta + activities.length) % activities.length];
+    if (next) onSelect(next.kind);
+  };
+
+  return (
+    <section className={styles.region} aria-label={`${channelName} activity`}>
+      <header className={styles.header}>
+        <span className={styles.channelName}>{channelName}</span>
+        <div className={styles.chips} role="tablist" aria-label="Channel activities">
+          {activities.map((activity, index) => (
+            <button
+              key={activity.kind}
+              type="button"
+              role="tab"
+              aria-selected={stage === activity.kind}
+              tabIndex={stage === activity.kind ? 0 : -1}
+              className={`${styles.chip} ${stage === activity.kind ? styles.chipActive : ''}`}
+              onClick={() => onSelect(activity.kind)}
+              onKeyDown={event => {
+                if (event.key === 'ArrowRight') { event.preventDefault(); move(index, 1); }
+                if (event.key === 'ArrowLeft') { event.preventDefault(); move(index, -1); }
+              }}
+            >
+              {activity.label}
+            </button>
+          ))}
+        </div>
+      </header>
+      <div className={styles.stage}>{children}</div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Write the stylesheet and the token**
+
+Add to the `:root` block of `src/Brmble.Web/src/index.css`, beside the other layout tokens:
+
+```css
+--activity-stage-min-height: 8rem;
+```
+
+```css
+/* src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.module.css */
+.region { display: flex; flex: 1; flex-direction: column; min-height: 0; min-width: 0; overflow: hidden; }
+.header { display: flex; align-items: center; gap: var(--space-xs); padding: var(--space-2xs) var(--space-sm); background: var(--bg-elevated); flex: none; }
+.channelName { font-weight: 600; }
+.chips { display: flex; gap: var(--space-2xs); flex-wrap: wrap; min-width: 0; }
+.chip { padding: var(--space-2xs) var(--space-xs); border: none; border-radius: var(--radius-pill); background: var(--bg-subtle); color: var(--text-secondary); cursor: pointer; transition: background var(--transition-fast); }
+.chip:hover { background: var(--bg-hover); }
+.chip:focus-visible { outline: 2px solid var(--accent-primary); outline-offset: 2px; }
+.chipActive { background: var(--accent-primary); color: var(--text-on-accent); }
+.stage { flex: 1; min-height: var(--activity-stage-min-height); display: flex; min-width: 0; overflow: hidden; }
+```
+
+Use the exact token names present in `src/Brmble.Web/src/themes/_template.css`. If `--radius-pill`, `--bg-subtle`, `--bg-hover` or `--text-on-accent` are not defined there, substitute the nearest existing token rather than inventing a literal, and record the substitution in the commit message.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- --run src/components/ChannelActivityRegion/ChannelActivityRegion.test.tsx`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/ChannelActivityRegion src/Brmble.Web/src/index.css
+git commit -m "feat: add the channel activity region"
+```
+
+---
+
+## Task 13: Grace-Period Hide For Backgrounded Shares
+
+When a share leaves the stage it stays subscribed for 10 seconds so quick switching is instant, then unsubscribes to stop decoding and downloading. Watched list, order, focus, receive quality, room membership and local publishing must be untouched throughout.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/hooks/useScreenShare.ts`
+- Test: `src/Brmble.Web/src/hooks/useScreenShare.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `setRemoteScreenSharesHidden(hidden: boolean): void` on the `useScreenShare` return value, and the exported constant `REMOTE_HIDE_GRACE_MS = 10_000`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// added to src/Brmble.Web/src/hooks/useScreenShare.test.ts
+import { REMOTE_HIDE_GRACE_MS } from './useScreenShare';
+
+it('keeps a hidden share subscribed during the grace period', async () => {
+  vi.useFakeTimers();
+  const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+  act(() => result.current.setRemoteScreenSharesHidden(true));
+  act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS - 1); });
+  expect(publicationFor(10).setSubscribed).not.toHaveBeenCalledWith(false);
+  vi.useRealTimers();
+});
+
+it('unsubscribes once the grace period elapses', async () => {
+  vi.useFakeTimers();
+  const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+  act(() => result.current.setRemoteScreenSharesHidden(true));
+  act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+  expect(publicationFor(10).setSubscribed).toHaveBeenCalledWith(false);
+  vi.useRealTimers();
+});
+
+it('cancels the pending unsubscribe when the share returns to the stage', async () => {
+  vi.useFakeTimers();
+  const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+  act(() => result.current.setRemoteScreenSharesHidden(true));
+  act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS - 1); });
+  act(() => result.current.setRemoteScreenSharesHidden(false));
+  act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+  expect(publicationFor(10).setSubscribed).not.toHaveBeenCalledWith(false);
+  vi.useRealTimers();
+});
+
+it('preserves viewer state while hidden and after restoring', async () => {
+  vi.useFakeTimers();
+  const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+  act(() => result.current.setRemoteScreenSharesHidden(true));
+  act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+  expect(result.current.viewerQualities.get(10)).toBe('medium');
+  expect(result.current.focusedShare?.userId).toBe(10);
+  expect(result.current.watchingShares).toHaveLength(1);
+  expect(mockRoom.disconnect).not.toHaveBeenCalled();
+  expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalledWith(false);
+  expect(result.current.isSharing).toBe(true);
+  vi.useRealTimers();
+});
+
+it('drops a share that ended while hidden instead of resubscribing to it', async () => {
+  vi.useFakeTimers();
+  const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+  act(() => result.current.setRemoteScreenSharesHidden(true));
+  act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+  act(() => emitScreenShareStopped(10));
+  act(() => result.current.setRemoteScreenSharesHidden(false));
+  expect(result.current.watchingShares).toHaveLength(0);
+  vi.useRealTimers();
+});
+
+it('immediately unsubscribes a share published while hidden', async () => {
+  vi.useFakeTimers();
+  const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+  act(() => result.current.setRemoteScreenSharesHidden(true));
+  act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+  act(() => emitTrackPublished(10, Track.Source.ScreenShare));
+  expect(publicationFor(10).setSubscribed).toHaveBeenLastCalledWith(false);
+  vi.useRealTimers();
+});
+
+it('clears the pending timer on unmount', async () => {
+  vi.useFakeTimers();
+  const { result, unmount } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+  act(() => result.current.setRemoteScreenSharesHidden(true));
+  unmount();
+  expect(() => vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS)).not.toThrow();
+  vi.useRealTimers();
+});
+```
+
+Extend the existing LiveKit mock in this file with `RoomEvent.TrackPublished` and helpers `publicationFor(userId)`, `emitTrackPublished(userId, source)` and `emitScreenShareStopped(userId)` if they are not already present.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- --run src/hooks/useScreenShare.test.ts`
+Expected: FAIL — `setRemoteScreenSharesHidden` and `REMOTE_HIDE_GRACE_MS` do not exist.
+
+- [ ] **Step 3: Implement the hide lifecycle**
+
+```ts
+export const REMOTE_HIDE_GRACE_MS = 10_000;
+```
+
+Add three refs beside the existing screen-share refs: `hiddenRef` (boolean target), `hideTimerRef` (`ReturnType<typeof setTimeout> | null`), and `hideGenerationRef` (number, incremented on every hide/restore and on room lifecycle reset). Reuse the existing `intentionalPublicationGenerationRef` pattern so a delayed `TrackUnsubscribed` from an older generation cannot remove logical state or disconnect the room.
+
+```ts
+const applyHidden = useCallback((hidden: boolean) => {
+  hiddenRef.current = hidden;
+  const generation = ++hideGenerationRef.current;
+  if (hideTimerRef.current) { clearTimeout(hideTimerRef.current); hideTimerRef.current = null; }
+
+  if (!hidden) {
+    forEachWatchedScreenPublication((pub, share) => {
+      intentionalPublicationGenerationRef.current.set(pub.trackSid, generation);
+      pub.setSubscribed(true);
+    });
+    reconcileEndedShares();
+    return;
+  }
+
+  hideTimerRef.current = setTimeout(() => {
+    if (generation !== hideGenerationRef.current || !hiddenRef.current) return;
+    forEachWatchedScreenPublication((pub, share) => {
+      intentionalPublicationGenerationRef.current.set(pub.trackSid, generation);
+      pub.setSubscribed(false);
+      if (pub.source === Track.Source.ScreenShareAudio) detachRemoteAudio(share.userId);
+    });
+    setRemoteVideoEls(new Map());
+  }, REMOTE_HIDE_GRACE_MS);
+}, [forEachWatchedScreenPublication, detachRemoteAudio, reconcileEndedShares]);
+
+const setRemoteScreenSharesHidden = useCallback((hidden: boolean) => {
+  if (hiddenRef.current === hidden) return;
+  applyHidden(hidden);
+}, [applyHidden]);
+```
+
+In the `TrackPublished` and `TrackSubscribed` handlers, if `hiddenRef.current` is true and the grace period has already elapsed, stamp the SID with the current generation and call `setSubscribed(false)` instead of attaching. `screenShare.stopped` remains authoritative and removes logical state immediately regardless of hidden state. Clear `hideTimerRef` in the existing unmount cleanup and wherever the room lifecycle resets. No code path in this API may call `localParticipant.setScreenShareEnabled(false)`.
+
+Export `setRemoteScreenSharesHidden` from the hook's return object.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- --run src/hooks/useScreenShare.test.ts src/components/ScreenShareGrid/ScreenShareGrid.test.tsx src/components/ScreenShareGrid/ScreenShareTile.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Brmble.Web/src/hooks/useScreenShare.ts src/Brmble.Web/src/hooks/useScreenShare.test.ts
+git commit -m "feat: hide backgrounded remote shares after a grace period"
+```
+
+---
+
+## Task 14: One Splitter, One Activity Region
+
+`ChatPanel` currently owns a second splitter for screen share. This task deletes it and moves screen share into the activity region, leaving exactly one split in the main panel.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx` (delete lines 66-67, 201-251, 253-254 gating, 889-921)
+- Modify: `src/Brmble.Web/src/components/ChatPanel/ChatPanel.css` (delete the block at lines 450-472)
+- Modify: `src/Brmble.Web/src/App.tsx`
+- Test: `src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx`, `src/Brmble.Web/src/App.activityRegion.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `ChannelActivityRegion` (Task 12), `selectStage` (Task 11), `setRemoteScreenSharesHidden` (Task 13), `MainPanel` (Task 10).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/Brmble.Web/src/App.activityRegion.test.tsx
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderConnectedApp } from './testing/appHarness';
+
+describe('channel activity region', () => {
+  it('shows no region and no divider in a quiet channel', () => {
+    renderConnectedApp({ joinedChannelId: '7' });
+    expect(screen.queryByRole('region', { name: /activity/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+  });
+
+  it('stages a screen share and offers paint as a chip', async () => {
+    const user = userEvent.setup();
+    const { screenShare } = renderConnectedApp({ joinedChannelId: '7', watchedShares: [shareFrom(10)], paintSessionId: 'p1' });
+    expect(screen.getByRole('tab', { name: 'Screen share' })).toHaveAttribute('aria-selected', 'true');
+    await user.click(screen.getByRole('tab', { name: 'Paint' }));
+    expect(screen.getByRole('tab', { name: 'Paint' })).toHaveAttribute('aria-selected', 'true');
+    expect(screenShare.setRemoteScreenSharesHidden).toHaveBeenLastCalledWith(true);
+  });
+
+  it('restores the share when it returns to the stage', async () => {
+    const user = userEvent.setup();
+    const { screenShare } = renderConnectedApp({ joinedChannelId: '7', watchedShares: [shareFrom(10)], paintSessionId: 'p1' });
+    await user.click(screen.getByRole('tab', { name: 'Paint' }));
+    await user.click(screen.getByRole('tab', { name: 'Screen share' }));
+    expect(screenShare.setRemoteScreenSharesHidden).toHaveBeenLastCalledWith(false);
+  });
+
+  it('never renders the activity region at server root', () => {
+    renderConnectedApp({ joinedChannelId: 'server-root', watchedShares: [shareFrom(10)] });
+    expect(screen.queryByRole('region', { name: /activity/ })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/App.activityRegion.test.tsx`
+Expected: FAIL — the activity region is not wired and screen share still renders inside `ChatPanel`.
+
+- [ ] **Step 3: Strip the splitter out of ChatPanel**
+
+Delete from `ChatPanel.tsx`: `SPLIT_STORAGE_KEY` and `DEFAULT_SPLIT` (lines 66-67), the `splitPercent` state and `isDraggingRef` (lines 201-205), the drag handler (lines 223-251), the `hasScreenShare` gate (line 253), the `div.chat-split-video` and `div.chat-split-divider` render (lines 889-921). Delete the `.chat-split-video` / `.chat-split-divider` block from `ChatPanel.css` (lines 450-472).
+
+Remove the now-unused screen-share props from `ChatPanelProps` (lines 34-43): `watchingShares`, `focusedShare`, `remoteVideoEls`, `roomQuality`, `shareQualities`, `viewerQualities`, `onFocusShare`, `onCloseShare`, `onViewerQualityChange`. Keep `screenShareViewerMode` and the `'new-window'` overlay path (lines 256-413) exactly as it is — the detached window is out of scope and must keep working.
+
+Delete the corresponding assertions from `ChatPanel.test.tsx`, including any that reference the divider's `aria-valuemin`/`aria-valuemax`.
+
+- [ ] **Step 4: Wire the region in App**
+
+```tsx
+const availableActivities = useMemo<ChannelActivityKind[]>(() => {
+  const kinds: ChannelActivityKind[] = [];
+  if (hasWatchableShare) kinds.push('screen-share');
+  if (activePaintSessionId) kinds.push('paint');
+  return kinds;
+}, [hasWatchableShare, activePaintSessionId]);
+
+const [explicitActivity, setExplicitActivity] = useState<ChannelActivityKind | null>(null);
+const previousStageRef = useRef<ChannelActivityKind | null>(null);
+const stage = selectStage({
+  available: availableActivities,
+  explicit: explicitActivity,
+  previous: previousStageRef.current,
+});
+useEffect(() => { previousStageRef.current = stage; }, [stage]);
+
+useEffect(() => {
+  screenShare.setRemoteScreenSharesHidden(stage !== 'screen-share');
+}, [stage, screenShare]);
+```
+
+The region renders only when `joinedChannelId` is a real channel and `availableActivities.length > 0`; otherwise pass `activityRegion={null}` to `MainPanel`, which already omits both pane and divider.
+
+- [ ] **Step 5: Migrate the storage keys**
+
+On first render, remove `brmble-paint-split` and `brmble-screenshare-split` from `localStorage`. Do not migrate their values; `brmble-main-split` starts at the 50% default because it now governs a different pair of surfaces.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm test -- --run src/App.activityRegion.test.tsx src/components/ChatPanel/ChatPanel.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Web/src
+git commit -m "refactor: move screen share into the channel activity region"
+```
+
+---
+
+## Task 15: Conversation Tab Strip
+
+**Files:**
+- Create: `src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx`
+- Create: `src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.module.css`
+- Test: `src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.test.tsx`
+
+**Interfaces:**
+- Consumes: `Conversation`, `conversationKey` from Task 1.
+- Produces: `ConversationTabStrip` with props:
+
+```ts
+interface ConversationTabItem {
+  conversation: Conversation;
+  key: string;              // conversationKey(conversation)
+  label: string;            // channel name or contact display name
+  isHome: boolean;
+  unreadCount: number;      // 0 when none or unavailable
+  mentionCount: number;
+}
+
+interface ConversationTabStripProps {
+  tabs: ConversationTabItem[];
+  activeKey: string | null;
+  onActivate: (key: string) => void;
+  onClose: (key: string) => void;
+}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.test.tsx
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ConversationTabStrip } from './ConversationTabStrip';
+
+const home = {
+  conversation: { kind: 'channel' as const, channelId: '7' },
+  key: 'channel:7', label: 'General', isHome: true, unreadCount: 0, mentionCount: 0,
+};
+const browsed = {
+  conversation: { kind: 'channel' as const, channelId: '9' },
+  key: 'channel:9', label: 'Random', isHome: false, unreadCount: 3, mentionCount: 0,
+};
+const contact = {
+  conversation: { kind: 'dm' as const, contactId: 'a' },
+  key: 'dm:a', label: 'Alice', isHome: false, unreadCount: 0, mentionCount: 1,
+};
+
+const renderStrip = (overrides = {}) => {
+  const props = { tabs: [home, browsed, contact], activeKey: 'channel:7', onActivate: vi.fn(), onClose: vi.fn(), ...overrides };
+  render(<ConversationTabStrip {...props} />);
+  return props;
+};
+
+describe('ConversationTabStrip', () => {
+  it('renders every tab with the home tab first and selected state', () => {
+    renderStrip();
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.map(tab => tab.textContent)).toEqual([
+      expect.stringContaining('General'),
+      expect.stringContaining('Random'),
+      expect.stringContaining('Alice'),
+    ]);
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('gives the home tab no close control', () => {
+    renderStrip();
+    expect(screen.queryByRole('button', { name: 'Close General' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close Random' })).toBeInTheDocument();
+  });
+
+  it('marks the home tab in its accessible name', () => {
+    renderStrip();
+    expect(screen.getByRole('tab', { name: /General \(you are here\)/ })).toBeInTheDocument();
+  });
+
+  it('activates on click', () => {
+    const props = renderStrip();
+    fireEvent.click(screen.getByRole('tab', { name: /Random/ }));
+    expect(props.onActivate).toHaveBeenCalledWith('channel:9');
+  });
+
+  it('closes without activating', () => {
+    const props = renderStrip();
+    fireEvent.click(screen.getByRole('button', { name: 'Close Random' }));
+    expect(props.onClose).toHaveBeenCalledWith('channel:9');
+    expect(props.onActivate).not.toHaveBeenCalled();
+  });
+
+  it('shows unread and mention counts', () => {
+    renderStrip();
+    expect(screen.getByRole('tab', { name: /Random/ })).toHaveTextContent('3');
+    expect(screen.getByRole('tab', { name: /Alice/ })).toHaveTextContent('@1');
+  });
+
+  it('hides a zero unread count', () => {
+    renderStrip({ tabs: [home] });
+    expect(screen.getByRole('tab', { name: /General/ })).not.toHaveTextContent('0');
+  });
+
+  it('moves between tabs with the arrow keys', () => {
+    const props = renderStrip();
+    fireEvent.keyDown(screen.getByRole('tab', { name: /General/ }), { key: 'ArrowRight' });
+    expect(props.onActivate).toHaveBeenCalledWith('channel:9');
+  });
+
+  it('wraps at both ends', () => {
+    const props = renderStrip({ activeKey: 'dm:a' });
+    fireEvent.keyDown(screen.getByRole('tab', { name: /Alice/ }), { key: 'ArrowRight' });
+    expect(props.onActivate).toHaveBeenCalledWith('channel:7');
+  });
+
+  it('closes the focused tab with Delete but never the home tab', () => {
+    const props = renderStrip({ activeKey: 'channel:9' });
+    fireEvent.keyDown(screen.getByRole('tab', { name: /Random/ }), { key: 'Delete' });
+    expect(props.onClose).toHaveBeenCalledWith('channel:9');
+    fireEvent.keyDown(screen.getByRole('tab', { name: /General/ }), { key: 'Delete' });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when there are no tabs', () => {
+    render(<ConversationTabStrip tabs={[]} activeKey={null} onActivate={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/components/ConversationTabStrip/ConversationTabStrip.test.tsx`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Write the component**
+
+```tsx
+// src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx
+import type { Conversation } from '../../workspace/conversation';
+import { Icon } from '../Icon/Icon';
+import styles from './ConversationTabStrip.module.css';
+
+export interface ConversationTabItem {
+  conversation: Conversation;
+  key: string;
+  label: string;
+  isHome: boolean;
+  unreadCount: number;
+  mentionCount: number;
+}
+
+interface ConversationTabStripProps {
+  tabs: ConversationTabItem[];
+  activeKey: string | null;
+  onActivate: (key: string) => void;
+  onClose: (key: string) => void;
+}
+
+export function ConversationTabStrip({ tabs, activeKey, onActivate, onClose }: ConversationTabStripProps) {
+  if (tabs.length === 0) return null;
+
+  const move = (index: number, delta: number) => {
+    const next = tabs[(index + delta + tabs.length) % tabs.length];
+    if (next) onActivate(next.key);
+  };
+
+  return (
+    <div className={styles.strip} role="tablist" aria-label="Conversations">
+      {tabs.map((tab, index) => (
+        <div key={tab.key} className={`${styles.tab} ${activeKey === tab.key ? styles.active : ''} ${tab.isHome ? styles.home : ''}`}>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeKey === tab.key}
+            tabIndex={activeKey === tab.key ? 0 : -1}
+            className={styles.label}
+            onClick={() => onActivate(tab.key)}
+            onKeyDown={event => {
+              if (event.key === 'ArrowRight') { event.preventDefault(); move(index, 1); }
+              if (event.key === 'ArrowLeft') { event.preventDefault(); move(index, -1); }
+              if (event.key === 'Delete' && !tab.isHome) { event.preventDefault(); onClose(tab.key); }
+            }}
+          >
+            <span className={styles.text}>{tab.label}</span>
+            {tab.isHome && <span className="sr-only"> (you are here)</span>}
+            {tab.mentionCount > 0 && <span className={styles.mention}>@{tab.mentionCount}</span>}
+            {tab.mentionCount === 0 && tab.unreadCount > 0 && <span className={styles.unread}>{tab.unreadCount}</span>}
+          </button>
+          {!tab.isHome && (
+            <button
+              type="button"
+              className={styles.close}
+              aria-label={`Close ${tab.label}`}
+              onClick={() => onClose(tab.key)}
+            >
+              <Icon name="x" size={10} />
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Write the stylesheet**
+
+```css
+/* src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.module.css */
+.strip { display: flex; align-items: stretch; gap: var(--space-2xs); padding: var(--space-2xs) var(--space-2xs) 0; background: var(--bg-elevated); flex: none; min-width: 0; }
+.tab { display: flex; align-items: center; border-radius: var(--radius-md) var(--radius-md) 0 0; background: var(--bg-subtle); min-width: 0; }
+.tab:hover { background: var(--bg-hover); }
+.active { background: var(--bg-deep); font-weight: 600; }
+.home { background: var(--bg-subtle); }
+.label { display: flex; align-items: center; gap: var(--space-2xs); padding: var(--space-2xs) var(--space-xs); border: none; background: none; color: inherit; font: inherit; cursor: pointer; min-width: 0; }
+.label:focus-visible { outline: 2px solid var(--accent-primary); outline-offset: -2px; }
+.text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.unread, .mention { border-radius: var(--radius-pill); padding: 0 var(--space-2xs); font-size: var(--font-size-xs); }
+.unread { background: var(--accent-danger); color: var(--text-on-accent); }
+.mention { background: var(--accent-warning); color: var(--text-on-accent); }
+.close { display: flex; align-items: center; border: none; background: none; color: var(--text-secondary); cursor: pointer; padding: 0 var(--space-2xs); }
+.close:hover { color: var(--text-primary); }
+.close:focus-visible { outline: 2px solid var(--accent-primary); outline-offset: -2px; }
+```
+
+Substitute the nearest existing token wherever one of these names is absent from `src/Brmble.Web/src/themes/_template.css`. Introduce no colour, size or radius literals.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- --run src/components/ConversationTabStrip/ConversationTabStrip.test.tsx`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/ConversationTabStrip
+git commit -m "feat: add the conversation tab strip"
+```
+
+---
+
+## Task 16: Tab Strip Overflow
+
+Labels shrink to a minimum legible width first; below that the strip scrolls, with the home tab pinned outside the scroll container so it never scrolls away.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx`
+- Modify: `src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.module.css`
+- Modify: `src/Brmble.Web/src/index.css` (add `--conversation-tab-min-width`, `--conversation-tab-max-width`)
+- Test: `src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.overflow.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: Task 15's props, unchanged. No new props.
+- Produces: nothing new. Overflow is purely presentational.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.overflow.test.tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { ConversationTabStrip } from './ConversationTabStrip';
+
+const tab = (n: number) => ({
+  conversation: { kind: 'channel' as const, channelId: String(n) },
+  key: `channel:${n}`, label: `channel-number-${n}`, isHome: false, unreadCount: 0, mentionCount: 0,
+});
+const home = {
+  conversation: { kind: 'channel' as const, channelId: '0' },
+  key: 'channel:0', label: 'General', isHome: true, unreadCount: 0, mentionCount: 0,
+};
+
+describe('ConversationTabStrip overflow', () => {
+  it('keeps the home tab outside the scrolling container', () => {
+    render(<ConversationTabStrip tabs={[home, ...Array.from({ length: 30 }, (_, i) => tab(i + 1))]}
+      activeKey="channel:0" onActivate={vi.fn()} onClose={vi.fn()} />);
+    const scroller = screen.getByTestId('conversation-tab-scroller');
+    expect(within(scroller).queryByRole('tab', { name: /General/ })).not.toBeInTheDocument();
+    expect(within(scroller).getAllByRole('tab')).toHaveLength(30);
+  });
+
+  it('exposes the scroller as horizontally scrollable and keyboard reachable', () => {
+    render(<ConversationTabStrip tabs={[home, ...Array.from({ length: 30 }, (_, i) => tab(i + 1))]}
+      activeKey="channel:0" onActivate={vi.fn()} onClose={vi.fn()} />);
+    const scroller = screen.getByTestId('conversation-tab-scroller');
+    expect(scroller).toHaveAttribute('tabindex', '0');
+    expect(scroller).toHaveAttribute('aria-label', 'Scroll conversations');
+  });
+
+  it('truncates long labels rather than wrapping', () => {
+    render(<ConversationTabStrip tabs={[home, tab(1)]} activeKey="channel:0" onActivate={vi.fn()} onClose={vi.fn()} />);
+    const label = screen.getByText('channel-number-1');
+    expect(label.className).toMatch(/text/);
+  });
+
+  it('still renders a single home tab without a scroller wrapper collapsing it', () => {
+    render(<ConversationTabStrip tabs={[home]} activeKey="channel:0" onActivate={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByRole('tab', { name: /General/ })).toBeInTheDocument();
+    expect(within(screen.getByTestId('conversation-tab-scroller')).queryAllByRole('tab')).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/components/ConversationTabStrip/ConversationTabStrip.overflow.test.tsx`
+Expected: FAIL — there is no scroller element.
+
+- [ ] **Step 3: Split the strip into pinned home and scroller**
+
+Render the home tab, when present, as a direct child of `.strip`, and every other tab inside:
+
+```tsx
+<div
+  className={styles.scroller}
+  data-testid="conversation-tab-scroller"
+  tabIndex={0}
+  role="group"
+  aria-label="Scroll conversations"
+>
+  {rest.map(/* … same tab markup … */)}
+</div>
+```
+
+Keep one `role="tablist"` on the outer `.strip` so home and scrolled tabs remain a single tab set for assistive technology. Arrow-key movement continues to traverse the combined list, so `move` must index into `tabs`, not into `rest`.
+
+- [ ] **Step 4: Add the tokens and the shrink rules**
+
+Add to `:root` in `src/Brmble.Web/src/index.css`:
+
+```css
+--conversation-tab-min-width: 4.5rem;
+--conversation-tab-max-width: 12rem;
+```
+
+```css
+.scroller { display: flex; gap: var(--space-2xs); overflow-x: auto; scrollbar-width: thin; min-width: 0; flex: 1; }
+.scroller:focus-visible { outline: 2px solid var(--accent-primary); outline-offset: -2px; }
+.tab { flex: 0 1 auto; min-width: var(--conversation-tab-min-width); max-width: var(--conversation-tab-max-width); }
+.active, .home { flex-shrink: 0.5; }
+```
+
+`flex: 0 1 auto` with a `min-width` produces exactly the specified behaviour: tabs shrink until they hit the minimum, after which the scroller overflows and scrolls.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- --run src/components/ConversationTabStrip`
+Expected: PASS, all 15 tests across both files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src/components/ConversationTabStrip src/Brmble.Web/src/index.css
+git commit -m "feat: shrink then scroll conversation tabs on overflow"
+```
+
+---
+
+## Task 17: One ChatPanel, Driven By The Active Tab
+
+This deletes the two-slide `.content-slider` and its transform animation. A single `ChatPanel` renders whatever the active tab points at, channel or DM.
+
+**Files:**
+- Modify: `src/Brmble.Web/src/App.tsx` (render block, `App.tsx:4873-4949`)
+- Modify: `src/Brmble.Web/src/App.css` (delete `.content-slider` / `.content-slide` rules at lines 70-93)
+- Test: `src/Brmble.Web/src/App.conversationRegion.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `ConversationTabStrip` (Tasks 15–16), workspace tabs and `activeConversation` (Task 5), `MainPanel` (Task 10).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/Brmble.Web/src/App.conversationRegion.test.tsx
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderConnectedApp } from './testing/appHarness';
+
+describe('conversation region', () => {
+  it('shows only the home tab on connect', () => {
+    renderConnectedApp({ joinedChannelId: '7', channels: [{ id: 7, name: 'General' }] });
+    expect(screen.getAllByRole('tab')).toHaveLength(1);
+    expect(screen.getByRole('tab', { name: /General \(you are here\)/ })).toBeInTheDocument();
+  });
+
+  it('opens a tab when browsing another channel and switches the chat body', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({ joinedChannelId: '7', channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }] });
+    await user.click(screen.getByRole('treeitem', { name: /Random/ }));
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    expect(screen.getByRole('tab', { name: /Random/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByPlaceholderText('Message #Random')).toBeInTheDocument();
+  });
+
+  it('opens a dm in the same strip', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({ joinedChannelId: '7', dmContacts: [{ id: 'a', name: 'Alice' }] });
+    await user.click(screen.getByRole('button', { name: /Alice/ }));
+    expect(screen.getByRole('tab', { name: /Alice/ })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('replaces the home tab when the user moves voice channel', async () => {
+    const { moveSelfToChannel } = renderConnectedApp({
+      joinedChannelId: '7', channels: [{ id: 7, name: 'General' }, { id: 12, name: 'Gaming' }],
+    });
+    moveSelfToChannel(12);
+    expect(screen.getByRole('tab', { name: /Gaming \(you are here\)/ })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: /General/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps browsed tabs across a voice channel move', async () => {
+    const user = userEvent.setup();
+    const { moveSelfToChannel } = renderConnectedApp({
+      joinedChannelId: '7', channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }, { id: 12, name: 'Gaming' }],
+    });
+    await user.click(screen.getByRole('treeitem', { name: /Random/ }));
+    moveSelfToChannel(12);
+    expect(screen.getByRole('tab', { name: /Random/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Gaming \(you are here\)/ })).toBeInTheDocument();
+  });
+
+  it('closes a tab and falls back to a neighbour', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({ joinedChannelId: '7', channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }] });
+    await user.click(screen.getByRole('treeitem', { name: /Random/ }));
+    await user.click(screen.getByRole('button', { name: 'Close Random' }));
+    expect(screen.queryByRole('tab', { name: /Random/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /General/ })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('restores persisted tabs on reconnect and drops invalid ones', () => {
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }],
+      persistedTabs: [{ kind: 'channel', channelId: '9' }, { kind: 'channel', channelId: '404' }],
+    });
+    expect(screen.getByRole('tab', { name: /Random/ })).toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+  });
+
+  it('keeps a browsed channel writable when the server permits it', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random', canSendChat: true }],
+    });
+    await user.click(screen.getByRole('treeitem', { name: /Random/ }));
+    expect(screen.getByPlaceholderText('Message #Random')).toBeEnabled();
+  });
+
+  it('blocks sending in a browsed channel the server disallows', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random', canSendChat: false }],
+    });
+    await user.click(screen.getByRole('treeitem', { name: /Random/ }));
+    expect(screen.getByPlaceholderText('Message #Random')).toBeDisabled();
+  });
+
+  it('shows the root chat as the home tab at server root', () => {
+    renderConnectedApp({ joinedChannelId: 'server-root', serverLabel: 'Brmble' });
+    expect(screen.getByRole('tab', { name: /Brmble \(you are here\)/ })).toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: /activity/ })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/App.conversationRegion.test.tsx`
+Expected: FAIL — the tab strip is not rendered and the two-slide layout is still present.
+
+- [ ] **Step 3: Build the conversation region**
+
+Replace the `.content-slider` block with a single region composed of the strip and one `ChatPanel`:
+
+```tsx
+const conversationRegion = (
+  <div className="conversation-region">
+    <ConversationTabStrip
+      tabs={conversationTabItems}
+      activeKey={workspace.activeKey}
+      onActivate={key => dispatchWorkspace({ type: 'ACTIVATE_CONVERSATION', key })}
+      onClose={key => dispatchWorkspace({ type: 'CLOSE_CONVERSATION', key })}
+    />
+    <ChatPanel {...chatPanelPropsForActiveConversation} />
+  </div>
+);
+```
+
+`conversationTabItems` maps `workspace.tabs` to `ConversationTabItem`, resolving each label from `channels` or from the DM contact list, and marking `isHome` with `isHomeKey(workspace, key)`. A channel whose name cannot be resolved falls back to the channel id so a tab is never blank.
+
+`chatPanelPropsForActiveConversation` selects between the existing channel props and the existing DM props based on `activeConversation.kind`. Both prop sets already exist at `App.tsx:4889-4919` and `App.tsx:4922-4948`; this task chooses between them instead of rendering both.
+
+Delete `foregroundDmContact`, `foregroundDmMessages` (`App.tsx:1691-1704`), `showDmConversation`, `showChannelConversation`, `isDmMode`, and the `.content-slider` / `.content-slide` CSS. Remove the `aria-hidden` / `inert` handling with them — there is no longer a hidden slide.
+
+`ChatPanel`'s `.chat-header` keeps its existing title. The presence signal now lives on the tab, not in the header, so no header change is required by this task.
+
+- [ ] **Step 4: Wire tab creation to the existing entry points**
+
+`handleSelectChannel` (`App.tsx:3428-3440`) dispatches `OPEN_CONVERSATION` with a channel conversation, retaining its `getChannelSelectionOutcome` permission check. `DMContactList`'s `onSelectContact` dispatches `OPEN_CONVERSATION` with a DM conversation. Neither joins voice; `onJoinChannel` is untouched.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- --run src/App.conversationRegion.test.tsx`
+Expected: PASS, 11 tests.
+
+The root-chat case relies on `canOpenChannelChat` and `canSendToChannelChat` already returning `true` for `'server-root'` (`App.tsx:696`, `App.tsx:703`). Root chat is not Matrix-backed — `getChannelMatrixRoomId` returns `null` for it (`App.tsx:719`) — so its tab has no unread badge source and must render no badge rather than a zero.
+
+Run: `npm test -- --run`
+Expected: PASS. Delete any remaining case that asserts slide transitions, `dm-active`, or `inert` slides.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src
+git commit -m "feat: render one chat panel driven by the active conversation tab"
+```
+
+---
+
+## Task 18: Permanently Visible User Panel
+
+**Files:**
+- Modify: `src/Brmble.Web/src/components/DMContactList/DMContactList.tsx`
+- Modify: `src/Brmble.Web/src/components/DMContactList/DMContactList.css`
+- Modify: `src/Brmble.Web/src/App.tsx`, `src/Brmble.Web/src/App.css`
+- Modify: `src/Brmble.Web/src/components/Header/Header.tsx` (remove the panel toggle control)
+- Test: `src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `DMContactList` loses its `visible` and `onToggleVisibility` props. Its remaining props are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// added to src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
+it('renders without a visibility toggle', () => {
+  render(<DMContactList {...props} />);
+  expect(screen.queryByRole('button', { name: /Collapse Messages panel/ })).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: /Expand Messages panel/ })).not.toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Messages' })).toBeInTheDocument();
+});
+
+it('always shows unread counts', () => {
+  render(<DMContactList {...props} contacts={[{ id: 'a', name: 'Alice', unreadCount: 4 }]} />);
+  expect(screen.getByText('4')).toBeInTheDocument();
+});
+
+it('keeps unread counts in the narrow rail', () => {
+  document.documentElement.style.setProperty('--force-narrow', '1');
+  render(<DMContactList {...props} contacts={[{ id: 'a', name: 'Alice', unreadCount: 4 }]} />);
+  expect(screen.getByText('4')).toBeInTheDocument();
+  document.documentElement.style.removeProperty('--force-narrow');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/components/DMContactList/DMContactList.test.tsx`
+Expected: FAIL — the toggle button still renders and `showUnread` still gates on `visible`.
+
+- [ ] **Step 3: Remove the visibility model**
+
+Delete the `visible` prop from `DMContactListProps` (line 16) and every use of it (lines 19, 44-51, 65, 93-94, 100). Delete `onToggleVisibility` and the header toggle button. Delete the `showUnread` gate so counts always render.
+
+In `App.tsx` delete `messagesPanelExpanded`, `toggleMessagesPanel` (`App.tsx:1714-1717`), the `app-body--messages-collapsed` class (`App.tsx:4811`) and the `workspace-conversation--with-panel` modifier (`App.tsx:4855`), replacing them with a static three-column `.app-body` layout. Remove the corresponding Header prop and control.
+
+- [ ] **Step 4: Add the width-driven rail**
+
+In `DMContactList.css`, collapse the panel to a compact rail below a breakpoint. This is presentation only — no state, no toggle, no JavaScript:
+
+```css
+@media (max-width: 60rem) {
+  .dm-contact-list { width: var(--dm-rail-width); }
+  .dm-contact-list .dm-contact-name,
+  .dm-contact-list .dm-contact-list-header h3,
+  .dm-contact-list .dm-contact-search { display: none; }
+  .dm-contact-list .dm-contact-unread { position: absolute; inset-block-start: 0; inset-inline-end: 0; }
+}
+```
+
+Add `--dm-rail-width` to `:root` in `index.css` beside `--sidebar-width`. Each contact entry keeps an accessible name via `aria-label` so the rail remains usable when the visible text is hidden.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -- --run src/components/DMContactList/DMContactList.test.tsx src/App.dmDirectoryBehavior.test.tsx`
+Expected: PASS. Delete the cases in `App.dmDirectoryBehavior.test.tsx` that assert panel auto-collapse during remote watching and DM foreground fallback — both behaviours are intentionally gone.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Brmble.Web/src
+git commit -m "feat: keep the user panel permanently visible with a narrow rail"
+```
+
+---
+
+## Task 19: One Badge Per Conversation
+
+An unread conversation must be announced in exactly one place. Once it is open as a tab, the tab owns its badge and the sidebar row or contact entry goes quiet.
+
+**Files:**
+- Create: `src/Brmble.Web/src/workspace/unreadOwnership.ts`
+- Test: `src/Brmble.Web/src/workspace/unreadOwnership.test.ts`
+- Modify: `src/Brmble.Web/src/App.tsx` (the `channelUnreads` memo at `App.tsx:4302-4316` and `dmContactsWithUnreads` at `App.tsx:1759-1769`)
+
+**Interfaces:**
+- Consumes: `Conversation`, `conversationKey` from Task 1.
+- Produces: `suppressOpenConversations<T>(entries: Map<string, T>, openKeys: Set<string>, keyOf: (id: string) => string): Map<string, T>` — returns a new map with every entry whose conversation is open removed. Aggregate counts such as the OS badge are computed *before* suppression and are unaffected.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/Brmble.Web/src/workspace/unreadOwnership.test.ts
+import { describe, expect, it } from 'vitest';
+import { suppressOpenConversations } from './unreadOwnership';
+
+describe('suppressOpenConversations', () => {
+  const keyOf = (id: string) => `channel:${id}`;
+
+  it('removes entries whose conversation is open', () => {
+    const result = suppressOpenConversations(new Map([['7', 3], ['9', 1]]), new Set(['channel:7']), keyOf);
+    expect([...result.keys()]).toEqual(['9']);
+  });
+
+  it('leaves everything when nothing is open', () => {
+    const result = suppressOpenConversations(new Map([['7', 3]]), new Set(), keyOf);
+    expect([...result.keys()]).toEqual(['7']);
+  });
+
+  it('does not mutate the input', () => {
+    const input = new Map([['7', 3]]);
+    suppressOpenConversations(input, new Set(['channel:7']), keyOf);
+    expect(input.size).toBe(1);
+  });
+
+  it('returns an empty map when every conversation is open', () => {
+    const result = suppressOpenConversations(new Map([['7', 3]]), new Set(['channel:7']), keyOf);
+    expect(result.size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/workspace/unreadOwnership.test.ts`
+Expected: FAIL — cannot resolve `./unreadOwnership`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/Brmble.Web/src/workspace/unreadOwnership.ts
+export function suppressOpenConversations<T>(
+  entries: Map<string, T>,
+  openKeys: Set<string>,
+  keyOf: (id: string) => string,
+): Map<string, T> {
+  const result = new Map<string, T>();
+  for (const [id, value] of entries) {
+    if (openKeys.has(keyOf(id))) continue;
+    result.set(id, value);
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Apply it at both badge sources**
+
+In `App.tsx`, compute the open key set once:
+
+```tsx
+const openConversationKeys = useMemo(
+  () => new Set(workspace.tabs.map(conversationKey)),
+  [workspace.tabs],
+);
+```
+
+Wrap `channelUnreads` before it is passed to `Sidebar` (`App.tsx:4837`):
+
+```tsx
+const sidebarChannelUnreads = suppressOpenConversations(
+  channelUnreads, openConversationKeys, id => `channel:${id}`);
+```
+
+Do the same for the DM contact list, suppressing `unreadCount` for open contacts. Compute `totalDmUnreadCount` (`App.tsx:1747-1756`) and the OS badge (`App.tsx:3719`) from the **unsuppressed** values — the aggregate must still count conversations that happen to be open in a background tab.
+
+Feed the unsuppressed per-conversation counts into `conversationTabItems` so the tab shows what the sidebar no longer does.
+
+- [ ] **Step 5: Write the integration test**
+
+```tsx
+// added to src/Brmble.Web/src/App.conversationRegion.test.tsx
+it('moves an unread badge from the sidebar to the tab when a conversation is opened', async () => {
+  const user = userEvent.setup();
+  renderConnectedApp({
+    joinedChannelId: '7',
+    channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }],
+    unreads: { '9': { notificationCount: 3, highlightCount: 0 } },
+  });
+  expect(within(screen.getByRole('treeitem', { name: /Random/ })).getByText('3')).toBeInTheDocument();
+  await user.click(screen.getByRole('treeitem', { name: /Random/ }));
+  expect(within(screen.getByRole('treeitem', { name: /Random/ })).queryByText('3')).not.toBeInTheDocument();
+  expect(screen.getByRole('tab', { name: /Random/ })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm test -- --run src/workspace/unreadOwnership.test.ts src/App.conversationRegion.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Brmble.Web/src
+git commit -m "feat: give an open conversation tab sole ownership of its unread badge"
+```
+
+---
+
+## Task 20: Documentation And Final Verification
+
+**Files:**
+- Modify: `docs/UI_GUIDE.md`
+
+**Interfaces:**
+- Consumes: everything.
+- Produces: the patterns future UI work is required to follow.
+
+- [ ] **Step 1: Add the Main Panel Region pattern**
+
+Under Component Patterns, add `Main Panel Region Pattern` with these exact rules:
+
+1. The main panel has exactly two modes. In `game` mode a single game surface fills it entirely — no activity chips, no tab strip, no chat. In `split` mode the channel activity region sits above the conversation region, separated by one `VerticalSplitPane` keyed `brmble-main-split`.
+2. Game mode is entered by participating in a game, never by spectating one. Opening the solo idle game is participation.
+3. The channel activity region is bound to the joined voice channel and to nothing else. It never renders at server root, and never renders when the channel has no activity — in that case the panel has no upper pane and no divider.
+4. The activity region stages exactly one activity. Chips list everything live; the first activity to appear takes the stage, later arrivals never steal it, and an explicit chip click always wins.
+5. A backgrounded screen share stays subscribed for a 10-second grace period, then unsubscribes. Watched list, order, focus, receive quality, room membership and local publishing are never changed by staging.
+6. No component may introduce a second splitter inside the main panel.
+
+- [ ] **Step 2: Add the Conversation Tab Strip pattern**
+
+1. The strip is a single `role="tablist"`. The home tab is first, is derived from the joined voice channel, has no close control, and is pinned outside the scroll container.
+2. Moving voice channel replaces the home tab. A browsed tab for the new channel is absorbed rather than duplicated. Presence never creates history.
+3. Only an explicit click to read a channel or a user creates a tab, and every such click creates a permanent tab. There are no preview tabs.
+4. Overflow shrinks labels to `--conversation-tab-min-width` with ellipsis, then scrolls horizontally.
+5. An open conversation's unread badge lives on its tab; its sidebar row or contact entry shows nothing. Aggregate counts are computed before suppression.
+6. Tabs persist per server and are validated on restore. The home tab is never restored from storage.
+
+- [ ] **Step 3: Rewrite the affected existing sections**
+
+Update `Vertical Split Pane Pattern` to state that the main panel has exactly one split and to name `brmble-main-split`. Update `Minigame Modal Pattern` to record that participant surfaces are full-panel and are not dialogs — they carry no `role="dialog"`, no `aria-modal`, and no overlay dismissal. Leave the temporary duel-queue-modal guidance in place; the follow-up minigame project retires it.
+
+- [ ] **Step 4: Full verification**
+
+Run, from `src/Brmble.Web`:
+
+```bash
+npx tsc -b --noEmit
+npm run lint
+npm test -- --run
+npm run build
+```
+
+From the repository root:
+
+```bash
+dotnet build
+dotnet test
+```
+
+Expected: all PASS. The .NET side is untouched by this plan; run it to prove that.
+
+- [ ] **Step 5: Manual verification checklist**
+
+Confirm by hand, since none of these are covered by automated tests:
+
+- Drag the single divider; reload; the size persists.
+- Start a paint session, click another channel to read it, confirm the canvas survives.
+- Watch a screen share, browse another channel, confirm the share is still watchable.
+- Switch from share to paint and back within 10 seconds; the picture returns instantly.
+- Switch to paint, wait 15 seconds, switch back; the picture reacquires.
+- Open the idle game; confirm it fills the panel and that paint underneath survives closing it.
+- Narrow the window past the breakpoint; confirm the user panel becomes a rail and unread counts remain visible.
+- Verify all of the above in Classic and Retro Terminal themes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/UI_GUIDE.md
+git commit -m "docs: document main panel region and conversation tab patterns"
+```
+
+---
+
+## Self-Review Notes
+
+Recorded so the executor knows these were considered rather than missed.
+
+- **`currentChannelId` is deliberately retired in two stages.** Task 5 keeps it as a derived alias so the build survives; Task 17 removes the alias when the last consumer goes. Do not try to delete it in Task 5.
+- **`ChannelActivityKind` will gain `'duel'`** in the follow-up minigame project. `selectStage` must stay agnostic — no member of the union may be special-cased.
+- **The `'new-window'` screen-share overlay is untouched.** It bypasses React and the modal shell today and continues to; the grace-period logic applies only to in-app viewing.
+- **Aggregate unread counts are computed before suppression.** Suppressing the OS badge for open tabs would hide activity while the window is not focused.
+- **Task 3 intentionally leaves the tree red** until Task 5. The `tsc` run in Task 3 Step 5 exists to size the work, not to pass.
+- **Two names in Task 10 must be confirmed against the codebase before use.** `activeGameMatch` stands for whatever `components/Games/useGameState.ts` exposes as the local user's current match, and `serverId` in Task 5 stands for the stable identifier of the connected server. Neither name is asserted to exist — read the source, use the real name, and do not invent a new state variable for either.
+- **Test harness.** Tasks 14, 17 and 19 assume a `src/testing/appHarness.tsx` exposing `renderConnectedApp`. If no equivalent helper exists in the repository, build it as the first step of Task 14 rather than duplicating connection setup across three suites.

--- a/docs/superpowers/specs/2026-08-19-main-panel-regions-and-conversation-tabs-design.md
+++ b/docs/superpowers/specs/2026-08-19-main-panel-regions-and-conversation-tabs-design.md
@@ -1,0 +1,174 @@
+# Main Panel Regions And Conversation Tabs — Design
+
+Date: 2026-08-19
+Status: Approved for planning
+Branch: `feature/main-panel-regions`
+
+## Problem
+
+Brmble's main panel has no owner. Optional surfaces were added one at a time, each bringing its own splitter, and they now compete without coordination.
+
+- Collaborative paint renders in a `VerticalSplitPane` **outside** `ChatPanel`, persisted under `brmble-paint-split`, bounded 20–80%.
+- Screen share renders in `.chat-split-video` **inside** `ChatPanel`, persisted under `brmble-screenshare-split`, bounded 20–80%.
+- Chat messages are `flex: 1` — the residual, and therefore the surface that always loses.
+
+The two splitters nest. With both dragged to their maximum, chat receives roughly 4% of the panel minus header and input. Both panes additionally carry hard floors (`min-height: 100px` and `calc(var(--space-3xl) * 2)`) that can exceed their own percentage allocation. Adding a duel or spectator surface would introduce a third uncoordinated competitor.
+
+Underneath the layout problem is a modelling problem. The UI has exactly one channel identity, `currentChannelId` (`App.tsx:1032`), and it means the **viewed** channel. The joined voice channel has no state at all; it is re-derived ad hoc as `users.find(u => u.self)?.channelId` (`App.tsx:4340`). The workspace reducer's foreground variant, `{ kind: 'channel' }` (`workspace/workspaceState.ts:2`), carries no channel id whatsoever.
+
+Features consequently bind to whichever identity their author reached for, producing four live defects:
+
+| Site | Binds to | Defect |
+|---|---|---|
+| Paint survival guard `App.tsx:1371-1379` | viewed | Browsing another channel silently closes a live paint canvas |
+| Share watch + discovery `App.tsx:477`, `App.tsx:4432-4437` | viewed | After clicking another channel you can no longer watch your own channel's share, although you can still publish into it |
+| Challenge context item `ChannelTree.tsx:635-651` | viewed | Offered where `DuelOrchestrator.cs:121-125` will reject it; hidden where it would succeed |
+| Sidebar current highlight `ChannelTree.tsx:285` | viewed | No pixel anywhere in the app indicates which channel the user is actually in |
+
+## Goal
+
+Give the main panel a single owner built on an explicit distinction between **presence** (the channel you are in) and **conversation** (what you are reading), and land it as one PR.
+
+## Non-goals
+
+Deliberately excluded, to be built on top of this work in a later project:
+
+- `SpectatorService`, privacy-safe `SpectatorView` on `IGameEngine`, and spectator boards
+- The duel activity chip, `DuelActivity`, and retirement of `DuelQueueModal`
+- Arena Knockoff and the continuous-simulation runtime
+- Tiling more than one activity simultaneously
+- Persisting open tabs across sessions
+
+Note that `docs/superpowers/plans/2026-07-25-generic-spectator-and-foreground-activity.md` must not be executed as written. Its server half survives into the follow-up project largely intact; its client half — the foreground hook, the `ChatPanel` slot, and screen-share pause/restore — is superseded by this design. That plan predates collaborative paint entirely.
+
+---
+
+## Architecture
+
+### 1. State model
+
+Two named concepts replace the single overloaded `currentChannelId`.
+
+**Presence.** `joinedChannelId` is promoted from an ad-hoc derivation into one named selector. Every presence-bound feature reads only this value.
+
+**Conversation.** An explicit open-tab model owned by `workspace/workspaceState.ts`:
+
+```ts
+type Conversation =
+  | { kind: 'channel'; channelId: string }
+  | { kind: 'dm'; contactId: string };
+
+interface ConversationState {
+  conversations: Conversation[];   // [0] is the home tab when one exists
+  activeConversation: Conversation;
+}
+```
+
+`conversations[0]` is the home tab, derived from `joinedChannelId`. It is marked, has no close control, and is pinned outside the scroll container. All later entries were opened by an explicit click.
+
+Removed from the reducer: `foreground`, `messagesPanelExpanded`, `previousContent`, `remoteWatchCount`, and the events `TOGGLE_MESSAGES_PANEL`, `OPEN_MESSAGES_PANEL`, `REMOTE_WATCH_COUNT_CHANGED`, `SELECT_CHANNEL`, `SELECT_DM`, `SELECTED_DM_INVALIDATED`.
+
+Added: `JOINED_CHANNEL_CHANGED`, `OPEN_CONVERSATION`, `CLOSE_CONVERSATION`, `ACTIVATE_CONVERSATION`, `CONVERSATION_INVALIDATED`.
+
+**Rebinds.** Paint survival, share watching and discovery, and challenge-menu eligibility all move to `joinedChannelId`. The sidebar renders two distinct signals: an active-conversation highlight and a separate presence marker for the joined channel.
+
+**Server root.** At `channelId === 0` / `'server-root'` there is no channel chat. No home tab exists in that state; the strip contains only browsed tabs, and may be empty.
+
+### 2. Main panel modes
+
+**Game mode** occupies the entire main panel: no activity chips, no tab strip, no chat. It is entered by opening the Neon-D solo idle game, or by *participating* in a channel minigame.
+
+This brings existing surfaces into scope. `DeathrollModal` and `RpsModal` are modal overlays today and become the fullscreen game surface. `NeonDGame` already replaces `<main>` (`App.tsx:4870`) but does so as a special case governed by three ad-hoc suppression rules; it becomes an ordinary instance of this mode.
+
+Game mode is exited when the match reaches a terminal state or the player forfeits, or when the user closes Neon-D. On exit the panel returns to split mode with the activity region and tab strip in the state they held before entry; a paint session or screen share that was live continues running underneath and is restored, not torn down. The existing rule where an active paint session suppresses Neon-D (`App.tsx:4870`) is removed — game mode simply takes precedence.
+
+Accepted cost: chat is unavailable while playing. Voice is unaffected.
+
+**Split mode** renders the channel activity region above the conversation region, separated by one divider.
+
+A single splitter replaces two. `brmble-paint-split` and `brmble-screenshare-split` are retired in favour of one key, defaulting to 50%, bounded 20–80%. The surviving implementation is `VerticalSplitPane`; `ChatPanel`'s bespoke splitter is deleted along with its defects — mouse rather than pointer events, `aria-valuemin=0 / aria-valuemax=100` against true bounds of 20/80, no `:focus-visible` style, no clamp on read, and hardcoded `100px` / `4px` values that violate the token rule.
+
+When the joined channel has no activity the region does not render at all and chat receives the full panel.
+
+### 3. Channel activity region
+
+A header showing the joined channel and one chip per live activity, above a stage rendering exactly one activity.
+
+Chips in this PR: **screen share** and **paint**. The duel chip requires `SpectatorService`, which does not exist, and belongs to the follow-up project.
+
+Focus rules:
+
+- The first activity to appear takes the stage.
+- Later activities light a chip but never steal the stage.
+- An explicit chip click always wins.
+
+A backgrounded screen share stays subscribed for a grace period of 10 seconds, defined as a single named constant, so quick switching is instant; after that it unsubscribes to stop decoding and downloading a stream nobody is watching. Restoration reconciles shares that ended while hidden. Watched list, order, focus, receive quality, room membership and local publishing are never altered by this mechanism.
+
+### 4. Conversation region
+
+A tab strip above a single `ChatPanel` instance.
+
+**Identity and dedupe.** Channel tabs key on `channelId`, DM tabs on `contactId`. Clicking an already-open conversation activates its tab instead of duplicating it.
+
+**Home retarget.** When `joinedChannelId` changes, the home slot retargets to the new channel. If that channel was already open as a browsed tab it is absorbed into home rather than appearing twice. The previous home is dropped: presence retargets the pinned slot and never creates history.
+
+**Tab creation.** Only an explicit click to read a channel or a user creates a tab. Every such click creates a permanent tab; there are no preview tabs.
+
+**Overflow.** Labels shrink toward a minimum legible width with ellipsis, with the active and home tabs retaining more width than the rest. Below that minimum, shrinking stops and the strip scrolls horizontally. The home tab is pinned outside the scroll container. Counts of off-screen unread are surfaced on the scroll affordances.
+
+**Unread.** Once a conversation is open as a tab its badge lives on the tab and the corresponding sidebar row or user-panel entry goes quiet, so each unread conversation is announced in exactly one place. The active tab marks read; background tabs accumulate. Mention badges retain their distinct treatment.
+
+**Closing** a tab activates the right neighbour, else the left, else home.
+
+**Invalidation.** `CONVERSATION_INVALIDATED` closes a tab whose conversation is no longer readable — a channel removed, chat permission lost per `canOpenChannelChat`, or a DM contact closed. If the invalidated tab was active, activation falls through to the same neighbour rule. Invalidating the joined channel is not possible; a channel removal moves the user, which retargets home instead.
+
+**Sending.** A browsed channel tab remains writable wherever `canOpenChannelChat` allows it today. Reading a channel you are not in does not restrict sending, and this design does not change that.
+
+**Accessibility.** `role="tablist"` with roving tabindex and arrow-key navigation; close controls reachable from the keyboard. This replaces `.content-slider`, so the 400ms slide transition that `ChatPanel` scroll restoration currently has to outlast is removed.
+
+**Persistence.** Tabs are session-only and reset to home on disconnect.
+
+### 5. DM merge and the right panel
+
+`.content-slider` and its two `.content-slide` children are deleted. One `ChatPanel` instance renders whatever `activeConversation` points at, channel or DM.
+
+`DMContactList` becomes permanently visible alongside the channel tree, exactly as the left sidebar is, and ceases to be a reading surface — clicking a contact opens a tab. Its `visible` prop, expand/collapse control, and visibility-driven focus effects are removed. `dmStore.selectedContact` collapses into the tab model, taking `foregroundDmContact` and `foregroundDmMessages` with it; those exist only to keep an outgoing slide rendering during a transition that no longer occurs.
+
+---
+
+## Design tokens and documentation
+
+New tokens are required for stage minimum height and tab minimum width. No hardcoded colours, sizes, spacing, radii or transitions are introduced; the existing `min-height: 100px` violation is removed rather than replicated.
+
+`docs/UI_GUIDE.md` gains a Main Panel Region pattern, a Conversation Tab Strip pattern, and a Game Takeover pattern. Its existing Vertical Split Pane Pattern and Minigame Modal Pattern sections are rewritten, and the temporary duel-queue-modal guidance is left in place until the follow-up project retires it.
+
+## Testing
+
+- Reducer tests covering every tab operation, home retarget, absorb-on-retarget, close-neighbour selection, and server-root behaviour.
+- Tab strip component tests for shrink, scroll, close, unread and mention badges, and keyboard navigation.
+- `VerticalSplitPane` consumer tests for the single main-panel split, including the removal of the old keys.
+- Screen-share tests for grace-period unsubscribe, restoration, and reconciliation of shares that ended while hidden, asserting that watched list, focus, quality, room membership and local publishing are untouched.
+- Game mode tests confirming Neon-D and an active Deathroll or RPS match take the full main panel.
+- Integration tests asserting the three defects directly: browsing another channel does not close paint; the joined channel's share remains watchable while reading elsewhere; the challenge item appears exactly where the server would accept it.
+
+## Risks
+
+The change runs through the centre of `App.tsx`, which is 5,545 lines and owns nearly all affected state. The agreed mitigation is strict internal ordering within the single PR: the state model and rebinds land and go green before any layout moves, then the regions, then the tab strip and DM merge.
+
+Removing `DMContactList`'s collapse behaviour permanently widens the app's minimum comfortable width. Responsive behaviour at narrow widths must be verified, including Classic and Retro Terminal themes.
+
+## Decisions recorded
+
+| Decision | Choice |
+|---|---|
+| Activity region binding | Always the joined voice channel |
+| Activities on screen at once | Exactly one; chips switch |
+| Conversation surface | Tab strip |
+| DMs in the strip | Yes; content-slider removed |
+| Home tab on channel move | Replaced, not demoted |
+| Game participation | Fills the entire main panel |
+| Right user panel | Always visible; toggle removed |
+| Preview tabs | No; every click opens a permanent tab |
+| Backgrounded share | Grace period, then unsubscribe |
+| Unread badges | Tab wins once the conversation is open |
+| PR shape | One PR, strictly ordered internally |

--- a/docs/superpowers/specs/2026-08-19-main-panel-regions-and-conversation-tabs-design.md
+++ b/docs/superpowers/specs/2026-08-19-main-panel-regions-and-conversation-tabs-design.md
@@ -128,13 +128,17 @@ A tab strip above a single `ChatPanel` instance.
 
 **Accessibility.** `role="tablist"` with roving tabindex and arrow-key navigation; close controls reachable from the keyboard. This replaces `.content-slider`, so the 400ms slide transition that `ChatPanel` scroll restoration currently has to outlast is removed.
 
-**Persistence.** Tabs are session-only and reset to home on disconnect.
+**Persistence.** Open tabs are persisted and restored across reconnects and app restarts, scoped per server so that switching servers does not resurrect another server's conversations.
+
+Restore is validated, never trusted. The home tab is always recomputed from the current `joinedChannelId` and is never restored from storage. A restored channel tab is dropped if the channel no longer exists or `canOpenChannelChat` now returns `false`; a restored DM tab is dropped if the contact no longer resolves. A malformed or unparseable stored value resets the strip to home rather than failing. The active conversation is restored only if its tab survived validation, otherwise activation falls back to home.
 
 ### 5. DM merge and the right panel
 
 `.content-slider` and its two `.content-slide` children are deleted. One `ChatPanel` instance renders whatever `activeConversation` points at, channel or DM.
 
 `DMContactList` becomes permanently visible alongside the channel tree, exactly as the left sidebar is, and ceases to be a reading surface — clicking a contact opens a tab. Its `visible` prop, expand/collapse control, and visibility-driven focus effects are removed. `dmStore.selectedContact` collapses into the tab model, taking `foregroundDmContact` and `foregroundDmMessages` with it; those exist only to keep an outgoing slide rendering during a transition that no longer occurs.
+
+Below a defined narrow-width breakpoint the right panel collapses to a compact rail so the conversation region stays usable. This collapse is presentation-only and driven by width alone: it is not user-toggleable, holds no reducer state, and must not resurrect the `messagesPanelExpanded` model or any activity-driven auto-collapse. Unread counts remain visible in the collapsed form.
 
 ---
 
@@ -146,8 +150,10 @@ New tokens are required for stage minimum height and tab minimum width. No hardc
 
 ## Testing
 
-- Reducer tests covering every tab operation, home retarget, absorb-on-retarget, close-neighbour selection, and server-root behaviour.
+- Reducer tests covering every tab operation, home retarget, absorb-on-retarget, close-neighbour selection, invalidation, and server-root behaviour.
+- Persistence tests covering round-trip save and restore, per-server scoping, and every rejection path: missing channel, revoked `canOpenChannelChat`, unresolved DM contact, malformed stored value, and fallback activation.
 - Tab strip component tests for shrink, scroll, close, unread and mention badges, and keyboard navigation.
+- Right panel tests for the width-driven collapsed rail, asserting unread counts survive and that no toggle state is reintroduced.
 - `VerticalSplitPane` consumer tests for the single main-panel split, including the removal of the old keys.
 - Screen-share tests for grace-period unsubscribe, restoration, and reconciliation of shares that ended while hidden, asserting that watched list, focus, quality, room membership and local publishing are untouched.
 - Game mode tests confirming Neon-D and an active Deathroll or RPS match take the full main panel.
@@ -157,7 +163,7 @@ New tokens are required for stage minimum height and tab minimum width. No hardc
 
 The change runs through the centre of `App.tsx`, which is 5,545 lines and owns nearly all affected state. The agreed mitigation is strict internal ordering within the single PR: the state model and rebinds land and go green before any layout moves, then the regions, then the tab strip and DM merge.
 
-Removing `DMContactList`'s collapse behaviour permanently widens the app's minimum comfortable width. Responsive behaviour at narrow widths must be verified, including Classic and Retro Terminal themes.
+Removing `DMContactList`'s user-facing collapse widens the app's minimum comfortable width. The width-driven rail mitigates this, but responsive behaviour must be verified across breakpoints, including Classic and Retro Terminal themes.
 
 ## Decisions recorded
 
@@ -169,8 +175,9 @@ Removing `DMContactList`'s collapse behaviour permanently widens the app's minim
 | DMs in the strip | Yes; content-slider removed |
 | Home tab on channel move | Replaced, not demoted |
 | Game participation | Fills the entire main panel |
-| Right user panel | Always visible; toggle removed |
+| Right user panel | Always visible; toggle removed; width-driven rail when narrow |
 | Preview tabs | No; every click opens a permanent tab |
 | Backgrounded share | Grace period, then unsubscribe |
 | Unread badges | Tab wins once the conversation is open |
+| Tab persistence | Persisted per server, validated on restore |
 | PR shape | One PR, strictly ordered internally |

--- a/docs/superpowers/specs/2026-08-19-main-panel-regions-and-conversation-tabs-design.md
+++ b/docs/superpowers/specs/2026-08-19-main-panel-regions-and-conversation-tabs-design.md
@@ -72,7 +72,9 @@ Added: `JOINED_CHANNEL_CHANGED`, `OPEN_CONVERSATION`, `CLOSE_CONVERSATION`, `ACT
 
 **Rebinds.** Paint survival, share watching and discovery, and challenge-menu eligibility all move to `joinedChannelId`. The sidebar renders two distinct signals: an active-conversation highlight and a separate presence marker for the joined channel.
 
-**Server root.** At `channelId === 0` / `'server-root'` there is no channel chat. No home tab exists in that state; the strip contains only browsed tabs, and may be empty.
+**Server root.** Being at `channelId === 0` / `'server-root'` counts as not being in any channel. The channel activity region therefore never renders at root, which matches `canWatchShareFromChannel` already returning `false` there (`App.tsx:478`) and paint already requiring a non-zero voice channel (`App.tsx:4650`).
+
+The home tab still exists at root and shows the root chat, which is always readable and sendable (`canOpenChannelChat` and `canSendToChannelChat` both return `true` for `'server-root'`, `App.tsx:696` and `App.tsx:703`). Note this conversation is not Matrix-backed — `getChannelMatrixRoomId` returns `null` for root (`App.tsx:719`) and its messages live in the local store under the `'server-root'` key. It therefore has no unread badge source, and the badge is simply absent rather than zero.
 
 ### 2. Main panel modes
 

--- a/src/Brmble.Client/Services/AppConfig/AppSettings.cs
+++ b/src/Brmble.Client/Services/AppConfig/AppSettings.cs
@@ -20,7 +20,6 @@ public record ShortcutsSettings(
     string? ToggleMuteKey = null,
     string? ToggleMuteDeafenKey = null,
     string? ToggleLeaveVoiceKey = null,
-    string? ToggleDMScreenKey = null,
     string? ToggleScreenShareKey = null,
     string? ToggleGameKey = null
 );

--- a/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
+++ b/src/Brmble.Client/Services/Voice/MumbleAdapter.cs
@@ -335,10 +335,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
             case "toggleLeaveVoice":
                 LeaveVoice();
                 break;
-            case "toggleDmScreen":
-                _bridge?.Send("voice.toggleDmScreen", null);
-                _bridge?.NotifyUiThread();
-                break;
             case "toggleScreenShare":
                 _bridge?.Send("voice.toggleScreenShare", null);
                 _bridge?.NotifyUiThread();
@@ -985,7 +981,6 @@ internal sealed class MumbleAdapter : BasicMumbleProtocol, VoiceService
         _inputRouter?.SetShortcutBinding("toggleMute", settings.Shortcuts.ToggleMuteKey);
         _inputRouter?.SetShortcutBinding("toggleMuteDeafen", settings.Shortcuts.ToggleMuteDeafenKey);
         _inputRouter?.SetShortcutBinding("toggleLeaveVoice", settings.Shortcuts.ToggleLeaveVoiceKey);
-        _inputRouter?.SetShortcutBinding("toggleDmScreen", settings.Shortcuts.ToggleDMScreenKey);
         _inputRouter?.SetShortcutBinding("toggleScreenShare", settings.Shortcuts.ToggleScreenShareKey);
         _inputRouter?.SetShortcutBinding("toggleGame", settings.Shortcuts.ToggleGameKey);
         _audioManager?.SetInputVolume(settings.Audio.InputVolume);

--- a/src/Brmble.Web/src/App.activityRegion.test.tsx
+++ b/src/Brmble.Web/src/App.activityRegion.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderConnectedApp, resetAppHarness } from './testing/appHarness';
+
+function shareFrom(userId: number) {
+  return { roomName: 'channel-7', userId, userName: `User ${userId}` };
+}
+
+describe('channel activity region', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetAppHarness();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows no region and no divider in a quiet channel', () => {
+    renderConnectedApp({ joinedChannelId: '7' });
+    expect(screen.queryByRole('region', { name: /activity/ })).not.toBeInTheDocument();
+    // The sidebar keeps its own vertical resize handle; what must be absent is the
+    // main panel's horizontal split.
+    expect(screen.queryByRole('separator', { name: /Resize channel activity/ })).not.toBeInTheDocument();
+  });
+
+  it('stages a screen share and offers paint as a chip', async () => {
+    const user = userEvent.setup();
+    const { screenShare } = renderConnectedApp({
+      joinedChannelId: '7',
+      watchedShares: [shareFrom(10)],
+      paintSessionId: 'p1',
+    });
+    expect(screen.getByRole('tab', { name: 'Screen share' })).toHaveAttribute('aria-selected', 'true');
+    await user.click(screen.getByRole('tab', { name: 'Paint' }));
+    expect(screen.getByRole('tab', { name: 'Paint' })).toHaveAttribute('aria-selected', 'true');
+    expect(screenShare.setRemoteScreenSharesHidden).toHaveBeenLastCalledWith(true);
+  });
+
+  it('restores the share when it returns to the stage', async () => {
+    const user = userEvent.setup();
+    const { screenShare } = renderConnectedApp({
+      joinedChannelId: '7',
+      watchedShares: [shareFrom(10)],
+      paintSessionId: 'p1',
+    });
+    await user.click(screen.getByRole('tab', { name: 'Paint' }));
+    await user.click(screen.getByRole('tab', { name: 'Screen share' }));
+    expect(screenShare.setRemoteScreenSharesHidden).toHaveBeenLastCalledWith(false);
+  });
+
+  it('never renders the activity region at server root', () => {
+    renderConnectedApp({ joinedChannelId: 'server-root', watchedShares: [shareFrom(10)] });
+    expect(screen.queryByRole('region', { name: /activity/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/Brmble.Web/src/App.activityRegion.test.tsx
+++ b/src/Brmble.Web/src/App.activityRegion.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderConnectedApp, resetAppHarness } from './testing/appHarness';
 
@@ -53,5 +53,27 @@ describe('channel activity region', () => {
   it('never renders the activity region at server root', () => {
     renderConnectedApp({ joinedChannelId: 'server-root', watchedShares: [shareFrom(10)] });
     expect(screen.queryByRole('region', { name: /activity/ })).not.toBeInTheDocument();
+  });
+
+  // Hiding a share past the grace period is what makes the hook drop its video elements
+  // (useScreenShare.ts:784). The chip must survive that, or there is no way back.
+  it('keeps offering the screen share chip after the hidden share drops its video element', async () => {
+    const user = userEvent.setup();
+    const { screenShare, rerenderApp } = renderConnectedApp({
+      joinedChannelId: '7',
+      watchedShares: [shareFrom(10)],
+      paintSessionId: 'p1',
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Paint' }));
+    // The grace period elapses: the hook unsubscribes and empties remoteVideoEls while
+    // keeping the share in watchingShares.
+    screenShare.remoteVideoEls = new Map();
+    act(() => { rerenderApp(); });
+
+    expect(screen.getByRole('tab', { name: 'Screen share' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'Screen share' }));
+    expect(screenShare.setRemoteScreenSharesHidden).toHaveBeenLastCalledWith(false);
   });
 });

--- a/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
+++ b/src/Brmble.Web/src/App.adminChannelUpdate.test.tsx
@@ -89,7 +89,7 @@ const mockValues = vi.hoisted(() => {
     shareQualities: new Map(),
     addWatchingShare: vi.fn(),
     removeWatchingShare: vi.fn(),
-    disconnectViewer: vi.fn(),
+    disconnectViewer: vi.fn(), setRemoteScreenSharesHidden: vi.fn(),
     connectAsViewer: vi.fn(),
     handleScreenShareServiceUnavailable: vi.fn(),
   };

--- a/src/Brmble.Web/src/App.conversationRegion.test.tsx
+++ b/src/Brmble.Web/src/App.conversationRegion.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderConnectedApp, resetAppHarness } from './testing/appHarness';
+import bridge from './bridge';
 
 // The real ChatPanel observes its scroller; jsdom ships neither observer.
 beforeAll(() => {
@@ -118,5 +119,67 @@ describe('conversation region', () => {
     renderConnectedApp({ joinedChannelId: 'server-root', serverLabel: 'Brmble' });
     const homeTab = screen.getByRole('tab', { name: /Brmble \(you are here\)/ });
     expect(homeTab.textContent).toBe('BrmbleBrmble (you are here)');
+  });
+
+  // Task 19: an unread conversation is announced in exactly one place. The tab owns the
+  // badge once the conversation is open; the sidebar row / contact entry goes quiet.
+  it('moves an unread badge from the sidebar to the tab when a conversation is opened', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }],
+      unreads: { '9': { notificationCount: 3, highlightCount: 0 } },
+    });
+    // ChannelTree rows are role="button" (Task 17), not treeitem. Scope to the row:
+    // once the tab exists there is also a "Close Random" button.
+    const randomRow = () => screen.getByRole('button', { name: /^Random/ });
+    expect(within(randomRow()).getByText('3')).toBeInTheDocument();
+    await user.click(randomRow());
+    expect(within(randomRow()).queryByText('3')).not.toBeInTheDocument();
+    const tab = screen.getByRole('tab', { name: /Random/ });
+    expect(tab).toBeInTheDocument();
+    expect(within(tab).getByText('3')).toBeInTheDocument();
+  });
+
+  it('keeps mention counts distinct from plain unreads when the tab takes ownership', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }],
+      unreads: { '9': { notificationCount: 3, highlightCount: 2 } },
+    });
+    const randomRow = () => screen.getByRole('button', { name: /^Random/ });
+    expect(within(randomRow()).getByText('@2')).toBeInTheDocument();
+    await user.click(randomRow());
+    expect(within(randomRow()).queryByText('@2')).not.toBeInTheDocument();
+    const tab = screen.getByRole('tab', { name: /Random/ });
+    // Mentions keep their distinct `@n` treatment and take precedence on the tab.
+    expect(within(tab).getByText('@2')).toBeInTheDocument();
+    expect(within(tab).queryByText('3')).not.toBeInTheDocument();
+  });
+
+  // The aggregate (taskbar) badge is computed from the UNSUPPRESSED counts. Suppressing
+  // it would hide activity while the window is not focused.
+  it('still counts a conversation open in a background tab in the taskbar badge', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }],
+      dmContacts: [{ id: 'a', name: 'Alice', unreadCount: 3, isEphemeral: true }],
+    });
+    // Ephemeral contacts render in the always-visible "Mumble users" section.
+    await user.click(screen.getByRole('button', { name: /^Alice/ }));
+    // Send the DM tab to the background by re-selecting the home tab.
+    await user.click(screen.getByRole('tab', { name: /General \(you are here\)/ }));
+
+    // The contact entry is quiet — the tab owns the badge...
+    expect(within(screen.getByRole('button', { name: /^Alice/ })).queryByText('3')).not.toBeInTheDocument();
+    expect(within(screen.getByRole('tab', { name: /Alice/ })).getByText('3')).toBeInTheDocument();
+
+    // ...but the aggregate taskbar badge still reports the unread DM.
+    const badgeCalls = vi.mocked(bridge.send).mock.calls
+      .filter(call => call[0] === 'notification.badge');
+    expect(badgeCalls.length).toBeGreaterThan(0);
+    expect(badgeCalls[badgeCalls.length - 1]![1]).toMatchObject({ unreadDMs: true });
   });
 });

--- a/src/Brmble.Web/src/App.conversationRegion.test.tsx
+++ b/src/Brmble.Web/src/App.conversationRegion.test.tsx
@@ -183,3 +183,94 @@ describe('conversation region', () => {
     expect(badgeCalls[badgeCalls.length - 1]![1]).toMatchObject({ unreadDMs: true });
   });
 });
+
+/** The name rendered in the chat header — the thing the user actually reads. */
+function chatHeaderName(): string {
+  const heading = document.querySelector('.chat-header .heading-section');
+  if (!heading) throw new Error('chat header is not rendered');
+  return heading.textContent ?? '';
+}
+
+/** The label of the currently selected conversation tab, badges stripped. */
+function activeTabLabel(): string {
+  const tab = screen.getAllByRole('tab').find(candidate => candidate.getAttribute('aria-selected') === 'true');
+  if (!tab) throw new Error('no active tab');
+  return within(tab).getByTestId('conversation-tab-label').textContent ?? '';
+}
+
+// The conversation region must render the ACTIVE TAB. It used to be driven by the
+// legacy `currentChannelId`/`currentChannelName` presence state, which only the voice
+// handlers and the sidebar wrote, so activating an already-open tab left the header,
+// the messages and the permissions describing a different conversation.
+describe('conversation region follows the active tab', () => {
+  it('restores the home tab name in the chat header when switching back to it', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'Channel 3' }, { id: 9, name: 'Channel 2' }, { id: 12, name: 'Channel 1' }],
+    });
+    await user.click(screen.getByRole('button', { name: /^Channel 1/ }));
+    await user.click(screen.getByRole('button', { name: /^Channel 2/ }));
+    expect(chatHeaderName()).toBe('Channel 2');
+
+    await user.click(screen.getByRole('tab', { name: /Channel 3 \(you are here\)/ }));
+    expect(chatHeaderName()).toBe('Channel 3');
+
+    await user.click(screen.getByRole('tab', { name: /^Channel 1/ }));
+    expect(chatHeaderName()).toBe('Channel 1');
+  });
+
+  it('keeps the tab label and the chat header in agreement for every tab', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }, { id: 12, name: 'Gaming' }],
+    });
+    await user.click(screen.getByRole('button', { name: /^Random/ }));
+    await user.click(screen.getByRole('button', { name: /^Gaming/ }));
+
+    for (const name of [/General \(you are here\)/, /^Random/, /^Gaming/, /General \(you are here\)/]) {
+      await user.click(screen.getByRole('tab', { name }));
+      expect(chatHeaderName()).toBe(activeTabLabel());
+    }
+  });
+
+  it('follows a voice-driven channel move in the chat header', () => {
+    const { moveSelfToChannel } = renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 12, name: 'Gaming' }],
+    });
+    expect(chatHeaderName()).toBe('General');
+    moveSelfToChannel(12);
+    expect(chatHeaderName()).toBe('Gaming');
+    expect(chatHeaderName()).toBe(activeTabLabel());
+  });
+});
+
+// Root chat is not Matrix-backed: its history lives in the local chat store under the
+// 'server-root' key and everyone may read and write it.
+describe('server root chat', () => {
+  it('renders the stored root messages', () => {
+    renderConnectedApp({
+      joinedChannelId: 'server-root',
+      serverLabel: 'Brmble',
+      chatStore: {
+        'server-root': [{
+          id: 'm1',
+          channelId: 'server-root',
+          sender: 'Alice',
+          content: 'hello from the root',
+          timestamp: new Date('2024-01-01T00:00:00Z'),
+        }],
+      },
+    });
+    expect(screen.getByText('hello from the root')).toBeInTheDocument();
+    expect(screen.queryByText(/No messages yet/i)).not.toBeInTheDocument();
+  });
+
+  it('leaves the composer enabled at the server root', () => {
+    renderConnectedApp({ joinedChannelId: 'server-root', serverLabel: 'Brmble' });
+    expect(screen.queryByPlaceholderText('User is offline')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Message #Brmble')).toBeEnabled();
+  });
+});

--- a/src/Brmble.Web/src/App.conversationRegion.test.tsx
+++ b/src/Brmble.Web/src/App.conversationRegion.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderConnectedApp, resetAppHarness } from './testing/appHarness';
+
+// The real ChatPanel observes its scroller; jsdom ships neither observer.
+beforeAll(() => {
+  class ObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('ResizeObserver', ObserverMock);
+  vi.stubGlobal('IntersectionObserver', ObserverMock);
+  Element.prototype.scrollIntoView = () => {};
+});
+
+afterEach(() => {
+  cleanup();
+  resetAppHarness();
+  localStorage.clear();
+});
+
+describe('conversation region', () => {
+  it('shows only the home tab on connect', () => {
+    renderConnectedApp({ joinedChannelId: '7', channels: [{ id: 7, name: 'General' }] });
+    expect(screen.getAllByRole('tab')).toHaveLength(1);
+    expect(screen.getByRole('tab', { name: /General \(you are here\)/ })).toBeInTheDocument();
+  });
+
+  it('opens a tab when browsing another channel and switches the chat body', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({ joinedChannelId: '7', channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }] });
+    await user.click(screen.getByRole('button', { name: /Random/ }));
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    expect(screen.getByRole('tab', { name: /Random/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByPlaceholderText('Message #Random')).toBeInTheDocument();
+  });
+
+  it('opens a dm in the same strip', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({ joinedChannelId: '7', dmContacts: [{ id: 'a', name: 'Alice' }] });
+    // Non-recent contacts live in the collapsed "Others" section.
+    await user.click(screen.getByRole('button', { name: 'Others' }));
+    await user.click(screen.getByRole('button', { name: /Alice/ }));
+    expect(screen.getByRole('tab', { name: /Alice/ })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('replaces the home tab when the user moves voice channel', async () => {
+    const { moveSelfToChannel } = renderConnectedApp({
+      joinedChannelId: '7', channels: [{ id: 7, name: 'General' }, { id: 12, name: 'Gaming' }],
+    });
+    moveSelfToChannel(12);
+    expect(screen.getByRole('tab', { name: /Gaming \(you are here\)/ })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: /General/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps browsed tabs across a voice channel move', async () => {
+    const user = userEvent.setup();
+    const { moveSelfToChannel } = renderConnectedApp({
+      joinedChannelId: '7', channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }, { id: 12, name: 'Gaming' }],
+    });
+    await user.click(screen.getByRole('button', { name: /Random/ }));
+    moveSelfToChannel(12);
+    expect(screen.getByRole('tab', { name: /Random/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Gaming \(you are here\)/ })).toBeInTheDocument();
+  });
+
+  it('closes a tab and falls back to a neighbour', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({ joinedChannelId: '7', channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }] });
+    await user.click(screen.getByRole('button', { name: /Random/ }));
+    await user.click(screen.getByRole('button', { name: 'Close Random' }));
+    expect(screen.queryByRole('tab', { name: /Random/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /General/ })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('restores persisted tabs on reconnect and drops invalid ones', () => {
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }],
+      persistedTabs: [{ kind: 'channel', channelId: '9' }, { kind: 'channel', channelId: '404' }],
+    });
+    expect(screen.getByRole('tab', { name: /Random/ })).toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+  });
+
+  it('keeps a browsed channel writable when the server permits it', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random', canSendChat: true }],
+    });
+    await user.click(screen.getByRole('button', { name: /Random/ }));
+    expect(screen.getByPlaceholderText('Message #Random')).toBeEnabled();
+  });
+
+  it('blocks sending in a browsed channel the server disallows', async () => {
+    const user = userEvent.setup();
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random', canSendChat: false }],
+    });
+    await user.click(screen.getByRole('button', { name: /Random/ }));
+    expect(screen.getByRole('tab', { name: /Random/ })).toHaveAttribute('aria-selected', 'true');
+    // MessageInput replaces the placeholder while disabled (pre-existing behaviour),
+    // so the composer is identified by that copy rather than "Message #Random".
+    expect(screen.getByPlaceholderText('User is offline')).toBeDisabled();
+  });
+
+  it('shows the root chat as the home tab at server root', () => {
+    renderConnectedApp({ joinedChannelId: 'server-root', serverLabel: 'Brmble' });
+    expect(screen.getByRole('tab', { name: /Brmble \(you are here\)/ })).toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: /activity/ })).not.toBeInTheDocument();
+  });
+
+  it('renders no unread badge on the root home tab', () => {
+    renderConnectedApp({ joinedChannelId: 'server-root', serverLabel: 'Brmble' });
+    const homeTab = screen.getByRole('tab', { name: /Brmble \(you are here\)/ });
+    expect(homeTab.textContent).toBe('BrmbleBrmble (you are here)');
+  });
+});

--- a/src/Brmble.Web/src/App.conversationTabs.test.tsx
+++ b/src/Brmble.Web/src/App.conversationTabs.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { conversationKey } from './workspace/conversation';
+import { selectJoinedChannelId } from './workspace/presence';
+import {
+  createWorkspaceState,
+  selectActiveConversation,
+  selectHomeKey,
+  workspaceReducer,
+} from './workspace/workspaceState';
+
+// Presence and tabs must agree: whatever selectJoinedChannelId reports is the home tab.
+describe('App presence and tab wiring contract', () => {
+  it('derives the home tab from the self user channel', () => {
+    const joinedChannelId = selectJoinedChannelId([{ channelId: 3 }, { self: true, channelId: 7 }]);
+    const state = workspaceReducer(createWorkspaceState(), { type: 'JOINED_CHANNEL_CHANGED', channelId: joinedChannelId });
+    expect(selectHomeKey(state)).toBe('channel:7');
+  });
+
+  it('opens a browsed channel without disturbing presence', () => {
+    let state = workspaceReducer(createWorkspaceState(), { type: 'JOINED_CHANNEL_CHANGED', channelId: '7' });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: { kind: 'channel', channelId: '9' } });
+    expect(state.joinedChannelId).toBe('7');
+    expect(selectHomeKey(state)).toBe('channel:7');
+    expect(conversationKey(selectActiveConversation(state)!)).toBe('channel:9');
+  });
+
+  it('invalidates a dm by key', () => {
+    let state = workspaceReducer(createWorkspaceState(), { type: 'JOINED_CHANNEL_CHANGED', channelId: '7' });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: 'a' } });
+    state = workspaceReducer(state, { type: 'CONVERSATION_INVALIDATED', key: conversationKey({ kind: 'dm', contactId: 'a' }) });
+    expect(state.tabs.map(conversationKey)).toEqual(['channel:7']);
+  });
+});

--- a/src/Brmble.Web/src/App.css
+++ b/src/Brmble.Web/src/App.css
@@ -1,5 +1,4 @@
 .app {
-  --messages-rail-width: 48px;
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -8,15 +7,12 @@
   overflow: hidden;
 }
 
+/* Static three-column workspace: sidebar | main content | user panel.
+   The user panel is permanently visible and narrows to a rail by width alone. */
 .app-body {
   flex: 1;
   display: flex;
   overflow: hidden;
-}
-
-.app-body--messages-collapsed .dm-contact-list {
-  width: var(--messages-rail-width);
-  min-width: var(--messages-rail-width);
 }
 
 .sidebar {
@@ -74,10 +70,6 @@
   height: 100%;
   min-width: 0;
   overflow: hidden;
-}
-
-.workspace-conversation--with-panel {
-  min-width: 0;
 }
 
 /* Page load animations */

--- a/src/Brmble.Web/src/App.css
+++ b/src/Brmble.Web/src/App.css
@@ -67,29 +67,13 @@
   overflow: hidden;
 }
 
-.content-slider {
-  display: flex;
-  width: 100%;
-  height: 100%;
-  transition: transform var(--transition-slow);
-  will-change: transform;
-}
-
-.content-slider.dm-active {
-  transform: translateX(-100%);
-}
-
-.content-slide {
-  flex: 0 0 100%;
-  height: 100%;
-  min-width: 0;
+.conversation-region {
   display: flex;
   flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
   overflow: hidden;
-}
-
-.content-slide[aria-hidden="true"] {
-  pointer-events: none;
 }
 
 .workspace-conversation--with-panel {

--- a/src/Brmble.Web/src/App.customCompanion.test.tsx
+++ b/src/Brmble.Web/src/App.customCompanion.test.tsx
@@ -95,7 +95,7 @@ const mockValues = vi.hoisted(() => {
     setViewerQuality: vi.fn(),
     addWatchingShare: vi.fn(),
     removeWatchingShare: vi.fn(),
-    disconnectViewer: vi.fn(),
+    disconnectViewer: vi.fn(), setRemoteScreenSharesHidden: vi.fn(),
     connectAsViewer: vi.fn(),
     handleScreenShareServiceUnavailable: vi.fn(),
   };

--- a/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
+++ b/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
@@ -573,18 +573,6 @@ describe('DM route Matrix isolation', () => {
     expect(mockValues.dmChatPanelProps?.messages).toEqual([]);
   });
 
-  it('uses the Messages panel state for the Header DM control', () => {
-    renderConnectedApp();
-
-    expect(mockValues.headerProps?.dmActive).toBe(true);
-
-    act(() => {
-      (mockValues.headerProps?.onToggleDM as () => void)();
-    });
-
-    expect(mockValues.headerProps?.dmActive).toBe(false);
-  });
-
   it('requests channel chat access when the active non-root channel is missing from roomMap', async () => {
     render(<ServiceStatusProvider><App /></ServiceStatusProvider>);
 
@@ -616,12 +604,6 @@ describe('DM route Matrix isolation', () => {
     renderConnectedApp();
 
     expect(mockValues.dmContactListProps?.onToggleVisibility).toBe(mockValues.headerProps?.onToggleDM);
-
-    act(() => {
-      (mockValues.dmContactListProps?.onToggleVisibility as () => void)();
-    });
-
-    expect(mockValues.headerProps?.dmActive).toBe(false);
   });
 
   it('resets the Messages panel when reconnecting', async () => {
@@ -683,14 +665,12 @@ describe('DM route Matrix isolation', () => {
     mockValues.screenShare.remoteWatchCount = 1;
     view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
     await waitFor(() => {
-      expect(mockValues.headerProps?.dmActive).toBe(false);
       expect(document.querySelector('.content-slider')).toHaveClass('dm-active');
     });
 
     mockValues.screenShare.remoteWatchCount = 0;
     view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
     await waitFor(() => {
-      expect(mockValues.headerProps?.dmActive).toBe(true);
       expect(document.querySelector('.content-slider')).toHaveClass('dm-active');
     });
   });
@@ -766,7 +746,6 @@ describe('DM route Matrix isolation', () => {
 
     mockValues.screenShare.remoteWatchCount = 1;
     view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
-    await waitFor(() => expect(mockValues.headerProps?.dmActive).toBe(false));
 
     act(() => {
       (mockValues.dmContactListProps?.onCloseConversation as (id: string) => void)('@val:example.com');
@@ -820,7 +799,6 @@ describe('DM route Matrix isolation', () => {
     const view = renderConnectedApp();
     mockValues.screenShare.remoteWatchCount = 1;
     view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
-    await waitFor(() => expect(mockValues.headerProps?.dmActive).toBe(false));
     mockValues.screenShare.disconnectViewer.mockClear();
 
     act(() => view.getByTestId('sidebar-select-channel').click());

--- a/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
+++ b/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
@@ -1,10 +1,16 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import App from './App';
+import {
+  appHarnessMocks,
+  overrideComponent,
+  renderConnectedApp as renderApp,
+  renderDisconnectedApp,
+  resetAppHarness,
+  type HarnessProps,
+} from './testing/appHarness';
 import bridge from './bridge';
-import { ServiceStatusProvider } from './hooks/useServiceStatus';
-import type { ChatMessage, MediaAttachment } from './types';
+import type { MediaAttachment } from './types';
 
 const paintSourceMocks = vi.hoisted(() => ({
   prepare: vi.fn(),
@@ -20,210 +26,52 @@ vi.mock('./utils/chatImagePaintSource', async (importOriginal) => {
   };
 });
 
-const mockValues = vi.hoisted(() => {
-  let dmChatPanelProps: Record<string, unknown> | undefined;
-  let channelChatPanelProps: Record<string, unknown> | undefined;
-  let dmContactListProps: Record<string, unknown> | undefined;
-  let headerProps: Record<string, unknown> | undefined;
-  let dmStoreOptions: Record<string, unknown> | undefined;
-  const matrixClient = {
-    lastMessages: new Map(),
-    activeMessages: [],
-    setActiveChannel: vi.fn(),
-    sendMessage: vi.fn(),
-    sendImageMessage: vi.fn(),
-    uploadContent: vi.fn(),
-    fetchHistory: vi.fn(),
-    sendReaction: vi.fn(),
-    removeReaction: vi.fn(),
-    dmLastMessages: new Map(),
-    activeDmMessages: [],
-    setActiveDmContact: vi.fn(),
-    dmRoomMap: new Map<string, string>(),
-    dmUserDisplayNames: new Map(),
-    dmUserAvatarUrls: new Map(),
-    sendDMMessage: vi.fn(),
-    fetchDMHistory: vi.fn(),
-    fetchAvatarUrl: vi.fn().mockResolvedValue(undefined),
-    client: { marker: 'matrix-client', getRoom: vi.fn((): unknown => undefined) },
-    activeTypingText: 'Val is typing',
-    startTyping: vi.fn(),
-    stopTyping: vi.fn(),
-  };
-  const dmStore = {
-    contacts: [],
-    selectedContact: null as { id: string; displayName: string; unreadCount: number; isEphemeral?: boolean; mumbleSessionId?: number | null } | null,
-    messages: [] as ChatMessage[],
-    selectContact: vi.fn(),
-    sendMessage: vi.fn(),
-    startDM: vi.fn(),
-    clearSelection: vi.fn(),
-    closeDM: vi.fn(),
-    selectedContactIdRef: { current: null as string | null },
-    receiveMumbleDM: vi.fn(),
-    updateMumbleSession: vi.fn(),
-    clearMumbleContacts: vi.fn(),
-    startMumbleDM: vi.fn(),
-  };
-  const unreadTracker = {
-    roomUnreads: new Map(),
-    getRoomUnread: vi.fn(() => ({ notificationCount: 0, highlightCount: 0, fullyReadEventId: null })),
-    markRoomRead: vi.fn(),
-    getFullyReadEventId: vi.fn(() => null),
-    getMarkerTimestamp: vi.fn((): number | null => null),
-    totalUnreadCount: 0,
-    totalDmUnreadCount: 0,
-  };
-  const idleActions = { autoLeftAt: null, preLeaveStartedAt: null, preLeaveCancelledAt: null, dismissNotification: vi.fn(), dismissPreLeaveCancelled: vi.fn() };
-  const screenShare = {
-    isSharing: false, startSharing: vi.fn(), stopSharing: vi.fn(), markLocalShareTeardownIntent: vi.fn(), error: null,
-    activeShare: null, activeShares: [], watchingShare: null, watchingShares: [] as Array<{ roomName: string; userId: number; userName: string }>, pendingViewerShares: [], remoteWatchCount: 0, isViewerConnectPending: false,
-    focusedShare: null as { roomName: string; userId: number; userName: string } | null, setFocusedShare: vi.fn(), setDiscoveryTarget: vi.fn(), remoteVideoEl: null, remoteVideoEls: new Map<number, HTMLVideoElement>(),
-    roomQuality: undefined as string | undefined, shareQualities: new Map<number, string>(), viewerQualities: new Map<number, string>(), addWatchingShare: vi.fn(), removeWatchingShare: vi.fn(),
-    disconnectViewer: vi.fn(), connectAsViewer: vi.fn(), setViewerQuality: vi.fn(), handleScreenShareServiceUnavailable: vi.fn(),
-  };
-  const notificationQueueIds = new Set<string>();
-  const notificationQueue = {
-    register: vi.fn((id: string) => {
-      notificationQueueIds.add(id);
-    }),
-    unregister: vi.fn((id: string) => {
-      notificationQueueIds.delete(id);
-    }),
-    isVisible: vi.fn((id: string) => notificationQueueIds.has(id)),
-    visibleCount: 0,
-    totalCount: 0,
-  };
+// The shared harness owns every App mock; this suite only needs the recorded props and
+// the simplified stubs it has always asserted against.
+const mockValues = {
+  matrixClient: appHarnessMocks.matrixClient,
+  dmStore: appHarnessMocks.dmStore,
+  unreadTracker: appHarnessMocks.unreadTracker,
+  screenShare: appHarnessMocks.screenShare,
+  notificationQueue: appHarnessMocks.notificationQueue,
+  notificationQueueIds: appHarnessMocks.notificationQueueIds,
+  get headerProps(): HarnessProps | undefined { return appHarnessMocks.captured.get('Header'); },
+  get channelChatPanelProps(): HarnessProps | undefined { return appHarnessMocks.captured.get('ChatPanel:channel'); },
+  get dmChatPanelProps(): HarnessProps | undefined { return appHarnessMocks.captured.get('ChatPanel:dm'); },
+  get dmContactListProps(): HarnessProps | undefined { return appHarnessMocks.captured.get('DMContactList'); },
+  get dmStoreOptions(): HarnessProps | undefined { return appHarnessMocks.captured.get('useDMStore'); },
+};
 
-  return {
-    matrixClient, dmStore, unreadTracker, idleActions, screenShare,
-    notificationQueue, notificationQueueIds,
-    get dmChatPanelProps() { return dmChatPanelProps; },
-    setDmChatPanelProps: (props: Record<string, unknown> | undefined) => { dmChatPanelProps = props; },
-    get channelChatPanelProps() { return channelChatPanelProps; },
-    setChannelChatPanelProps: (props: Record<string, unknown> | undefined) => { channelChatPanelProps = props; },
-    get dmContactListProps() { return dmContactListProps; },
-    setDmContactListProps: (props: Record<string, unknown> | undefined) => { dmContactListProps = props; },
-    get headerProps() { return headerProps; },
-    setHeaderProps: (props: Record<string, unknown> | undefined) => { headerProps = props; },
-    get dmStoreOptions() { return dmStoreOptions; },
-    setDmStoreOptions: (options: Record<string, unknown> | undefined) => { dmStoreOptions = options; },
-  };
-});
-
-vi.mock('./bridge', () => {
-  const handlers = new Map<string, Set<(data: unknown) => void>>();
-  return { default: {
-    send: vi.fn(),
-    on: vi.fn((event: string, handler: (data: unknown) => void) => { if (!handlers.has(event)) handlers.set(event, new Set()); handlers.get(event)!.add(handler); }),
-    off: vi.fn((event: string, handler: (data: unknown) => void) => handlers.get(event)?.delete(handler)),
-    __emit: (event: string, data?: unknown) => {
-      handlers.get(event)?.forEach(handler => handler(data));
-      // The client emits membership as voice.usersReset immediately after voice.connected.
-      const users = (data as { users?: unknown[] } | undefined)?.users;
-      if (event === 'voice.connected' && users) {
-        handlers.get('voice.usersReset')?.forEach(handler => handler({ users }));
-      }
-    },
-    __reset: () => handlers.clear(),
-  } };
-});
-
-vi.mock('./components/Header/Header', () => ({ Header: (props: Record<string, unknown>) => { mockValues.setHeaderProps(props); return <header />; } }));
-vi.mock('./components/Sidebar/Sidebar', () => ({
-  Sidebar: (props: Record<string, unknown>) => {
-    return (
-      <>
-        <button type="button" data-testid="sidebar-select-channel" onClick={() => (props.onSelectChannel as ((channelId: number) => void) | undefined)?.(1)} />
-        <button type="button" data-testid="sidebar-select-server" onClick={() => (props.onSelectServer as (() => void) | undefined)?.()} />
-      </>
-    );
-  },
-}));
-vi.mock('./components/ChatPanel/ChatPanel', () => ({
-  ChatPanel: (props: Record<string, unknown>) => {
-    if (props.isDM) mockValues.setDmChatPanelProps(props);
-    else mockValues.setChannelChatPanelProps(props);
-    return (
-      <section
-        data-testid={
-          props.isDM ? 'dm-chat-panel' : 'channel-chat-panel'
-        }
-      />
-    );
-  },
-}));
-vi.mock('./components/ServerList/ServerList', () => ({ ServerList: () => <section /> }));
-vi.mock('./components/ConnectionState/ConnectionState', () => ({ ConnectionState: () => <section /> }));
-vi.mock('./components/DMContactList/DMContactList', () => ({
-  DMContactList: (props: Record<string, unknown>) => {
-    mockValues.setDmContactListProps(props);
-    return null;
-  },
-}));
-vi.mock('./components/NeonD/NeonDGame', () => ({ NeonDGame: () => null }));
-vi.mock('./components/SettingsModal/SettingsModal', () => ({
-  DEFAULT_SCREEN_SHARE: { captureAudio: false, resolution: '1080p', fps: 30, systemAudio: false, viewerMode: 'in-app' },
-  SettingsModal: () => null,
-}));
-vi.mock('./hooks/useMatrixClient', () => ({ useMatrixClient: () => mockValues.matrixClient }));
-vi.mock('./hooks/useChatStore', () => ({ useChatStore: () => ({ messages: [], addMessage: vi.fn() }), addMessageToStore: vi.fn(), clearChatStorage: vi.fn(), purgeEphemeralMessages: vi.fn() }));
-vi.mock('./hooks/useDMStore', () => ({ useDMStore: (options: Record<string, unknown>) => { mockValues.setDmStoreOptions(options); return mockValues.dmStore; } }));
-vi.mock('./hooks/useUnreadTracker', () => ({ resetMarkersCache: vi.fn(), useUnreadTracker: () => mockValues.unreadTracker }));
-vi.mock('./hooks/useBrmbleIdle', () => ({ useBrmbleIdle: () => 0 }));
-vi.mock('./hooks/useIdleStatus', () => ({ useIdleStatus: () => ({ voiceIdle: {}, systemIdle: 0, isLocked: false }) }));
-vi.mock('./hooks/useIdleActions', () => ({ AFK_THRESHOLD_SEC: 600, useIdleActions: () => mockValues.idleActions }));
-vi.mock('./hooks/useServerHealth', () => ({ useServerHealth: () => undefined }));
-vi.mock('./hooks/useCompanionOverlayPublisher', () => ({ useCompanionOverlayPublisher: () => undefined }));
-vi.mock('./hooks/useLeaveVoiceCooldown', () => ({ useLeaveVoiceCooldown: () => ({ isOnCooldown: false, trigger: vi.fn() }) }));
-vi.mock('./hooks/useNotificationQueue', () => ({ useNotificationQueue: () => mockValues.notificationQueue }));
-vi.mock('./hooks/useScreenShare', () => ({ useScreenShare: () => mockValues.screenShare }));
+function installStubs() {
+  overrideComponent('Header', () => <header />);
+  overrideComponent('Sidebar', (props: HarnessProps) => (
+    <>
+      <button type="button" data-testid="sidebar-select-channel" onClick={() => (props.onSelectChannel as ((channelId: number) => void) | undefined)?.(1)} />
+      <button type="button" data-testid="sidebar-select-server" onClick={() => (props.onSelectServer as (() => void) | undefined)?.()} />
+    </>
+  ));
+  overrideComponent('ChatPanel', (props: HarnessProps) => (
+    <section data-testid={props.isDM ? 'dm-chat-panel' : 'channel-chat-panel'} />
+  ));
+  overrideComponent('DMContactList', () => null);
+}
 
 function renderConnectedApp() {
-  const view = render(<ServiceStatusProvider><App /></ServiceStatusProvider>);
-  act(() => {
-    (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('server.credentials', {
-      matrix: { homeserverUrl: 'https://example.com', accessToken: 'token', userId: '@me:example.com', roomMap: {} },
-    });
-    (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('voice.connected', {
-      username: 'Me', channelId: 1, channels: [{ id: 1, name: 'General' }], users: [],
-    });
+  return renderApp({
+    joinedChannelId: '1',
+    channels: [{ id: 1, name: 'General' }],
+    users: [],
+    matrixRoomMap: {},
   });
-  return view;
 }
 
 function renderPaintReadyApp() {
-  const view = render(
-    <ServiceStatusProvider>
-      <App />
-    </ServiceStatusProvider>,
-  );
-  act(() => {
-    (bridge as unknown as {
-      __emit: (event: string, data?: unknown) => void;
-    }).__emit('server.credentials', {
-      matrix: {
-        homeserverUrl: 'https://example.com',
-        accessToken: 'token',
-        userId: '@me:example.com',
-        roomMap: { '1': '!general:example.com' },
-      },
-    });
-    (bridge as unknown as {
-      __emit: (event: string, data?: unknown) => void;
-    }).__emit('voice.connected', {
-      username: 'Me',
-      channelId: 1,
-      channels: [{ id: 1, name: 'General' }],
-      users: [{
-        session: 7,
-        name: 'Me',
-        self: true,
-        channelId: 1,
-      }],
-    });
+  return renderApp({
+    joinedChannelId: '1',
+    channels: [{ id: 1, name: 'General' }],
+    users: [{ session: 7, name: 'Me', self: true, channelId: 1 }],
+    matrixRoomMap: { '1': '!general:example.com' },
   });
-  return view;
 }
 
 const sharedImage: MediaAttachment = {
@@ -254,12 +102,8 @@ describe('DM route Matrix isolation', () => {
       revokeObjectURL: vi.fn(),
     });
     localStorage.clear();
-    (bridge as unknown as { __reset: () => void }).__reset();
-    mockValues.setDmChatPanelProps(undefined);
-    mockValues.setChannelChatPanelProps(undefined);
-    mockValues.setDmContactListProps(undefined);
-    mockValues.setHeaderProps(undefined);
-    mockValues.setDmStoreOptions(undefined);
+    resetAppHarness();
+    installStubs();
     mockValues.matrixClient.dmRoomMap.clear();
     mockValues.dmStore.selectedContact = null;
     mockValues.dmStore.messages = [];
@@ -574,7 +418,7 @@ describe('DM route Matrix isolation', () => {
   });
 
   it('requests channel chat access when the active non-root channel is missing from roomMap', async () => {
-    render(<ServiceStatusProvider><App /></ServiceStatusProvider>);
+    renderDisconnectedApp();
 
     act(() => {
       (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('brmble.serviceStatus', {
@@ -663,52 +507,16 @@ describe('DM route Matrix isolation', () => {
     await waitFor(() => expect(document.querySelector('.content-slider')).toHaveClass('dm-active'));
 
     mockValues.screenShare.remoteWatchCount = 1;
-    view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
+    view.rerenderApp();
     await waitFor(() => {
       expect(document.querySelector('.content-slider')).toHaveClass('dm-active');
     });
 
     mockValues.screenShare.remoteWatchCount = 0;
-    view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
+    view.rerenderApp();
     await waitFor(() => {
       expect(document.querySelector('.content-slider')).toHaveClass('dm-active');
     });
-  });
-
-  it('supplies the remote viewer to the foreground DM panel without duplicating it in the inactive channel panel', async () => {
-    const share = { roomName: 'channel-1', userId: 10, userName: 'Vanilla Val' };
-    const remoteVideoEls = new Map([[10, document.createElement('video')]]);
-    const shareQualities = new Map([[10, 'high']]);
-    const viewerQualities = new Map([[10, 'low']]);
-    mockValues.dmStore.selectedContact = { id: '@val:example.com', displayName: 'Vanilla Val', unreadCount: 0 };
-    mockValues.screenShare.watchingShares = [share];
-    mockValues.screenShare.focusedShare = share;
-    mockValues.screenShare.remoteVideoEls = remoteVideoEls;
-    mockValues.screenShare.roomQuality = 'good';
-    mockValues.screenShare.shareQualities = shareQualities;
-    mockValues.screenShare.viewerQualities = viewerQualities;
-    const view = renderConnectedApp();
-
-    act(() => {
-      (mockValues.dmContactListProps?.onSelectContact as (id: string) => void)('@val:example.com');
-    });
-    view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
-
-    await waitFor(() => {
-      expect(mockValues.dmChatPanelProps).toEqual(expect.objectContaining({
-        watchingShares: [share],
-        focusedShare: share,
-        remoteVideoEls,
-        roomQuality: 'good',
-        shareQualities,
-        viewerQualities,
-        onFocusShare: mockValues.screenShare.setFocusedShare,
-        onCloseShare: expect.any(Function),
-        onViewerQualityChange: mockValues.screenShare.setViewerQuality,
-        screenShareViewerMode: 'in-app',
-      }));
-    });
-    expect(mockValues.channelChatPanelProps).not.toHaveProperty('watchingShares');
   });
 
   it('marks inactive conversation slides inert as well as aria-hidden', async () => {
@@ -745,7 +553,7 @@ describe('DM route Matrix isolation', () => {
     await waitFor(() => expect(document.querySelector('.content-slider')).toHaveClass('dm-active'));
 
     mockValues.screenShare.remoteWatchCount = 1;
-    view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
+    view.rerenderApp();
 
     act(() => {
       (mockValues.dmContactListProps?.onCloseConversation as (id: string) => void)('@val:example.com');
@@ -761,7 +569,7 @@ describe('DM route Matrix isolation', () => {
     act(() => view.getByTestId('sidebar-select-channel').click());
     await waitFor(() => expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active'));
     mockValues.unreadTracker.totalDmUnreadCount = 3;
-    view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
+    view.rerenderApp();
 
     await waitFor(() => expect(mockValues.headerProps?.unreadDMCount).toBe(3));
     expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active');
@@ -789,7 +597,7 @@ describe('DM route Matrix isolation', () => {
     mockValues.unreadTracker.roomUnreads = new Map([['!val:example.com', { notificationCount: 1 }]]);
     mockValues.unreadTracker.getRoomUnread.mockReturnValue({ notificationCount: 1, highlightCount: 0, fullyReadEventId: null });
     mockValues.unreadTracker.getMarkerTimestamp.mockReturnValue(1234);
-    view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
+    view.rerenderApp();
 
     await waitFor(() => expect(mockValues.headerProps?.dmActive).toBe(true));
     expect(mockValues.unreadTracker.markRoomRead).not.toHaveBeenCalledWith('!val:example.com', '$latest-dm-event');
@@ -798,7 +606,7 @@ describe('DM route Matrix isolation', () => {
   it('keeps active remote watches connected when selecting channel chat or server chat', async () => {
     const view = renderConnectedApp();
     mockValues.screenShare.remoteWatchCount = 1;
-    view.rerender(<ServiceStatusProvider><App /></ServiceStatusProvider>);
+    view.rerenderApp();
     mockValues.screenShare.disconnectViewer.mockClear();
 
     act(() => view.getByTestId('sidebar-select-channel').click());
@@ -821,7 +629,7 @@ describe('DM route Matrix isolation', () => {
       (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('voice.disconnected', { reconnectAvailable: true });
     }],
   ])('does not reserve Messages panel space on the %s screen', async (_label, enterScreen) => {
-    render(<ServiceStatusProvider><App /></ServiceStatusProvider>);
+    renderDisconnectedApp();
 
     act(() => enterScreen());
 

--- a/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
+++ b/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
@@ -528,7 +528,7 @@ describe('DM route Matrix isolation', () => {
     expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument();
   });
 
-  // The Header no longer carries an aggregate DM badge � the permanently visible
+  // The Header no longer carries an aggregate DM badge — the permanently visible
   // Messages panel shows per-contact unread counts. The surviving aggregate consumer is
   // the native taskbar badge, so that is what this asserts.
   it('updates the taskbar DM badge without leaving the foreground channel', async () => {

--- a/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
+++ b/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
@@ -132,6 +132,12 @@ describe('DM route Matrix isolation', () => {
       expect(mockValues.channelChatPanelProps
         ?.onUseAsPaintBackground).toEqual(expect.any(Function));
     });
+
+    act(() => {
+      (mockValues.dmContactListProps?.onSelectContact as (id: string) => void)('@val:example.com');
+    });
+
+    await waitFor(() => expect(mockValues.dmChatPanelProps).toBeDefined());
     expect(mockValues.dmChatPanelProps)
       .not.toHaveProperty('onUseAsPaintBackground');
   });
@@ -414,7 +420,10 @@ describe('DM route Matrix isolation', () => {
 
     renderConnectedApp();
 
-    expect(mockValues.dmChatPanelProps?.messages).toEqual([]);
+    // With one tab-driven ChatPanel there is no DM panel at all while a channel is
+    // active, so stale DM messages have nowhere to leak to.
+    expect(mockValues.dmChatPanelProps).toBeUndefined();
+    expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument();
   });
 
   it('requests channel chat access when the active non-root channel is missing from roomMap', async () => {
@@ -479,20 +488,21 @@ describe('DM route Matrix isolation', () => {
     act(() => {
       (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('voice.disconnected', { reconnectAvailable: true });
     });
-    await waitFor(() => expect(document.querySelector('.content-slider')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByTestId('channel-chat-panel')).not.toBeInTheDocument());
 
     act(() => {
       (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('voice.connected', { username: 'Me', channelId: 0, users: [] });
     });
 
     await waitFor(() => expect(mockValues.matrixClient.setActiveDmContact).toHaveBeenLastCalledWith(null));
-    expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active');
+    expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument();
   });
 
   it('lands on channel chat after connecting', async () => {
     renderConnectedApp();
 
-    expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active');
+    expect(screen.getByTestId('channel-chat-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument();
     await waitFor(() => expect(mockValues.matrixClient.setActiveChannel).toHaveBeenCalledWith(null));
   });
 
@@ -504,43 +514,19 @@ describe('DM route Matrix isolation', () => {
       (mockValues.dmContactListProps?.onSelectContact as (id: string) => void)('@val:example.com');
     });
 
-    await waitFor(() => expect(document.querySelector('.content-slider')).toHaveClass('dm-active'));
+    await waitFor(() => expect(screen.getByTestId('dm-chat-panel')).toBeInTheDocument());
 
     mockValues.screenShare.remoteWatchCount = 1;
     view.rerenderApp();
     await waitFor(() => {
-      expect(document.querySelector('.content-slider')).toHaveClass('dm-active');
+      expect(screen.getByTestId('dm-chat-panel')).toBeInTheDocument();
     });
 
     mockValues.screenShare.remoteWatchCount = 0;
     view.rerenderApp();
     await waitFor(() => {
-      expect(document.querySelector('.content-slider')).toHaveClass('dm-active');
+      expect(screen.getByTestId('dm-chat-panel')).toBeInTheDocument();
     });
-  });
-
-  it('marks inactive conversation slides inert as well as aria-hidden', async () => {
-    mockValues.dmStore.selectedContact = { id: '@val:example.com', displayName: 'Vanilla Val', unreadCount: 0 };
-    const view = renderConnectedApp();
-
-    act(() => {
-      (mockValues.dmContactListProps?.onSelectContact as (id: string) => void)('@val:example.com');
-    });
-
-    await waitFor(() => {
-      const [channelSlide, dmSlide] = Array.from(document.querySelectorAll('.content-slide'));
-      expect(channelSlide).toHaveAttribute('aria-hidden', 'true');
-      expect(channelSlide).toHaveAttribute('inert');
-      expect(dmSlide).toHaveAttribute('aria-hidden', 'false');
-      expect(dmSlide).not.toHaveAttribute('inert');
-    });
-
-    act(() => view.getByTestId('sidebar-select-channel').click());
-    const [channelSlide, dmSlide] = Array.from(document.querySelectorAll('.content-slide'));
-    expect(channelSlide).toHaveAttribute('aria-hidden', 'false');
-    expect(channelSlide).not.toHaveAttribute('inert');
-    expect(dmSlide).toHaveAttribute('aria-hidden', 'true');
-    expect(dmSlide).toHaveAttribute('inert');
   });
 
   it('falls back to the channel foreground when a selected conversation closes during a remote watch', async () => {
@@ -550,7 +536,7 @@ describe('DM route Matrix isolation', () => {
     act(() => {
       (mockValues.dmContactListProps?.onSelectContact as (id: string) => void)('@val:example.com');
     });
-    await waitFor(() => expect(document.querySelector('.content-slider')).toHaveClass('dm-active'));
+    await waitFor(() => expect(screen.getByTestId('dm-chat-panel')).toBeInTheDocument());
 
     mockValues.screenShare.remoteWatchCount = 1;
     view.rerenderApp();
@@ -560,19 +546,19 @@ describe('DM route Matrix isolation', () => {
     });
 
     expect(mockValues.dmStore.closeDM).toHaveBeenCalledWith('@val:example.com');
-    expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active');
+    expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument();
   });
 
   it('updates the unread DM badge without leaving the foreground channel', async () => {
     const view = renderConnectedApp();
 
     act(() => view.getByTestId('sidebar-select-channel').click());
-    await waitFor(() => expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active'));
+    await waitFor(() => expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument());
     mockValues.unreadTracker.totalDmUnreadCount = 3;
     view.rerenderApp();
 
     await waitFor(() => expect(mockValues.headerProps?.unreadDMCount).toBe(3));
-    expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active');
+    expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument();
   });
 
   it('does not mark a selected Matrix DM as read when a channel is in the foreground', async () => {
@@ -588,11 +574,11 @@ describe('DM route Matrix isolation', () => {
     act(() => {
       (mockValues.dmContactListProps?.onSelectContact as (id: string) => void)('@val:example.com');
     });
-    await waitFor(() => expect(document.querySelector('.content-slider')).toHaveClass('dm-active'));
+    await waitFor(() => expect(screen.getByTestId('dm-chat-panel')).toBeInTheDocument());
     mockValues.unreadTracker.markRoomRead.mockClear();
 
     act(() => view.getByTestId('sidebar-select-channel').click());
-    await waitFor(() => expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active'));
+    await waitFor(() => expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument());
 
     mockValues.unreadTracker.roomUnreads = new Map([['!val:example.com', { notificationCount: 1 }]]);
     mockValues.unreadTracker.getRoomUnread.mockReturnValue({ notificationCount: 1, highlightCount: 0, fullyReadEventId: null });

--- a/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
+++ b/src/Brmble.Web/src/App.dmDirectoryBehavior.test.tsx
@@ -453,27 +453,6 @@ describe('DM route Matrix isolation', () => {
     });
   });
 
-  it('routes DMContactList visibility through the shared Messages panel toggle', () => {
-    renderConnectedApp();
-
-    expect(mockValues.dmContactListProps?.onToggleVisibility).toBe(mockValues.headerProps?.onToggleDM);
-  });
-
-  it('resets the Messages panel when reconnecting', async () => {
-    renderConnectedApp();
-    act(() => {
-      (mockValues.headerProps?.onToggleDM as () => void)();
-      (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('voice.disconnected', { reconnectAvailable: true });
-    });
-
-    await waitFor(() => expect(mockValues.headerProps?.dmActive).toBe(false));
-
-    act(() => {
-      (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('voice.connected', { username: 'Me', channelId: 0, users: [] });
-    });
-
-    await waitFor(() => expect(mockValues.headerProps?.dmActive).toBe(true));
-  });
 
   it('returns to channel chat and clears Matrix DM routing after reconnecting with a retained selection', async () => {
     mockValues.dmStore.selectedContact = { id: '@val:example.com', displayName: 'Vanilla Val', unreadCount: 0 };
@@ -549,7 +528,10 @@ describe('DM route Matrix isolation', () => {
     expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument();
   });
 
-  it('updates the unread DM badge without leaving the foreground channel', async () => {
+  // The Header no longer carries an aggregate DM badge � the permanently visible
+  // Messages panel shows per-contact unread counts. The surviving aggregate consumer is
+  // the native taskbar badge, so that is what this asserts.
+  it('updates the taskbar DM badge without leaving the foreground channel', async () => {
     const view = renderConnectedApp();
 
     act(() => view.getByTestId('sidebar-select-channel').click());
@@ -557,7 +539,10 @@ describe('DM route Matrix isolation', () => {
     mockValues.unreadTracker.totalDmUnreadCount = 3;
     view.rerenderApp();
 
-    await waitFor(() => expect(mockValues.headerProps?.unreadDMCount).toBe(3));
+    await waitFor(() => expect(bridge.send).toHaveBeenCalledWith(
+      'notification.badge',
+      expect.objectContaining({ unreadDMs: true }),
+    ));
     expect(screen.queryByTestId('dm-chat-panel')).not.toBeInTheDocument();
   });
 
@@ -585,7 +570,7 @@ describe('DM route Matrix isolation', () => {
     mockValues.unreadTracker.getMarkerTimestamp.mockReturnValue(1234);
     view.rerenderApp();
 
-    await waitFor(() => expect(mockValues.headerProps?.dmActive).toBe(true));
+    await waitFor(() => expect(mockValues.unreadTracker.getRoomUnread).toHaveBeenCalledWith('!val:example.com'));
     expect(mockValues.unreadTracker.markRoomRead).not.toHaveBeenCalledWith('!val:example.com', '$latest-dm-event');
   });
 
@@ -614,13 +599,13 @@ describe('DM route Matrix isolation', () => {
       });
       (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit('voice.disconnected', { reconnectAvailable: true });
     }],
-  ])('does not reserve Messages panel space on the %s screen', async (_label, enterScreen) => {
+  ])('does not render the Messages panel on the %s screen', async (_label, enterScreen) => {
     renderDisconnectedApp();
 
     act(() => enterScreen());
 
     await waitFor(() => {
-      expect(document.querySelector('.workspace-conversation')).not.toHaveClass('workspace-conversation--with-panel');
+      expect(document.querySelector('.app-body')).toBeInTheDocument();
     });
     expect(mockValues.dmContactListProps).toBeUndefined();
   });

--- a/src/Brmble.Web/src/App.dmTabRestore.test.tsx
+++ b/src/Brmble.Web/src/App.dmTabRestore.test.tsx
@@ -1,0 +1,130 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, screen } from '@testing-library/react';
+import { HARNESS_SERVER_ADDRESS, renderConnectedApp, resetAppHarness } from './testing/appHarness';
+import { loadConversationTabs } from './workspace/conversationStorage';
+import { conversationKey } from './workspace/conversation';
+
+// The real ChatPanel observes its scroller; jsdom ships neither observer.
+beforeAll(() => {
+  class ObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('ResizeObserver', ObserverMock);
+  vi.stubGlobal('IntersectionObserver', ObserverMock);
+  Element.prototype.scrollIntoView = () => {};
+});
+
+afterEach(() => {
+  cleanup();
+  resetAppHarness();
+  localStorage.clear();
+});
+
+const storedKeys = () => loadConversationTabs(HARNESS_SERVER_ADDRESS, () => true).map(conversationKey);
+
+describe('restoring persisted dm tabs', () => {
+  it('drops a persisted dm tab whose contact no longer resolves', () => {
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }],
+      persistedTabs: [{ kind: 'dm', contactId: '@2:localhost' }],
+      dmContacts: [],
+    });
+
+    expect(screen.queryByRole('tab', { name: /@2:localhost/ })).not.toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(1);
+  });
+
+  it('does not re-persist a dropped dm tab', () => {
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }],
+      persistedTabs: [{ kind: 'dm', contactId: '@2:localhost' }],
+      dmContacts: [],
+    });
+
+    expect(storedKeys()).not.toContain('dm:@2:localhost');
+  });
+
+  it('keeps a persisted dm tab whose contact only resolves after channels arrive', () => {
+    const { setDmContacts, emitCredentials } = renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }],
+      persistedTabs: [{ kind: 'dm', contactId: '@alice:example.com' }],
+      dmContacts: [],
+      deferCredentials: true,
+    });
+
+    // Channels and presence have landed but no DM identity data has: validating now
+    // would reject a perfectly good tab, so nothing may be dropped yet.
+    expect(storedKeys()).toContain('dm:@alice:example.com');
+
+    setDmContacts([{ id: '@alice:example.com', name: 'Alice' }]);
+    emitCredentials();
+
+    expect(screen.getByRole('tab', { name: /Alice/ })).toBeInTheDocument();
+    expect(storedKeys()).toContain('dm:@alice:example.com');
+  });
+
+  it('keeps a persisted dm tab that resolves only through the server dm room map', () => {
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }],
+      persistedTabs: [{ kind: 'dm', contactId: '@alice:example.com' }],
+      dmContacts: [],
+      dmRoomMap: { '@alice:example.com': '!alice:example.com' },
+    });
+
+    expect(storedKeys()).toContain('dm:@alice:example.com');
+  });
+
+  it('keeps a persisted dm tab that resolves only through the server directory', () => {
+    renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }],
+      persistedTabs: [{ kind: 'dm', contactId: '@alice:example.com' }],
+      dmContacts: [],
+      userMappings: { Alice: '@alice:example.com' },
+    });
+
+    expect(storedKeys()).toContain('dm:@alice:example.com');
+  });
+
+  it('drops a dm tab whose contact stops resolving after the restore', () => {
+    const { setDmContacts } = renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }],
+      persistedTabs: [{ kind: 'dm', contactId: '@alice:example.com' }],
+      dmContacts: [{ id: '@alice:example.com', name: 'Alice' }],
+    });
+    expect(screen.getByRole('tab', { name: /Alice/ })).toBeInTheDocument();
+
+    setDmContacts([]);
+
+    expect(screen.queryByRole('tab', { name: /Alice/ })).not.toBeInTheDocument();
+    expect(storedKeys()).not.toContain('dm:@alice:example.com');
+  });
+});
+
+describe('closing a dm contact', () => {
+  it('invalidates its tab even when that tab is not the active one', () => {
+    const { props } = renderConnectedApp({
+      joinedChannelId: '7',
+      channels: [{ id: 7, name: 'General' }, { id: 9, name: 'Random' }],
+      persistedTabs: [
+        { kind: 'dm', contactId: '@alice:example.com' },
+        { kind: 'channel', channelId: '9' },
+      ],
+      dmContacts: [{ id: '@alice:example.com', name: 'Alice' }],
+    });
+
+    expect(screen.getByRole('tab', { name: /Alice/ })).toHaveAttribute('aria-selected', 'false');
+
+    const onCloseConversation = props('DMContactList')?.onCloseConversation as (id: string) => void;
+    act(() => { onCloseConversation('@alice:example.com'); });
+
+    expect(screen.queryByRole('tab', { name: /Alice/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/Brmble.Web/src/App.duelOrchestration.test.tsx
+++ b/src/Brmble.Web/src/App.duelOrchestration.test.tsx
@@ -438,6 +438,7 @@ describe('App duel orchestration', () => {
     mocks.gameState.ended = ended;
     mocks.duelQueue.outgoingRematch = { offerId: 8, sourceMatchId: 91, gameType: 'rps' };
     renderApp();
+    connectSelf(0);
 
     expect(screen.getByRole('button', { name: 'Rematch pending' })).toBeDisabled();
     mocks.duelQueue.outgoingRematch = null;
@@ -451,6 +452,7 @@ describe('App duel orchestration', () => {
     mocks.gameState.ended = ended;
     mocks.duelQueue.incomingRematch = { offerId: 73, sourceMatchId: 91, gameType: 'rps' };
     renderApp();
+    connectSelf(0);
 
     expect(screen.getByRole('button', { name: 'Rematch pending' })).toBeDisabled();
     mocks.gameState.ended = null;
@@ -460,6 +462,7 @@ describe('App duel orchestration', () => {
     mocks.gameState.ended = ended;
     mocks.duelQueue.incomingRematch = { offerId: 73, sourceMatchId: 92, gameType: 'rps' };
     renderApp();
+    connectSelf(0);
 
     expect(screen.getByRole('button', { name: 'Rematch' })).toBeEnabled();
     mocks.gameState.ended = null;
@@ -468,6 +471,7 @@ describe('App duel orchestration', () => {
   it('locks a rematch request against double click and unlocks on a correlated error', () => {
     mocks.gameState.ended = ended;
     const { rerender } = renderApp();
+    connectSelf(0);
 
     const rematch = screen.getByRole('button', { name: 'Rematch' });
     fireEvent.click(rematch);

--- a/src/Brmble.Web/src/App.duelOrchestration.test.tsx
+++ b/src/Brmble.Web/src/App.duelOrchestration.test.tsx
@@ -49,7 +49,7 @@ const mocks = vi.hoisted(() => {
     activeShare: null, activeShares: [], watchingShare: null, watchingShares: [], pendingViewerShares: [], remoteWatchCount: 0,
     isViewerConnectPending: false, focusedShare: null, setFocusedShare: vi.fn(), setDiscoveryTarget: vi.fn(), remoteVideoEl: null,
     remoteVideoEls: new Map(), roomQuality: undefined, shareQualities: new Map(), addWatchingShare: vi.fn(), removeWatchingShare: vi.fn(),
-    disconnectViewer: vi.fn(), connectAsViewer: vi.fn(), handleScreenShareServiceUnavailable: vi.fn(),
+    disconnectViewer: vi.fn(), setRemoteScreenSharesHidden: vi.fn(), connectAsViewer: vi.fn(), handleScreenShareServiceUnavailable: vi.fn(),
   };
   return { ids, gameState, duelQueue, notificationQueue, sidebarProps, headerProps, matrixClient, dmStore, unreadTracker, idleActions, screenShare };
 });

--- a/src/Brmble.Web/src/App.gameMode.test.tsx
+++ b/src/Brmble.Web/src/App.gameMode.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MainPanel } from './components/MainPanel/MainPanel';
+
+// MainPanel is the extracted render decision; App composes it.
+describe('main panel game mode', () => {
+  const base = {
+    activityRegion: <div>activity</div>,
+    conversationRegion: <div>conversation</div>,
+    gameSurface: <div>game surface</div>,
+  };
+
+  it('renders the split layout when not playing', () => {
+    render(<MainPanel {...base} mode="split" />);
+    expect(screen.getByText('activity')).toBeInTheDocument();
+    expect(screen.getByText('conversation')).toBeInTheDocument();
+    expect(screen.queryByText('game surface')).not.toBeInTheDocument();
+  });
+
+  it('renders only the game surface when playing', () => {
+    render(<MainPanel {...base} mode="game" />);
+    expect(screen.getByText('game surface')).toBeInTheDocument();
+    expect(screen.queryByText('activity')).not.toBeInTheDocument();
+    expect(screen.queryByText('conversation')).not.toBeInTheDocument();
+  });
+
+  it('omits the activity region entirely when there is no activity', () => {
+    render(<MainPanel {...base} mode="split" activityRegion={null} />);
+    expect(screen.queryByText('activity')).not.toBeInTheDocument();
+    expect(screen.getByText('conversation')).toBeInTheDocument();
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+  });
+});

--- a/src/Brmble.Web/src/App.paintPresence.test.tsx
+++ b/src/Brmble.Web/src/App.paintPresence.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { shouldKeepPaintSession } from './App';
+
+// The viewed channel is deliberately not a parameter of this predicate: browsing
+// cannot affect paint survival because there is nothing here to observe it with.
+// The cases below therefore vary only session ownership and connection.
+describe('paint session survival', () => {
+  it('survives while the joined channel still owns the session', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: '7', joinedChannelId: '7' })).toBe(true);
+  });
+
+  it('ends when the user moves to a different voice channel', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: '7', joinedChannelId: '12' })).toBe(false);
+  });
+
+  it('ends when the user leaves voice entirely', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: '7', joinedChannelId: null })).toBe(false);
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: '7', joinedChannelId: 'server-root' })).toBe(false);
+  });
+
+  it('ends when the connection drops', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'disconnected', sessionChannelId: '7', joinedChannelId: '7' })).toBe(false);
+  });
+
+  it('ends when no owning channel was recorded for the session', () => {
+    expect(shouldKeepPaintSession({ connectionStatus: 'connected', sessionChannelId: undefined, joinedChannelId: '7' })).toBe(false);
+  });
+});

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -202,6 +202,7 @@ vi.mock('./hooks/useScreenShare', () => ({
     disconnectViewer,
     connectAsViewer,
     isViewerConnectPending: screenShareState.isViewerConnectPending,
+    setRemoteScreenSharesHidden: vi.fn(),
     };
   },
 }));

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -321,6 +321,7 @@ vi.mock('./components/Sidebar/Sidebar', () => ({
     onWatchScreenShare?: (roomName: string, userId?: number, matrixUserId?: string) => void;
     onJoinChannel?: (channelId: number) => void;
     onSelectChannel?: (channelId: number) => void;
+    onSelectServer?: () => void;
     channels?: Array<{ id: number; canEnter?: boolean; hasPasswordRestriction?: boolean; position?: number; description?: string }>;
   }) => {
     sidebarProps.current = props;
@@ -344,6 +345,11 @@ vi.mock('./components/Sidebar/Sidebar', () => ({
       type: 'button',
       'data-testid': 'sidebar-select-channel-2',
       onClick: () => props.onSelectChannel?.(2),
+    }),
+    React.createElement('button', {
+      type: 'button',
+      'data-testid': 'sidebar-select-server',
+      onClick: () => props.onSelectServer?.(),
     }),
   );
   },
@@ -605,34 +611,8 @@ describe('active share discovery', () => {
     });
   });
 
-  it('closes Messages while a viewer connection is pending, then reopens it when that only attempt fails', async () => {
-    const view = render(React.createElement(App));
 
-    act(() => {
-      bridge.emit('voice.connected', {
-        username: 'TestUser',
-        channelId: 1,
-        channels: [{ id: 1, name: 'General' }],
-        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
-      });
-    });
-
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
-
-    screenShareState.pendingViewerShares = [{ roomName: 'channel-1', userId: 10 }];
-    screenShareState.remoteWatchCount = 1;
-    view.rerender(React.createElement(App));
-
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(false));
-
-    screenShareState.pendingViewerShares = [];
-    screenShareState.remoteWatchCount = 0;
-    view.rerender(React.createElement(App));
-
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
-  });
-
-  it('keeps the channel foreground while active remote watches collapse Messages', async () => {
+  it('keeps the channel foreground while remote watches are active', async () => {
     const view = render(React.createElement(App));
 
     act(() => {
@@ -653,37 +633,9 @@ describe('active share discovery', () => {
     screenShareState.remoteWatchCount = 1;
     view.rerender(React.createElement(App));
 
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(false));
-    expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active');
+    await waitFor(() => expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active'));
   });
 
-  it('keeps Messages collapsed until the final remote watch ends, including duplicate final-watch updates', async () => {
-    const view = render(React.createElement(App));
-
-    act(() => {
-      bridge.emit('voice.connected', {
-        username: 'TestUser',
-        channelId: 1,
-        channels: [{ id: 1, name: 'General' }],
-        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
-      });
-    });
-
-    screenShareState.remoteWatchCount = 2;
-    view.rerender(React.createElement(App));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(false));
-
-    screenShareState.remoteWatchCount = 1;
-    view.rerender(React.createElement(App));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(false));
-
-    screenShareState.remoteWatchCount = 0;
-    view.rerender(React.createElement(App));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
-
-    view.rerender(React.createElement(App));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
-  });
 
   it('does not collapse Messages for local sharing alone', async () => {
     screenShareState.isSharing = true;
@@ -703,37 +655,8 @@ describe('active share discovery', () => {
     view.unmount();
   });
 
-  it('preserves manual panel intent during a remote watch and reopens Messages when the final watch ends', async () => {
-    const view = render(React.createElement(App));
 
-    act(() => {
-      bridge.emit('voice.connected', {
-        username: 'TestUser',
-        channelId: 1,
-        channels: [{ id: 1, name: 'General' }],
-        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
-      });
-    });
-
-    screenShareState.remoteWatchCount = 1;
-    view.rerender(React.createElement(App));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(false));
-
-    act(() => view.getByTestId('header-toggle-messages').click());
-    expect(dmContactListProps.current.visible).toBe(true);
-
-    view.rerender(React.createElement(App));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
-
-    act(() => view.getByTestId('header-toggle-messages').click());
-    expect(dmContactListProps.current.visible).toBe(false);
-
-    screenShareState.remoteWatchCount = 0;
-    view.rerender(React.createElement(App));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
-  });
-
-  it('keeps viewers connected during channel selection and lets cleared watches reopen Messages', async () => {
+  it('keeps viewers connected during channel selection', async () => {
     const view = render(React.createElement(App));
 
     act(() => {
@@ -749,7 +672,6 @@ describe('active share discovery', () => {
     screenShareState.pendingViewerShares = [{ roomName: 'channel-1', userId: 10 }];
     screenShareState.remoteWatchCount = 1;
     view.rerender(React.createElement(App));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(false));
 
     const cleanupCallsBeforeChannelSelection = vi.mocked(disconnectViewer).mock.calls.length;
     act(() => view.getByTestId('sidebar-select-channel-2').click());
@@ -764,35 +686,8 @@ describe('active share discovery', () => {
     screenShareState.pendingViewerShares = [];
     screenShareState.remoteWatchCount = 0;
     view.rerender(React.createElement(App));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
     expect(screenShareState.pendingViewerShares).toEqual([]);
     expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active');
-  });
-
-  it('routes the native Messages shortcut through the Header panel state', async () => {
-    const view = render(React.createElement(App));
-
-    act(() => {
-      bridge.emit('voice.connected', {
-        username: 'TestUser',
-        channelId: 1,
-        channels: [{ id: 1, name: 'General' }],
-        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
-      });
-    });
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
-
-    act(() => view.getByTestId('header-toggle-messages').click());
-    expect(dmContactListProps.current.visible).toBe(false);
-
-    act(() => bridge.emit('voice.toggleDmScreen'));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
-
-    act(() => view.getByTestId('header-toggle-messages').click());
-    expect(dmContactListProps.current.visible).toBe(false);
-
-    act(() => bridge.emit('voice.toggleDmScreen'));
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
   });
 
   it('renders a pre-idle warning notification when idle pre-leave starts', async () => {
@@ -1328,8 +1223,11 @@ describe('active share discovery', () => {
       });
     });
 
+    // Browse the server root while still connected to voice channel 1: the share
+    // notification is raised against the voice channel, but Watch is refused
+    // because the viewed channel is root.
     act(() => {
-      bridge.emit('voice.channelChanged', { channelId: 0, name: 'Root' });
+      view.getByTestId('sidebar-select-server').click();
     });
 
     act(() => {
@@ -1765,6 +1663,11 @@ describe('active share discovery', () => {
 
     act(() => {
       bridge.emit('voice.channelChanged', { channelId: 0, name: 'Root' });
+      // The viewed channel now follows presence for root moves.
+      bridge.emit('voice.usersChanged', {
+        changed: [{ session: 7, name: 'TestUser', self: true, channelId: 0 }],
+        removed: [],
+      });
     });
 
     await waitFor(() => {

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -613,31 +613,6 @@ describe('active share discovery', () => {
   });
 
 
-  it('keeps the channel foreground while remote watches are active', async () => {
-    const view = render(React.createElement(App));
-
-    act(() => {
-      bridge.emit('voice.connected', {
-        username: 'TestUser',
-        channelId: 1,
-        channels: [{ id: 1, name: 'General' }, { id: 2, name: 'Work' }],
-        users: [{ session: 7, name: 'TestUser', self: true, channelId: 1 }],
-      });
-    });
-
-    act(() => {
-      view.getByTestId('sidebar-select-channel-2').click();
-    });
-
-    expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active');
-
-    screenShareState.remoteWatchCount = 1;
-    view.rerender(React.createElement(App));
-
-    await waitFor(() => expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active'));
-  });
-
-
   it('does not collapse Messages for local sharing alone', async () => {
     screenShareState.isSharing = true;
     const view = render(React.createElement(App));
@@ -691,7 +666,6 @@ describe('active share discovery', () => {
     screenShareState.remoteWatchCount = 0;
     view.rerender(React.createElement(App));
     expect(screenShareState.pendingViewerShares).toEqual([]);
-    expect(document.querySelector('.content-slider')).not.toHaveClass('dm-active');
   });
 
   it('renders a pre-idle warning notification when idle pre-leave starts', async () => {

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -286,10 +286,9 @@ vi.mock('./components/ErrorBoundary', () => ({
 }));
 
 vi.mock('./components/Header/Header', () => ({
-  Header: ({ onLeaveVoice, onToggleScreenShare, onToggleDM }: {
+  Header: ({ onLeaveVoice, onToggleScreenShare }: {
     onLeaveVoice?: () => void;
     onToggleScreenShare?: () => void;
-    onToggleDM?: () => void;
   }) => React.createElement(React.Fragment, null,
     React.createElement('button', {
       type: 'button',
@@ -300,11 +299,6 @@ vi.mock('./components/Header/Header', () => ({
       type: 'button',
       'data-testid': 'header-toggle-screen-share',
       onClick: onToggleScreenShare,
-    }),
-    React.createElement('button', {
-      type: 'button',
-      'data-testid': 'header-toggle-messages',
-      onClick: onToggleDM,
     }),
   ),
 }));
@@ -374,10 +368,10 @@ vi.mock('./components/CloseDialog/CloseDialog', () => ({ CloseDialog: () => null
 vi.mock('./components/OnboardingWizard/OnboardingWizard', () => ({ OnboardingWizard: () => null }));
 vi.mock('./components/Version/Version', () => ({ Version: () => null }));
 vi.mock('./components/ZoomIndicator/ZoomIndicator', () => ({ ZoomIndicator: () => null }));
-const dmContactListProps = vi.hoisted(() => ({ current: { visible: false } }));
+const dmContactListProps = vi.hoisted(() => ({ current: { rendered: false } }));
 vi.mock('./components/DMContactList/DMContactList', () => ({
-  DMContactList: (props: { visible: boolean }) => {
-    dmContactListProps.current = props;
+  DMContactList: () => {
+    dmContactListProps.current = { rendered: true };
     return null;
   },
 }));
@@ -613,7 +607,8 @@ describe('active share discovery', () => {
   });
 
 
-  it('does not collapse Messages for local sharing alone', async () => {
+  // The Messages panel is permanently visible now; local sharing must not remove it.
+  it('keeps the Messages panel mounted for local sharing alone', async () => {
     screenShareState.isSharing = true;
     const view = render(React.createElement(App));
 
@@ -626,7 +621,7 @@ describe('active share discovery', () => {
       });
     });
 
-    await waitFor(() => expect(dmContactListProps.current.visible).toBe(true));
+    await waitFor(() => expect(dmContactListProps.current.rendered).toBe(true));
     expect(screenShareState.remoteWatchCount).toBe(0);
     view.unmount();
   });

--- a/src/Brmble.Web/src/App.screenShareStart.test.ts
+++ b/src/Brmble.Web/src/App.screenShareStart.test.ts
@@ -552,7 +552,7 @@ describe('shouldClearLocalShareStartPending', () => {
 });
 
 describe('canWatchShareFromChannel', () => {
-  it('blocks watch attempts when current channel does not match share room', () => {
+  it('blocks watch attempts when the JOINED channel does not match the share room', () => {
     expect(canWatchShareFromChannel('server-root', 'channel-1')).toBe(false);
     expect(canWatchShareFromChannel('2', 'channel-1')).toBe(false);
     expect(canWatchShareFromChannel('1', 'channel-1')).toBe(true);
@@ -675,13 +675,16 @@ describe('active share discovery', () => {
 
     const cleanupCallsBeforeChannelSelection = vi.mocked(disconnectViewer).mock.calls.length;
     act(() => view.getByTestId('sidebar-select-channel-2').click());
-    await waitFor(() => expect(getActiveShareRequests()).toHaveLength(2));
 
     expect(disconnectViewer.mock.calls.length).toBe(cleanupCallsBeforeChannelSelection);
+    // Merely BROWSING another channel is not a presence move, so it must not
+    // re-run share discovery: the only discovery is still the one for the
+    // joined channel from connect.
+    expect(getActiveShareRequests()).toHaveLength(1);
     const channelTwoDiscoveryCall = vi.mocked(bridge.send).mock.calls
       .map(([type, payload], index) => ({ type, payload, order: vi.mocked(bridge.send).mock.invocationCallOrder[index] }))
       .find(call => call.type === 'livekit.checkActiveShare' && (call.payload as { roomName?: string }).roomName === 'channel-2');
-    expect(channelTwoDiscoveryCall).toBeDefined();
+    expect(channelTwoDiscoveryCall).toBeUndefined();
 
     screenShareState.pendingViewerShares = [];
     screenShareState.remoteWatchCount = 0;
@@ -1199,7 +1202,7 @@ describe('active share discovery', () => {
     expect(serviceStatus.updateStatus).not.toHaveBeenCalledWith('livekit', { state: 'idle', error: undefined });
   });
 
-  it('notification watch does not connect as viewer from root selected channel', async () => {
+  it('notification watch still connects as viewer while browsing the server root', async () => {
     vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'screen-share');
     screenShareState.activeShares = [{
       roomName: 'channel-1',
@@ -1223,9 +1226,9 @@ describe('active share discovery', () => {
       });
     });
 
-    // Browse the server root while still connected to voice channel 1: the share
-    // notification is raised against the voice channel, but Watch is refused
-    // because the viewed channel is root.
+    // Browse the server root while still JOINED to voice channel 1. Watching
+    // follows presence, not selection, so the share in your own channel stays
+    // watchable while you look around.
     act(() => {
       view.getByTestId('sidebar-select-server').click();
     });
@@ -1245,12 +1248,11 @@ describe('active share discovery', () => {
       await Promise.resolve();
     });
 
-    expect(connectAsViewer).not.toHaveBeenCalled();
-    expect(serviceStatus.updateStatus).not.toHaveBeenCalledWith('livekit', { state: 'connecting', error: undefined });
+    expect(connectAsViewer).toHaveBeenCalledWith('channel-1', 42, '@alice:example.com');
+    expect(serviceStatus.updateStatus).toHaveBeenCalledWith('livekit', { state: 'connecting', error: undefined });
   });
 
-  it('notification watch does not connect as viewer from the wrong selected channel', async () => {
-    vi.mocked(notifQueue.isVisible).mockImplementation((id: string) => id === 'screen-share');
+  it('does not connect as viewer for a share in a channel the user has moved out of', async () => {
     screenShareState.activeShares = [{
       roomName: 'channel-1',
       userName: 'Alice',
@@ -1276,22 +1278,18 @@ describe('active share discovery', () => {
       });
     });
 
+    // A real presence move: the gate is keyed to where you are standing, and
+    // presence is the source of truth for that.
     act(() => {
       bridge.emit('voice.channelChanged', { channelId: 2, name: 'Gaming' });
-    });
-
-    act(() => {
-      bridge.emit('livekit.screenShareStarted', {
-        roomName: 'channel-1',
-        userName: 'Alice',
-        userId: 42,
-        matrixUserId: '@alice:example.com',
-        sessionId: 2,
+      bridge.emit('voice.usersChanged', {
+        changed: [{ session: 7, name: 'TestUser', self: true, channelId: 2 }],
+        removed: [],
       });
     });
 
     await act(async () => {
-      view.getByText('Watch').click();
+      view.getByTestId('sidebar-watch-share').click();
       await Promise.resolve();
     });
 
@@ -1570,8 +1568,14 @@ describe('active share discovery', () => {
 
     vi.mocked(notifQueue.unregister).mockClear();
 
+    // Presence is the source of truth for "switching channels" now, so the
+    // fixture must move the self user too.
     act(() => {
       bridge.emit('voice.channelChanged', { channelId: 2, name: 'Gaming' });
+      bridge.emit('voice.usersChanged', {
+        changed: [{ session: 7, name: 'TestUser', self: true, channelId: 2 }],
+        removed: [],
+      });
     });
 
     expect(notifQueue.unregister).toHaveBeenCalledWith('screen-share');
@@ -1655,6 +1659,10 @@ describe('active share discovery', () => {
 
     act(() => {
       bridge.emit('voice.channelChanged', { channelId: 2, name: 'Gaming' });
+      bridge.emit('voice.usersChanged', {
+        changed: [{ session: 7, name: 'TestUser', self: true, channelId: 2 }],
+        removed: [],
+      });
     });
 
     await waitFor(() => {
@@ -1663,7 +1671,7 @@ describe('active share discovery', () => {
 
     act(() => {
       bridge.emit('voice.channelChanged', { channelId: 0, name: 'Root' });
-      // The viewed channel now follows presence for root moves.
+      // Discovery follows presence, so root moves must land in presence too.
       bridge.emit('voice.usersChanged', {
         changed: [{ session: 7, name: 'TestUser', self: true, channelId: 0 }],
         removed: [],
@@ -1708,6 +1716,10 @@ describe('active share discovery', () => {
 
     act(() => {
       bridge.emit('voice.channelChanged', { channelId: 2, name: 'Gaming' });
+      bridge.emit('voice.usersChanged', {
+        changed: [{ session: 7, name: 'TestUser', self: true, channelId: 2 }],
+        removed: [],
+      });
     });
 
     await waitFor(() => {

--- a/src/Brmble.Web/src/App.sharePresence.test.tsx
+++ b/src/Brmble.Web/src/App.sharePresence.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { canWatchShareFromChannel } from './App';
+
+describe('canWatchShareFromChannel', () => {
+  // Browsing another channel can no longer affect the answer: the viewed channel
+  // is not a parameter at all. Independence from selection is structural, so
+  // there is nothing observable to assert about it here.
+
+  it('allows watching a share published into the joined channel', () => {
+    expect(canWatchShareFromChannel('7', 'channel-7')).toBe(true);
+  });
+
+  it('rejects a share from any other channel', () => {
+    expect(canWatchShareFromChannel('7', 'channel-9')).toBe(false);
+  });
+
+  it('rejects when not in a channel', () => {
+    expect(canWatchShareFromChannel(null, 'channel-7')).toBe(false);
+  });
+
+  it('rejects server-root because it owns no shares', () => {
+    expect(canWatchShareFromChannel('server-root', 'channel-7')).toBe(false);
+    expect(canWatchShareFromChannel('server-root', 'channel-server-root')).toBe(false);
+  });
+
+  it('rejects a room name that is not a channel activity room', () => {
+    expect(canWatchShareFromChannel('7', 'room-7')).toBe(false);
+    expect(canWatchShareFromChannel('7', 'channel-')).toBe(false);
+    expect(canWatchShareFromChannel('7', '')).toBe(false);
+  });
+});

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -99,7 +99,7 @@ import {
 } from './workspace/workspaceState';
 import { conversationKey } from './workspace/conversation';
 import { SERVER_ROOT_CHANNEL_ID, selectJoinedChannelId } from './workspace/presence';
-import { activityChannelMatchesPresence, channelActivityRoomName } from './workspace/activityPresence';
+import { activityChannelMatchesPresence, channelActivityRoomName, parseChannelActivityRoomName } from './workspace/activityPresence';
 import { loadConversationTabs, saveConversationTabs } from './workspace/conversationStorage';
 import { paintApi } from './api/paint';
 import type { PaintSessionStatus } from './types/paint';
@@ -483,9 +483,13 @@ export function shouldClearLocalShareStartPending({
   return isLocalShareStartPending && (selfLeftVoice || voiceChannelId == null || voiceChannelId === 0);
 }
 
-export function canWatchShareFromChannel(currentChannelId: string | undefined, shareRoomName: string): boolean {
-  if (!currentChannelId || currentChannelId === 'server-root') return false;
-  return shareRoomName === `channel-${currentChannelId}`;
+/**
+ * You may watch a share only while standing in the channel that owns it. The channel
+ * you are *browsing* is irrelevant — this mirrors the publish gate, which is also
+ * bound to presence.
+ */
+export function canWatchShareFromChannel(joinedChannelId: string | null, shareRoomName: string): boolean {
+  return activityChannelMatchesPresence(joinedChannelId, parseChannelActivityRoomName(shareRoomName));
 }
 
 export async function toggleLocalScreenShare({
@@ -4414,7 +4418,8 @@ const handleConnect = (serverData: SavedServer) => {
     const onRemoteShareStarted = (data: unknown) => {
       const d = data as { roomName: string; userName: string; userId?: number; matrixUserId?: string; sessionId?: number };
       const selfUser = usersRef.current.find(u => u.self);
-      const voiceChannelId = selfUser?.channelId;
+      // Keyed to presence, exactly like the watch gate and the publish gate.
+      const joinedChannelId = selectJoinedChannelId(usersRef.current);
       // Only show notification for other users' shares in our channel.
       // Prefer the session id to identify self; when the server payload omits
       // it, fall back to matching the Matrix identity so the broadcaster does
@@ -4425,8 +4430,7 @@ const handleConnect = (serverData: SavedServer) => {
         ? d.sessionId === selfUser.session
         : (selfMatrixUserId != null && d.matrixUserId != null && d.matrixUserId === selfMatrixUserId);
       if (
-        voiceChannelId != null &&
-        d.roomName === `channel-${voiceChannelId}` &&
+        activityChannelMatchesPresence(joinedChannelId, parseChannelActivityRoomName(d.roomName)) &&
         !isSelfShare &&
         shouldShowOptionalNotification(optionalNotificationSettingsRef.current, 'notificationRemoteScreenShare')
       ) {
@@ -4469,8 +4473,10 @@ const handleConnect = (serverData: SavedServer) => {
 
   requestActiveShareDiscoveryRef.current = requestActiveShareDiscovery;
 
-  // Check for active screen shares when switching channels.
-  // Depends ONLY on currentChannelId: the other collaborators (notifQueue and
+  // Check for active screen shares when the user's presence moves.
+  // Discovery follows the JOINED channel, not the browsed one, so that browsing
+  // elsewhere never tears down or hides your own channel's share.
+  // Depends ONLY on joinedChannelId: the other collaborators (notifQueue and
   // requestActiveShareDiscovery) are accessed via refs so their
   // identity churn — notably notifQueue changing on every register/unregister —
   // does not re-run this effect and wipe a freshly shown screen-share
@@ -4478,9 +4484,9 @@ const handleConnect = (serverData: SavedServer) => {
   useEffect(() => {
     setScreenShareNotification(null);
     notifQueueRef.current.unregister('screen-share');
-    requestActiveShareDiscoveryRef.current?.(currentChannelId);
+    requestActiveShareDiscoveryRef.current?.(joinedChannelId ?? undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentChannelId]);
+  }, [joinedChannelId]);
 
   useEffect(() => {
     const previousConnectionStatus = previousWorkspaceConnectionStatusRef.current;
@@ -4616,7 +4622,7 @@ const handleConnect = (serverData: SavedServer) => {
       ?? null;
     const actualRoomName = share?.roomName ?? roomName;
 
-    if (!canWatchShareFromChannel(currentChannelId, actualRoomName)) {
+    if (!canWatchShareFromChannel(joinedChannelId, actualRoomName)) {
       return;
     }
 
@@ -4624,7 +4630,7 @@ const handleConnect = (serverData: SavedServer) => {
     void Promise.resolve(connectAsViewer(actualRoomName, userId, matrixUserId ?? share?.matrixUserId)).catch(err => {
       updateStatus('livekit', { state: 'disconnected', error: err instanceof Error ? err.message : 'Failed to connect as viewer' });
     });
-  }, [activeShares, connectAsViewer, currentChannelId, updateStatus]);
+  }, [activeShares, connectAsViewer, joinedChannelId, updateStatus]);
 
   // Track which channel/DM was last opened so we only snapshot + mark-read on actual switches.
   const prevChannelIdRef = useRef<string | undefined>(undefined);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1678,21 +1678,36 @@ function App() {
     return set;
   }, [matrixClient?.dmRoomMap]);
 
+  // The conversation region renders the ACTIVE TAB, so every chat-scoped derivation below
+  // is keyed off the tab model rather than `currentChannelId`. `currentChannelId` tracks
+  // presence-driven navigation for the voice/companion/bridge consumers and can legitimately
+  // disagree with the tab the user is reading; driving the chat from it rendered another
+  // conversation's name, history and permissions.
+  const activeConversation = selectActiveConversation(workspace);
+  const activeChatChannelId = activeConversation?.kind === 'channel'
+    ? activeConversation.channelId
+    : undefined;
+
   // Per-panel Matrix room IDs for scoping mention suggestions
   const channelMatrixRoomId = useMemo(() => {
-    const matrixChannelId = getPermittedMatrixChannelId(currentChannelId, channels);
+    const matrixChannelId = getPermittedMatrixChannelId(activeChatChannelId, channels);
     if (matrixChannelId && matrixCredentials?.roomMap?.[matrixChannelId]) {
       return matrixCredentials.roomMap[matrixChannelId];
     }
     return null;
-  }, [channels, currentChannelId, matrixCredentials?.roomMap]);
+  }, [channels, activeChatChannelId, matrixCredentials?.roomMap]);
 
-  const channelKey = currentChannelId === 'server-root' ? 'server-root' : currentChannelId ? `channel-${currentChannelId}` : 'no-channel';
+  const channelKey = activeChatChannelId === 'server-root'
+    ? 'server-root'
+    : activeChatChannelId ? `channel-${activeChatChannelId}` : 'no-channel';
   const { messages, addMessage } = useChatStore(channelKey);
   const [optimisticImages, setOptimisticImages] = useState<ChatMessage[]>([]);
 
-  const activeChannelId = currentChannelId && currentChannelId !== 'server-root'
-    ? currentChannelId
+  // Matrix-scoped view of the same id: the root chat is local-only, so it collapses to
+  // undefined for everything that talks to Matrix. Chat permissions must NOT use this —
+  // they need to see 'server-root', which is readable and writable by everyone.
+  const activeChannelId = activeChatChannelId && activeChatChannelId !== 'server-root'
+    ? activeChatChannelId
     : undefined;
   const permittedActiveMatrixChannelId = getPermittedMatrixChannelId(activeChannelId, channels);
   const selectedDmContactIdRef = useRef<string | null>(null);
@@ -1718,10 +1733,6 @@ function App() {
       activePaintChannelIdRef.current = undefined;
     }
   }, [activePaintSessionId, connectionStatus, joinedChannelId]);
-  const activeConversation = selectActiveConversation(workspace);
-  const activeChannelChatId = activeConversation?.kind === 'channel'
-    ? activeConversation.channelId
-    : undefined;
 
   const dmStore = useDMStore({
     matrixDmLastMessages: matrixClient.dmLastMessages,
@@ -3538,7 +3549,9 @@ const handleConnect = (serverData: SavedServer) => {
   const handleSendMessage = async (content: string, image?: File) => {
     if (!username || (!content && !image)) return;
 
-    const channelId = currentChannelId;
+    // Send to the conversation on screen, which is the active tab — the same id the
+    // composer's enabled state and the rendered history were derived from.
+    const channelId = activeChatChannelId;
     if (!channelId) return;
     if (!shouldAllowChannelChatSend(channelId, channelsRef.current, statusesRef.current, brmbleServiceBootstrapPhase)) {
       return;
@@ -3917,12 +3930,16 @@ const handleConnect = (serverData: SavedServer) => {
     brmbleServicesConnectedOnceRef.current,
   );
   const brmbleServiceChatNotice = getBrmbleServiceChatNotice(activeChannelId, statuses, brmbleServiceBootstrapPhase);
-  const canOpenActiveChannelChat = canOpenChannelChat(activeChannelId, channels);
-  const canSendActiveChannelChat = canSendToChannelChat(activeChannelId, channels)
-    || isTemporaryChannelChatActive(activeChannelId, statuses, brmbleServiceBootstrapPhase);
-  const channelChatAccessNotice = activeChannelId && activeChannelId !== 'server-root' && !canOpenActiveChannelChat
+  // Permissions read the FULL chat id, including 'server-root': the root chat is
+  // local-only but every user may read and write it. Collapsing root to undefined here
+  // made canOpen/canSend both false, which emptied the root history and disabled the
+  // composer (it falls back to the "User is offline" placeholder when disabled).
+  const canOpenActiveChannelChat = canOpenChannelChat(activeChatChannelId, channels);
+  const canSendActiveChannelChat = canSendToChannelChat(activeChatChannelId, channels)
+    || isTemporaryChannelChatActive(activeChatChannelId, statuses, brmbleServiceBootstrapPhase);
+  const channelChatAccessNotice = activeChatChannelId && activeChatChannelId !== 'server-root' && !canOpenActiveChannelChat
     ? 'You do not have access to this channel chat.'
-    : activeChannelId && activeChannelId !== 'server-root' && !canSendActiveChannelChat
+    : activeChatChannelId && activeChatChannelId !== 'server-root' && !canSendActiveChannelChat
       ? 'You can read this channel chat, but cannot send messages.'
       : undefined;
   const matrixMessages = activeChannelId
@@ -3945,10 +3962,10 @@ const handleConnect = (serverData: SavedServer) => {
         : messages;
       return [
         ...base,
-        ...optimisticImages.filter(m => m.channelId === currentChannelId),
+        ...optimisticImages.filter(m => m.channelId === activeChatChannelId),
       ];
     },
-    [canOpenActiveChannelChat, isMatrixActive, matrixMessages, messages, optimisticImages, currentChannelId],
+    [canOpenActiveChannelChat, isMatrixActive, matrixMessages, messages, optimisticImages, activeChatChannelId],
   );
 
   const { Prompt, PromptWithInput } = usePrompt();
@@ -4599,19 +4616,21 @@ const handleConnect = (serverData: SavedServer) => {
     saveConversationTabs(serverAddress, workspace.tabs.filter(tab => conversationKey(tab) !== homeKey));
   }, [connected, serverAddress, workspace.tabs, workspace.joinedChannelId]);
 
-  // Stage one of retiring `currentChannelId`: the tab model owns which channel chat
-  // is shown, and this mirrors it into the still-widely-read state. Task 17 removes it.
+  // The conversation region no longer reads `currentChannelId` — it is driven by
+  // `activeChatChannelId` directly. This mirror survives for the remaining consumers that
+  // still track "which channel chat is on screen" through the legacy state: the sidebar
+  // highlight, the server-chat flag and screen-share discovery.
   // Only *transitions* of the active channel tab are mirrored: the voice handlers still
   // write `currentChannelId` directly, and re-asserting the tab value on every render
   // would fight them and fire the channel-change effects twice.
-  const mirroredChannelChatIdRef = useRef(activeChannelChatId);
+  const mirroredChannelChatIdRef = useRef(activeChatChannelId);
   useEffect(() => {
     const previous = mirroredChannelChatIdRef.current;
-    mirroredChannelChatIdRef.current = activeChannelChatId;
-    if (activeChannelChatId === undefined || activeChannelChatId === previous) return;
-    if (activeChannelChatId === currentChannelIdRef.current) return;
-    setCurrentChannelId(activeChannelChatId);
-  }, [activeChannelChatId, setCurrentChannelId]);
+    mirroredChannelChatIdRef.current = activeChatChannelId;
+    if (activeChatChannelId === undefined || activeChatChannelId === previous) return;
+    if (activeChatChannelId === currentChannelIdRef.current) return;
+    setCurrentChannelId(activeChatChannelId);
+  }, [activeChatChannelId, setCurrentChannelId]);
 
   useEffect(() => {
     const previousConnectionStatus = previousConnectionStatusRef.current;
@@ -4966,6 +4985,15 @@ const handleConnect = (serverData: SavedServer) => {
     localStorage.removeItem('brmble-screenshare-split');
   }, []);
 
+  // One resolver for the name of a channel conversation, shared by the tab label and the
+  // chat header so the two can never disagree. Never returns an empty string: an
+  // unresolvable channel falls back to its id.
+  const resolveChannelChatLabel = useCallback((channelId: string): string => (
+    channelId === 'server-root'
+      ? (serverLabel || 'Server')
+      : channels.find(channel => String(channel.id) === channelId)?.name ?? channelId
+  ), [channels, serverLabel]);
+
   // One tab per open conversation. Labels resolve from the channel list or the DM
   // contact list; an unresolvable channel falls back to its id so a tab is never blank.
   const conversationTabItems = useMemo<ConversationTabItem[]>(() => (
@@ -4975,14 +5003,10 @@ const handleConnect = (serverData: SavedServer) => {
       if (conversation.kind === 'channel') {
         // Root chat is not Matrix-backed, so it has no unread source and shows no badge.
         const unread = channelUnreads.get(conversation.channelId);
-        const label = conversation.channelId === 'server-root'
-          ? (serverLabel || 'Server')
-          : channels.find(channel => String(channel.id) === conversation.channelId)?.name
-            ?? conversation.channelId;
         return {
           conversation,
           key,
-          label,
+          label: resolveChannelChatLabel(conversation.channelId),
           isHome,
           unreadCount: unread?.notificationCount ?? 0,
           mentionCount: unread?.highlightCount ?? 0,
@@ -4998,7 +5022,7 @@ const handleConnect = (serverData: SavedServer) => {
         mentionCount: 0,
       };
     })
-  ), [workspace, channels, serverLabel, channelUnreads, dmContactsWithUnreads]);
+  ), [workspace, resolveChannelChatLabel, channelUnreads, dmContactsWithUnreads]);
 
   // One ChatPanel renders the active tab. This picks which prop set feeds it; the
   // channel and DM shapes are otherwise unchanged.
@@ -5028,8 +5052,8 @@ const handleConnect = (serverData: SavedServer) => {
       paintSessionStatuses,
     }
     : {
-      channelId: currentChannelId || undefined,
-      channelName: currentChannelId === 'server-root' ? (serverLabel || 'Server') : currentChannelName,
+      channelId: activeChatChannelId || undefined,
+      channelName: activeChatChannelId ? resolveChannelChatLabel(activeChatChannelId) : '',
       messages: channelChatMessages,
       currentUsername: username,
       onSendMessage: handleSendMessage,

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -99,6 +99,7 @@ import {
 } from './workspace/workspaceState';
 import { conversationKey } from './workspace/conversation';
 import { SERVER_ROOT_CHANNEL_ID, selectJoinedChannelId } from './workspace/presence';
+import { activityChannelMatchesPresence, channelActivityRoomName } from './workspace/activityPresence';
 import { loadConversationTabs, saveConversationTabs } from './workspace/conversationStorage';
 import { paintApi } from './api/paint';
 import type { PaintSessionStatus } from './types/paint';
@@ -513,7 +514,7 @@ export async function toggleLocalScreenShare({
   }
 
   try {
-    const started = await startSharing(`channel-${voiceChannelId}`);
+    const started = await startSharing(channelActivityRoomName(String(voiceChannelId)));
     if (!started) {
       return;
     }
@@ -714,8 +715,7 @@ export function shouldKeepPaintSession(input: {
   joinedChannelId: string | null;
 }): boolean {
   if (input.connectionStatus !== 'connected') return false;
-  if (input.joinedChannelId === null || input.joinedChannelId === SERVER_ROOT_CHANNEL_ID) return false;
-  return input.sessionChannelId === input.joinedChannelId;
+  return activityChannelMatchesPresence(input.joinedChannelId, input.sessionChannelId);
 }
 
 export function canSendToChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
@@ -4462,8 +4462,9 @@ const handleConnect = (serverData: SavedServer) => {
       return;
     }
 
-    setDiscoveryTarget({ roomName: `channel-${channelId}`, requestId });
-    bridge.send('livekit.checkActiveShare', { roomName: `channel-${channelId}`, requestId });
+    const roomName = channelActivityRoomName(channelId);
+    setDiscoveryTarget({ roomName, requestId });
+    bridge.send('livekit.checkActiveShare', { roomName, requestId });
   }, [setDiscoveryTarget]);
 
   requestActiveShareDiscoveryRef.current = requestActiveShareDiscovery;

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -104,6 +104,7 @@ import {
   workspaceReducer,
 } from './workspace/workspaceState';
 import { conversationKey } from './workspace/conversation';
+import { suppressOpenConversations } from './workspace/unreadOwnership';
 import { ConversationTabStrip, type ConversationTabItem } from './components/ConversationTabStrip/ConversationTabStrip';
 import { SERVER_ROOT_CHANNEL_ID, selectJoinedChannelId } from './workspace/presence';
 import { activityChannelMatchesPresence, channelActivityRoomName, parseChannelActivityRoomName } from './workspace/activityPresence';
@@ -1814,6 +1815,27 @@ function App() {
       return { ...contact, unreadCount: unread.notificationCount };
     });
   }, [dmStore.contacts, matrixClient?.dmRoomMap, unreadTracker]);
+
+  // Every conversation that currently owns a tab. A tab owns its own unread badge, so
+  // these conversations are suppressed from the sidebar and the DM contact list.
+  const openConversationKeys = useMemo(
+    () => new Set(workspace.tabs.map(conversationKey)),
+    [workspace.tabs],
+  );
+
+  // The contact list copy goes quiet for contacts that are already open as a tab.
+  // `dmContactsWithUnreads` stays unsuppressed: it feeds the tabs and the aggregates.
+  const sidebarDmContacts = useMemo(() => {
+    const visible = suppressOpenConversations(
+      new Map(dmContactsWithUnreads.map(contact => [contact.id, contact.unreadCount])),
+      openConversationKeys,
+      id => `dm:${id}`,
+    );
+    return dmContactsWithUnreads.map(contact => {
+      const unreadCount = visible.get(contact.id) ?? 0;
+      return unreadCount === contact.unreadCount ? contact : { ...contact, unreadCount };
+    });
+  }, [dmContactsWithUnreads, openConversationKeys]);
 
   const updateBadge = useCallback((unread: number, invite: boolean) => {
     const effectiveUnreadDMs = unread > 0;
@@ -4355,6 +4377,13 @@ const handleConnect = (serverData: SavedServer) => {
     return map;
   }, [channels, matrixCredentials?.roomMap, unreadTracker.roomUnreads]);
 
+  // The sidebar copy goes quiet for channels that are already open as a tab.
+  // `channelUnreads` stays unsuppressed: it feeds the tabs and the aggregates.
+  const sidebarChannelUnreads = useMemo(
+    () => suppressOpenConversations(channelUnreads, openConversationKeys, id => `channel:${id}`),
+    [channelUnreads, openConversationKeys],
+  );
+
   useEffect(() => {
     if (screenShareError) {
       console.error('Screen share error:', screenShareError);
@@ -5144,7 +5173,7 @@ const handleConnect = (serverData: SavedServer) => {
           connectionStatus={connectionStatus}
           onCancelReconnect={handleCancelReconnect}
           pendingChannelAction={pendingChannelAction}
-          channelUnreads={channelUnreads}
+          channelUnreads={sidebarChannelUnreads}
           sharingChannelId={sharingChannelId ? Number(sharingChannelId) : (activeShares.length > 0 ? Number(activeShares[0].roomName.replace('channel-', '')) : undefined)}
           sharingUserSession={isSharing ? selfSession : activeShare?.sessionId}
           activeShares={activeShares}
@@ -5209,7 +5238,7 @@ const handleConnect = (serverData: SavedServer) => {
 
         {connected && (
           <DMContactList
-            contacts={dmContactsWithUnreads}
+            contacts={sidebarDmContacts}
             selectedUserId={dmStore.selectedContact?.id ?? null}
             onSelectContact={(id: string) => {
               dmStore.selectContact(id);

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1419,6 +1419,11 @@ function App() {
   const [hasPendingInvite] = useState(false);
 
   const [brmbleDMUsers, setBrmbleDMUsers] = useState<BrmbleDMUser[]>([]);
+  // True once `server.credentials` has been delivered for this session. Both the
+  // server directory (`userMappings`) and the server-owned DM room map arrive in that
+  // one payload, so this is the single point after which a DM contact id can be judged
+  // resolvable. Nothing may validate a DM tab before it flips.
+  const [serverDirectoryLoaded, setServerDirectoryLoaded] = useState(false);
   const matrixOverlayCallbacks = useMemo(() => ({
     onChannelMessage: (channelId: string, message: ChatMessage) => {
       const settings = overlaySettingsRef.current;
@@ -1815,6 +1820,23 @@ function App() {
       return { ...contact, unreadCount: unread.notificationCount };
     });
   }, [dmStore.contacts, matrixClient?.dmRoomMap, unreadTracker]);
+
+  // Every DM contact id that can currently be resolved to a real conversation.
+  //
+  // This is the union of the three sources a DM contact can come from, and it is what
+  // decides whether a persisted DM tab is still valid. `dmStore.contacts` alone is not
+  // enough: it derives its Matrix half from `matrixClient.dmRoomMap`, which is only
+  // republished at Matrix sync `PREPARED` and therefore lags. The server sends the same
+  // map inside the credentials payload (`matrixCredentials.dmRoomMap`) together with the
+  // directory (`brmbleDMUsers`), so folding those two in makes the set complete the
+  // instant `serverDirectoryLoaded` flips, with no window where a valid tab looks dead.
+  const resolvableDmContactIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const contact of dmContactsWithUnreads) ids.add(contact.id);
+    for (const user of brmbleDMUsers) ids.add(user.matrixUserId);
+    for (const matrixUserId of Object.keys(matrixCredentials?.dmRoomMap ?? {})) ids.add(matrixUserId);
+    return ids;
+  }, [dmContactsWithUnreads, brmbleDMUsers, matrixCredentials]);
 
   // Every conversation that currently owns a tab. A tab owns its own unread badge, so
   // these conversations are suppressed from the sidebar and the DM contact list.
@@ -2333,6 +2355,7 @@ function App() {
       hasMatrixCredentialsForSessionRef.current = false;
       setMatrixCredentials(null);
       setBrmbleDMUsers([]);
+      setServerDirectoryLoaded(false);
       setCurrentUserAvatarUrl(undefined);
       fetchedAvatarIdsRef.current.clear();
       disconnectViewerRef.current?.();
@@ -2350,6 +2373,7 @@ function App() {
 
     const onServerCredentials = (data: unknown) => {
       setConnectionError(null);
+      setServerDirectoryLoaded(true);
       const wrapped = data as { matrix?: MatrixCredentials; userMappings?: Record<string, string> } | undefined;
       const d = wrapped?.matrix;
       if (d?.homeserverUrl && d.accessToken && d.userId && d.roomMap) {
@@ -3725,6 +3749,7 @@ const handleConnect = (serverData: SavedServer) => {
         hasMatrixCredentialsForSessionRef.current = false;
         setMatrixCredentials(null);
         setBrmbleDMUsers([]);
+        setServerDirectoryLoaded(false);
         setSharingChannelId(undefined);
       },
     });
@@ -4521,10 +4546,11 @@ const handleConnect = (serverData: SavedServer) => {
     dispatchWorkspace({ type: 'JOINED_CHANNEL_CHANGED', channelId: joinedChannelId });
   }, [joinedChannelId]);
 
-  // Restore persisted tabs exactly once per connection, and only once both the
-  // channel roster and our own presence have arrived — restoring earlier would
-  // reject every channel tab as unknown and leave a restored tab active instead
-  // of the joined channel.
+  // Restore persisted tabs exactly once per connection, and only once the channel
+  // roster, our own presence and the server directory have all arrived — restoring
+  // earlier would reject every channel tab as unknown and leave a restored tab active
+  // instead of the joined channel, and would reject every DM tab as unresolvable
+  // because DM identity data arrives on `server.credentials`, independently of voice.
   const restoredForServerRef = useRef<string | null>(null);
   useEffect(() => {
     if (!connected || !serverAddress) {
@@ -4532,10 +4558,13 @@ const handleConnect = (serverData: SavedServer) => {
       return;
     }
     if (channels.length === 0 || joinedChannelId === null) return;
+    if (!serverDirectoryLoaded) return;
     if (restoredForServerRef.current === serverAddress) return;
     restoredForServerRef.current = serverAddress;
     const restored = loadConversationTabs(serverAddress, conversation => {
-      if (conversation.kind === 'dm') return true;
+      // A persisted tab for a contact this server can no longer resolve is invalid:
+      // it would render with a raw Matrix id for a label and no conversation behind it.
+      if (conversation.kind === 'dm') return resolvableDmContactIds.has(conversation.contactId);
       // A persisted tab for a channel this server no longer has is invalid. This is
       // stricter than `canOpenChannelChat`, which deliberately treats an unknown
       // channel as permitted for legacy servers that omit the flag.
@@ -4544,7 +4573,23 @@ const handleConnect = (serverData: SavedServer) => {
       return canOpenChannelChat(conversation.channelId, channels);
     });
     dispatchWorkspace({ type: 'RESTORE_CONVERSATIONS', conversations: restored });
-  }, [connected, serverAddress, channels, joinedChannelId]);
+  }, [connected, serverAddress, channels, joinedChannelId, serverDirectoryLoaded, resolvableDmContactIds]);
+
+  // Safety net for DM tabs that stop resolving after the restore — a contact removed
+  // from the directory mid-session, or a tab persisted by an older build that never
+  // validated DM tabs at all. Gated on the same `serverDirectoryLoaded` signal as the
+  // restore, so it can never fire while DM identity data is still in flight.
+  useEffect(() => {
+    if (!connected || !serverAddress) return;
+    if (!serverDirectoryLoaded) return;
+    if (restoredForServerRef.current !== serverAddress) return;
+    for (const tab of workspace.tabs) {
+      if (tab.kind !== 'dm') continue;
+      if (resolvableDmContactIds.has(tab.contactId)) continue;
+      dispatchWorkspace({ type: 'CONVERSATION_INVALIDATED', key: conversationKey(tab) });
+    }
+  }, [connected, serverAddress, serverDirectoryLoaded, resolvableDmContactIds, workspace.tabs]);
+
 
   // The home tab follows presence, so it is never persisted.
   useEffect(() => {
@@ -5246,12 +5291,12 @@ const handleConnect = (serverData: SavedServer) => {
             }}
             onCloseConversation={(id: string) => {
               dmStore.closeDM(id);
-              if (dmStore.selectedContact?.id === id) {
-                dispatchWorkspace({
-                  type: 'CONVERSATION_INVALIDATED',
-                  key: conversationKey({ kind: 'dm', contactId: id }),
-                });
-              }
+              // The tab owns the conversation, not the selection: a contact closed
+              // while its tab sits in the background must still lose that tab.
+              dispatchWorkspace({
+                type: 'CONVERSATION_INVALIDATED',
+                key: conversationKey({ kind: 'dm', contactId: id }),
+              });
             }}
           />
         )}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -91,7 +91,15 @@ import { gameDisplayName } from './utils/games';
 import { useQueuedDuelConfirmation } from './components/Games/useQueuedDuelConfirmation';
 import { useMissedReadyCheck } from './components/Games/useMissedReadyCheck';
 import { estimateText, pairLabel } from './components/Games/duelFormatting';
-import { createWorkspaceState, workspaceReducer } from './workspace/workspaceState';
+import {
+  createWorkspaceState,
+  selectActiveConversation,
+  selectHomeKey,
+  workspaceReducer,
+} from './workspace/workspaceState';
+import { conversationKey } from './workspace/conversation';
+import { SERVER_ROOT_CHANNEL_ID, selectJoinedChannelId } from './workspace/presence';
+import { loadConversationTabs, saveConversationTabs } from './workspace/conversationStorage';
 import { paintApi } from './api/paint';
 import type { PaintSessionStatus } from './types/paint';
 import { prepareChatImagePaintSource } from './utils/chatImagePaintSource';
@@ -1664,6 +1672,17 @@ function App() {
   const permittedActiveMatrixChannelId = getPermittedMatrixChannelId(activeChannelId, channels);
   const selectedDmContactIdRef = useRef<string | null>(null);
 
+  const joinedChannelId = selectJoinedChannelId(users);
+  // Thin numeric alias over the single presence derivation. 'server-root' collapses to
+  // undefined, which every consumer already treats the same as the numeric root (0).
+  const selfVoiceChannelId = joinedChannelId === null || joinedChannelId === SERVER_ROOT_CHANNEL_ID
+    ? undefined
+    : Number(joinedChannelId);
+  const activeConversation = selectActiveConversation(workspace);
+  const activeChannelChatId = activeConversation?.kind === 'channel'
+    ? activeConversation.channelId
+    : undefined;
+
   const dmStore = useDMStore({
     matrixDmLastMessages: matrixClient.dmLastMessages,
     activeDmMessages: matrixClient.activeDmMessages,
@@ -1674,8 +1693,8 @@ function App() {
     fetchDMHistory: matrixClient.fetchDMHistory,
     brmbleUsers: brmbleDMUsers,
     isSelectedConversationForeground: () =>
-      workspace.foreground.kind === 'dm' &&
-      workspace.foreground.contactId === selectedDmContactIdRef.current,
+      activeConversation?.kind === 'dm' &&
+      activeConversation.contactId === selectedDmContactIdRef.current,
     users,
     username,
     sendMumbleDM: (targetSession: number, text: string) => {
@@ -1684,12 +1703,14 @@ function App() {
   });
   selectedDmContactIdRef.current = dmStore.selectedContact?.id ?? null;
 
-  const showDmConversation = workspace.foreground.kind === 'dm';
+  const showDmConversation = activeConversation?.kind === 'dm';
+  // Kept as the strict negation of the DM flag so the channel slide stays visible
+  // (and focusable) before any conversation exists — e.g. the connection screens.
   const showChannelConversation = !showDmConversation;
   const isDmMode = showDmConversation;
-  const messagesPanelExpanded = connected && workspace.messagesPanelExpanded;
-  const foregroundDmContactId = workspace.foreground.kind === 'dm'
-    ? workspace.foreground.contactId
+  const messagesPanelExpanded = connected;
+  const foregroundDmContactId = activeConversation?.kind === 'dm'
+    ? activeConversation.contactId
     : null;
   const foregroundDmContact = foregroundDmContactId
     ? dmStore.contacts.find(contact => contact.id === foregroundDmContactId)
@@ -1713,7 +1734,6 @@ function App() {
 
   const toggleMessagesPanel = useCallback(() => {
     setShowGame(false);
-    dispatchWorkspace({ type: 'TOGGLE_MESSAGES_PANEL' });
   }, []);
 
   // Determine active Matrix room ID (depends on dmStore.selectedContact)
@@ -1783,6 +1803,10 @@ function App() {
   addMessageRef.current = addMessage;
   const currentChannelIdRef = useRef(currentChannelId);
   currentChannelIdRef.current = currentChannelId;
+  // Ref mirror of the single presence derivation so ref-reading callbacks can use it
+  // without gaining a reactive dependency.
+  const joinedVoiceChannelIdRef = useRef(selfVoiceChannelId);
+  joinedVoiceChannelIdRef.current = selfVoiceChannelId;
   const currentChannelNameRef = useRef(currentChannelName);
   currentChannelNameRef.current = currentChannelName;
   const previousConnectionStatusRef = useRef(connectionStatus);
@@ -2153,7 +2177,6 @@ function App() {
       // Registered Mumble users may be placed in their last channel.
       const initialChannelId = d?.channelId ?? 0;
       if (initialChannelId === 0) {
-        setCurrentChannelId('server-root');
         setCurrentChannelName('');
       } else {
         setCurrentChannelId(String(initialChannelId));
@@ -2713,7 +2736,6 @@ function App() {
         }
 
         if (d.channelId === 0) {
-          setCurrentChannelId('server-root');
           setCurrentChannelName('');
         } else {
           setCurrentChannelId(String(d.channelId));
@@ -3367,8 +3389,7 @@ const handleConnect = (serverData: SavedServer) => {
   };
 
   const handleJoinChannel = async (channelId: number) => {
-    const selfVoiceChannelId = users.find(u => u.self)?.channelId;
-    if (selfVoiceChannelId === channelId) {
+    if (joinedChannelId === String(channelId)) {
       return;
     }
     const channel = channels.find(c => c.id === channelId);
@@ -3433,7 +3454,10 @@ const handleConnect = (serverData: SavedServer) => {
       setUnreadCount(0);
       setShowGame(false);
 
-      dispatchWorkspace({ type: 'SELECT_CHANNEL' });
+      dispatchWorkspace({
+        type: 'OPEN_CONVERSATION',
+        conversation: { kind: 'channel', channelId: selection.channelId },
+      });
 
       if (!selection.canOpenChat) return;
     }
@@ -3442,7 +3466,10 @@ const handleConnect = (serverData: SavedServer) => {
   const handleSelectServer = () => {
     setCurrentChannelId('server-root');
     setCurrentChannelName(serverLabel || 'Server');
-    dispatchWorkspace({ type: 'SELECT_CHANNEL' });
+    dispatchWorkspace({
+      type: 'OPEN_CONVERSATION',
+      conversation: { kind: 'channel', channelId: 'server-root' },
+    });
   };
 
   const handleSendMessage = async (content: string, image?: File) => {
@@ -3752,17 +3779,17 @@ const handleConnect = (serverData: SavedServer) => {
     if (user?.isBrmbleClient && user.matrixUserId) {
       // Brmble client → Matrix DM (persistent)
       dmStore.startDM(user.matrixUserId, userName, user.avatarUrl);
-      dispatchWorkspace({ type: 'SELECT_DM', contactId: user.matrixUserId });
+      dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: user.matrixUserId } });
     } else if (user?.certHash) {
       // Mumble client (even if Brmble-registered) → Mumble DM (ephemeral)
       // Check for existing ephemeral contact first
       const existingMumbleContact = dmStore.contacts.find(c => c.isEphemeral && c.mumbleCertHash === user.certHash);
       if (existingMumbleContact) {
         dmStore.selectContact(existingMumbleContact.id);
-        dispatchWorkspace({ type: 'SELECT_DM', contactId: existingMumbleContact.id });
+        dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: existingMumbleContact.id } });
       } else {
         dmStore.startMumbleDM(user.certHash, user.session, userName);
-        dispatchWorkspace({ type: 'SELECT_DM', contactId: user.certHash });
+        dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: user.certHash } });
       }
     } else {
       console.warn('[DM] Cannot start DM: user has no certHash');
@@ -3779,15 +3806,15 @@ const handleConnect = (serverData: SavedServer) => {
     if (user) {
       if (user.isBrmbleClient && user.matrixUserId) {
         dmStore.startDM(user.matrixUserId, sender, user.avatarUrl);
-        dispatchWorkspace({ type: 'SELECT_DM', contactId: user.matrixUserId });
+        dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: user.matrixUserId } });
       } else if (user.certHash) {
         const existingMumbleContact = dmStore.contacts.find(c => c.isEphemeral && c.mumbleCertHash === user!.certHash);
         if (existingMumbleContact) {
           dmStore.selectContact(existingMumbleContact.id);
-          dispatchWorkspace({ type: 'SELECT_DM', contactId: existingMumbleContact.id });
+          dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: existingMumbleContact.id } });
         } else {
           dmStore.startMumbleDM(user.certHash, user.session, sender);
-          dispatchWorkspace({ type: 'SELECT_DM', contactId: user.certHash });
+          dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: user.certHash } });
         }
       } else {
         console.warn('[DM] Cannot start DM: user has no certHash');
@@ -3796,7 +3823,7 @@ const handleConnect = (serverData: SavedServer) => {
       // Fallback: try starting DM by matrixUserId directly for users not in the users list
       if (senderMatrixUserId) {
         dmStore.startDM(senderMatrixUserId, sender, undefined);
-        dispatchWorkspace({ type: 'SELECT_DM', contactId: senderMatrixUserId });
+        dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: senderMatrixUserId } });
       } else {
         console.warn('[DM] Cannot start DM: user not found');
       }
@@ -4001,7 +4028,7 @@ const handleConnect = (serverData: SavedServer) => {
     setWatchedShareEndedNotifications(prev => [...prev, notification]);
   }, []);
 
-  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, pendingViewerShares, remoteWatchCount, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, roomQuality, shareQualities, viewerQualities, setViewerQuality, disconnectViewer, connectAsViewer, isViewerConnectPending, handleScreenShareServiceUnavailable } = useScreenShare(() => {
+  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, pendingViewerShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, roomQuality, shareQualities, viewerQualities, setViewerQuality, disconnectViewer, connectAsViewer, isViewerConnectPending, handleScreenShareServiceUnavailable } = useScreenShare(() => {
     setSharingChannelId(undefined);
     sharingChannelIdRef.current = undefined;
   }, screenShareSettings, handleLocalScreenShareEnded, handleWatchedShareEnded);
@@ -4023,10 +4050,6 @@ const handleConnect = (serverData: SavedServer) => {
     onViewerQualityChange: setViewerQuality,
     screenShareViewerMode: screenShareSettings.viewerMode,
   };
-
-  useEffect(() => {
-    dispatchWorkspace({ type: 'REMOTE_WATCH_COUNT_CHANGED', count: remoteWatchCount });
-  }, [remoteWatchCount]);
 
   const handleLiveCompanionChange = useCallback((
     nextCompanion: CompanionSelection,
@@ -4337,7 +4360,6 @@ const handleConnect = (serverData: SavedServer) => {
     }
   }, [isSharing, watchingShares.length, screenShareError, isLocalShareStartPending, isViewerConnectPending, hasPendingViewerShares, updateStatus]);
 
-  const selfVoiceChannelId = users.find(u => u.self)?.channelId;
   const canScreenShare = connected && !selfLeftVoice && (selfVoiceChannelId ?? 0) !== 0;
 
   useEffect(() => {
@@ -4441,9 +4463,56 @@ const handleConnect = (serverData: SavedServer) => {
     previousWorkspaceConnectionStatusRef.current = connectionStatus;
 
     if (connectionStatus === 'connected' && previousConnectionStatus !== 'connected') {
-      dispatchWorkspace({ type: 'CONNECTION_WORKSPACE_READY' });
+      dispatchWorkspace({ type: 'WORKSPACE_RESET' });
     }
   }, [connectionStatus]);
+
+  // Presence is the single source of truth for the home tab.
+  useEffect(() => {
+    dispatchWorkspace({ type: 'JOINED_CHANNEL_CHANGED', channelId: joinedChannelId });
+  }, [joinedChannelId]);
+
+  // Restore persisted tabs exactly once per connection, and only once both the
+  // channel roster and our own presence have arrived — restoring earlier would
+  // reject every channel tab as unknown and leave a restored tab active instead
+  // of the joined channel.
+  const restoredForServerRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!connected || !serverAddress) {
+      restoredForServerRef.current = null;
+      return;
+    }
+    if (channels.length === 0 || joinedChannelId === null) return;
+    if (restoredForServerRef.current === serverAddress) return;
+    restoredForServerRef.current = serverAddress;
+    const restored = loadConversationTabs(serverAddress, conversation =>
+      conversation.kind === 'dm'
+        ? true
+        : canOpenChannelChat(conversation.channelId, channels));
+    dispatchWorkspace({ type: 'RESTORE_CONVERSATIONS', conversations: restored });
+  }, [connected, serverAddress, channels, joinedChannelId]);
+
+  // The home tab follows presence, so it is never persisted.
+  useEffect(() => {
+    if (!connected || !serverAddress) return;
+    if (restoredForServerRef.current !== serverAddress) return;
+    const homeKey = selectHomeKey(workspace);
+    saveConversationTabs(serverAddress, workspace.tabs.filter(tab => conversationKey(tab) !== homeKey));
+  }, [connected, serverAddress, workspace.tabs, workspace.joinedChannelId]);
+
+  // Stage one of retiring `currentChannelId`: the tab model owns which channel chat
+  // is shown, and this mirrors it into the still-widely-read state. Task 17 removes it.
+  // Only *transitions* of the active channel tab are mirrored: the voice handlers still
+  // write `currentChannelId` directly, and re-asserting the tab value on every render
+  // would fight them and fire the channel-change effects twice.
+  const mirroredChannelChatIdRef = useRef(activeChannelChatId);
+  useEffect(() => {
+    const previous = mirroredChannelChatIdRef.current;
+    mirroredChannelChatIdRef.current = activeChannelChatId;
+    if (activeChannelChatId === undefined || activeChannelChatId === previous) return;
+    if (activeChannelChatId === currentChannelIdRef.current) return;
+    setCurrentChannelId(activeChannelChatId);
+  }, [activeChannelChatId, setCurrentChannelId]);
 
   useEffect(() => {
     const previousConnectionStatus = previousConnectionStatusRef.current;
@@ -4465,12 +4534,12 @@ const handleConnect = (serverData: SavedServer) => {
   }, [currentChannelId]);
 
   const handleToggleScreenShare = useCallback(async () => {
-    const selfUser = usersRef.current.find(u => u.self);
+    const joinedVoiceChannelId = joinedVoiceChannelIdRef.current;
     const canUseScreenshare = effectiveLiveKitStateRef.current === 'connected';
-    const shouldStartSharing = !isSharing && canUseScreenshare && !selfLeftVoice && selfUser?.channelId != null && selfUser.channelId !== 0;
+    const shouldStartSharing = !isSharing && canUseScreenshare && !selfLeftVoice && joinedVoiceChannelId != null && joinedVoiceChannelId !== 0;
     const sharingState = isSharing ? 'sharing' : 'notSharing';
     const leftVoiceState = selfLeftVoice ? 'leftVoice' : 'inVoice';
-    const channelState = selfUser?.channelId == null ? 'noSelfChannel' : `channel-${selfUser.channelId}`;
+    const channelState = joinedVoiceChannelId == null ? 'noSelfChannel' : `channel-${joinedVoiceChannelId}`;
     const actionState = shouldStartSharing ? 'canStart' : 'blocked';
 
     try {
@@ -4492,7 +4561,7 @@ const handleConnect = (serverData: SavedServer) => {
     await toggleLocalScreenShare({
       isSharing,
       selfLeftVoice,
-      voiceChannelId: selfUser?.channelId,
+      voiceChannelId: joinedVoiceChannelId,
       liveKitState: liveKitStateRef.current,
       startSharing,
       stopSharing,
@@ -4967,12 +5036,15 @@ const handleConnect = (serverData: SavedServer) => {
             selectedUserId={dmStore.selectedContact?.id ?? null}
             onSelectContact={(id: string) => {
               dmStore.selectContact(id);
-              dispatchWorkspace({ type: 'SELECT_DM', contactId: id });
+              dispatchWorkspace({ type: 'OPEN_CONVERSATION', conversation: { kind: 'dm', contactId: id } });
             }}
             onCloseConversation={(id: string) => {
               dmStore.closeDM(id);
               if (dmStore.selectedContact?.id === id) {
-                dispatchWorkspace({ type: 'SELECTED_DM_INVALIDATED' });
+                dispatchWorkspace({
+                  type: 'CONVERSATION_INVALIDATED',
+                  key: conversationKey({ kind: 'dm', contactId: id }),
+                });
               }
             }}
             onToggleVisibility={toggleMessagesPanel}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -23,7 +23,6 @@ import { Header } from './components/Header/Header';
 import { BrmbleLogo } from './components/Header/BrmbleLogo';
 import { PaintSessionSetupModal } from './components/Paint/PaintSessionSetupModal';
 import { PaintSessionView } from './components/Paint/PaintSessionView';
-import { VerticalSplitPane } from './components/VerticalSplitPane/VerticalSplitPane';
 import { Sidebar } from './components/Sidebar/Sidebar';
 import { ChatPanel } from './components/ChatPanel/ChatPanel';
 import { ConnectModal } from './components/ConnectModal/ConnectModal';
@@ -47,6 +46,9 @@ import { DeathrollModal } from './components/Games/DeathrollModal';
 import { RpsModal } from './components/Games/RpsModal';
 import { GameSurface } from './components/Games/GameSurface';
 import { MainPanel } from './components/MainPanel/MainPanel';
+import { ChannelActivityRegion } from './components/ChannelActivityRegion/ChannelActivityRegion';
+import { ScreenShareGrid } from './components/ScreenShareGrid';
+import { selectStage, type ChannelActivityKind } from './workspace/channelActivity';
 import { selectMainPanelMode } from './workspace/mainPanelMode';
 import { useGameState } from './components/Games/useGameState';
 import { useDuelQueueState } from './components/Games/useDuelQueueState';
@@ -4057,7 +4059,7 @@ const handleConnect = (serverData: SavedServer) => {
     setWatchedShareEndedNotifications(prev => [...prev, notification]);
   }, []);
 
-  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, pendingViewerShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, roomQuality, shareQualities, viewerQualities, setViewerQuality, disconnectViewer, connectAsViewer, isViewerConnectPending, handleScreenShareServiceUnavailable } = useScreenShare(() => {
+  const { isSharing, startSharing, stopSharing, markLocalShareTeardownIntent, error: screenShareError, activeShare, activeShares, watchingShares, pendingViewerShares, focusedShare, setFocusedShare, setDiscoveryTarget, remoteVideoEls, roomQuality, shareQualities, viewerQualities, setViewerQuality, disconnectViewer, connectAsViewer, isViewerConnectPending, setRemoteScreenSharesHidden, handleScreenShareServiceUnavailable } = useScreenShare(() => {
     setSharingChannelId(undefined);
     sharingChannelIdRef.current = undefined;
   }, screenShareSettings, handleLocalScreenShareEnded, handleWatchedShareEnded);
@@ -4067,16 +4069,16 @@ const handleConnect = (serverData: SavedServer) => {
   handleScreenShareServiceUnavailableRef.current = handleScreenShareServiceUnavailable;
 
   const hasPendingViewerShares = pendingViewerShares.length > 0;
+  const handleCloseWatchedShare = useCallback(
+    (share: ShareInfo) => disconnectViewer(share.userId),
+    [disconnectViewer],
+  );
+  // ChatPanel keeps only what the detached `'new-window'` overlay needs; the in-app
+  // viewer lives in the channel activity region.
   const screenShareViewerProps = {
     watchingShares,
-    focusedShare,
     remoteVideoEls,
-    roomQuality,
-    shareQualities,
-    viewerQualities,
-    onFocusShare: setFocusedShare,
-    onCloseShare: (share: ShareInfo) => disconnectViewer(share.userId),
-    onViewerQualityChange: setViewerQuality,
+    onCloseShare: handleCloseWatchedShare,
     screenShareViewerMode: screenShareSettings.viewerMode,
   };
 
@@ -4860,6 +4862,82 @@ const handleConnect = (serverData: SavedServer) => {
       : null;
   const mainPanelMode = selectMainPanelMode({ idleGameOpen: showGame, participatingMatchId });
 
+  // The activity region is scoped to the channel the user is *in*, not the one being
+  // browsed, so its label follows presence.
+  const joinedChannelName = useMemo(
+    () => channels.find(channel => String(channel.id) === joinedChannelId)?.name ?? '',
+    [channels, joinedChannelId],
+  );
+  const hasWatchableShare = screenShareSettings.viewerMode === 'in-app'
+    && watchingShares.length > 0
+    && remoteVideoEls.size > 0;
+  const availableActivities = useMemo<ChannelActivityKind[]>(() => {
+    const kinds: ChannelActivityKind[] = [];
+    if (hasWatchableShare) kinds.push('screen-share');
+    if (activePaintSessionId) kinds.push('paint');
+    return kinds;
+  }, [hasWatchableShare, activePaintSessionId]);
+
+  const [explicitActivity, setExplicitActivity] = useState<ChannelActivityKind | null>(null);
+  const previousStageRef = useRef<ChannelActivityKind | null>(null);
+  const stage = selectStage({
+    available: availableActivities,
+    explicit: explicitActivity,
+    previous: previousStageRef.current,
+  });
+  useEffect(() => { previousStageRef.current = stage; }, [stage]);
+
+  useEffect(() => {
+    setRemoteScreenSharesHidden(stage !== 'screen-share');
+  }, [stage, setRemoteScreenSharesHidden]);
+
+  // Both of the old per-surface splits are gone; the main panel owns the only one left.
+  useEffect(() => {
+    localStorage.removeItem('brmble-paint-split');
+    localStorage.removeItem('brmble-screenshare-split');
+  }, []);
+
+  const activityRegion = joinedChannelId !== null
+    && joinedChannelId !== SERVER_ROOT_CHANNEL_ID
+    && availableActivities.length > 0
+    ? (
+      <ErrorBoundary label="ChannelActivityRegion">
+        <ChannelActivityRegion
+          channelName={joinedChannelName}
+          activities={availableActivities.map(kind => ({
+            kind,
+            label: kind === 'screen-share' ? 'Screen share' : 'Paint',
+          }))}
+          stage={stage}
+          onSelect={setExplicitActivity}
+        >
+          {stage === 'screen-share' ? (
+            <ScreenShareGrid
+              watchingShares={watchingShares}
+              focusedShare={focusedShare}
+              videoElements={remoteVideoEls}
+              roomQuality={roomQuality}
+              shareQualities={shareQualities}
+              viewerQualities={viewerQualities}
+              onFocus={setFocusedShare}
+              onClose={handleCloseWatchedShare}
+              onViewerQualityChange={setViewerQuality}
+            />
+          ) : stage === 'paint' && activePaintSessionId ? (
+            <PaintSessionView
+              key={activePaintSessionId}
+              sessionId={activePaintSessionId}
+              matrixClient={matrixClient.client}
+              channelRoomMap={matrixCredentials?.roomMap}
+              onClose={handleClosePaint}
+            />
+          ) : null}
+        </ChannelActivityRegion>
+      </ErrorBoundary>
+    )
+    : null;
+
+
   const gameSurface = participatingMatchId !== null ? (
     <GameSurface>
       {(gameState.activeMatch?.gameType ?? gameState.ended?.gameType) === 'rps' ? (
@@ -5021,25 +5099,12 @@ const handleConnect = (serverData: SavedServer) => {
           ) : connectionStatus === 'connected' ? (
             <MainPanel
               mode={mainPanelMode}
-              activityRegion={null}
+              activityRegion={activityRegion}
               gameSurface={gameSurface}
               conversationRegion={(
               <div className={`content-slider ${showDmConversation ? 'dm-active' : ''}`}>
                 <div className="content-slide" aria-hidden={!showChannelConversation} inert={!showChannelConversation}>
                   <ErrorBoundary label="ChatPanel:Channel">
-                    <VerticalSplitPane
-                      top={activePaintSessionId ? (
-                        <PaintSessionView
-                          key={activePaintSessionId}
-                          sessionId={activePaintSessionId}
-                          matrixClient={matrixClient.client}
-                          channelRoomMap={matrixCredentials?.roomMap}
-                          onClose={handleClosePaint}
-                        />
-                      ) : null}
-                      storageKey="brmble-paint-split"
-                      label="Resize paint and channel chat"
-                    >
                       <ChatPanel
                         channelId={currentChannelId || undefined}
                         channelName={currentChannelId === 'server-root' ? (serverLabel || 'Server') : currentChannelName}
@@ -5070,7 +5135,6 @@ const handleConnect = (serverData: SavedServer) => {
                           ? { onUseAsPaintBackground: handleUseAsPaintBackground }
                           : {})}
                       />
-                    </VerticalSplitPane>
                   </ErrorBoundary>
                 </div>
                 <div className="content-slide" aria-hidden={!showDmConversation} inert={!showDmConversation}>

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo, useReducer } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo, useReducer, type ComponentProps } from 'react';
 import bridge from './bridge';
 import type { ConnectionStatus, ChatMessage, MediaAttachment, NativeBrmbleServiceStatus, ServiceStatus, ServiceStatusMap, User } from './types';
 import { prepareImageForMumble, type PreparedMumbleImage } from './utils/imageUpload';
@@ -98,11 +98,13 @@ import { useMissedReadyCheck } from './components/Games/useMissedReadyCheck';
 import { estimateText, pairLabel } from './components/Games/duelFormatting';
 import {
   createWorkspaceState,
+  isHomeKey,
   selectActiveConversation,
   selectHomeKey,
   workspaceReducer,
 } from './workspace/workspaceState';
 import { conversationKey } from './workspace/conversation';
+import { ConversationTabStrip, type ConversationTabItem } from './components/ConversationTabStrip/ConversationTabStrip';
 import { SERVER_ROOT_CHANNEL_ID, selectJoinedChannelId } from './workspace/presence';
 import { activityChannelMatchesPresence, channelActivityRoomName, parseChannelActivityRoomName } from './workspace/activityPresence';
 import { loadConversationTabs, saveConversationTabs } from './workspace/conversationStorage';
@@ -1735,30 +1737,28 @@ function App() {
   });
   selectedDmContactIdRef.current = dmStore.selectedContact?.id ?? null;
 
-  const showDmConversation = activeConversation?.kind === 'dm';
-  // Kept as the strict negation of the DM flag so the channel slide stays visible
-  // (and focusable) before any conversation exists — e.g. the connection screens.
-  const showChannelConversation = !showDmConversation;
-  const isDmMode = showDmConversation;
+  // The single ChatPanel renders whatever the active tab points at, so this is a
+  // semantic "the open conversation is a DM" flag, not a slide-visibility flag.
+  const activeConversationIsDm = activeConversation?.kind === 'dm';
   const messagesPanelExpanded = connected;
-  const foregroundDmContactId = activeConversation?.kind === 'dm'
+  const activeDmContactId = activeConversation?.kind === 'dm'
     ? activeConversation.contactId
     : null;
-  const foregroundDmContact = foregroundDmContactId
-    ? dmStore.contacts.find(contact => contact.id === foregroundDmContactId)
-      ?? (dmStore.selectedContact?.id === foregroundDmContactId ? dmStore.selectedContact : null)
+  const activeDmContact = activeDmContactId
+    ? dmStore.contacts.find(contact => contact.id === activeDmContactId)
+      ?? (dmStore.selectedContact?.id === activeDmContactId ? dmStore.selectedContact : null)
     : null;
-  const foregroundDmMessages = foregroundDmContact != null && foregroundDmContact.id === dmStore.selectedContact?.id
+  const activeDmMessages = activeDmContact != null && activeDmContact.id === dmStore.selectedContact?.id
     ? dmStore.messages
     : [];
-  const selectedDmIsMumble = foregroundDmContact?.isEphemeral === true;
-  const activeDmMatrixContactId = foregroundDmContactId && !selectedDmIsMumble
-    ? foregroundDmContactId
+  const selectedDmIsMumble = activeDmContact?.isEphemeral === true;
+  const activeDmMatrixContactId = activeDmContactId && !selectedDmIsMumble
+    ? activeDmContactId
     : null;
 
   useLayoutEffect(() => {
-    matrixClient.setActiveChannel(isDmMode ? null : permittedActiveMatrixChannelId);
-  }, [isDmMode, matrixClient.setActiveChannel, permittedActiveMatrixChannelId]);
+    matrixClient.setActiveChannel(activeConversationIsDm ? null : permittedActiveMatrixChannelId);
+  }, [activeConversationIsDm, matrixClient.setActiveChannel, permittedActiveMatrixChannelId]);
 
   useLayoutEffect(() => {
     matrixClient.setActiveDmContact(activeDmMatrixContactId);
@@ -1770,7 +1770,7 @@ function App() {
 
   // Determine active Matrix room ID (depends on dmStore.selectedContact)
   const activeMatrixRoomId = useMemo(() => {
-    if (isDmMode) {
+    if (activeConversationIsDm) {
       return activeDmMatrixContactId && matrixClient?.dmRoomMap
         ? matrixClient.dmRoomMap.get(activeDmMatrixContactId) ?? null
         : null;
@@ -1780,7 +1780,7 @@ function App() {
       return matrixCredentials.roomMap[permittedActiveMatrixChannelId];
     }
     return null;
-  }, [isDmMode, activeDmMatrixContactId, matrixClient?.dmRoomMap, matrixCredentials?.roomMap, permittedActiveMatrixChannelId]);
+  }, [activeConversationIsDm, activeDmMatrixContactId, matrixClient?.dmRoomMap, matrixCredentials?.roomMap, permittedActiveMatrixChannelId]);
 
   const dmMatrixRoomId = useMemo(() => {
     if (!activeDmMatrixContactId || !matrixClient?.dmRoomMap) return null;
@@ -3479,7 +3479,7 @@ const handleConnect = (serverData: SavedServer) => {
   };
 
   const handleSelectChannel = (channelId: number) => {
-    const selection = getChannelSelectionOutcome(channelId, channels, isDmMode ? 'dm' : 'channels');
+    const selection = getChannelSelectionOutcome(channelId, channels, activeConversationIsDm ? 'dm' : 'channels');
     if (selection) {
       setCurrentChannelId(selection.channelId);
       setCurrentChannelName(selection.channelName);
@@ -4519,10 +4519,15 @@ const handleConnect = (serverData: SavedServer) => {
     if (channels.length === 0 || joinedChannelId === null) return;
     if (restoredForServerRef.current === serverAddress) return;
     restoredForServerRef.current = serverAddress;
-    const restored = loadConversationTabs(serverAddress, conversation =>
-      conversation.kind === 'dm'
-        ? true
-        : canOpenChannelChat(conversation.channelId, channels));
+    const restored = loadConversationTabs(serverAddress, conversation => {
+      if (conversation.kind === 'dm') return true;
+      // A persisted tab for a channel this server no longer has is invalid. This is
+      // stricter than `canOpenChannelChat`, which deliberately treats an unknown
+      // channel as permitted for legacy servers that omit the flag.
+      if (conversation.channelId !== 'server-root'
+        && !channels.some(channel => String(channel.id) === conversation.channelId)) return false;
+      return canOpenChannelChat(conversation.channelId, channels);
+    });
     dispatchWorkspace({ type: 'RESTORE_CONVERSATIONS', conversations: restored });
   }, [connected, serverAddress, channels, joinedChannelId]);
 
@@ -4704,7 +4709,7 @@ const handleConnect = (serverData: SavedServer) => {
       prevDMUserIdRef.current = selectedId;
     }
 
-    if (!selectedId || !foregroundDmContact) {
+    if (!selectedId || !activeDmContact) {
       if (dmChanged) setDmDividerTs(null);
       return;
     }
@@ -4748,7 +4753,7 @@ const handleConnect = (serverData: SavedServer) => {
         return markerTs;
       });
     }
-  }, [activeDmMatrixContactId, foregroundDmContact, unreadTracker.roomUnreads, matrixClient.client, unreadTracker, matrixClient?.dmRoomMap]);
+  }, [activeDmMatrixContactId, activeDmContact, unreadTracker.roomUnreads, matrixClient.client, unreadTracker, matrixClient?.dmRoomMap]);
 
   const paintChannelId = selfVoiceChannelId && selfVoiceChannelId !== 0 ? selfVoiceChannelId : null;
   const paintChannelRoomId = paintChannelId === null ? null : matrixCredentials?.roomMap?.[String(paintChannelId)] ?? null;
@@ -4896,6 +4901,98 @@ const handleConnect = (serverData: SavedServer) => {
     localStorage.removeItem('brmble-paint-split');
     localStorage.removeItem('brmble-screenshare-split');
   }, []);
+
+  // One tab per open conversation. Labels resolve from the channel list or the DM
+  // contact list; an unresolvable channel falls back to its id so a tab is never blank.
+  const conversationTabItems = useMemo<ConversationTabItem[]>(() => (
+    workspace.tabs.map(conversation => {
+      const key = conversationKey(conversation);
+      const isHome = isHomeKey(workspace, key);
+      if (conversation.kind === 'channel') {
+        // Root chat is not Matrix-backed, so it has no unread source and shows no badge.
+        const unread = channelUnreads.get(conversation.channelId);
+        const label = conversation.channelId === 'server-root'
+          ? (serverLabel || 'Server')
+          : channels.find(channel => String(channel.id) === conversation.channelId)?.name
+            ?? conversation.channelId;
+        return {
+          conversation,
+          key,
+          label,
+          isHome,
+          unreadCount: unread?.notificationCount ?? 0,
+          mentionCount: unread?.highlightCount ?? 0,
+        };
+      }
+      const contact = dmContactsWithUnreads.find(candidate => candidate.id === conversation.contactId);
+      return {
+        conversation,
+        key,
+        label: contact?.displayName ?? conversation.contactId,
+        isHome,
+        unreadCount: contact?.unreadCount ?? 0,
+        mentionCount: 0,
+      };
+    })
+  ), [workspace, channels, serverLabel, channelUnreads, dmContactsWithUnreads]);
+
+  // One ChatPanel renders the active tab. This picks which prop set feeds it; the
+  // channel and DM shapes are otherwise unchanged.
+  const chatPanelPropsForActiveConversation: ComponentProps<typeof ChatPanel> = activeConversationIsDm
+    ? {
+      channelId: activeDmContact ? `dm-${activeDmContact.id}` : undefined,
+      channelName: activeDmContact?.displayName ?? '',
+      messages: activeDmMessages,
+      currentUsername: username,
+      onSendMessage: dmStore.sendMessage,
+      isDM: true,
+      matrixClient: activeDmContact && !selectedDmIsMumble ? matrixClient.client : null,
+      matrixRoomId: activeDmContact && !selectedDmIsMumble ? dmMatrixRoomId : null,
+      readMarkerTs: activeDmContact && !selectedDmIsMumble ? dmDividerTs : null,
+      ...screenShareViewerProps,
+      users,
+      disabled: activeDmContact?.isEphemeral === true && activeDmContact.mumbleSessionId == null,
+      topNotice: selectedDmIsMumble ? 'This is a Mumble direct message. Chat history will be lost when you disconnect.' : undefined,
+      onMessageContextMenu: handleChatMessageContextMenu,
+      onCopyToClipboard: handleCopyToClipboard,
+      currentUserMatrixId: activeDmContact && !selectedDmIsMumble ? matrixCredentials?.userId : undefined,
+      onToggleReaction: activeDmContact && !selectedDmIsMumble ? handleToggleDmReaction : undefined,
+      typingIndicatorText: activeDmContact && !selectedDmIsMumble ? matrixClient.activeTypingText : undefined,
+      typingTargetId: activeDmContact && !selectedDmIsMumble ? (activeDmMatrixContactId ?? undefined) : undefined,
+      onTypingStart: activeDmContact && !selectedDmIsMumble ? matrixClient.startTyping : undefined,
+      onTypingStop: activeDmContact && !selectedDmIsMumble ? matrixClient.stopTyping : undefined,
+      paintSessionStatuses,
+    }
+    : {
+      channelId: currentChannelId || undefined,
+      channelName: currentChannelId === 'server-root' ? (serverLabel || 'Server') : currentChannelName,
+      messages: channelChatMessages,
+      currentUsername: username,
+      onSendMessage: handleSendMessage,
+      onDismissMessage: handleDismissMessage,
+      matrixClient: matrixClient.client,
+      matrixRoomId: channelMatrixRoomId,
+      readMarkerTs: channelDividerTs,
+      ...screenShareViewerProps,
+      users,
+      disabled: !canSendActiveChannelChat,
+      topNotice: channelChatAccessNotice ?? brmbleServiceChatNotice,
+      onMessageContextMenu: handleChatMessageContextMenu,
+      onCopyToClipboard: handleCopyToClipboard,
+      currentUserMatrixId: matrixCredentials?.userId,
+      onToggleReaction: handleToggleChannelReaction,
+      typingIndicatorText: matrixClient.activeTypingText,
+      typingTargetId: activeChannelId ?? undefined,
+      onTypingStart: matrixClient.startTyping,
+      onTypingStop: matrixClient.stopTyping,
+      currentUserId: selfSession,
+      paintSessionStatuses,
+      onJoinPaint: handleJoinPaint,
+      onOpenPaint: handleOpenPaint,
+      ...(canStartPaint && !activePaintSessionId
+        ? { onUseAsPaintBackground: handleUseAsPaintBackground }
+        : {}),
+    };
 
   const activityRegion = joinedChannelId !== null
     && joinedChannelId !== SERVER_ROOT_CHANNEL_ID
@@ -5102,69 +5199,16 @@ const handleConnect = (serverData: SavedServer) => {
               activityRegion={activityRegion}
               gameSurface={gameSurface}
               conversationRegion={(
-              <div className={`content-slider ${showDmConversation ? 'dm-active' : ''}`}>
-                <div className="content-slide" aria-hidden={!showChannelConversation} inert={!showChannelConversation}>
-                  <ErrorBoundary label="ChatPanel:Channel">
-                      <ChatPanel
-                        channelId={currentChannelId || undefined}
-                        channelName={currentChannelId === 'server-root' ? (serverLabel || 'Server') : currentChannelName}
-                        messages={channelChatMessages}
-                        currentUsername={username}
-                        onSendMessage={handleSendMessage}
-                        onDismissMessage={handleDismissMessage}
-                        matrixClient={matrixClient.client}
-                        matrixRoomId={channelMatrixRoomId}
-                        readMarkerTs={channelDividerTs}
-                        {...(showChannelConversation ? screenShareViewerProps : {})}
-                        users={users}
-                        disabled={!canSendActiveChannelChat}
-                        topNotice={channelChatAccessNotice ?? brmbleServiceChatNotice}
-                        onMessageContextMenu={handleChatMessageContextMenu}
-                        onCopyToClipboard={handleCopyToClipboard}
-                        currentUserMatrixId={matrixCredentials?.userId}
-                        onToggleReaction={handleToggleChannelReaction}
-                        typingIndicatorText={isDmMode ? undefined : matrixClient.activeTypingText}
-                        typingTargetId={activeChannelId ?? undefined}
-                        onTypingStart={matrixClient.startTyping}
-                        onTypingStop={matrixClient.stopTyping}
-                        currentUserId={selfSession}
-                        paintSessionStatuses={paintSessionStatuses}
-                        onJoinPaint={handleJoinPaint}
-                        onOpenPaint={handleOpenPaint}
-                        {...(canStartPaint && !activePaintSessionId
-                          ? { onUseAsPaintBackground: handleUseAsPaintBackground }
-                          : {})}
-                      />
-                  </ErrorBoundary>
-                </div>
-                <div className="content-slide" aria-hidden={!showDmConversation} inert={!showDmConversation}>
-                  <ErrorBoundary label="ChatPanel:DM">
-                   <ChatPanel
-                    channelId={foregroundDmContact ? `dm-${foregroundDmContact.id}` : undefined}
-                    channelName={foregroundDmContact?.displayName ?? ''}
-                    messages={foregroundDmMessages}
-                    currentUsername={username}
-                    onSendMessage={dmStore.sendMessage}
-                    isDM={true}
-                    matrixClient={foregroundDmContact && !selectedDmIsMumble ? matrixClient.client : null}
-                    matrixRoomId={foregroundDmContact && !selectedDmIsMumble ? dmMatrixRoomId : null}
-                    readMarkerTs={foregroundDmContact && !selectedDmIsMumble ? dmDividerTs : null}
-                    {...(showDmConversation ? screenShareViewerProps : {})}
-                    users={users}
-                    disabled={foregroundDmContact?.isEphemeral === true && foregroundDmContact.mumbleSessionId == null}
-                    topNotice={selectedDmIsMumble ? 'This is a Mumble direct message. Chat history will be lost when you disconnect.' : undefined}
-                    onMessageContextMenu={handleChatMessageContextMenu}
-                    onCopyToClipboard={handleCopyToClipboard}
-                    currentUserMatrixId={foregroundDmContact && !selectedDmIsMumble ? matrixCredentials?.userId : undefined}
-                    onToggleReaction={foregroundDmContact && !selectedDmIsMumble ? handleToggleDmReaction : undefined}
-                    typingIndicatorText={foregroundDmContact && !selectedDmIsMumble && isDmMode ? matrixClient.activeTypingText : undefined}
-                    typingTargetId={foregroundDmContact && !selectedDmIsMumble ? (activeDmMatrixContactId ?? undefined) : undefined}
-                    onTypingStart={foregroundDmContact && !selectedDmIsMumble ? matrixClient.startTyping : undefined}
-                    onTypingStop={foregroundDmContact && !selectedDmIsMumble ? matrixClient.stopTyping : undefined}
-                    paintSessionStatuses={paintSessionStatuses}
-                  />
-                  </ErrorBoundary>
-                </div>
+              <div className="conversation-region">
+                <ConversationTabStrip
+                  tabs={conversationTabItems}
+                  activeKey={workspace.activeKey}
+                  onActivate={key => dispatchWorkspace({ type: 'ACTIVATE_CONVERSATION', key })}
+                  onClose={key => dispatchWorkspace({ type: 'CLOSE_CONVERSATION', key })}
+                />
+                <ErrorBoundary label="ChatPanel">
+                  <ChatPanel {...chatPanelPropsForActiveConversation} />
+                </ErrorBoundary>
               </div>
               )}
             />

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4913,6 +4913,7 @@ const handleConnect = (serverData: SavedServer) => {
           channels={channels}
           users={users}
           currentChannelId={currentChannelId && currentChannelId !== 'server-root' ? Number(currentChannelId) : undefined}
+          joinedChannelId={selfVoiceChannelId}
           onJoinChannel={handleJoinChannel}
           onSelectChannel={handleSelectChannel}
           onSelectServer={handleSelectServer}

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -45,6 +45,9 @@ import { usePrompt, confirm, prompt } from './hooks/usePrompt';
 import { NeonDGame } from './components/NeonD/NeonDGame';
 import { DeathrollModal } from './components/Games/DeathrollModal';
 import { RpsModal } from './components/Games/RpsModal';
+import { GameSurface } from './components/Games/GameSurface';
+import { MainPanel } from './components/MainPanel/MainPanel';
+import { selectMainPanelMode } from './workspace/mainPanelMode';
 import { useGameState } from './components/Games/useGameState';
 import { useDuelQueueState } from './components/Games/useDuelQueueState';
 import { collectCommittedSessions } from './components/Games/committedSessions';
@@ -1759,9 +1762,9 @@ function App() {
     matrixClient.setActiveDmContact(activeDmMatrixContactId);
   }, [activeDmMatrixContactId, matrixClient.setActiveDmContact]);
 
-  const toggleMessagesPanel = useCallback(() => {
-    setShowGame(false);
-  }, []);
+  // Opening a conversation no longer leaves game mode: an active match owns the main
+  // panel until it ends, and the idle game is closed by its own control.
+  const toggleMessagesPanel = useCallback(() => {}, []);
 
   // Determine active Matrix room ID (depends on dmStore.selectedContact)
   const activeMatrixRoomId = useMemo(() => {
@@ -3479,7 +3482,6 @@ const handleConnect = (serverData: SavedServer) => {
       setCurrentChannelId(selection.channelId);
       setCurrentChannelName(selection.channelName);
       setUnreadCount(0);
-      setShowGame(false);
 
       dispatchWorkspace({
         type: 'OPEN_CONVERSATION',
@@ -4847,6 +4849,56 @@ const handleConnect = (serverData: SavedServer) => {
     setActivePaintSessionId(null);
   }, [invalidatePaintPreparation]);
 
+  // A game the local player is participating in — or the result of the one that just
+  // finished — owns the whole main panel; it is not a dialog. The idle NeonD game does
+  // the same. `activeMatch` becomes null on `game.ended`, and `ended` is cleared by
+  // dismissing the result, so the panel returns to `split` on its own with no exit effect.
+  const participatingMatchId = gameState.activeMatch
+    ? String(gameState.activeMatch.matchId)
+    : gameState.ended
+      ? String(gameState.ended.matchId)
+      : null;
+  const mainPanelMode = selectMainPanelMode({ idleGameOpen: showGame, participatingMatchId });
+
+  const gameSurface = participatingMatchId !== null ? (
+    <GameSurface>
+      {(gameState.activeMatch?.gameType ?? gameState.ended?.gameType) === 'rps' ? (
+        <RpsModal
+          key={`rps-${gameState.activeMatch?.matchId ?? gameState.ended?.matchId ?? 'none'}`}
+          view={gameState.view}
+          ended={gameState.ended}
+          myUserId={selfSession}
+          turnDeadline={gameState.turnDeadline}
+          turnWindowMs={gameState.turnWindowMs}
+          penalty={gameState.penalty}
+          resolveName={resolveGamePlayerName}
+          onPick={(pick) => gameState.sendAction({ pick })}
+          onForfeit={confirmForfeit}
+          onClose={gameState.ended ? gameState.dismissEnded : confirmForfeit}
+          onRematch={gameState.ended ? () => requestRematch(gameState.ended!.sourceMatchId) : undefined}
+          rematchPending={rematchPending}
+        />
+      ) : (
+        <DeathrollModal
+          view={gameState.view}
+          ended={gameState.ended}
+          myUserId={selfSession}
+          turnDeadline={gameState.turnDeadline}
+          turnWindowMs={gameState.turnWindowMs}
+          penalty={gameState.penalty}
+          resolveName={resolveGamePlayerName}
+          onRoll={gameState.roll}
+          onForfeit={confirmForfeit}
+          onClose={gameState.ended ? gameState.dismissEnded : confirmForfeit}
+          onRematch={gameState.ended ? () => requestRematch(gameState.ended!.sourceMatchId) : undefined}
+          rematchPending={rematchPending}
+        />
+      )}
+    </GameSurface>
+  ) : showGame ? (
+    <NeonDGame onClose={() => setShowGame(false)} />
+  ) : null;
+
   return (
     <div className={`app${showOnboarding ? ' app--onboarding' : ''}`}>
       <WindowResizeHandles />
@@ -4967,9 +5019,11 @@ const handleConnect = (serverData: SavedServer) => {
               </div>
             )
           ) : connectionStatus === 'connected' ? (
-            showGame && !activePaintSessionId ? (
-              <NeonDGame onClose={() => setShowGame(false)} />
-            ) : (
+            <MainPanel
+              mode={mainPanelMode}
+              activityRegion={null}
+              gameSurface={gameSurface}
+              conversationRegion={(
               <div className={`content-slider ${showDmConversation ? 'dm-active' : ''}`}>
                 <div className="content-slide" aria-hidden={!showChannelConversation} inert={!showChannelConversation}>
                   <ErrorBoundary label="ChatPanel:Channel">
@@ -5048,7 +5102,8 @@ const handleConnect = (serverData: SavedServer) => {
                   </ErrorBoundary>
                 </div>
               </div>
-            )
+              )}
+            />
           ) : (
             <ConnectionState
               connectionStatus={connectionStatus}
@@ -5157,41 +5212,6 @@ const handleConnect = (serverData: SavedServer) => {
         onMinimize={handleCloseMinimize}
         onQuit={handleCloseQuit}
       />
-
-      {(gameState.activeMatch || gameState.ended) && (
-        (gameState.activeMatch?.gameType ?? gameState.ended?.gameType) === 'rps' ? (
-          <RpsModal
-            key={`rps-${gameState.activeMatch?.matchId ?? gameState.ended?.matchId ?? 'none'}`}
-            view={gameState.view}
-            ended={gameState.ended}
-            myUserId={selfSession}
-            turnDeadline={gameState.turnDeadline}
-            turnWindowMs={gameState.turnWindowMs}
-            penalty={gameState.penalty}
-            resolveName={resolveGamePlayerName}
-            onPick={(pick) => gameState.sendAction({ pick })}
-            onForfeit={confirmForfeit}
-            onClose={gameState.ended ? gameState.dismissEnded : confirmForfeit}
-            onRematch={gameState.ended ? () => requestRematch(gameState.ended!.sourceMatchId) : undefined}
-            rematchPending={rematchPending}
-          />
-        ) : (
-          <DeathrollModal
-            view={gameState.view}
-            ended={gameState.ended}
-            myUserId={selfSession}
-            turnDeadline={gameState.turnDeadline}
-            turnWindowMs={gameState.turnWindowMs}
-            penalty={gameState.penalty}
-            resolveName={resolveGamePlayerName}
-            onRoll={gameState.roll}
-            onForfeit={confirmForfeit}
-            onClose={gameState.ended ? gameState.dismissEnded : confirmForfeit}
-            onRematch={gameState.ended ? () => requestRematch(gameState.ended!.sourceMatchId) : undefined}
-            rematchPending={rematchPending}
-          />
-        )
-      )}
 
       {selectedDuelSnapshot && (
         <DuelQueueModal

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -706,6 +706,18 @@ export function canOpenChannelChat(channelId: string | undefined, channels: Chan
   return channel?.canOpenChat !== false;
 }
 
+// A paint session belongs to the voice channel the user joined, not the channel they
+// happen to be viewing. Browsing elsewhere must not tear the canvas down.
+export function shouldKeepPaintSession(input: {
+  connectionStatus: string;
+  sessionChannelId: string | undefined;
+  joinedChannelId: string | null;
+}): boolean {
+  if (input.connectionStatus !== 'connected') return false;
+  if (input.joinedChannelId === null || input.joinedChannelId === SERVER_ROOT_CHANNEL_ID) return false;
+  return input.sessionChannelId === input.joinedChannelId;
+}
+
 export function canSendToChannelChat(channelId: string | undefined, channels: Channel[]): boolean {
   if (!channelId) return false;
   if (channelId === 'server-root') return true;
@@ -1376,14 +1388,10 @@ function App() {
     if (!connected) setShowAvatarEditor(false);
   }, [connected]);
 
+  // Switching the viewed channel invalidates any in-flight paint preparation, but it
+  // deliberately does NOT end an active session — sessions belong to the joined channel.
   useEffect(() => {
     invalidatePaintPreparation();
-    if (!activePaintSessionId) return;
-    if (connectionStatus !== 'connected' || activePaintChannelIdRef.current !== currentChannelId) {
-      activePaintSessionIdRef.current = null;
-      setActivePaintSessionId(null);
-      activePaintChannelIdRef.current = undefined;
-    }
   }, [activePaintSessionId, connectionStatus, currentChannelId, invalidatePaintPreparation]);
 
   useEffect(() => {
@@ -1678,6 +1686,21 @@ function App() {
   const selfVoiceChannelId = joinedChannelId === null || joinedChannelId === SERVER_ROOT_CHANNEL_ID
     ? undefined
     : Number(joinedChannelId);
+
+  // Survival guard: an active paint session ends only when the connection drops or the
+  // user leaves/changes the voice channel that owns it. Viewing another channel is fine.
+  useEffect(() => {
+    if (!activePaintSessionId) return;
+    if (!shouldKeepPaintSession({
+      connectionStatus,
+      sessionChannelId: activePaintChannelIdRef.current,
+      joinedChannelId,
+    })) {
+      activePaintSessionIdRef.current = null;
+      setActivePaintSessionId(null);
+      activePaintChannelIdRef.current = undefined;
+    }
+  }, [activePaintSessionId, connectionStatus, joinedChannelId]);
   const activeConversation = selectActiveConversation(workspace);
   const activeChannelChatId = activeConversation?.kind === 'channel'
     ? activeConversation.channelId
@@ -4806,7 +4829,7 @@ const handleConnect = (serverData: SavedServer) => {
   }, []);
   const handleOpenPaint = useCallback((sessionId: string) => {
     invalidatePaintPreparation();
-    activePaintChannelIdRef.current = currentChannelId;
+    activePaintChannelIdRef.current = joinedChannelId ?? undefined;
     activePaintSessionIdRef.current = sessionId;
     setActivePaintSessionId(sessionId);
   }, [currentChannelId, invalidatePaintPreparation]);
@@ -4868,7 +4891,7 @@ const handleConnect = (serverData: SavedServer) => {
           initialSourceFile={paintSetupInitialSource}
           onComplete={(sessionId) => {
             invalidatePaintPreparation();
-            activePaintChannelIdRef.current = currentChannelId;
+            activePaintChannelIdRef.current = joinedChannelId ?? undefined;
             activePaintSessionIdRef.current = sessionId;
             setActivePaintSessionId(sessionId);
             closePaintSetup();

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -1740,7 +1740,6 @@ function App() {
   // The single ChatPanel renders whatever the active tab points at, so this is a
   // semantic "the open conversation is a DM" flag, not a slide-visibility flag.
   const activeConversationIsDm = activeConversation?.kind === 'dm';
-  const messagesPanelExpanded = connected;
   const activeDmContactId = activeConversation?.kind === 'dm'
     ? activeConversation.contactId
     : null;
@@ -1763,10 +1762,6 @@ function App() {
   useLayoutEffect(() => {
     matrixClient.setActiveDmContact(activeDmMatrixContactId);
   }, [activeDmMatrixContactId, matrixClient.setActiveDmContact]);
-
-  // Opening a conversation no longer leaves game mode: an active match owns the main
-  // panel until it ends, and the idle game is closed by its own control.
-  const toggleMessagesPanel = useCallback(() => {}, []);
 
   // Determine active Matrix room ID (depends on dmStore.selectedContact)
   const activeMatrixRoomId = useMemo(() => {
@@ -2955,7 +2950,6 @@ function App() {
       toggleMute: 'mute',
       toggleMuteDeafen: 'deaf',
       toggleLeaveVoice: 'leave',
-      toggleDmScreen: 'dm',
       toggleScreenShare: 'screen',
     };
 
@@ -2972,12 +2966,6 @@ function App() {
       if (d?.action) {
         const btn = ACTION_TO_BTN[d.action];
         if (btn) setHotkeyPressedBtn(prev => prev === btn ? null : prev);
-      }
-    };
-
-    const onToggleDmScreen = () => {
-      if (connectionStatusRef.current === 'connected') {
-        toggleMessagesPanel();
       }
     };
 
@@ -3208,7 +3196,6 @@ function App() {
     bridge.on('voice.moderation', onVoiceModeration);
     bridge.on('voice.shortcutPressed', onShortcutPressed);
     bridge.on('voice.shortcutReleased', onShortcutReleased);
-    bridge.on('voice.toggleDmScreen', onToggleDmScreen);
     bridge.on('voice.toggleScreenShare', onToggleScreenShare);
     bridge.on('game.toggle', onToggleGame);
     bridge.on('window.showCloseDialog', onShowCloseDialog);
@@ -3294,7 +3281,6 @@ function App() {
       bridge.off('voice.loss', onVoiceLoss);
       bridge.off('voice.shortcutPressed', onShortcutPressed);
       bridge.off('voice.shortcutReleased', onShortcutReleased);
-      bridge.off('voice.toggleDmScreen', onToggleDmScreen);
       bridge.off('voice.toggleScreenShare', onToggleScreenShare);
       bridge.off('game.toggle', onToggleGame);
       bridge.off('window.showCloseDialog', onShowCloseDialog);
@@ -5081,9 +5067,6 @@ const handleConnect = (serverData: SavedServer) => {
       <ErrorBoundary label="Header">
       <Header
         username={username}
-        onToggleDM={connected ? toggleMessagesPanel : undefined}
-        dmActive={messagesPanelExpanded}
-        unreadDMCount={totalDmUnreadCount}
         onOpenSettings={() => { setSettingsTab('profile'); setShowSettings(true); }}
         onOpenAudioSettings={() => { setSettingsTab('audio'); setShowSettings(true); }}
         onAvatarClick={connected ? () => setShowAvatarEditor(true) : undefined}
@@ -5134,7 +5117,7 @@ const handleConnect = (serverData: SavedServer) => {
         />
       )}
       
-      <div className={`app-body ${messagesPanelExpanded ? '' : 'app-body--messages-collapsed'}`}>
+      <div className="app-body">
         <ErrorBoundary label="Sidebar">
         <Sidebar
           channels={channels}
@@ -5179,7 +5162,7 @@ const handleConnect = (serverData: SavedServer) => {
         />
         </ErrorBoundary>
         
-        <main className={`main-content workspace-conversation ${messagesPanelExpanded ? 'workspace-conversation--with-panel' : ''}`}>
+        <main className="main-content workspace-conversation">
           {connectionStatus === 'idle' ? (
             certExists === true ? (
               <ServerList onConnect={handleServerConnect} connectDisabled={brokenCertInfo != null && !brokenCertInfo.hasHealthyFallback} connectionError={connectionError} onClearError={() => setConnectionError(null)} activeProfileName={activeProfileName} />
@@ -5241,8 +5224,6 @@ const handleConnect = (serverData: SavedServer) => {
                 });
               }
             }}
-            onToggleVisibility={toggleMessagesPanel}
-            visible={messagesPanelExpanded}
           />
         )}
       </div>

--- a/src/Brmble.Web/src/App.tsx
+++ b/src/Brmble.Web/src/App.tsx
@@ -4933,9 +4933,13 @@ const handleConnect = (serverData: SavedServer) => {
     () => channels.find(channel => String(channel.id) === joinedChannelId)?.name ?? '',
     [channels, joinedChannelId],
   );
+  // Availability is a LOGICAL question, so it reads the watched list only. It must not
+  // depend on `remoteVideoEls`: hiding a share past the grace period deliberately empties
+  // that map (useScreenShare.ts), and deriving the chip from it made hiding erase the
+  // only route back to the share. ScreenShareGrid already renders nothing for a share
+  // with no element yet, so the stage stays blank rather than disappearing.
   const hasWatchableShare = screenShareSettings.viewerMode === 'in-app'
-    && watchingShares.length > 0
-    && remoteVideoEls.size > 0;
+    && watchingShares.length > 0;
   const availableActivities = useMemo<ChannelActivityKind[]>(() => {
     const kinds: ChannelActivityKind[] = [];
     if (hasWatchableShare) kinds.push('screen-share');

--- a/src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.module.css
+++ b/src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.module.css
@@ -1,0 +1,60 @@
+.region {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-2xs) var(--space-sm);
+  background: var(--bg-elevated);
+  flex: none;
+}
+
+.channelName {
+  font-weight: 600;
+}
+
+.chips {
+  display: flex;
+  gap: var(--space-2xs);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.chip {
+  padding: var(--space-2xs) var(--space-xs);
+  border: none;
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.chip:hover {
+  background: var(--bg-hover);
+}
+
+.chip:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+.chipActive {
+  background: var(--accent-primary);
+  color: var(--bg-deep);
+}
+
+.stage {
+  flex: 1;
+  min-height: var(--activity-stage-min-height);
+  display: flex;
+  min-width: 0;
+  overflow: hidden;
+}

--- a/src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.test.tsx
+++ b/src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ChannelActivityRegion } from './ChannelActivityRegion';
+
+const activities = [
+  { kind: 'screen-share' as const, label: 'Screen share' },
+  { kind: 'paint' as const, label: 'Paint' },
+];
+
+describe('ChannelActivityRegion', () => {
+  it('names the channel and lists every live activity', () => {
+    render(
+      <ChannelActivityRegion channelName="General" activities={activities} stage="screen-share" onSelect={vi.fn()}>
+        <div>stage content</div>
+      </ChannelActivityRegion>,
+    );
+    expect(screen.getByRole('region', { name: 'General activity' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Screen share' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Paint' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByText('stage content')).toBeInTheDocument();
+  });
+
+  it('reports an explicit selection', () => {
+    const onSelect = vi.fn();
+    render(
+      <ChannelActivityRegion channelName="General" activities={activities} stage="screen-share" onSelect={onSelect}>
+        <div>stage content</div>
+      </ChannelActivityRegion>,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Paint' }));
+    expect(onSelect).toHaveBeenCalledWith('paint');
+  });
+
+  it('renders a single chip without a switcher affordance disappearing', () => {
+    render(
+      <ChannelActivityRegion channelName="General" activities={[activities[0]]} stage="screen-share" onSelect={vi.fn()}>
+        <div>stage content</div>
+      </ChannelActivityRegion>,
+    );
+    expect(screen.getAllByRole('tab')).toHaveLength(1);
+  });
+
+  it('moves between chips with the arrow keys', () => {
+    const onSelect = vi.fn();
+    render(
+      <ChannelActivityRegion channelName="General" activities={activities} stage="screen-share" onSelect={onSelect}>
+        <div>stage content</div>
+      </ChannelActivityRegion>,
+    );
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Screen share' }), { key: 'ArrowRight' });
+    expect(onSelect).toHaveBeenCalledWith('paint');
+  });
+});

--- a/src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.tsx
+++ b/src/Brmble.Web/src/components/ChannelActivityRegion/ChannelActivityRegion.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import type { ChannelActivityKind } from '../../workspace/channelActivity';
+import styles from './ChannelActivityRegion.module.css';
+
+interface ChannelActivityRegionProps {
+  channelName: string;
+  activities: { kind: ChannelActivityKind; label: string }[];
+  stage: ChannelActivityKind | null;
+  onSelect: (kind: ChannelActivityKind) => void;
+  children: ReactNode;
+}
+
+export function ChannelActivityRegion({
+  channelName,
+  activities,
+  stage,
+  onSelect,
+  children,
+}: ChannelActivityRegionProps) {
+  const move = (index: number, delta: number) => {
+    const next = activities[(index + delta + activities.length) % activities.length];
+    if (next) onSelect(next.kind);
+  };
+
+  return (
+    <section className={styles.region} aria-label={`${channelName} activity`}>
+      <header className={styles.header}>
+        <span className={styles.channelName}>{channelName}</span>
+        <div className={styles.chips} role="tablist" aria-label="Channel activities">
+          {activities.map((activity, index) => (
+            <button
+              key={activity.kind}
+              type="button"
+              role="tab"
+              aria-selected={stage === activity.kind}
+              tabIndex={stage === activity.kind ? 0 : -1}
+              className={`${styles.chip} ${stage === activity.kind ? styles.chipActive : ''}`}
+              onClick={() => onSelect(activity.kind)}
+              onKeyDown={event => {
+                if (event.key === 'ArrowRight') {
+                  event.preventDefault();
+                  move(index, 1);
+                }
+                if (event.key === 'ArrowLeft') {
+                  event.preventDefault();
+                  move(index, -1);
+                }
+              }}
+            >
+              {activity.label}
+            </button>
+          ))}
+        </div>
+      </header>
+      <div className={styles.stage}>{children}</div>
+    </section>
+  );
+}

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.css
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.css
@@ -446,27 +446,3 @@
   outline: 2px solid var(--accent-primary);
   outline-offset: 2px;
 }
-
-/* Screen share split layout */
-.chat-split-video {
-  min-height: 100px;
-  overflow: hidden;
-  display: flex;
-}
-
-.chat-split-video .screen-share-viewer {
-  flex: 1;
-}
-
-.chat-split-divider {
-  flex: none;
-  height: 4px;
-  background: var(--border-subtle);
-  cursor: row-resize;
-  transition: background var(--transition-fast);
-}
-
-.chat-split-divider:hover,
-.chat-split-divider:active {
-  background: var(--accent-primary);
-}

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -1,7 +1,33 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
 import { ChatPanel } from './ChatPanel';
+
+afterEach(cleanup);
+
+// A DM only reaches ChatPanel through a tab the user already opened, so the old
+// "right-click a user to start a private conversation" prompt was both unreachable
+// and wrong. Tabs for contacts that no longer resolve are dropped instead.
+describe('ChatPanel empty state', () => {
+  it('shows the generic welcome state and no direct-message prompt without a channel', () => {
+    render(
+      <ChatPanel
+        channelId={undefined}
+        channelName=""
+        messages={[]}
+        currentUsername="Alice"
+        onSendMessage={() => {}}
+        isDM
+      />,
+    );
+
+    expect(screen.getByText('Welcome to Brmble')).toBeInTheDocument();
+    expect(screen.queryByText('Direct Messages')).not.toBeInTheDocument();
+    expect(screen.queryByText('Right-click a user to start a private conversation')).not.toBeInTheDocument();
+  });
+});
+
 
 beforeAll(() => {
   class ResizeObserverMock {
@@ -404,3 +430,4 @@ describe('ChatPanel edit flow', () => {
     });
   });
 });
+

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -728,17 +728,11 @@ const [replyState, setReplyState] = useState<{
     return (
       <div className="chat-panel chat-panel--empty">
         <div className="chat-empty-state">
-          {isDM ? (
-            <div className="empty-icon">
-              <Icon name="message-circle" size={48} strokeWidth={1.5} />
-            </div>
-          ) : (
-            <div className="empty-logo">
-              <BrmbleLogo size={192} heartbeat />
-            </div>
-          )}
-          <h2 className="heading-title">{isDM ? 'Direct Messages' : 'Welcome to Brmble'}</h2>
-          <p>{isDM ? 'Right-click a user to start a private conversation' : 'Select a channel to start talking and chatting'}</p>
+          <div className="empty-logo">
+            <BrmbleLogo size={192} heartbeat />
+          </div>
+          <h2 className="heading-title">Welcome to Brmble</h2>
+          <p>Select a channel to start talking and chatting</p>
         </div>
       </div>
     );

--- a/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
+++ b/src/Brmble.Web/src/components/ChatPanel/ChatPanel.tsx
@@ -6,9 +6,7 @@ import { BrmbleLogo } from '../Header/BrmbleLogo';
 import { groupMessages } from '../../utils/groupMessages';
 import { formatDateSeparator, formatFullDate } from '../../utils/formatDateSeparator';
 import type { ChatMessage, MediaAttachment, MentionableUser } from '../../types';
-import { ScreenShareGrid } from '../ScreenShareGrid';
-import type { ShareInfo, ViewerQuality } from '../../hooks/useScreenShare';
-import type { ScreenShareQuality } from '../../utils/screenShareQuality';
+import type { ShareInfo } from '../../hooks/useScreenShare';
 import { ContextMenu } from '../ContextMenu/ContextMenu';
 import type { ContextMenuItem } from '../ContextMenu/ContextMenu';
 import { Tooltip } from '../Tooltip/Tooltip';
@@ -31,15 +29,11 @@ interface ChatPanelProps {
   matrixClient?: MatrixClient | null;
   matrixRoomId?: string | null;
   readMarkerTs?: number | null;
+  // Screen share is staged by the channel activity region, not by ChatPanel. These three
+  // remain only to drive the detached `'new-window'` overlay, which ChatPanel still owns.
   watchingShares?: ShareInfo[];
-  focusedShare?: ShareInfo | null;
   remoteVideoEls?: Map<number, HTMLVideoElement>;
-  roomQuality?: ScreenShareQuality;
-  shareQualities?: Map<number, ScreenShareQuality>;
-  viewerQualities?: Map<number, ViewerQuality>;
-  onFocusShare?: (share: ShareInfo | null) => void;
   onCloseShare?: (share: ShareInfo) => void;
-  onViewerQualityChange?: (userId: number, quality: ViewerQuality) => void;
   screenShareViewerMode?: 'in-app' | 'new-window';
   /** Connected users for avatar lookup by sender name */
   /** `matrixUserId` is tri-state on the projection: null means the server has not said yet. */
@@ -63,11 +57,9 @@ interface ChatPanelProps {
 }
 
 const SCROLL_THRESHOLD = 150;
-const SPLIT_STORAGE_KEY = 'brmble-screenshare-split';
-const DEFAULT_SPLIT = 50;
 const REPLY_TARGET_HIGHLIGHT_MS = 1600;
 
-export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, focusedShare, remoteVideoEls, roomQuality, shareQualities, viewerQualities, onFocusShare, onCloseShare, onViewerQualityChange, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard, currentUserMatrixId, onToggleReaction, typingIndicatorText, typingTargetId, onTypingStart, onTypingStop, currentUserId, paintSessionStatuses, onJoinPaint, onOpenPaint, onUseAsPaintBackground }: ChatPanelProps) {
+export function ChatPanel({ channelId, channelName, messages, currentUsername, onSendMessage, onDismissMessage, isDM, matrixClient, matrixRoomId, readMarkerTs, watchingShares, remoteVideoEls, onCloseShare, screenShareViewerMode, users, disabled, topNotice, onMessageContextMenu, onCopyToClipboard, currentUserMatrixId, onToggleReaction, typingIndicatorText, typingTargetId, onTypingStart, onTypingStop, currentUserId, paintSessionStatuses, onJoinPaint, onOpenPaint, onUseAsPaintBackground }: ChatPanelProps) {
   // Build lookup maps from sender name and matrixUserId → avatar data for MessageBubble.
   // Name-based lookup works when Mumble name matches message sender.
   // MatrixUserId-based lookup handles cases where the user connected with a different
@@ -198,11 +190,6 @@ const [replyState, setReplyState] = useState<{
     eventId: string;
     originalContent: string;
   } | null>(null);
-  const [splitPercent, setSplitPercent] = useState(() => {
-    const stored = localStorage.getItem(SPLIT_STORAGE_KEY);
-    return stored ? Number(stored) : DEFAULT_SPLIT;
-  });
-  const isDraggingRef = useRef(false);
 
   const editingMessage = useMemo(() => {
     if (!editState) return null;
@@ -220,37 +207,6 @@ const [replyState, setReplyState] = useState<{
     }
   }, [matrixClient, matrixRoomId]);
 
-  const handleDividerMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    isDraggingRef.current = true;
-
-    const onMouseMove = (moveEvent: MouseEvent) => {
-      const panel = panelRef.current;
-      if (!panel) return;
-      const rect = panel.getBoundingClientRect();
-      const headerEl = panel.querySelector('.chat-header') as HTMLElement;
-      const headerHeight = headerEl ? headerEl.offsetHeight : 0;
-      const availableHeight = rect.height - headerHeight;
-      const y = moveEvent.clientY - rect.top - headerHeight;
-      const pct = Math.min(80, Math.max(20, (y / availableHeight) * 100));
-      setSplitPercent(pct);
-    };
-
-    const onMouseUp = () => {
-      isDraggingRef.current = false;
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      setSplitPercent(prev => {
-        localStorage.setItem(SPLIT_STORAGE_KEY, String(prev));
-        return prev;
-      });
-    };
-
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }, []);
-
-  const hasScreenShare = screenShareViewerMode === 'in-app' && (watchingShares?.length ?? 0) > 0 && remoteVideoEls && remoteVideoEls.size > 0 && onCloseShare;
   const hasNewWindowScreenShare = screenShareViewerMode === 'new-window' && (watchingShares?.length ?? 0) > 0 && remoteVideoEls && remoteVideoEls.size > 0 && onCloseShare;
 
   useEffect(() => {
@@ -883,45 +839,6 @@ const [replyState, setReplyState] = useState<{
           </Tooltip>
         </div>
       </div>
-
-      {hasScreenShare && (
-        <>
-          <div className="chat-split-video" style={{ flex: `0 0 ${splitPercent}%` }}>
-            <ScreenShareGrid
-              watchingShares={watchingShares!}
-              focusedShare={focusedShare ?? null}
-              videoElements={remoteVideoEls!}
-              roomQuality={roomQuality}
-              shareQualities={shareQualities}
-              viewerQualities={viewerQualities}
-              onFocus={onFocusShare ?? (() => {})}
-              onClose={onCloseShare!}
-              onViewerQualityChange={onViewerQualityChange}
-            />
-          </div>
-          <div
-            className="chat-split-divider"
-            role="separator"
-            aria-orientation="horizontal"
-            aria-valuenow={splitPercent}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            tabIndex={0}
-            onMouseDown={handleDividerMouseDown}
-            onKeyDown={(event) => {
-              if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
-                event.preventDefault();
-                const delta = event.key === 'ArrowUp' ? -5 : 5;
-                const next = Math.min(80, Math.max(20, splitPercent + delta));
-                if (next !== splitPercent) {
-                  setSplitPercent(next);
-                  localStorage.setItem(SPLIT_STORAGE_KEY, String(next));
-                }
-              }
-            }}
-          />
-        </>
-      )}
 
       <div className="chat-messages" ref={messagesContainerRef} onScroll={handleScroll}>
         {topNotice && (

--- a/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.module.css
+++ b/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.module.css
@@ -8,12 +8,28 @@
   min-width: 0;
 }
 
+.scroller {
+  display: flex;
+  gap: var(--space-2xs);
+  overflow-x: auto;
+  scrollbar-width: thin;
+  min-width: 0;
+  flex: 1;
+}
+
+.scroller:focus-visible {
+  outline: var(--border-width-strong) solid var(--accent-primary);
+  outline-offset: calc(-1 * var(--border-width-strong));
+}
+
 .tab {
   display: flex;
   align-items: center;
   border-radius: var(--radius-md) var(--radius-md) 0 0;
   background: var(--bg-surface);
-  min-width: 0;
+  min-width: var(--conversation-tab-min-width);
+  max-width: var(--conversation-tab-max-width);
+  flex: 0 1 auto;
 }
 
 .tab:hover {
@@ -27,6 +43,11 @@
 
 .home {
   background: var(--bg-surface);
+}
+
+.active,
+.home {
+  flex-shrink: 0.5;
 }
 
 .label {

--- a/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.module.css
+++ b/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.module.css
@@ -1,0 +1,90 @@
+.strip {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-2xs) 0;
+  background: var(--bg-elevated);
+  flex: none;
+  min-width: 0;
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  background: var(--bg-surface);
+  min-width: 0;
+}
+
+.tab:hover {
+  background: var(--bg-hover);
+}
+
+.active {
+  background: var(--bg-deep);
+  font-weight: 600;
+}
+
+.home {
+  background: var(--bg-surface);
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: var(--space-2xs) var(--space-xs);
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  min-width: 0;
+}
+
+.label:focus-visible {
+  outline: var(--border-width-strong) solid var(--accent-primary);
+  outline-offset: calc(-1 * var(--border-width-strong));
+}
+
+.text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.unread,
+.mention {
+  border-radius: var(--radius-lg);
+  padding: 0 var(--space-2xs);
+  font-size: var(--text-xs);
+}
+
+.unread {
+  background: var(--accent-danger);
+  color: var(--bg-deep);
+}
+
+.mention {
+  background: var(--accent-warning);
+  color: var(--bg-deep);
+}
+
+.close {
+  display: flex;
+  align-items: center;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0 var(--space-2xs);
+}
+
+.close:hover {
+  color: var(--text-primary);
+}
+
+.close:focus-visible {
+  outline: var(--border-width-strong) solid var(--accent-primary);
+  outline-offset: calc(-1 * var(--border-width-strong));
+}

--- a/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.overflow.test.tsx
+++ b/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.overflow.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { ConversationTabStrip } from './ConversationTabStrip';
+
+const tab = (n: number) => ({
+  conversation: { kind: 'channel' as const, channelId: String(n) },
+  key: `channel:${n}`, label: `channel-number-${n}`, isHome: false, unreadCount: 0, mentionCount: 0,
+});
+const home = {
+  conversation: { kind: 'channel' as const, channelId: '0' },
+  key: 'channel:0', label: 'General', isHome: true, unreadCount: 0, mentionCount: 0,
+};
+
+describe('ConversationTabStrip overflow', () => {
+  it('keeps the home tab outside the scrolling container', () => {
+    render(<ConversationTabStrip tabs={[home, ...Array.from({ length: 30 }, (_, i) => tab(i + 1))]}
+      activeKey="channel:0" onActivate={vi.fn()} onClose={vi.fn()} />);
+    const scroller = screen.getByTestId('conversation-tab-scroller');
+    expect(within(scroller).queryByRole('tab', { name: /General/ })).not.toBeInTheDocument();
+    expect(within(scroller).getAllByRole('tab')).toHaveLength(30);
+  });
+
+  it('exposes the scroller as horizontally scrollable and keyboard reachable', () => {
+    render(<ConversationTabStrip tabs={[home, ...Array.from({ length: 30 }, (_, i) => tab(i + 1))]}
+      activeKey="channel:0" onActivate={vi.fn()} onClose={vi.fn()} />);
+    const scroller = screen.getByTestId('conversation-tab-scroller');
+    expect(scroller).toHaveAttribute('tabindex', '0');
+    expect(scroller).toHaveAttribute('aria-label', 'Scroll conversations');
+  });
+
+  it('truncates long labels rather than wrapping', () => {
+    render(<ConversationTabStrip tabs={[home, tab(1)]} activeKey="channel:0" onActivate={vi.fn()} onClose={vi.fn()} />);
+    const label = screen.getByText('channel-number-1');
+    expect(label.className).toMatch(/text/);
+  });
+
+  it('still renders a single home tab without a scroller wrapper collapsing it', () => {
+    render(<ConversationTabStrip tabs={[home]} activeKey="channel:0" onActivate={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.getByRole('tab', { name: /General/ })).toBeInTheDocument();
+    expect(within(screen.getByTestId('conversation-tab-scroller')).queryAllByRole('tab')).toHaveLength(0);
+  });
+});

--- a/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.test.tsx
+++ b/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ConversationTabStrip } from './ConversationTabStrip';
+
+const home = {
+  conversation: { kind: 'channel' as const, channelId: '7' },
+  key: 'channel:7', label: 'General', isHome: true, unreadCount: 0, mentionCount: 0,
+};
+const browsed = {
+  conversation: { kind: 'channel' as const, channelId: '9' },
+  key: 'channel:9', label: 'Random', isHome: false, unreadCount: 3, mentionCount: 0,
+};
+const contact = {
+  conversation: { kind: 'dm' as const, contactId: 'a' },
+  key: 'dm:a', label: 'Alice', isHome: false, unreadCount: 0, mentionCount: 1,
+};
+
+const renderStrip = (overrides = {}) => {
+  const props = { tabs: [home, browsed, contact], activeKey: 'channel:7', onActivate: vi.fn(), onClose: vi.fn(), ...overrides };
+  render(<ConversationTabStrip {...props} />);
+  return props;
+};
+
+describe('ConversationTabStrip', () => {
+  it('renders every tab with the home tab first and selected state', () => {
+    renderStrip();
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.map(tab => tab.textContent)).toEqual([
+      expect.stringContaining('General'),
+      expect.stringContaining('Random'),
+      expect.stringContaining('Alice'),
+    ]);
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('gives the home tab no close control', () => {
+    renderStrip();
+    expect(screen.queryByRole('button', { name: 'Close General' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close Random' })).toBeInTheDocument();
+  });
+
+  it('marks the home tab in its accessible name', () => {
+    renderStrip();
+    expect(screen.getByRole('tab', { name: /General \(you are here\)/ })).toBeInTheDocument();
+  });
+
+  it('activates on click', () => {
+    const props = renderStrip();
+    fireEvent.click(screen.getByRole('tab', { name: /Random/ }));
+    expect(props.onActivate).toHaveBeenCalledWith('channel:9');
+  });
+
+  it('closes without activating', () => {
+    const props = renderStrip();
+    fireEvent.click(screen.getByRole('button', { name: 'Close Random' }));
+    expect(props.onClose).toHaveBeenCalledWith('channel:9');
+    expect(props.onActivate).not.toHaveBeenCalled();
+  });
+
+  it('shows unread and mention counts', () => {
+    renderStrip();
+    expect(screen.getByRole('tab', { name: /Random/ })).toHaveTextContent('3');
+    expect(screen.getByRole('tab', { name: /Alice/ })).toHaveTextContent('@1');
+  });
+
+  it('hides a zero unread count', () => {
+    renderStrip({ tabs: [home] });
+    expect(screen.getByRole('tab', { name: /General/ })).not.toHaveTextContent('0');
+  });
+
+  it('moves between tabs with the arrow keys', () => {
+    const props = renderStrip();
+    fireEvent.keyDown(screen.getByRole('tab', { name: /General/ }), { key: 'ArrowRight' });
+    expect(props.onActivate).toHaveBeenCalledWith('channel:9');
+  });
+
+  it('wraps at both ends', () => {
+    const props = renderStrip({ activeKey: 'dm:a' });
+    fireEvent.keyDown(screen.getByRole('tab', { name: /Alice/ }), { key: 'ArrowRight' });
+    expect(props.onActivate).toHaveBeenCalledWith('channel:7');
+  });
+
+  it('closes the focused tab with Delete but never the home tab', () => {
+    const props = renderStrip({ activeKey: 'channel:9' });
+    fireEvent.keyDown(screen.getByRole('tab', { name: /Random/ }), { key: 'Delete' });
+    expect(props.onClose).toHaveBeenCalledWith('channel:9');
+    fireEvent.keyDown(screen.getByRole('tab', { name: /General/ }), { key: 'Delete' });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when there are no tabs', () => {
+    render(<ConversationTabStrip tabs={[]} activeKey={null} onActivate={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+  });
+});

--- a/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx
+++ b/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx
@@ -21,45 +21,58 @@ interface ConversationTabStripProps {
 export function ConversationTabStrip({ tabs, activeKey, onActivate, onClose }: ConversationTabStripProps) {
   if (tabs.length === 0) return null;
 
+  // Indexes into the combined `tabs` list so arrow keys traverse the pinned home
+  // tab and the scrolled tabs as one tab set.
   const move = (index: number, delta: number) => {
     const next = tabs[(index + delta + tabs.length) % tabs.length];
     if (next) onActivate(next.key);
   };
 
+  const renderTab = (tab: ConversationTabItem, index: number) => (
+    <div key={tab.key} className={`${styles.tab} ${activeKey === tab.key ? styles.active : ''} ${tab.isHome ? styles.home : ''}`}>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeKey === tab.key}
+        tabIndex={activeKey === tab.key ? 0 : -1}
+        className={styles.label}
+        onClick={() => onActivate(tab.key)}
+        onKeyDown={event => {
+          if (event.key === 'ArrowRight') { event.preventDefault(); move(index, 1); }
+          if (event.key === 'ArrowLeft') { event.preventDefault(); move(index, -1); }
+          if (event.key === 'Delete' && !tab.isHome) { event.preventDefault(); onClose(tab.key); }
+        }}
+      >
+        <span className={styles.text} aria-hidden={tab.isHome || undefined}>{tab.label}</span>
+        {tab.isHome && <span className="sr-only">{`${tab.label} (you are here)`}</span>}
+        {tab.mentionCount > 0 && <span className={styles.mention}>@{tab.mentionCount}</span>}
+        {tab.mentionCount === 0 && tab.unreadCount > 0 && <span className={styles.unread}>{tab.unreadCount}</span>}
+      </button>
+      {!tab.isHome && (
+        <button
+          type="button"
+          className={styles.close}
+          aria-label={`Close ${tab.label}`}
+          onClick={() => onClose(tab.key)}
+        >
+          <Icon name="x" size={10} />
+        </button>
+      )}
+    </div>
+  );
+
   return (
     <div className={styles.strip} role="tablist" aria-label="Conversations">
-      {tabs.map((tab, index) => (
-        <div key={tab.key} className={`${styles.tab} ${activeKey === tab.key ? styles.active : ''} ${tab.isHome ? styles.home : ''}`}>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={activeKey === tab.key}
-            tabIndex={activeKey === tab.key ? 0 : -1}
-            className={styles.label}
-            onClick={() => onActivate(tab.key)}
-            onKeyDown={event => {
-              if (event.key === 'ArrowRight') { event.preventDefault(); move(index, 1); }
-              if (event.key === 'ArrowLeft') { event.preventDefault(); move(index, -1); }
-              if (event.key === 'Delete' && !tab.isHome) { event.preventDefault(); onClose(tab.key); }
-            }}
-          >
-            <span className={styles.text} aria-hidden={tab.isHome || undefined}>{tab.label}</span>
-            {tab.isHome && <span className="sr-only">{`${tab.label} (you are here)`}</span>}
-            {tab.mentionCount > 0 && <span className={styles.mention}>@{tab.mentionCount}</span>}
-            {tab.mentionCount === 0 && tab.unreadCount > 0 && <span className={styles.unread}>{tab.unreadCount}</span>}
-          </button>
-          {!tab.isHome && (
-            <button
-              type="button"
-              className={styles.close}
-              aria-label={`Close ${tab.label}`}
-              onClick={() => onClose(tab.key)}
-            >
-              <Icon name="x" size={10} />
-            </button>
-          )}
-        </div>
-      ))}
+      {tabs.map((tab, index) => (tab.isHome ? renderTab(tab, index) : null))}
+      <div
+        className={styles.scroller}
+        data-testid="conversation-tab-scroller"
+        tabIndex={0}
+        role="group"
+        aria-label="Scroll conversations"
+      >
+        {tabs.map((tab, index) => (tab.isHome ? null : renderTab(tab, index)))}
+      </div>
     </div>
   );
 }

--- a/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx
+++ b/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx
@@ -1,0 +1,65 @@
+import type { Conversation } from '../../workspace/conversation';
+import { Icon } from '../Icon/Icon';
+import styles from './ConversationTabStrip.module.css';
+
+export interface ConversationTabItem {
+  conversation: Conversation;
+  key: string;
+  label: string;
+  isHome: boolean;
+  unreadCount: number;
+  mentionCount: number;
+}
+
+interface ConversationTabStripProps {
+  tabs: ConversationTabItem[];
+  activeKey: string | null;
+  onActivate: (key: string) => void;
+  onClose: (key: string) => void;
+}
+
+export function ConversationTabStrip({ tabs, activeKey, onActivate, onClose }: ConversationTabStripProps) {
+  if (tabs.length === 0) return null;
+
+  const move = (index: number, delta: number) => {
+    const next = tabs[(index + delta + tabs.length) % tabs.length];
+    if (next) onActivate(next.key);
+  };
+
+  return (
+    <div className={styles.strip} role="tablist" aria-label="Conversations">
+      {tabs.map((tab, index) => (
+        <div key={tab.key} className={`${styles.tab} ${activeKey === tab.key ? styles.active : ''} ${tab.isHome ? styles.home : ''}`}>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeKey === tab.key}
+            tabIndex={activeKey === tab.key ? 0 : -1}
+            className={styles.label}
+            onClick={() => onActivate(tab.key)}
+            onKeyDown={event => {
+              if (event.key === 'ArrowRight') { event.preventDefault(); move(index, 1); }
+              if (event.key === 'ArrowLeft') { event.preventDefault(); move(index, -1); }
+              if (event.key === 'Delete' && !tab.isHome) { event.preventDefault(); onClose(tab.key); }
+            }}
+          >
+            <span className={styles.text} aria-hidden={tab.isHome || undefined}>{tab.label}</span>
+            {tab.isHome && <span className="sr-only">{`${tab.label} (you are here)`}</span>}
+            {tab.mentionCount > 0 && <span className={styles.mention}>@{tab.mentionCount}</span>}
+            {tab.mentionCount === 0 && tab.unreadCount > 0 && <span className={styles.unread}>{tab.unreadCount}</span>}
+          </button>
+          {!tab.isHome && (
+            <button
+              type="button"
+              className={styles.close}
+              aria-label={`Close ${tab.label}`}
+              onClick={() => onClose(tab.key)}
+            >
+              <Icon name="x" size={10} />
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx
+++ b/src/Brmble.Web/src/components/ConversationTabStrip/ConversationTabStrip.tsx
@@ -43,7 +43,7 @@ export function ConversationTabStrip({ tabs, activeKey, onActivate, onClose }: C
           if (event.key === 'Delete' && !tab.isHome) { event.preventDefault(); onClose(tab.key); }
         }}
       >
-        <span className={styles.text} aria-hidden={tab.isHome || undefined}>{tab.label}</span>
+        <span className={styles.text} data-testid="conversation-tab-label" aria-hidden={tab.isHome || undefined}>{tab.label}</span>
         {tab.isHome && <span className="sr-only">{`${tab.label} (you are here)`}</span>}
         {tab.mentionCount > 0 && <span className={styles.mention}>@{tab.mentionCount}</span>}
         {tab.mentionCount === 0 && tab.unreadCount > 0 && <span className={styles.unread}>{tab.unreadCount}</span>}

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.css
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.css
@@ -1,58 +1,22 @@
 .dm-contact-list {
   position: relative;
-  width: var(--messages-rail-width, 48px);
-  min-width: var(--messages-rail-width, 48px);
+  width: var(--dm-panel-width);
+  min-width: var(--dm-panel-width);
   height: calc(100vh - var(--header-height));
   background: var(--bg-primary);
   border-left: var(--glass-border);
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition: width var(--transition-slow), min-width var(--transition-slow);
-}
-
-.dm-contact-list.visible {
-  width: 260px;
-  min-width: 260px;
-}
-
-.dm-contact-list-toggle {
-  align-items: center;
-  background: none;
-  border-radius: var(--radius-sm);
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  display: flex;
   flex-shrink: 0;
-  height: 24px;
-  justify-content: center;
-  margin: 0;
-  padding: 0;
-  width: 24px;
-}
-
-.dm-contact-list-toggle:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.dm-contact-list-toggle:focus-visible {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: -2px;
 }
 
 .dm-contact-list-content {
   display: flex;
   flex: 1;
   flex-direction: column;
-  min-width: 260px;
+  min-width: 0;
   overflow: hidden;
-  transition: opacity var(--transition-slow);
-}
-
-.dm-contact-list:not(.visible) .dm-contact-list-content {
-  opacity: 0;
 }
 
 .dm-contact-list-header {
@@ -60,19 +24,7 @@
   display: flex;
   flex-shrink: 0;
   gap: var(--space-2xs);
-  min-width: 260px;
   padding: var(--space-md) var(--space-md) var(--space-xs);
-}
-
-.dm-contact-list-header.collapsed {
-  gap: 0;
-  justify-content: center;
-  min-width: var(--messages-rail-width, 48px);
-  padding: var(--space-xs) 0;
-}
-
-.dm-contact-list-header.collapsed .heading-section {
-  display: none;
 }
 
 .dm-contact-search {
@@ -182,6 +134,7 @@
   transition: background var(--transition-fast);
   border: none;
   background: none;
+  position: relative;
 }
 
 .dm-contact-entry:hover {
@@ -264,9 +217,67 @@
   color: var(--text-muted);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .dm-contact-list,
-  .dm-contact-list-content {
-    transition: none;
+/* Presentation-only rail. Driven by viewport width alone — no state, no toggle, no
+   JavaScript. Unread badges stay visible; the accessible name survives via `.sr-only`. */
+@media (max-width: 60rem) {
+  .dm-contact-list {
+    width: var(--dm-rail-width);
+    min-width: var(--dm-rail-width);
+  }
+
+  .dm-contact-list .dm-contact-preview,
+  .dm-contact-list .dm-contact-time,
+  .dm-contact-list .dm-contact-ephemeral-tag,
+  .dm-contact-list .dm-contact-list-header .heading-section,
+  .dm-contact-list .dm-contact-section-title,
+  .dm-contact-list .dm-contact-section-toggle span,
+  .dm-contact-list .dm-contact-empty,
+  .dm-contact-list .dm-contact-search {
+    display: none;
+  }
+
+  /* The contact name is the entry's accessible name, so it is visually hidden rather
+     than removed — `display: none` would drop it from the accessibility tree and leave
+     the rail's buttons unnamed. Same technique as the global `.sr-only` utility, which
+     cannot be composed from a media query. */
+  .dm-contact-list .dm-contact-name {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    clip-path: inset(50%);
+  }
+
+  .dm-contact-list .dm-contact-list-header {
+    justify-content: center;
+    padding: var(--space-xs) 0;
+  }
+
+  .dm-contact-list .dm-contact-entries {
+    padding: 0 var(--space-2xs);
+  }
+
+  .dm-contact-list .dm-contact-entry {
+    justify-content: center;
+    padding: var(--space-xs) var(--space-2xs);
+  }
+
+  .dm-contact-list .dm-contact-info {
+    flex: 0 0 auto;
+  }
+
+  .dm-contact-list .dm-contact-unread {
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-end: 0;
+  }
+
+  .dm-contact-list .dm-contact-section-toggle {
+    justify-content: center;
+    padding: var(--space-xs) 0 var(--space-2xs);
   }
 }

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useState } from 'react';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fireEvent, render, screen } from '@testing-library/react';
@@ -46,7 +45,6 @@ const mumbleContact: DMContact = {
   mumbleSessionId: 44,
 };
 
-const appCss = readFileSync(join(process.cwd(), 'src', 'App.css'), 'utf8');
 const dmContactListCss = readFileSync(
   join(process.cwd(), 'src', 'components', 'DMContactList', 'DMContactList.css'),
   'utf8',
@@ -55,14 +53,11 @@ const dmContactListCss = readFileSync(
 function renderList(
   contacts: DMContact[] = [matrixContact, mumbleContact],
   options: Partial<{
-    visible: boolean;
-    onToggleVisibility: () => void;
     selectedUserId: string | null;
   }> = {},
 ) {
   const onSelectContact = vi.fn();
   const onCloseConversation = vi.fn();
-  const onToggleVisibility = options.onToggleVisibility ?? vi.fn();
 
   const view = render(
     <DMContactList
@@ -70,46 +65,10 @@ function renderList(
       selectedUserId={options.selectedUserId ?? null}
       onSelectContact={onSelectContact}
       onCloseConversation={onCloseConversation}
-      onToggleVisibility={onToggleVisibility}
-      visible={options.visible ?? true}
     />,
   );
 
-  return { ...view, onSelectContact, onCloseConversation, onToggleVisibility };
-}
-
-function VisibilityHarness({
-  contacts = [matrixContact],
-  selectedUserId = matrixContact.id,
-  onSelectContact = vi.fn(),
-  onCloseConversation = vi.fn(),
-  withExternalCollapseControl = false,
-}: Partial<{
-  contacts: DMContact[];
-  selectedUserId: string | null;
-  onSelectContact: (id: string, displayName: string) => void;
-  onCloseConversation: (id: string) => void;
-  withExternalCollapseControl: boolean;
-}>) {
-  const [visible, setVisible] = useState(true);
-
-  return (
-    <>
-      {withExternalCollapseControl && (
-        <button type="button" onMouseDown={(event) => event.preventDefault()} onClick={() => setVisible(false)}>
-          Collapse externally
-        </button>
-      )}
-      <DMContactList
-        contacts={contacts}
-        selectedUserId={selectedUserId}
-        onSelectContact={onSelectContact}
-        onCloseConversation={onCloseConversation}
-        onToggleVisibility={() => setVisible((current) => !current)}
-        visible={visible}
-      />
-    </>
-  );
+  return { ...view, onSelectContact, onCloseConversation };
 }
 
 describe('DMContactList directory behavior', () => {
@@ -118,91 +77,6 @@ describe('DMContactList directory behavior', () => {
     localStorage.clear();
     localStorage.setItem('volume_44', '100');
     localStorage.setItem('volume_33', '100');
-  });
-
-  it('expands the persistent Messages rail with Enter and restores the preserved search state', async () => {
-    const user = userEvent.setup();
-    render(<VisibilityHarness contacts={[matrixContact, mumbleContact]} />);
-
-    const search = screen.getByPlaceholderText('Search users...');
-    await user.type(search, 'val');
-    await user.click(screen.getByRole('button', { name: 'Collapse Messages panel' }));
-
-    const expand = screen.getByRole('button', { name: 'Expand Messages panel' });
-    expect(expand.querySelector('polyline')).toHaveAttribute('points', '18 6 12 12 18 18');
-    expand.focus();
-    await user.keyboard('{Enter}');
-
-    expect(screen.getByRole('button', { name: 'Collapse Messages panel' })).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Search users...')).toHaveValue('val');
-    expect(screen.getAllByText('Vanilla Val')).toHaveLength(2);
-  });
-
-  it('collapses the Messages panel with Space and updates the rail state', async () => {
-    const user = userEvent.setup();
-    render(<VisibilityHarness />);
-
-    const collapse = screen.getByRole('button', { name: 'Collapse Messages panel' });
-    expect(collapse.querySelector('polyline')).toHaveAttribute('points', '6 6 12 12 6 18');
-    collapse.focus();
-    await user.keyboard(' ');
-
-    const expand = screen.getByRole('button', { name: 'Expand Messages panel' });
-    expect(expand.querySelector('polyline')).toHaveAttribute('points', '18 6 12 12 18 18');
-    expect(screen.getByPlaceholderText('Search users...').closest('.dm-contact-list-content')).toHaveAttribute('aria-hidden', 'true');
-  });
-
-  it('moves focus to the rail control when a focused contact collapses through a state transition', async () => {
-    const user = userEvent.setup();
-    render(<VisibilityHarness withExternalCollapseControl />);
-
-    const contact = screen.getByRole('button', { name: /Vanilla Val/ });
-    contact.focus();
-    await user.click(screen.getByRole('button', { name: 'Collapse externally' }));
-
-    expect(screen.getByRole('button', { name: 'Expand Messages panel' })).toHaveFocus();
-  });
-
-  it('hides contact unread badges when collapsed without adding a separate rail badge', async () => {
-    const user = userEvent.setup();
-    render(<VisibilityHarness contacts={[matrixContact, mumbleContact]} />);
-
-    expect(screen.getAllByText('2')).toHaveLength(1);
-    expect(screen.getAllByText('1')).toHaveLength(1);
-    expect(screen.queryByLabelText('3 unread messages')).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'Collapse Messages panel' }));
-
-    expect(screen.queryByLabelText('3 unread messages')).not.toBeInTheDocument();
-    expect(screen.queryByText('2')).not.toBeInTheDocument();
-    expect(screen.queryByText('1')).not.toBeInTheDocument();
-  });
-
-  it('settles on the expanded state after rapid repeated rail toggles', async () => {
-    const user = userEvent.setup();
-    render(<VisibilityHarness />);
-
-    const collapse = screen.getByRole('button', { name: 'Collapse Messages panel' });
-    await user.dblClick(collapse);
-
-    expect(screen.getByRole('button', { name: 'Collapse Messages panel' })).toBeInTheDocument();
-  });
-
-  it('closes a contact context menu when the panel collapses without selection or close side effects', async () => {
-    const user = userEvent.setup();
-    const onSelectContact = vi.fn();
-    const onCloseConversation = vi.fn();
-    render(<VisibilityHarness onSelectContact={onSelectContact} onCloseConversation={onCloseConversation} />);
-
-    fireEvent.contextMenu(screen.getByRole('button', { name: /Vanilla Val/ }));
-    expect(screen.getByRole('button', { name: 'Send Direct Message' })).toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'Collapse Messages panel' }));
-
-    expect(screen.queryByRole('button', { name: 'Send Direct Message' })).not.toBeInTheDocument();
-    expect(onSelectContact).not.toHaveBeenCalled();
-    expect(onCloseConversation).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: /Vanilla Val/, hidden: true })).toHaveClass('active');
   });
 
   it('renders a registered standard-Mumble user as two visually distinct route entries', () => {
@@ -218,30 +92,6 @@ describe('DMContactList directory behavior', () => {
     expect(screen.getByTestId('mumble-avatar')).toBeInTheDocument();
   });
 
-  it('keeps the panel toggle in the Messages header row before the title', () => {
-    renderList();
-
-    const header = screen.getByRole('heading', { name: 'Messages' }).closest('.dm-contact-list-header');
-    expect(header).not.toBeNull();
-    expect(header?.children[0]).toBe(screen.getByRole('button', { name: 'Collapse Messages panel' }));
-    expect(header?.children[1]).toBe(screen.getByRole('heading', { name: 'Messages' }));
-  });
-
-  it('keeps the expand toggle in the visible collapsed rail header', () => {
-    const { container } = renderList([matrixContact], { visible: false });
-
-    const panel = container.querySelector('.dm-contact-list');
-    const header = container.querySelector('.dm-contact-list-header');
-    expect(panel).not.toHaveClass('visible');
-    expect(header).toHaveClass('collapsed');
-    expect(header?.children[0]).toBe(screen.getByRole('button', { name: 'Expand Messages panel' }));
-  });
-
-  it('keeps the collapsed Messages rail wide enough for the toggle', () => {
-    expect(appCss).toContain('--messages-rail-width: 48px;');
-    expect(dmContactListCss).toContain('width: var(--messages-rail-width, 48px);');
-    expect(dmContactListCss).toContain('min-width: var(--messages-rail-width, 48px);');
-  });
 
   it('keeps search results in their route sections when both routes match', async () => {
     const user = userEvent.setup();
@@ -371,8 +221,6 @@ describe('DMContactList directory behavior', () => {
         selectedUserId={null}
         onSelectContact={vi.fn()}
         onCloseConversation={vi.fn()}
-        onToggleVisibility={vi.fn()}
-        visible={true}
       />,
     );
 
@@ -403,6 +251,44 @@ describe('DMContactList directory behavior', () => {
     fireEvent.contextMenu(screen.getByRole('button', { name: /Offline Olive/ }));
 
     expect(screen.getByRole('button', { name: 'User Information' })).toBeDisabled();
+  });
+
+  it('renders without a visibility toggle', () => {
+    renderList();
+
+    expect(screen.queryByRole('button', { name: /Collapse Messages panel/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Expand Messages panel/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Messages' })).toBeInTheDocument();
+  });
+
+  it('always shows unread counts', () => {
+    renderList([{ id: 'a', displayName: 'Alice', unreadCount: 4, lastMessageTime: 1000 }]);
+
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  // The plan's third case set a `--force-narrow` custom property and re-asserted the
+  // badge. jsdom does not evaluate media queries against imported stylesheets, so that
+  // assertion is identical to the one above and proves nothing about the rail. The rail
+  // is presentation-only, so its contract is asserted against the stylesheet source and
+  // its rendered appearance is covered by the Task 20 manual checklist.
+  it('keeps unread counts out of the narrow rail collapse rules', () => {
+    expect(dmContactListCss).toContain('@media (max-width: 60rem)');
+    expect(dmContactListCss).toContain('width: var(--dm-rail-width);');
+    expect(dmContactListCss).not.toMatch(/\.dm-contact-unread\s*{[^}]*display:\s*none/);
+  });
+
+  // UI_GUIDE forbids `aria-label` on an element that also carries a visible unread badge
+  // (it would replace the whole accessible name and silence the count), and forbids
+  // `display: none` for text that must reach assistive technology. The rail therefore
+  // visually hides `.dm-contact-name` with the `.sr-only` technique instead of removing it.
+  it('keeps a rail-proof accessible name alongside the unread badge', () => {
+    renderList([matrixContact]);
+
+    const entry = screen.getByRole('button', { name: /Vanilla Val/ });
+    expect(entry).toHaveAccessibleName(/2/);
+    expect(dmContactListCss).not.toMatch(/\.dm-contact-name,/);
+    expect(dmContactListCss).toContain('clip-path: inset(50%);');
   });
 
   it('disables user info for an offline Mumble route', () => {

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.test.tsx
@@ -243,12 +243,6 @@ describe('DMContactList directory behavior', () => {
     expect(dmContactListCss).toContain('min-width: var(--messages-rail-width, 48px);');
   });
 
-  it('keeps each conversation slide exactly the width of the main content viewport', () => {
-    expect(appCss).toMatch(/\.content-slider\s*\{[\s\S]*?\bwidth:\s*100%;/);
-    expect(appCss).toMatch(/\.content-slider\.dm-active\s*\{[\s\S]*?transform:\s*translateX\(-100%\);/);
-    expect(appCss).toMatch(/\.content-slide\s*\{[\s\S]*?\bflex:\s*0 0 100%;/);
-  });
-
   it('keeps search results in their route sections when both routes match', async () => {
     const user = userEvent.setup();
     renderList();

--- a/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
+++ b/src/Brmble.Web/src/components/DMContactList/DMContactList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { ContextMenu } from '../ContextMenu/ContextMenu';
 import { UserInfoDialog } from '../UserInfoDialog/UserInfoDialog';
 import { Tooltip } from '../Tooltip/Tooltip';
@@ -12,17 +12,13 @@ interface DMContactListProps {
   selectedUserId: string | null;
   onSelectContact: (id: string, displayName: string) => void;
   onCloseConversation: (id: string) => void;
-  onToggleVisibility: () => void;
-  visible: boolean;
 }
 
-export function DMContactList({ contacts, selectedUserId, onSelectContact, onCloseConversation, onToggleVisibility, visible }: DMContactListProps) {
+export function DMContactList({ contacts, selectedUserId, onSelectContact, onCloseConversation }: DMContactListProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [othersExpanded, setOthersExpanded] = useState(() =>
     localStorage.getItem('dm-others-expanded') === 'true'
   );
-  const contentRef = useRef<HTMLDivElement>(null);
-  const toggleRef = useRef<HTMLButtonElement>(null);
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -40,16 +36,6 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
     onlineSessionId?: number;
   } | null>(null);
 
-  useEffect(() => {
-    if (!visible) setContextMenu(null);
-  }, [visible]);
-
-  useLayoutEffect(() => {
-    if (!visible && contentRef.current?.contains(document.activeElement)) {
-      toggleRef.current?.focus();
-    }
-  }, [visible]);
-
   const filtered = contacts.filter(c =>
     c.displayName.toLowerCase().includes(searchQuery.toLowerCase())
   );
@@ -60,13 +46,6 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
   const hasOtherContacts = contacts.some(c => !c.isEphemeral && c.lastMessageTime == null);
   const isSearchActive = searchQuery.length > 0;
   const showOtherContacts = othersExpanded || isSearchActive;
-
-  const handleToggleVisibility = () => {
-    if (visible && contentRef.current?.contains(document.activeElement)) {
-      toggleRef.current?.focus();
-    }
-    onToggleVisibility();
-  };
 
   const handleToggleOthers = () => {
     setOthersExpanded((current) => {
@@ -90,20 +69,11 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
   };
 
   return (
-    <div className={`dm-contact-list ${visible ? 'visible' : ''}`}>
-      <div className={`dm-contact-list-header ${visible ? '' : 'collapsed'}`}>
-        <button
-          type="button"
-          ref={toggleRef}
-          className="dm-contact-list-toggle"
-          onClick={handleToggleVisibility}
-          aria-label={visible ? 'Collapse Messages panel' : 'Expand Messages panel'}
-        >
-          <Icon name={visible ? 'chevron-right' : 'chevron-left'} size={18} />
-        </button>
+    <div className="dm-contact-list">
+      <div className="dm-contact-list-header">
         <h3 className="heading-section">Messages</h3>
       </div>
-      <div ref={contentRef} className="dm-contact-list-content" aria-hidden={!visible} inert={!visible}>
+      <div className="dm-contact-list-content">
 
       <div className="dm-contact-search">
         <Icon name="search" size={14} />
@@ -131,7 +101,6 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
                 contact={contact}
                 selected={selectedUserId === contact.id}
                 formatTime={formatTime}
-                showUnread={visible}
                 onSelectContact={onSelectContact}
                 onOpenContextMenu={setContextMenu}
               />
@@ -156,7 +125,6 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
                 contact={contact}
                 selected={selectedUserId === contact.id}
                 formatTime={formatTime}
-                showUnread={visible}
                 onSelectContact={onSelectContact}
                 onOpenContextMenu={setContextMenu}
               />
@@ -176,7 +144,6 @@ export function DMContactList({ contacts, selectedUserId, onSelectContact, onClo
                   contact={contact}
                   selected={selectedUserId === contact.id}
                   formatTime={formatTime}
-                  showUnread={visible}
                   onSelectContact={onSelectContact}
                   onOpenContextMenu={setContextMenu}
                 />
@@ -263,7 +230,6 @@ interface ContactEntryProps {
   contact: DMContact;
   selected: boolean;
   formatTime: (ts?: number) => string;
-  showUnread: boolean;
   onSelectContact: (id: string, displayName: string) => void;
   onOpenContextMenu: (menu: {
     x: number;
@@ -276,7 +242,7 @@ interface ContactEntryProps {
   }) => void;
 }
 
-function ContactEntry({ contact, selected, formatTime, showUnread, onSelectContact, onOpenContextMenu }: ContactEntryProps) {
+function ContactEntry({ contact, selected, formatTime, onSelectContact, onOpenContextMenu }: ContactEntryProps) {
   return (
     <button
       className={`dm-contact-entry ${selected ? 'active' : ''} ${contact.isEphemeral && contact.mumbleSessionId == null ? 'offline' : ''}`}
@@ -313,7 +279,7 @@ function ContactEntry({ contact, selected, formatTime, showUnread, onSelectConta
           <span className="dm-contact-preview">{contact.lastMessage}</span>
         )}
       </div>
-      {showUnread && contact.unreadCount > 0 && (
+      {contact.unreadCount > 0 && (
         <span className="dm-contact-unread">{contact.unreadCount}</span>
       )}
     </button>

--- a/src/Brmble.Web/src/components/Games/DeathrollModal.module.css
+++ b/src/Brmble.Web/src/components/Games/DeathrollModal.module.css
@@ -1,4 +1,5 @@
 .modal {
+  position: relative;
   width: 100%;
   max-width: 420px;
   padding: var(--space-xl);

--- a/src/Brmble.Web/src/components/Games/DeathrollModal.tsx
+++ b/src/Brmble.Web/src/components/Games/DeathrollModal.tsx
@@ -77,12 +77,10 @@ export function DeathrollModal({
     );
   };
 
+  // Not a dialog: a live match owns the whole main panel, so there is no overlay,
+  // no click-outside dismissal and no focus trap. Close/Forfeit remain the exits.
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div
-        className={`deathroll-modal glass-panel animate-slide-up ${styles.modal}`}
-        onClick={(e) => e.stopPropagation()}
-      >
+    <div className={`deathroll-modal glass-panel animate-slide-up ${styles.modal}`}>
         <button className="modal-close" onClick={onClose} aria-label="Close deathroll">
           <Icon name="x" size={20} />
         </button>
@@ -164,7 +162,6 @@ export function DeathrollModal({
             </>
           )}
         </div>
-      </div>
     </div>
   );
 }

--- a/src/Brmble.Web/src/components/Games/GameSurface.css
+++ b/src/Brmble.Web/src/components/Games/GameSurface.css
@@ -1,0 +1,10 @@
+.game-surface {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  min-width: 0;
+  padding: var(--space-lg);
+  overflow: auto;
+}

--- a/src/Brmble.Web/src/components/Games/GameSurface.tsx
+++ b/src/Brmble.Web/src/components/Games/GameSurface.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+import './GameSurface.css';
+
+/**
+ * Centers a minigame board inside the main panel. A live match owns the whole
+ * panel (it is not a dialog), so the board is laid out here rather than inside
+ * `div.modal-overlay`.
+ */
+export function GameSurface({ children }: { children: ReactNode }) {
+  return <div className="game-surface">{children}</div>;
+}

--- a/src/Brmble.Web/src/components/Games/RpsModal.module.css
+++ b/src/Brmble.Web/src/components/Games/RpsModal.module.css
@@ -1,4 +1,5 @@
 .modal {
+  position: relative;
   width: 100%;
   max-width: 420px;
   padding: var(--space-xl);

--- a/src/Brmble.Web/src/components/Games/RpsModal.tsx
+++ b/src/Brmble.Web/src/components/Games/RpsModal.tsx
@@ -176,12 +176,10 @@ export function RpsModal({
     );
   };
 
+  // Not a dialog: a live match owns the whole main panel, so there is no overlay,
+  // no click-outside dismissal and no focus trap. Close/Forfeit remain the exits.
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div
-        className={`rps-modal glass-panel animate-slide-up ${styles.modal}`}
-        onClick={(e) => e.stopPropagation()}
-      >
+    <div className={`rps-modal glass-panel animate-slide-up ${styles.modal}`}>
         <button className="modal-close" onClick={onClose} aria-label="Close rock paper scissors">
           <Icon name="x" size={20} />
         </button>
@@ -285,7 +283,6 @@ export function RpsModal({
             <button className="btn btn-danger" onClick={onForfeit}>Forfeit</button>
           )}
         </div>
-      </div>
     </div>
   );
 }

--- a/src/Brmble.Web/src/components/Header/Header.tsx
+++ b/src/Brmble.Web/src/components/Header/Header.tsx
@@ -7,9 +7,6 @@ import './Header.css';
 
 interface HeaderProps {
   username?: string;
-  onToggleDM?: () => void;
-  dmActive?: boolean;
-  unreadDMCount?: number;
   onOpenSettings: () => void;
   onOpenAudioSettings?: () => void;
   onAvatarClick?: () => void;
@@ -39,7 +36,7 @@ interface HeaderProps {
   activePaintSessionId?: string | null;
 }
 
-export function Header({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onOpenAudioSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, onToggleGame, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown, isMaximized, onStartPaint, canStartPaint, activePaintSessionId }: HeaderProps) {
+export function Header({ username, onOpenSettings, onOpenAudioSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, onToggleGame, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown, isMaximized, onStartPaint, canStartPaint, activePaintSessionId }: HeaderProps) {
   return (
     <header className="header">
       <div className="header-left">
@@ -59,9 +56,6 @@ export function Header({ username, onToggleDM, dmActive, unreadDMCount, onOpenSe
         )}
         <UserPanel
           username={username}
-          onToggleDM={onToggleDM}
-          dmActive={dmActive}
-          unreadDMCount={unreadDMCount}
           onOpenSettings={onOpenSettings}
           onOpenAudioSettings={onOpenAudioSettings}
           onAvatarClick={onAvatarClick}

--- a/src/Brmble.Web/src/components/MainPanel/MainPanel.tsx
+++ b/src/Brmble.Web/src/components/MainPanel/MainPanel.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import { VerticalSplitPane } from '../VerticalSplitPane/VerticalSplitPane';
+import type { MainPanelMode } from '../../workspace/mainPanelMode';
+
+export const MAIN_PANEL_SPLIT_STORAGE_KEY = 'brmble-main-split';
+
+interface MainPanelProps {
+  mode: MainPanelMode;
+  activityRegion: ReactNode | null;
+  conversationRegion: ReactNode;
+  gameSurface: ReactNode;
+}
+
+export function MainPanel({ mode, activityRegion, conversationRegion, gameSurface }: MainPanelProps) {
+  if (mode === 'game') return <>{gameSurface}</>;
+
+  return (
+    <VerticalSplitPane
+      top={activityRegion}
+      storageKey={MAIN_PANEL_SPLIT_STORAGE_KEY}
+      label="Resize channel activity and conversation"
+    >
+      {conversationRegion}
+    </VerticalSplitPane>
+  );
+}

--- a/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.css
+++ b/src/Brmble.Web/src/components/OnboardingWizard/OnboardingWizard.css
@@ -300,7 +300,7 @@
 }
 
 .onboarding-identity-badge.saved {
-  background: var(--bg-subtle);
+  background: var(--bg-surface);
   color: var(--text-muted);
 }
 

--- a/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
+++ b/src/Brmble.Web/src/components/SettingsModal/AdminSettingsTab.css
@@ -428,7 +428,7 @@
 .admin-user-badge {
   --admin-user-badge-padding-block: var(--space-2xs);
   padding: var(--admin-user-badge-padding-block) var(--space-xs);
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-lg);
   background: var(--bg-overlay);
   color: var(--text-secondary);
   white-space: nowrap;

--- a/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/SettingsModal.tsx
@@ -29,7 +29,6 @@ export const BINDING_LABELS: Record<string, string> = {
   toggleLeaveVoiceKey: 'Toggle Leave Voice',
   toggleMuteDeafenKey: 'Toggle Mute & Deafen',
   toggleMuteKey: 'Toggle Mute',
-  toggleDMScreenKey: 'Toggle Direct Messages Screen',
   toggleScreenShareKey: 'Toggle Screen Share',
   toggleGameKey: 'Toggle Game Panel',
 };
@@ -200,7 +199,6 @@ export function SettingsModal(props: SettingsModalProps) {
     toggleLeaveVoiceKey: settings.shortcuts.toggleLeaveVoiceKey,
     toggleMuteDeafenKey: settings.shortcuts.toggleMuteDeafenKey,
     toggleMuteKey: settings.shortcuts.toggleMuteKey,
-    toggleDMScreenKey: settings.shortcuts.toggleDMScreenKey,
     toggleScreenShareKey: settings.shortcuts.toggleScreenShareKey,
     toggleGameKey: settings.shortcuts.toggleGameKey,
   }), [settings.audio.pushToTalkKey, settings.shortcuts]);
@@ -330,7 +328,6 @@ export function SettingsModal(props: SettingsModalProps) {
         { action: 'toggleMute', key: shortcuts.toggleMuteKey },
         { action: 'toggleMuteDeafen', key: shortcuts.toggleMuteDeafenKey },
         { action: 'toggleLeaveVoice', key: shortcuts.toggleLeaveVoiceKey },
-        { action: 'toggleDmScreen', key: shortcuts.toggleDMScreenKey },
         { action: 'toggleScreenShare', key: shortcuts.toggleScreenShareKey },
         { action: 'toggleGame', key: shortcuts.toggleGameKey },
       ];
@@ -364,7 +361,6 @@ export function SettingsModal(props: SettingsModalProps) {
           toggleMuteKey: 'toggleMute',
           toggleMuteDeafenKey: 'toggleMuteDeafen',
           toggleLeaveVoiceKey: 'toggleLeaveVoice',
-          toggleDMScreenKey: 'toggleDmScreen',
           toggleScreenShareKey: 'toggleScreenShare',
           toggleGameKey: 'toggleGame',
         };

--- a/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.test.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.test.tsx
@@ -24,7 +24,6 @@ const baseSettings: ShortcutsSettings = {
   toggleMuteKey: null,
   toggleMuteDeafenKey: null,
   toggleLeaveVoiceKey: null,
-  toggleDMScreenKey: null,
   toggleScreenShareKey: null,
   toggleGameKey: null,
 };
@@ -33,6 +32,20 @@ describe('ShortcutsSettingsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     confirmMock.mockResolvedValue(false);
+  });
+
+  it('does not render a toggle direct messages screen binding', () => {
+    render(
+      <ShortcutsSettingsTab
+        settings={baseSettings}
+        onChange={vi.fn()}
+        allBindings={{}}
+        onClearBinding={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Toggle Direct Messages Screen')).toBeNull();
+    expect(screen.queryByText('Navigation')).toBeNull();
   });
 
   it('allows clearing an existing shortcut binding', () => {

--- a/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.tsx
+++ b/src/Brmble.Web/src/components/SettingsModal/ShortcutsSettingsTab.tsx
@@ -15,7 +15,6 @@ export interface ShortcutsSettings {
   toggleMuteKey: string | null;
   toggleMuteDeafenKey: string | null;
   toggleLeaveVoiceKey: string | null;
-  toggleDMScreenKey: string | null;
   toggleScreenShareKey: string | null;
   toggleGameKey: string | null;
 }
@@ -24,7 +23,6 @@ export const DEFAULT_SHORTCUTS: ShortcutsSettings = {
   toggleMuteKey: null,
   toggleMuteDeafenKey: null,
   toggleLeaveVoiceKey: null,
-  toggleDMScreenKey: null,
   toggleScreenShareKey: null,
   toggleGameKey: null,
 };
@@ -227,22 +225,6 @@ export function ShortcutsSettingsTab({ settings, onChange, allBindings, onClearB
               onClick={() => setRecordingKey(recordingKey === 'toggleMuteKey' ? null : 'toggleMuteKey')}
             >
                   {keyButtonLabel('toggleMuteKey')}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <div className="settings-section">
-        <h3 className="heading-section settings-section-title">Navigation</h3>
-        <div className="settings-item">
-          <label>Toggle Direct Messages Screen</label>
-          <div className="key-binding-actions">
-            {localSettings.toggleDMScreenKey && <button className="btn btn-secondary key-binding-clear-btn" aria-label="Clear Toggle Direct Messages Screen binding" onClick={() => clearBinding('toggleDMScreenKey')}>Clear</button>}
-            <button
-              className={keyButtonClass('toggleDMScreenKey')}
-              onClick={() => setRecordingKey(recordingKey === 'toggleDMScreenKey' ? null : 'toggleDMScreenKey')}
-            >
-                  {keyButtonLabel('toggleDMScreenKey')}
             </button>
           </div>
         </div>

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.css
@@ -35,6 +35,15 @@
   opacity: 1;
 }
 
+/*
+ * The channel you are actually standing in. Independent of .current (the conversation
+ * being read) — a row can carry both. Drawn as an inset left accent bar so it does not
+ * shift the row's computed indentation.
+ */
+.channel-row--joined {
+  box-shadow: inset var(--space-2xs) 0 0 var(--accent-primary);
+}
+
 /* Dim empty channels (no users, no unreads) */
 .channel-row--empty .channel-name {
   opacity: 0.45;

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.test.tsx
@@ -864,6 +864,93 @@ describe('ChannelTree duel activity badge', () => {
   });
 });
 
+// The joined channel (where your voice is) and the current channel (the conversation you
+// are reading) are independent. The sidebar has to mark both, and the server gates duels
+// on the joined one.
+describe('ChannelTree joined channel presence', () => {
+  const presenceChannels = [
+    { id: 7, name: 'General' },
+    { id: 9, name: 'Random' },
+  ];
+
+  it('marks the joined channel separately from the active conversation', () => {
+    render(
+      <ChannelTree
+        channels={presenceChannels}
+        users={[]}
+        currentChannelId={9}
+        joinedChannelId={7}
+        onJoinChannel={vi.fn()}
+      />,
+    );
+
+    const generalRow = screen.getByText('General').closest('.channel-row')!;
+    const randomRow = screen.getByText('Random').closest('.channel-row')!;
+
+    expect(generalRow).toHaveClass('channel-row--joined');
+    expect(generalRow).not.toHaveClass('current');
+    expect(randomRow).toHaveClass('current');
+    expect(randomRow).not.toHaveClass('channel-row--joined');
+  });
+
+  it('names the joined channel row for screen readers, not by colour alone', () => {
+    render(
+      <ChannelTree
+        channels={presenceChannels}
+        users={[]}
+        currentChannelId={9}
+        joinedChannelId={7}
+        onJoinChannel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /General \(you are here\)/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Random \(you are here\)/ })).not.toBeInTheDocument();
+  });
+
+  it('offers Challenge only for users in the joined channel', () => {
+    const users = [
+      { session: 1, name: 'Me', channelId: 7, self: true, isBrmbleClient: true },
+      { session: 2, name: 'Alice', channelId: 7, isBrmbleClient: true },
+    ];
+    const treeProps = {
+      channels: presenceChannels,
+      users,
+      currentChannelId: 9,
+      onJoinChannel: vi.fn(),
+      onChallengeDeathroll: vi.fn(),
+      onChallengeRps: vi.fn(),
+    };
+
+    const { rerender } = render(<ChannelTree {...treeProps} joinedChannelId={7} />);
+    fireEvent.contextMenu(screen.getByText('Alice').closest('.user-row')!);
+    expect(screen.getByRole('button', { name: 'Challenge to a duel' })).toBeInTheDocument();
+
+    rerender(<ChannelTree {...treeProps} joinedChannelId={9} />);
+    fireEvent.contextMenu(screen.getByText('Alice').closest('.user-row')!);
+    expect(screen.queryByText('Challenge to a duel')).not.toBeInTheDocument();
+  });
+
+  it('offers no Challenge while unjoined even when viewing the target channel', () => {
+    render(
+      <ChannelTree
+        channels={presenceChannels}
+        users={[
+          { session: 1, name: 'Me', channelId: 7, self: true, isBrmbleClient: true },
+          { session: 2, name: 'Alice', channelId: 7, isBrmbleClient: true },
+        ]}
+        currentChannelId={7}
+        onJoinChannel={vi.fn()}
+        onChallengeDeathroll={vi.fn()}
+        onChallengeRps={vi.fn()}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Alice').closest('.user-row')!);
+    expect(screen.queryByText('Challenge to a duel')).not.toBeInTheDocument();
+  });
+});
+
 // The server refuses a challenge when either side already holds a duel commitment, so
 // the entry is disabled rather than offered. These drive the real right-click path to
 // prove ChannelTree's own wiring — its `users.find(u => u.self)` lookup and the
@@ -881,6 +968,7 @@ describe('ChannelTree challenge entry', () => {
         channels={channels}
         users={duelUsers}
         currentChannelId={1}
+        joinedChannelId={1}
         onJoinChannel={vi.fn()}
         onChallengeDeathroll={vi.fn()}
         onChallengeRps={vi.fn()}

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -55,7 +55,14 @@ interface ChannelWithUsers extends Channel {
 interface ChannelTreeProps {
   channels: Channel[];
   users: User[];
+  /** The channel whose conversation is being read. Purely a view concern. */
   currentChannelId?: number;
+  /**
+   * The channel the local user's voice is actually in. `undefined` while unjoined or at
+   * server root — see `workspace/activityPresence.ts`, whose null/server-root guard is
+   * discharged by the caller when it narrows the string id down to this numeric prop.
+   */
+  joinedChannelId?: number;
   onJoinChannel: (channelId: number) => void;
   onSelectChannel?: (channelId: number) => void;
   onStartDM?: (userId: string, userName: string) => void;
@@ -99,7 +106,7 @@ function getManagedPasswordFromAclBody(body: string): string {
   }
 }
 
-export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, onSelectChannel, onStartDM, onChallengeDeathroll, onChallengeRps, duelChannelIds, personalDuelChannelIds, committedDuelSessions, onOpenDuelQueue, speakingUsers, voiceIdle, pendingChannelAction, channelUnreads, sharingChannelId, sharingUserSession, onWatchScreenShare, onStopWatching, activeShares, watchingShares, onEditAvatar, onMoveUser }: ChannelTreeProps) {
+export function ChannelTree({ channels, users, currentChannelId, joinedChannelId, onJoinChannel, onSelectChannel, onStartDM, onChallengeDeathroll, onChallengeRps, duelChannelIds, personalDuelChannelIds, committedDuelSessions, onOpenDuelQueue, speakingUsers, voiceIdle, pendingChannelAction, channelUnreads, sharingChannelId, sharingUserSession, onWatchScreenShare, onStopWatching, activeShares, watchingShares, onEditAvatar, onMoveUser }: ChannelTreeProps) {
   const [sortByNamePerChannel, setSortByNamePerChannel] = useState<Record<number, boolean>>({});
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; userId: string; userName: string; isSelf: boolean; channelId?: number } | null>(null);
   const [channelContextMenu, setChannelContextMenu] = useState<{ x: number; y: number; channelId: number; channelName: string } | null>(null);
@@ -284,6 +291,9 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     const isFolder = channel.children.length > 0;
     const isExpanded = expandedChannels.has(channel.id);
     const isCurrentChannel = currentChannelId === channel.id;
+    // Independent of isCurrentChannel: a row can be both the conversation you are reading
+    // and the channel you are standing in.
+    const isJoinedChannel = joinedChannelId != null && joinedChannelId === channel.id;
     const unreadInfo = channelUnreads?.get(String(channel.id));
     const hasUnread = ((unreadInfo?.notificationCount ?? 0) + (unreadInfo?.highlightCount ?? 0)) > 0;
     const lockIconName = channel.isEnterRestricted || channel.hasPasswordRestriction
@@ -301,9 +311,13 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
     return (
       <div key={channel.id} className={`channel-item${pendingChannelAction !== null ? ' channel-item--pending' : ''}`} data-level={level} data-channel-id={channel.id}>
         <div 
-          className={`channel-row ${isCurrentChannel ? 'current' : ''}${hasUnread ? ' channel-row--unread' : ''}${channel.users.length === 0 && !hasUnread ? ' channel-row--empty' : ''}${isFolder ? ' is-folder' : ''}${dropTargetChannel === channel.id ? ' channel-row--drop-target' : ''}${isChannelActive(channel.id) ? ' channel-row--context-active' : ''}`}
+          className={`channel-row ${isCurrentChannel ? 'current' : ''}${isJoinedChannel ? ' channel-row--joined' : ''}${hasUnread ? ' channel-row--unread' : ''}${channel.users.length === 0 && !hasUnread ? ' channel-row--empty' : ''}${isFolder ? ' is-folder' : ''}${dropTargetChannel === channel.id ? ' channel-row--drop-target' : ''}${isChannelActive(channel.id) ? ' channel-row--context-active' : ''}`}
           style={{ paddingLeft: `calc(16px + ${level * 20}px)` }}
           role="button"
+          // The left accent bar must not be the only signal. There is no `.sr-only`
+          // utility in this codebase, so the suffix goes on the accessible name rather
+          // than inventing a new visually-hidden CSS pattern.
+          aria-label={isJoinedChannel ? `${channel.name} (you are here)` : undefined}
           tabIndex={0}
           onClick={() => handleChannelClick(channel.id)}
           onDoubleClick={pendingChannelAction === null ? () => onJoinChannel(channel.id) : undefined}
@@ -636,9 +650,13 @@ onClick: () => {
             ...(() => {
               if (contextMenu.isSelf || !onChallengeDeathroll || !onChallengeRps) return [];
               const target = users.find(u => u.session === parseInt(contextMenu.userId));
+              // DuelOrchestrator rejects a challenge unless both players are in the same
+              // voice channel, so the entry is gated on where you actually are, not on
+              // whichever conversation you happen to be reading.
               const eligible = !!target?.isBrmbleClient
                 && contextMenu.channelId != null
-                && contextMenu.channelId === currentChannelId;
+                && joinedChannelId != null
+                && contextMenu.channelId === joinedChannelId;
               if (!eligible) return [];
               return [buildChallengeMenuItem(parseInt(contextMenu.userId), onChallengeDeathroll, onChallengeRps, {
                 committedSessions: committedDuelSessions,

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -17,6 +17,7 @@ import { Icon } from '../Icon/Icon';
 import { AclEditorDialog } from '../AclEditor/AclEditorDialog';
 import { getSavedChannelPassword } from '../../utils/channelPasswords';
 import { getOrderedChildChannels, sortChannels } from '../../utils/channelOrder';
+import { channelActivityRoomName } from '../../workspace/activityPresence';
 import './ChannelTree.css';
 
 interface User {
@@ -439,7 +440,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
                       e.preventDefault();
                       setContextMenu({ x: e.clientX, y: e.clientY, userId: String(user.session), userName: user.name, isSelf: !!user.self, channelId: channel.id });
                     }}
-                    onDoubleClick={isRemoteSharer ? () => onWatchScreenShare?.(`channel-${channel.id}`, share?.userId, share?.matrixUserId) : undefined}
+                    onDoubleClick={isRemoteSharer ? () => onWatchScreenShare?.(channelActivityRoomName(String(channel.id)), share?.userId, share?.matrixUserId) : undefined}
                   >
                     <span className="user-status-area">
                       {user.deafened && (
@@ -472,7 +473,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
                               if (isWatchingRemoteShare) {
                                 onStopWatching?.(share.userId);
                               } else {
-                                onWatchScreenShare?.(`channel-${channel.id}`, share.userId, share.matrixUserId);
+                                onWatchScreenShare?.(channelActivityRoomName(String(channel.id)), share.userId, share.matrixUserId);
                               }
                             }}
                             aria-label={`${isWatchingRemoteShare ? 'Watching' : 'Watch'} screen share from ${user.name}`}
@@ -621,7 +622,7 @@ export function ChannelTree({ channels, users, currentChannelId, onJoinChannel, 
 onClick: () => {
                 const channelId = contextMenu.channelId ?? currentChannelId;
                 const share = activeShares?.find(s => s.sessionId === Number(contextMenu.userId));
-                onWatchScreenShare?.(`channel-${channelId}`, share?.userId, share?.matrixUserId);
+                onWatchScreenShare?.(channelActivityRoomName(String(channelId)), share?.userId, share?.matrixUserId);
               },
             }] : []),
             ...(!contextMenu.isSelf && onStartDM ? [{

--- a/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/ChannelTree.tsx
@@ -314,10 +314,10 @@ export function ChannelTree({ channels, users, currentChannelId, joinedChannelId
           className={`channel-row ${isCurrentChannel ? 'current' : ''}${isJoinedChannel ? ' channel-row--joined' : ''}${hasUnread ? ' channel-row--unread' : ''}${channel.users.length === 0 && !hasUnread ? ' channel-row--empty' : ''}${isFolder ? ' is-folder' : ''}${dropTargetChannel === channel.id ? ' channel-row--drop-target' : ''}${isChannelActive(channel.id) ? ' channel-row--context-active' : ''}`}
           style={{ paddingLeft: `calc(16px + ${level * 20}px)` }}
           role="button"
-          // The left accent bar must not be the only signal. There is no `.sr-only`
-          // utility in this codebase, so the suffix goes on the accessible name rather
-          // than inventing a new visually-hidden CSS pattern.
-          aria-label={isJoinedChannel ? `${channel.name} (you are here)` : undefined}
+          // The left accent bar must not be the only signal. The "(you are here)" suffix
+          // is carried by a `.sr-only` span below, not `aria-label` — this row also holds
+          // visible dynamic content (user count, unread badges) that `aria-label` would
+          // silence. See the `.sr-only` section of docs/UI_GUIDE.md.
           tabIndex={0}
           onClick={() => handleChannelClick(channel.id)}
           onDoubleClick={pendingChannelAction === null ? () => onJoinChannel(channel.id) : undefined}
@@ -369,7 +369,10 @@ export function ChannelTree({ channels, users, currentChannelId, joinedChannelId
               <Icon name="folder" size={14} />
             )}
           </span>
-          <span className="channel-name">{channel.name}</span>
+          <span className="channel-name" aria-hidden={isJoinedChannel ? true : undefined}>{channel.name}</span>
+          {isJoinedChannel && (
+            <span className="sr-only">{`${channel.name} (you are here)`}</span>
+          )}
           {channel.users.length > 0 && (
             <Tooltip content={(sortByNamePerChannel[channel.id] ?? false) ? 'Sort by join order' : 'Sort alphabetically'}>
             <button

--- a/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
+++ b/src/Brmble.Web/src/components/Sidebar/Sidebar.tsx
@@ -28,6 +28,8 @@ interface SidebarProps {
   channels: Channel[];
   users: User[];
   currentChannelId?: number;
+  /** The channel the local user's voice is in — drives the presence marker and duel gate. */
+  joinedChannelId?: number;
   onJoinChannel: (channelId: number) => void;
   onSelectChannel: (channelId: number) => void;
   onSelectServer?: () => void;
@@ -70,6 +72,7 @@ export function Sidebar({
   channels,
   users,
   currentChannelId,
+  joinedChannelId,
   onJoinChannel,
   onSelectChannel,
   onSelectServer,
@@ -450,6 +453,7 @@ export function Sidebar({
           channels={nonRootChannels}
           users={nonRootUsers}
           currentChannelId={currentChannelId}
+          joinedChannelId={joinedChannelId}
           onJoinChannel={onJoinChannel}
           onSelectChannel={onSelectChannel}
           onStartDM={onStartDM}

--- a/src/Brmble.Web/src/components/UserPanel/UserPanel.css
+++ b/src/Brmble.Web/src/components/UserPanel/UserPanel.css
@@ -8,79 +8,6 @@
   display: inline-flex;
 }
 
-.user-panel-btn.dm-btn {
-  position: relative;
-}
-
-.user-panel-btn.dm-btn:hover:not(:disabled) {
-  color: var(--accent-primary);
-}
-
-.user-panel-btn.dm-btn.active {
-  color: var(--accent-primary);
-  background: var(--accent-primary-wash);
-}
-
-.dm-unread-badge {
-  position: absolute;
-  top: 2px;
-  right: 1px;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 var(--space-2xs);
-  border-radius: var(--radius-md);
-  background: linear-gradient(135deg, var(--accent-primary) 0%, var(--accent-primary-light) 100%);
-  color: var(--text-primary);
-  font-family: var(--font-body);
-  font-size: var(--text-2xs);
-  font-weight: 700;
-  line-height: 16px;
-  text-align: center;
-  letter-spacing: 0.02em;
-  box-shadow:
-    0 0 0 2px var(--bg-deep),
-    0 2px 8px var(--accent-primary-glow);
-  pointer-events: none;
-  animation: badgePop var(--animation-badge-pop) cubic-bezier(0.34, 1.56, 0.64, 1) both;
-}
-
-.dm-unread-badge::after {
-  content: '';
-  position: absolute;
-  inset: -1px;
-  border-radius: inherit;
-  background: var(--accent-primary);
-  opacity: 0;
-  animation: badgePulse var(--animation-badge-pulse) ease-in-out var(--animation-badge-pulse-delay) infinite;
-  z-index: -1;
-}
-
-@keyframes badgePop {
-  0% {
-    transform: scale(0);
-    opacity: 0;
-  }
-  60% {
-    transform: scale(1.15);
-    opacity: 1;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-@keyframes badgePulse {
-  0%, 100% {
-    opacity: 0;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.4;
-    transform: scale(1.6);
-  }
-}
-
 .user-panel-btn.user-settings-btn:hover:not(:disabled) {
   color: var(--accent-primary);
 }
@@ -154,12 +81,6 @@
 }
 
 .user-panel-btn.screen-share-btn.pressed {
-  color: var(--accent-secondary);
-  background: var(--accent-secondary-subtle);
-  transform: scale(0.95);
-}
-
-.user-panel-btn.dm-btn.pressed {
   color: var(--accent-secondary);
   background: var(--accent-secondary-subtle);
   transform: scale(0.95);

--- a/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
+++ b/src/Brmble.Web/src/components/UserPanel/UserPanel.tsx
@@ -10,9 +10,6 @@ type BridgeModule = { default: { on: (event: string, handler: (data: unknown) =>
 
 interface UserPanelProps {
   username?: string;
-  onToggleDM?: () => void;
-  dmActive?: boolean;
-  unreadDMCount?: number;
   onOpenSettings: () => void;
   onAvatarClick?: () => void;
   avatarUrl?: string;
@@ -37,7 +34,7 @@ interface UserPanelProps {
   onOpenAudioSettings?: () => void;
 }
 
-export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpenSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown, onOpenAudioSettings }: UserPanelProps) {
+export function UserPanel({ username, onOpenSettings, onAvatarClick, avatarUrl, matrixUserId, muted, deafened, leftVoice, canRejoin, onToggleMute, onToggleDeaf, onLeaveVoice, screenSharing, screenShareError, onToggleScreenShare, canScreenShare, speaking, pendingChannelAction, hotkeyPressedBtn, leaveVoiceOnCooldown, muteOnCooldown, deafOnCooldown, onOpenAudioSettings }: UserPanelProps) {
   const [pressedBtn, setPressedBtn] = useState<string | null>(null);
   const [voiceContextMenu, setVoiceContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [deafenContextMenu, setDeafenContextMenu] = useState<{ x: number; y: number } | null>(null);
@@ -351,27 +348,9 @@ export function UserPanel({ username, onToggleDM, dmActive, unreadDMCount, onOpe
         </Tooltip>
       )}
 
-      {onToggleDM && (
-      <Tooltip content={dmActive ? 'Collapse Messages panel' : 'Expand Messages panel'} position="bottom" align="end">
-      <button
-        className={`btn btn-ghost btn-icon user-panel-btn dm-btn ${dmActive ? 'active' : ''} ${activeBtn === 'dm' ? 'pressed' : ''}`}
-        aria-label={dmActive ? 'Collapse Messages panel' : 'Expand Messages panel'}
-        onMouseDown={handleMouseDown('dm')}
-        onMouseUp={handleMouseUp('dm', onToggleDM)}
-        onMouseLeave={handleMouseLeave}
-        onKeyDown={handleKeyDown('dm')}
-        onKeyUp={handleKeyUp('dm', onToggleDM)}
-      >
-        <Icon name="message-square" size={18} />
-        {unreadDMCount != null && unreadDMCount > 0 && (
-          <span className="dm-unread-badge" key={unreadDMCount}>
-            {unreadDMCount > 9 ? '9+' : unreadDMCount}
-          </span>
-        )}
-      </button>
-      </Tooltip>
-      )}
-      
+      {/* The Messages panel is permanently visible, so there is no DM toggle button.
+          Unread counts live on the contact entries in that panel. */}
+
       <Tooltip content="Settings" position="bottom" align="end">
       <button 
         className="btn btn-ghost btn-icon user-panel-btn user-settings-btn" 

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -4035,6 +4035,29 @@ describe('useScreenShare', () => {
       expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalledWith(false);
     });
 
+    // The reviewer's scenario: once our own intentional unsubscribe has echoed back and
+    // we have restored the share, a LATER unsubscribe is genuine (publisher stopped or
+    // the SFU dropped us) and must clean the watcher state up. `screenShare.stopped` is
+    // not guaranteed for every such path — a publisher restarting their capture
+    // unpublishes and republishes without one — so this event has to be honoured.
+    it('cleans up a watched share when a genuine unsubscribe arrives after a hide/restore cycle', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+
+      // Hide past the grace period: we stamp the SID and unsubscribe, and the mock
+      // publication echoes TrackUnsubscribed back exactly as real LiveKit does.
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+      // Restore: we are no longer intentionally unsubscribed from anything.
+      act(() => { result.current.setRemoteScreenSharesHidden(false); });
+      expect(result.current.watchingShares).toHaveLength(1);
+
+      // The publisher now genuinely stops, with no screenShare.stopped in between.
+      act(() => { emitTrackUnsubscribed(10); });
+
+      expect(result.current.watchingShares).toHaveLength(0);
+    });
+
     // The Task 13 tests only asserted that setSubscribed(true) was CALLED. That is not
     // the user-visible contract: what matters is that a video element exists again for
     // the share, because that element is what the stage renders.

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useScreenShare, type ScreenShareSettings } from './useScreenShare';
+import { useScreenShare, REMOTE_HIDE_GRACE_MS, type ScreenShareSettings, type ViewerQuality } from './useScreenShare';
 import bridge from '../bridge';
 
 const roomEventHandlers = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -109,6 +109,7 @@ vi.mock('livekit-client', () => ({
     ConnectionQualityChanged: 'connectionQualityChanged',
     TrackSubscribed: 'trackSubscribed',
     TrackUnsubscribed: 'trackUnsubscribed',
+    TrackPublished: 'trackPublished',
   },
   ConnectionQuality: {
     Excellent: 'excellent',
@@ -149,9 +150,126 @@ const liveKitToken = (token: string, url = 'ws://localhost/livekit') => {
   return { token, url, requestId };
 };
 
+// --- Shared fixtures for remote screen-share publications ---------------------------
+// Bridge handlers captured by identity so helpers can emit bridge events without each
+// test wiring up its own bridge.on implementation.
+const bridgeHandlers = new Map<string, (data: unknown) => void>();
+const captureBridgeHandlers = () => {
+  (bridge.on as ReturnType<typeof vi.fn>).mockImplementation((type: string, handler: (data: unknown) => void) => {
+    bridgeHandlers.set(type, handler);
+  });
+};
+
+const remoteIdentities = new Map<number, string>([[10, '@alice:test'], [20, '@bob:test']]);
+const identityFor = (userId: number) => remoteIdentities.get(userId) ?? `@user${userId}:test`;
+
+type MockScreenSharePublication = {
+  trackSid: string;
+  kind: string;
+  source: string;
+  setSubscribed: ReturnType<typeof vi.fn>;
+  setVideoQuality: ReturnType<typeof vi.fn>;
+  track: { kind: string; source: string; attach: ReturnType<typeof vi.fn>; detach: ReturnType<typeof vi.fn> };
+};
+
+const screenSharePublications = new Map<number, MockScreenSharePublication>();
+
+const publicationFor = (userId: number): MockScreenSharePublication => {
+  const pub = screenSharePublications.get(userId);
+  if (!pub) {
+    throw new Error(`no mock screen-share publication registered for user ${userId}`);
+  }
+  return pub;
+};
+
+const registerRemotePublisher = (userId: number) => {
+  const identity = identityFor(userId);
+  const pub: MockScreenSharePublication = {
+    trackSid: `sid-screen-${userId}`,
+    kind: 'video',
+    source: 'screen_share',
+    setSubscribed: vi.fn(),
+    setVideoQuality: vi.fn(),
+    track: {
+      kind: 'video',
+      source: 'screen_share',
+      attach: vi.fn(() => document.createElement('video')),
+      detach: vi.fn(),
+    },
+  };
+  screenSharePublications.set(userId, pub);
+  mockRoom.remoteParticipants.set(identity, {
+    identity,
+    connectionQuality: 'good',
+    trackPublications: new Map([[pub.trackSid, pub]]),
+  });
+  return pub;
+};
+
+const participantFor = (userId: number) => mockRoom.remoteParticipants.get(identityFor(userId));
+
+const emitTrackPublished = (userId: number, source: string) => {
+  const pub = publicationFor(userId);
+  pub.source = source;
+  emitRoomEvent('trackPublished', pub, participantFor(userId));
+};
+
+const emitTrackUnsubscribed = (userId: number) => {
+  const pub = publicationFor(userId);
+  emitRoomEvent('trackUnsubscribed', pub.track, pub, participantFor(userId));
+};
+
+const emitScreenShareStopped = (userId: number) => {
+  bridgeHandlers.get('livekit.screenShareStopped')?.({ roomName: 'channel-1', userId });
+};
+
+/**
+ * A hook rendered as BOTH a local publisher and a viewer watching one remote share,
+ * with focus and an explicit receive quality applied. Built from the same primitives
+ * the rest of this file uses rather than duplicating connection scaffolding.
+ */
+const connectedViewerAndPublisher = async ({ focusedUserId, quality }: { focusedUserId: number; quality: ViewerQuality }) => {
+  captureBridgeHandlers();
+  const identity = identityFor(focusedUserId);
+  registerRemotePublisher(focusedUserId);
+
+  const rendered = renderHook(() => useScreenShare());
+  const { result } = rendered;
+
+  await act(async () => {
+    const promise = result.current.startSharing('channel-1');
+    bridgeHandlers.get('livekit.token')?.(liveKitToken('jwt'));
+    await promise;
+  });
+
+  act(() => {
+    bridgeHandlers.get('livekit.screenShareStarted')?.({
+      roomName: 'channel-1',
+      userName: 'alice',
+      userId: focusedUserId,
+      matrixUserId: identity,
+    });
+  });
+
+  await act(async () => {
+    const promise = result.current.connectAsViewer('channel-1', focusedUserId, identity);
+    bridgeHandlers.get('livekit.token')?.(liveKitToken('jwt'));
+    await promise;
+  });
+
+  act(() => {
+    result.current.setFocusedShare(result.current.watchingShares[0] ?? null);
+    result.current.setViewerQuality(focusedUserId, quality);
+  });
+
+  return rendered;
+};
+
 describe('useScreenShare', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    bridgeHandlers.clear();
+    screenSharePublications.clear();
     mockRoom.state = undefined;
     mockRoom.startAudio.mockResolvedValue(undefined);
     mockRoom.remoteParticipants.clear();
@@ -3774,6 +3892,130 @@ describe('useScreenShare', () => {
 
       expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalled();
       expect(mockScreenShareSender.setParameters).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('grace-period hide for backgrounded remote shares', () => {
+    it('keeps a hidden share subscribed during the grace period', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS - 1); });
+
+      expect(publicationFor(10).setSubscribed).not.toHaveBeenCalledWith(false);
+    });
+
+    it('unsubscribes once the grace period elapses', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+
+      expect(publicationFor(10).setSubscribed).toHaveBeenCalledWith(false);
+    });
+
+    it('cancels the pending unsubscribe when the share returns to the stage', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS - 1); });
+      act(() => { result.current.setRemoteScreenSharesHidden(false); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+
+      expect(publicationFor(10).setSubscribed).not.toHaveBeenCalledWith(false);
+    });
+
+    it('preserves viewer state while hidden and after restoring', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+
+      expect(result.current.viewerQualities.get(10)).toBe('medium');
+      expect(result.current.focusedShare?.userId).toBe(10);
+      expect(result.current.watchingShares).toHaveLength(1);
+      expect(mockRoom.disconnect).not.toHaveBeenCalled();
+      expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalledWith(false);
+      expect(result.current.isSharing).toBe(true);
+
+      act(() => { result.current.setRemoteScreenSharesHidden(false); });
+
+      expect(result.current.viewerQualities.get(10)).toBe('medium');
+      expect(result.current.focusedShare?.userId).toBe(10);
+      expect(result.current.watchingShares).toHaveLength(1);
+      expect(publicationFor(10).setSubscribed).toHaveBeenLastCalledWith(true);
+      expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalledWith(false);
+      expect(result.current.isSharing).toBe(true);
+    });
+
+    it('drops a share that ended while hidden instead of resubscribing to it', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+      publicationFor(10).setSubscribed.mockClear();
+
+      act(() => { emitScreenShareStopped(10); });
+
+      // screenShare.stopped is authoritative: logical state goes immediately, hidden or not.
+      expect(result.current.watchingShares).toHaveLength(0);
+
+      act(() => { result.current.setRemoteScreenSharesHidden(false); });
+
+      expect(result.current.watchingShares).toHaveLength(0);
+      expect(publicationFor(10).setSubscribed).not.toHaveBeenCalledWith(true);
+    });
+
+    it('immediately unsubscribes a share published while hidden', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+      act(() => { emitTrackPublished(10, 'screen_share'); });
+
+      expect(publicationFor(10).setSubscribed).toHaveBeenLastCalledWith(false);
+    });
+
+    it('clears the pending timer on unmount', async () => {
+      vi.useFakeTimers();
+      const { result, unmount } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      unmount();
+
+      expect(() => vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS)).not.toThrow();
+      expect(publicationFor(10).setSubscribed).not.toHaveBeenCalledWith(false);
+    });
+
+    // The flagged hazard: a TrackUnsubscribed we caused ourselves, delivered late and
+    // stamped by a superseded hide generation, must not tear down logical viewer state.
+    it('ignores a delayed stale-generation TrackUnsubscribed for a deliberately hidden share', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+
+      // Generation N: hide and let the grace elapse so we stamp + unsubscribe.
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+      // Generations N+1 / N+2: restore, then hide and elapse again.
+      act(() => { result.current.setRemoteScreenSharesHidden(false); });
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+
+      // Only now does the unsubscribe event from generation N arrive.
+      act(() => { emitTrackUnsubscribed(10); });
+
+      expect(result.current.watchingShares).toHaveLength(1);
+      expect(result.current.watchingShares[0].userId).toBe(10);
+      expect(result.current.focusedShare?.userId).toBe(10);
+      expect(result.current.viewerQualities.get(10)).toBe('medium');
+      expect(mockRoom.disconnect).not.toHaveBeenCalled();
+      expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalledWith(false);
     });
   });
 });

--- a/src/Brmble.Web/src/hooks/useScreenShare.test.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.test.ts
@@ -184,11 +184,23 @@ const publicationFor = (userId: number): MockScreenSharePublication => {
 
 const registerRemotePublisher = (userId: number) => {
   const identity = identityFor(userId);
+  // Real LiveKit does not treat setSubscribed as a no-op: flipping it to false makes the
+  // SFU stop the stream and the client emit TrackUnsubscribed, and flipping it back to
+  // true makes the server redeliver the track and the client emit a FRESH TrackSubscribed.
+  // The previous inert vi.fn() meant no test ever exercised re-delivery, which is exactly
+  // how a share that never comes back could pass review.
   const pub: MockScreenSharePublication = {
     trackSid: `sid-screen-${userId}`,
     kind: 'video',
     source: 'screen_share',
-    setSubscribed: vi.fn(),
+    setSubscribed: vi.fn((subscribed: boolean) => {
+      emitRoomEvent(
+        subscribed ? 'trackSubscribed' : 'trackUnsubscribed',
+        pub.track,
+        pub,
+        mockRoom.remoteParticipants.get(identity),
+      );
+    }),
     setVideoQuality: vi.fn(),
     track: {
       kind: 'video',
@@ -217,6 +229,11 @@ const emitTrackPublished = (userId: number, source: string) => {
 const emitTrackUnsubscribed = (userId: number) => {
   const pub = publicationFor(userId);
   emitRoomEvent('trackUnsubscribed', pub.track, pub, participantFor(userId));
+};
+
+const emitTrackSubscribed = (userId: number) => {
+  const pub = publicationFor(userId);
+  emitRoomEvent('trackSubscribed', pub.track, pub, participantFor(userId));
 };
 
 const emitScreenShareStopped = (userId: number) => {
@@ -4016,6 +4033,37 @@ describe('useScreenShare', () => {
       expect(result.current.viewerQualities.get(10)).toBe('medium');
       expect(mockRoom.disconnect).not.toHaveBeenCalled();
       expect(mockRoom.localParticipant.setScreenShareEnabled).not.toHaveBeenCalledWith(false);
+    });
+
+    // The Task 13 tests only asserted that setSubscribed(true) was CALLED. That is not
+    // the user-visible contract: what matters is that a video element exists again for
+    // the share, because that element is what the stage renders.
+    it('still has a video element for a share hidden and restored inside the grace period', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+      act(() => { emitTrackSubscribed(10); });
+      expect(result.current.remoteVideoEls.has(10)).toBe(true);
+
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS - 1); });
+      act(() => { result.current.setRemoteScreenSharesHidden(false); });
+
+      expect(result.current.remoteVideoEls.has(10)).toBe(true);
+    });
+
+    it('gets a video element back for a share hidden past the grace period and restored', async () => {
+      vi.useFakeTimers();
+      const { result } = await connectedViewerAndPublisher({ focusedUserId: 10, quality: 'medium' });
+      act(() => { emitTrackSubscribed(10); });
+      expect(result.current.remoteVideoEls.has(10)).toBe(true);
+
+      act(() => { result.current.setRemoteScreenSharesHidden(true); });
+      act(() => { vi.advanceTimersByTime(REMOTE_HIDE_GRACE_MS); });
+      expect(result.current.remoteVideoEls.has(10)).toBe(false);
+
+      act(() => { result.current.setRemoteScreenSharesHidden(false); });
+
+      expect(result.current.remoteVideoEls.has(10)).toBe(true);
     });
   });
 });

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -375,10 +375,6 @@ export function useScreenShare(
   const hideElapsedRef = useRef(false);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hideGenerationRef = useRef(0);
-  // SIDs we unsubscribed on purpose, stamped with the hide generation that did it.
-  // A TrackUnsubscribed for a stamped SID is OUR OWN event echoing back and must never
-  // remove logical state — see the TrackUnsubscribed handler in bindRoomEvents.
-  const intentionalPublicationGenerationRef = useRef(new Map<string, number>());
   onDisconnectedRef.current = onDisconnected;
   onLocalShareEndedRef.current = onLocalShareEnded;
   onWatchedShareEndedRef.current = onWatchedShareEnded;
@@ -397,24 +393,25 @@ export function useScreenShare(
 
   /**
    * Reset the hide machinery because the room lifecycle restarted. Bumping the
-   * generation orphans any in-flight hide timer, and the intentional-unsubscribe stamps
-   * belong to publications on a room that no longer exists.
+   * generation orphans any in-flight hide timer, and clearing the elapsed flag drops
+   * the "we intend watched publications to be unsubscribed" state along with the room
+   * whose publications it described.
    */
   const resetHideLifecycle = useCallback(() => {
     hideGenerationRef.current += 1;
     hideElapsedRef.current = false;
-    intentionalPublicationGenerationRef.current.clear();
     clearHideTimer();
   }, [clearHideTimer]);
 
-  /** Mark a publication as one WE unsubscribed, then unsubscribe it. */
+  /**
+   * Unsubscribe a publication because we are backgrounding it. While `hiddenRef` and
+   * `hideElapsedRef` are both set we intend every watched screen publication to stay
+   * unsubscribed, which is what the TrackUnsubscribed handler uses to recognise the
+   * resulting events as our own.
+   */
   const unsubscribeIntentionally = useCallback((
-    pub: { trackSid?: string; setSubscribed?: (subscribed: boolean) => void },
-    generation: number,
+    pub: { setSubscribed?: (subscribed: boolean) => void },
   ) => {
-    if (pub.trackSid) {
-      intentionalPublicationGenerationRef.current.set(pub.trackSid, generation);
-    }
     try {
       pub.setSubscribed?.(false);
     } catch {
@@ -776,7 +773,7 @@ export function useScreenShare(
       }
       hideElapsedRef.current = true;
       forEachWatchedScreenPublication((pub, share) => {
-        unsubscribeIntentionally(pub, generation);
+        unsubscribeIntentionally(pub);
         if (pub.source === Track.Source.ScreenShareAudio) {
           detachRemoteAudio(share.userId);
         }
@@ -1066,7 +1063,7 @@ export function useScreenShare(
       // Grace already elapsed: we are hidden and this track arrived anyway. Drop it
       // instead of attaching, so a share published while hidden costs nothing.
       if (hiddenRef.current && hideElapsedRef.current) {
-        unsubscribeIntentionally(pub, hideGenerationRef.current);
+        unsubscribeIntentionally(pub);
         return;
       }
 
@@ -1092,24 +1089,31 @@ export function useScreenShare(
         return;
       }
 
-      // We unsubscribed this publication ourselves to background it. This event is our
-      // own action echoing back — possibly late, and possibly stamped by a hide
-      // generation that has since been superseded. Detach the media, but NEVER remove
-      // logical state: the watched list, focus and receive quality survive untouched,
-      // and no room-teardown path is entered. The stamp is deliberately NOT consumed,
-      // so a duplicate or reordered echo for the same SID is suppressed too; stamps are
-      // cleared wholesale when the room lifecycle resets.
-      if (pub.trackSid && intentionalPublicationGenerationRef.current.has(pub.trackSid)) {
-        try { track.detach(); } catch { /* ignore */ }
-        return;
-      }
-
       const watching = watchingSharesRef.current;
       const matchedShare = watching.find(s => {
         const identity = s.matrixUserId ?? String(s.userId);
         return identity === participant.identity;
       });
       if (!matchedShare) return;
+
+      // While we are hidden past the grace period we have deliberately unsubscribed
+      // every watched screen publication, so this event is our own action echoing back —
+      // possibly late, and possibly caused by a hide generation that has since been
+      // superseded. Detach the media, but NEVER remove logical state: the watched list,
+      // focus and receive quality survive untouched, and no room-teardown path is
+      // entered. The suppression is scoped to that intent rather than remembered per
+      // SID, so it ends the instant we restore: a genuine publisher stop or network
+      // unsubscribe arriving after that is handled normally below.
+      const isScreenSharePublication =
+        pub.source === Track.Source.ScreenShare ||
+        pub.source === Track.Source.ScreenShareAudio ||
+        track.source === Track.Source.ScreenShare ||
+        track.source === Track.Source.ScreenShareAudio;
+      if (hiddenRef.current && hideElapsedRef.current && isScreenSharePublication) {
+        try { track.detach(); } catch { /* ignore */ }
+        return;
+      }
+
       if (
         track.kind === Track.Kind.Video &&
         track.source === Track.Source.ScreenShare
@@ -1143,7 +1147,7 @@ export function useScreenShare(
       const isWatched = watchingSharesRef.current.some(s => (s.matrixUserId ?? String(s.userId)) === participant.identity);
       if (!isWatched) return;
 
-      unsubscribeIntentionally(pub, hideGenerationRef.current);
+      unsubscribeIntentionally(pub);
     });
 
     room.on(RoomEvent.Reconnecting, () => {

--- a/src/Brmble.Web/src/hooks/useScreenShare.ts
+++ b/src/Brmble.Web/src/hooks/useScreenShare.ts
@@ -40,6 +40,13 @@ export interface ScreenShareSettings {
 /** Debounce window before applying edited settings to an already-active share. */
 const APPLY_SETTINGS_DEBOUNCE_MS = 400;
 
+/**
+ * How long a remote screen share stays subscribed after it leaves the stage. Quick
+ * switching inside this window is instant; past it we unsubscribe so we stop decoding
+ * and downloading a stream nobody is watching.
+ */
+export const REMOTE_HIDE_GRACE_MS = 10_000;
+
 const SCREEN_SHARE_RESOLUTION_MAP: Record<string, { width: number; height: number }> = {
   '720p': { width: 1280, height: 720 },
   '1080p': { width: 1920, height: 1080 },
@@ -360,6 +367,18 @@ export function useScreenShare(
   const pendingViewerAttemptsRef = useRef(new Map<number, PendingViewerAttempt>());
   const endedWatchedShareKeysRef = useRef(new Set<string>());
   const pendingUnsubscribedWatchedSharesRef = useRef(new Map<string, ShareInfo>());
+  // --- Grace-period hide state -------------------------------------------------------
+  // hiddenRef is the caller's intent; hideElapsedRef records that the grace period for
+  // the current hide already expired (so newly published tracks are dropped on arrival
+  // rather than attached). hideGenerationRef supersedes in-flight hides.
+  const hiddenRef = useRef(false);
+  const hideElapsedRef = useRef(false);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hideGenerationRef = useRef(0);
+  // SIDs we unsubscribed on purpose, stamped with the hide generation that did it.
+  // A TrackUnsubscribed for a stamped SID is OUR OWN event echoing back and must never
+  // remove logical state — see the TrackUnsubscribed handler in bindRoomEvents.
+  const intentionalPublicationGenerationRef = useRef(new Map<string, number>());
   onDisconnectedRef.current = onDisconnected;
   onLocalShareEndedRef.current = onLocalShareEnded;
   onWatchedShareEndedRef.current = onWatchedShareEnded;
@@ -367,6 +386,40 @@ export function useScreenShare(
   const clearLocalShareEndListener = useCallback(() => {
     localShareEndCleanupRef.current?.();
     localShareEndCleanupRef.current = null;
+  }, []);
+
+  const clearHideTimer = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Reset the hide machinery because the room lifecycle restarted. Bumping the
+   * generation orphans any in-flight hide timer, and the intentional-unsubscribe stamps
+   * belong to publications on a room that no longer exists.
+   */
+  const resetHideLifecycle = useCallback(() => {
+    hideGenerationRef.current += 1;
+    hideElapsedRef.current = false;
+    intentionalPublicationGenerationRef.current.clear();
+    clearHideTimer();
+  }, [clearHideTimer]);
+
+  /** Mark a publication as one WE unsubscribed, then unsubscribe it. */
+  const unsubscribeIntentionally = useCallback((
+    pub: { trackSid?: string; setSubscribed?: (subscribed: boolean) => void },
+    generation: number,
+  ) => {
+    if (pub.trackSid) {
+      intentionalPublicationGenerationRef.current.set(pub.trackSid, generation);
+    }
+    try {
+      pub.setSubscribed?.(false);
+    } catch {
+      // Subscription steering is best-effort; never break the viewer.
+    }
   }, []);
 
   const beginViewerConnectAttempt = useCallback(() => {
@@ -654,6 +707,89 @@ export function useScreenShare(
     }
   }, []);
 
+  /**
+   * Visit every screen-share publication (video and audio) of every share we are
+   * currently watching. Shares already known to have ended are skipped so we never
+   * touch a dead publication.
+   */
+  const forEachWatchedScreenPublication = useCallback((
+    visit: (pub: RemoteTrackPublication, share: ShareInfo) => void,
+  ) => {
+    const room = roomRef.current;
+    if (!room) return;
+
+    for (const share of watchingSharesRef.current) {
+      if (endedWatchedShareKeysRef.current.has(watchedShareKey(share.roomName, share.userId))) {
+        continue;
+      }
+      const identity = share.matrixUserId ?? String(share.userId);
+      const participant = room.remoteParticipants.get(identity);
+      participant?.trackPublications?.forEach((pub: RemoteTrackPublication) => {
+        if (pub.source === Track.Source.ScreenShare || pub.source === Track.Source.ScreenShareAudio) {
+          visit(pub, share);
+        }
+      });
+    }
+  }, []);
+
+  /**
+   * Drop watched shares that ended while we were hidden. Only shares already recorded
+   * as ended are removed, so this can never evict a live share.
+   */
+  const reconcileEndedShares = useCallback(() => {
+    for (const share of [...watchingSharesRef.current]) {
+      if (endedWatchedShareKeysRef.current.has(watchedShareKey(share.roomName, share.userId))) {
+        removeWatchingShare(share.userId);
+      }
+    }
+  }, [removeWatchingShare]);
+
+  /**
+   * Hide/restore remote screen shares. This is purely a SUBSCRIPTION concern: the
+   * watched list, its order, focus, receive quality, room membership and local
+   * publishing are never touched here.
+   */
+  const applyHidden = useCallback((hidden: boolean) => {
+    hiddenRef.current = hidden;
+    const generation = ++hideGenerationRef.current;
+    clearHideTimer();
+
+    if (!hidden) {
+      hideElapsedRef.current = false;
+      // Reconcile first so we never resubscribe to a share that died while hidden.
+      reconcileEndedShares();
+      forEachWatchedScreenPublication((pub) => {
+        try {
+          pub.setSubscribed?.(true);
+        } catch {
+          // Subscription steering is best-effort; never break the viewer.
+        }
+      });
+      return;
+    }
+
+    hideTimerRef.current = setTimeout(() => {
+      hideTimerRef.current = null;
+      // A newer hide/restore, or a room lifecycle reset, superseded this one.
+      if (generation !== hideGenerationRef.current || !hiddenRef.current) {
+        return;
+      }
+      hideElapsedRef.current = true;
+      forEachWatchedScreenPublication((pub, share) => {
+        unsubscribeIntentionally(pub, generation);
+        if (pub.source === Track.Source.ScreenShareAudio) {
+          detachRemoteAudio(share.userId);
+        }
+      });
+      setRemoteVideoEls(new Map());
+    }, REMOTE_HIDE_GRACE_MS);
+  }, [clearHideTimer, detachRemoteAudio, forEachWatchedScreenPublication, reconcileEndedShares, unsubscribeIntentionally]);
+
+  const setRemoteScreenSharesHidden = useCallback((hidden: boolean) => {
+    if (hiddenRef.current === hidden) return;
+    applyHidden(hidden);
+  }, [applyHidden]);
+
   const notifyUnexpectedWatchedShareEnds = useCallback(() => {
     for (const share of [...watchingSharesRef.current]) {
       endWatchedShare(share, 'unexpected');
@@ -728,8 +864,9 @@ export function useScreenShare(
   const invalidateRoomLifecycle = useCallback((reason = 'unknown') => {
     sendScreenShareDebugEvent(`invalidateRoomLifecycle.${reason}`);
     roomLifecycleGenerationRef.current += 1;
+    resetHideLifecycle();
     cancelPendingRoomRequest();
-  }, [cancelPendingRoomRequest]);
+  }, [cancelPendingRoomRequest, resetHideLifecycle]);
 
   const maybeCancelPendingRoomForViewerRoom = useCallback((roomName: string) => {
     const hasRemainingPendingViewersForRoom = Array.from(pendingViewerAttemptsRef.current.values()).some(attempt => attempt.roomName === roomName);
@@ -925,6 +1062,14 @@ export function useScreenShare(
         }
       }
       if (!matchedShare) return;
+
+      // Grace already elapsed: we are hidden and this track arrived anyway. Drop it
+      // instead of attaching, so a share published while hidden costs nothing.
+      if (hiddenRef.current && hideElapsedRef.current) {
+        unsubscribeIntentionally(pub, hideGenerationRef.current);
+        return;
+      }
+
       if (
         track.kind === Track.Kind.Video &&
         track.source === Track.Source.ScreenShare
@@ -944,6 +1089,18 @@ export function useScreenShare(
 
     room.on(RoomEvent.TrackUnsubscribed, (track, pub, participant) => {
       if (roomRef.current !== room) {
+        return;
+      }
+
+      // We unsubscribed this publication ourselves to background it. This event is our
+      // own action echoing back — possibly late, and possibly stamped by a hide
+      // generation that has since been superseded. Detach the media, but NEVER remove
+      // logical state: the watched list, focus and receive quality survive untouched,
+      // and no room-teardown path is entered. The stamp is deliberately NOT consumed,
+      // so a duplicate or reordered echo for the same SID is suppressed too; stamps are
+      // cleared wholesale when the room lifecycle resets.
+      if (pub.trackSid && intentionalPublicationGenerationRef.current.has(pub.trackSid)) {
+        try { track.detach(); } catch { /* ignore */ }
         return;
       }
 
@@ -968,6 +1125,25 @@ export function useScreenShare(
         track.detach();
         detachRemoteAudio(matchedShare.userId);
       }
+    });
+
+    // A watched publisher (re)published while we are hidden past the grace period:
+    // unsubscribe on arrival instead of letting it start streaming.
+    room.on(RoomEvent.TrackPublished, (pub, participant) => {
+      if (roomRef.current !== room) {
+        return;
+      }
+      if (!hiddenRef.current || !hideElapsedRef.current) {
+        return;
+      }
+      if (pub.source !== Track.Source.ScreenShare && pub.source !== Track.Source.ScreenShareAudio) {
+        return;
+      }
+
+      const isWatched = watchingSharesRef.current.some(s => (s.matrixUserId ?? String(s.userId)) === participant.identity);
+      if (!isWatched) return;
+
+      unsubscribeIntentionally(pub, hideGenerationRef.current);
     });
 
     room.on(RoomEvent.Reconnecting, () => {
@@ -1658,9 +1834,10 @@ export function useScreenShare(
       clearLocalShareEndListener();
       cancelPendingViewerAttempts();
       clearTokenLease();
+      clearHideTimer();
       invalidateRoomLifecycle('unmount');
     };
-  }, [clearLocalShareEndListener, cancelPendingViewerAttempts, clearTokenLease, invalidateRoomLifecycle]);
+  }, [clearLocalShareEndListener, cancelPendingViewerAttempts, clearTokenLease, clearHideTimer, invalidateRoomLifecycle]);
 
   // Backward compat: expose first active share as activeShare
   const activeShare: ActiveShare | null = activeShares.length > 0
@@ -1713,6 +1890,7 @@ export function useScreenShare(
     setViewerQuality,     // new
     addWatchingShare,      // new
     removeWatchingShare,   // new
+    setRemoteScreenSharesHidden, // new: grace-period hide for backgrounded shares
     disconnectViewer,
     connectAsViewer,
     handleScreenShareServiceUnavailable,

--- a/src/Brmble.Web/src/index.css
+++ b/src/Brmble.Web/src/index.css
@@ -22,6 +22,8 @@
 
   /* Layout */
   --sidebar-width: 340px;
+  --dm-panel-width: 260px;
+  --dm-rail-width: 48px;
   --header-height: 60px;
   --border-width-thin: 1px;
   --border-width-strong: 2px;

--- a/src/Brmble.Web/src/index.css
+++ b/src/Brmble.Web/src/index.css
@@ -34,6 +34,8 @@
   --neond-arrow-width: var(--space-xs);
   --neond-arrow-height: var(--space-sm);
   --neond-modal-max-width: 26.25rem;
+  --conversation-tab-min-width: 4.5rem;
+  --conversation-tab-max-width: 12rem;
   --neond-talent-ledger-max-width: calc(var(--neond-panel-max-width) + var(--neond-panel-max-width) + var(--neond-grid-gap));
 
   /* Transitions */

--- a/src/Brmble.Web/src/index.css
+++ b/src/Brmble.Web/src/index.css
@@ -25,6 +25,7 @@
   --header-height: 60px;
   --border-width-thin: 1px;
   --border-width-strong: 2px;
+  --activity-stage-min-height: 8rem;
   --neond-grid-gap: var(--space-md);
   --neond-grid-max-width: 80rem;
   --neond-panel-max-width: 35rem;

--- a/src/Brmble.Web/src/index.css
+++ b/src/Brmble.Web/src/index.css
@@ -71,6 +71,21 @@
   box-sizing: border-box;
 }
 
+/* Screen-reader-only text: visually hidden, still in the accessibility tree.
+   Use for supplementary text that must extend an element's accessible name
+   without hiding the element's other visible content (badges, counts). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  clip-path: inset(50%);
+}
+
 html, body {
   margin: 0;
   padding: 0;

--- a/src/Brmble.Web/src/testing/appHarness.tsx
+++ b/src/Brmble.Web/src/testing/appHarness.tsx
@@ -142,9 +142,14 @@ const harness = vi.hoisted(() => {
     totalCount: 0,
   };
 
+  // Local chat store contents by store key ('server-root', `channel-<id>`, 'no-channel').
+  // Arrays are handed back by identity so a re-render does not invalidate memos.
+  const chatStore = new Map<string, unknown[]>();
+
   return {
     overrides,
     captured,
+    chatStore,
     matrixClient,
     dmStore,
     unreadTracker,
@@ -264,8 +269,12 @@ vi.mock('../components/SettingsModal/SettingsModal', () => ({
 }));
 
 vi.mock('../hooks/useMatrixClient', () => ({ useMatrixClient: () => harness.matrixClient }));
+const EMPTY_CHAT_STORE: unknown[] = [];
 vi.mock('../hooks/useChatStore', () => ({
-  useChatStore: () => ({ messages: [], addMessage: vi.fn() }),
+  useChatStore: (key: string) => ({
+    messages: harness.chatStore.get(key) ?? EMPTY_CHAT_STORE,
+    addMessage: vi.fn(),
+  }),
   addMessageToStore: vi.fn(),
   clearChatStorage: vi.fn(),
   purgeEphemeralMessages: vi.fn(),
@@ -333,6 +342,11 @@ export interface RenderConnectedAppOptions {
   paintSessionId?: string | null;
   /** Conversation tabs seeded into storage before the first render. */
   persistedTabs?: Conversation[];
+  /**
+   * Local (non-Matrix) chat store contents, keyed by store key: `'server-root'` for the
+   * root chat, `channel-<id>` for a channel.
+   */
+  chatStore?: Record<string, unknown[]>;
   /** Per-channel unread counts, keyed by channel id. */
   unreads?: Record<string, { notificationCount: number; highlightCount: number }>;
   serverLabel?: string;
@@ -383,6 +397,7 @@ export function overrideComponent(
 export function resetAppHarness(): void {
   harness.overrides.clear();
   harness.captured.clear();
+  harness.chatStore.clear();
   harness.roomUnreads.clear();
   harness.screenShare.watchingShares = [];
   harness.screenShare.remoteVideoEls = new Map();
@@ -453,6 +468,10 @@ export function renderConnectedApp(options: RenderConnectedAppOptions = {}): Con
   }
 
   harness.dmStore.contacts = toDmContacts(options.dmContacts ?? []);
+
+  for (const [key, storeMessages] of Object.entries(options.chatStore ?? {})) {
+    harness.chatStore.set(key, storeMessages);
+  }
 
   const shares = options.watchedShares ?? [];
   harness.screenShare.watchingShares = shares;

--- a/src/Brmble.Web/src/testing/appHarness.tsx
+++ b/src/Brmble.Web/src/testing/appHarness.tsx
@@ -336,6 +336,16 @@ export interface RenderConnectedAppOptions {
   /** Per-channel unread counts, keyed by channel id. */
   unreads?: Record<string, { notificationCount: number; highlightCount: number }>;
   serverLabel?: string;
+  /** Server directory snapshot: display name -> matrix user id. */
+  userMappings?: Record<string, string>;
+  /** Server-owned DM rooms: matrix user id -> matrix room id. */
+  dmRoomMap?: Record<string, string>;
+  /**
+   * Connects without emitting `server.credentials`, so a test can drive the real
+   * ordering where channels and presence land before any DM identity data.
+   * Call `emitCredentials()` to deliver it afterwards.
+   */
+  deferCredentials?: boolean;
 }
 
 export interface ConnectedAppHandles extends RenderResult {
@@ -351,6 +361,10 @@ export interface ConnectedAppHandles extends RenderResult {
   props: (name: string) => HarnessProps | undefined;
   /** Re-renders the same `<App />` tree, for asserting on freshly captured props. */
   rerenderApp: () => void;
+  /** Emits `server.credentials`; used with `deferCredentials` to control arrival order. */
+  emitCredentials: () => void;
+  /** Replaces the DM contact list, modelling contacts that resolve only later. */
+  setDmContacts: (contacts: HarnessDmContact[]) => void;
 }
 
 const SERVER_HOST = 'voice.example.com';
@@ -401,6 +415,15 @@ function channelIdNumber(joinedChannelId: string | null): number | undefined {
   return Number(joinedChannelId);
 }
 
+function toDmContacts(contacts: HarnessDmContact[]): unknown[] {
+  return contacts.map(contact => ({
+    ...contact,
+    id: contact.id,
+    displayName: contact.name,
+    unreadCount: contact.unreadCount ?? 0,
+  }));
+}
+
 /**
  * Renders `App` and drives it to the connected state.
  *
@@ -429,12 +452,7 @@ export function renderConnectedApp(options: RenderConnectedAppOptions = {}): Con
     });
   }
 
-  harness.dmStore.contacts = (options.dmContacts ?? []).map(contact => ({
-    ...contact,
-    id: contact.id,
-    displayName: contact.name,
-    unreadCount: contact.unreadCount ?? 0,
-  }));
+  harness.dmStore.contacts = toDmContacts(options.dmContacts ?? []);
 
   const shares = options.watchedShares ?? [];
   harness.screenShare.watchingShares = shares;
@@ -452,6 +470,28 @@ export function renderConnectedApp(options: RenderConnectedAppOptions = {}): Con
     </ServiceStatusProvider>,
   );
 
+  const rerenderApp = () => {
+    view.rerender(
+      <ServiceStatusProvider>
+        <App />
+      </ServiceStatusProvider>,
+    );
+  };
+
+  const credentialsPayload = {
+    matrix: {
+      homeserverUrl: 'https://example.com',
+      accessToken: 'token',
+      userId: '@me:example.com',
+      roomMap,
+      ...(options.dmRoomMap ? { dmRoomMap: options.dmRoomMap } : {}),
+    },
+    ...(options.userMappings ? { userMappings: options.userMappings } : {}),
+  };
+  const emitCredentials = () => {
+    act(() => { emit('server.credentials', credentialsPayload); });
+  };
+
   act(() => {
     emit('voice.autoConnect', {
       id: 'harness-server',
@@ -459,14 +499,7 @@ export function renderConnectedApp(options: RenderConnectedAppOptions = {}): Con
       host: SERVER_HOST,
       port: SERVER_PORT,
     });
-    emit('server.credentials', {
-      matrix: {
-        homeserverUrl: 'https://example.com',
-        accessToken: 'token',
-        userId: '@me:example.com',
-        roomMap,
-      },
-    });
+    if (!options.deferCredentials) emit('server.credentials', credentialsPayload);
     emit('voice.connected', {
       username: 'Me',
       channelId: selfChannelId ?? 0,
@@ -500,12 +533,11 @@ export function renderConnectedApp(options: RenderConnectedAppOptions = {}): Con
       });
     },
     props: (name: string) => harness.captured.get(name),
-    rerenderApp: () => {
-      view.rerender(
-        <ServiceStatusProvider>
-          <App />
-        </ServiceStatusProvider>,
-      );
+    rerenderApp,
+    emitCredentials,
+    setDmContacts: (contacts: HarnessDmContact[]) => {
+      harness.dmStore.contacts = toDmContacts(contacts);
+      act(() => { rerenderApp(); });
     },
   };
 }

--- a/src/Brmble.Web/src/testing/appHarness.tsx
+++ b/src/Brmble.Web/src/testing/appHarness.tsx
@@ -1,0 +1,511 @@
+/**
+ * Shared App test harness.
+ *
+ * `App` is a very large component with a wide mock surface: every suite that renders it
+ * needs the same twenty-odd module mocks plus the same "emit credentials, then emit
+ * presence" connection dance. This module owns that once.
+ *
+ * The `vi.mock` calls below are hoisted to the top of *this* module, which is evaluated
+ * before `App` is imported, so importing this harness from a test file is enough to
+ * install them. A test file must therefore import this harness before anything that
+ * pulls in `App`.
+ *
+ * Suites that need a stub instead of the real component (to capture props, or to expose
+ * a simpler DOM) call `overrideComponent(name, render)`; everything else renders the
+ * real implementation.
+ */
+import { act, render, type RenderResult } from '@testing-library/react';
+import { vi } from 'vitest';
+import type { ComponentType, ReactNode } from 'react';
+import App from '../App';
+import bridge from '../bridge';
+import { ServiceStatusProvider } from '../hooks/useServiceStatus';
+import { saveConversationTabs } from '../workspace/conversationStorage';
+import type { Conversation } from '../workspace/conversation';
+
+export type HarnessProps = Record<string, unknown>;
+
+export type OverridableComponent =
+  | 'Header'
+  | 'Sidebar'
+  | 'ChatPanel'
+  | 'DMContactList'
+  | 'ServerList'
+  | 'ConnectionState'
+  | 'PaintSessionView'
+  | 'ScreenShareGrid';
+
+const harness = vi.hoisted(() => {
+  const overrides = new Map<string, (props: HarnessProps) => unknown>();
+  const captured = new Map<string, HarnessProps>();
+
+  const matrixClient = {
+    lastMessages: new Map(),
+    activeMessages: [] as unknown[],
+    setActiveChannel: vi.fn(),
+    sendMessage: vi.fn(),
+    sendImageMessage: vi.fn(),
+    uploadContent: vi.fn(),
+    fetchHistory: vi.fn(),
+    sendReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    dmLastMessages: new Map(),
+    activeDmMessages: [] as unknown[],
+    setActiveDmContact: vi.fn(),
+    dmRoomMap: new Map<string, string>(),
+    dmUserDisplayNames: new Map(),
+    dmUserAvatarUrls: new Map(),
+    sendDMMessage: vi.fn(),
+    fetchDMHistory: vi.fn(),
+    fetchAvatarUrl: vi.fn().mockResolvedValue(undefined),
+    client: { marker: 'matrix-client', getRoom: vi.fn((): unknown => undefined) },
+    activeTypingText: null as string | null,
+    startTyping: vi.fn(),
+    stopTyping: vi.fn(),
+  };
+
+  const dmStore = {
+    contacts: [] as unknown[],
+    selectedContact: null as
+      | { id: string; displayName: string; unreadCount: number; isEphemeral?: boolean; mumbleSessionId?: number | null }
+      | null,
+    messages: [] as unknown[],
+    selectContact: vi.fn(),
+    sendMessage: vi.fn(),
+    startDM: vi.fn(),
+    clearSelection: vi.fn(),
+    closeDM: vi.fn(),
+    selectedContactIdRef: { current: null as string | null },
+    receiveMumbleDM: vi.fn(),
+    updateMumbleSession: vi.fn(),
+    clearMumbleContacts: vi.fn(),
+    startMumbleDM: vi.fn(),
+  };
+
+  const roomUnreads = new Map<string, { notificationCount: number; highlightCount?: number; fullyReadEventId?: string | null }>();
+  const unreadTracker = {
+    roomUnreads,
+    getRoomUnread: vi.fn((roomId: string) => (
+      roomUnreads.get(roomId) ?? { notificationCount: 0, highlightCount: 0, fullyReadEventId: null }
+    )),
+    markRoomRead: vi.fn(),
+    getFullyReadEventId: vi.fn(() => null),
+    getMarkerTimestamp: vi.fn((): number | null => null),
+    totalUnreadCount: 0,
+    totalDmUnreadCount: 0,
+  };
+
+  const idleActions = {
+    autoLeftAt: null,
+    preLeaveStartedAt: null,
+    preLeaveCancelledAt: null,
+    dismissNotification: vi.fn(),
+    dismissPreLeaveCancelled: vi.fn(),
+  };
+
+  const screenShare = {
+    isSharing: false,
+    startSharing: vi.fn(),
+    stopSharing: vi.fn(),
+    markLocalShareTeardownIntent: vi.fn(),
+    error: null as string | null,
+    activeShare: null as unknown,
+    activeShares: [] as unknown[],
+    watchingShare: null as unknown,
+    watchingShares: [] as Array<{ roomName: string; userId: number; userName: string }>,
+    pendingViewerShares: [] as unknown[],
+    remoteWatchCount: 0,
+    isViewerConnectPending: false,
+    focusedShare: null as { roomName: string; userId: number; userName: string } | null,
+    setFocusedShare: vi.fn(),
+    setDiscoveryTarget: vi.fn(),
+    remoteVideoEl: null as HTMLVideoElement | null,
+    remoteVideoEls: new Map<number, HTMLVideoElement>(),
+    roomQuality: undefined as string | undefined,
+    shareQualities: new Map<number, string>(),
+    viewerQualities: new Map<number, string>(),
+    addWatchingShare: vi.fn(),
+    removeWatchingShare: vi.fn(),
+    disconnectViewer: vi.fn(),
+    connectAsViewer: vi.fn(),
+    setViewerQuality: vi.fn(),
+    setRemoteScreenSharesHidden: vi.fn(),
+    handleScreenShareServiceUnavailable: vi.fn(),
+  };
+
+  const notificationQueueIds = new Set<string>();
+  const notificationQueue = {
+    register: vi.fn((id: string) => { notificationQueueIds.add(id); }),
+    unregister: vi.fn((id: string) => { notificationQueueIds.delete(id); }),
+    isVisible: vi.fn((id: string) => notificationQueueIds.has(id)),
+    visibleCount: 0,
+    totalCount: 0,
+  };
+
+  return {
+    overrides,
+    captured,
+    matrixClient,
+    dmStore,
+    unreadTracker,
+    roomUnreads,
+    idleActions,
+    screenShare,
+    notificationQueue,
+    notificationQueueIds,
+    record(name: string, props: HarnessProps) {
+      captured.set(name, props);
+      return overrides.get(name);
+    },
+  };
+});
+
+vi.mock('../bridge', () => {
+  const handlers = new Map<string, Set<(data: unknown) => void>>();
+  return {
+    default: {
+      send: vi.fn(),
+      on: vi.fn((event: string, handler: (data: unknown) => void) => {
+        if (!handlers.has(event)) handlers.set(event, new Set());
+        handlers.get(event)!.add(handler);
+      }),
+      off: vi.fn((event: string, handler: (data: unknown) => void) => handlers.get(event)?.delete(handler)),
+      __emit: (event: string, data?: unknown) => {
+        handlers.get(event)?.forEach(handler => handler(data));
+        // The client emits membership as voice.usersReset immediately after voice.connected.
+        const users = (data as { users?: unknown[] } | undefined)?.users;
+        if (event === 'voice.connected' && users) {
+          handlers.get('voice.usersReset')?.forEach(handler => handler({ users }));
+        }
+      },
+      __reset: () => handlers.clear(),
+    },
+  };
+});
+
+vi.mock('../components/Header/Header', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const Actual = actual.Header as ComponentType<HarnessProps>;
+  return {
+    Header: (props: HarnessProps) => {
+      const override = harness.record('Header', props);
+      return override ? override(props) : <Actual {...props} />;
+    },
+  };
+});
+
+vi.mock('../components/Sidebar/Sidebar', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const Actual = actual.Sidebar as ComponentType<HarnessProps>;
+  return {
+    Sidebar: (props: HarnessProps) => {
+      const override = harness.record('Sidebar', props);
+      return override ? override(props) : <Actual {...props} />;
+    },
+  };
+});
+
+vi.mock('../components/ChatPanel/ChatPanel', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const Actual = actual.ChatPanel as ComponentType<HarnessProps>;
+  return {
+    ChatPanel: (props: HarnessProps) => {
+      harness.record(props.isDM ? 'ChatPanel:dm' : 'ChatPanel:channel', props);
+      const override = harness.overrides.get('ChatPanel');
+      return override ? override(props) : <Actual {...props} />;
+    },
+  };
+});
+
+vi.mock('../components/DMContactList/DMContactList', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const Actual = actual.DMContactList as ComponentType<HarnessProps>;
+  return {
+    DMContactList: (props: HarnessProps) => {
+      const override = harness.record('DMContactList', props);
+      return override ? override(props) : <Actual {...props} />;
+    },
+  };
+});
+
+vi.mock('../components/ServerList/ServerList', () => ({
+  ServerList: (props: HarnessProps) => {
+    const override = harness.record('ServerList', props);
+    return override ? override(props) : <section data-testid="server-list" />;
+  },
+}));
+
+vi.mock('../components/ConnectionState/ConnectionState', () => ({
+  ConnectionState: (props: HarnessProps) => {
+    const override = harness.record('ConnectionState', props);
+    return override ? override(props) : <section data-testid="connection-state" />;
+  },
+}));
+
+vi.mock('../components/Paint/PaintSessionView', () => ({
+  PaintSessionView: (props: HarnessProps) => {
+    const override = harness.record('PaintSessionView', props);
+    return override ? override(props) : <div data-testid="paint-session-view" />;
+  },
+}));
+
+vi.mock('../components/ScreenShareGrid', () => ({
+  ScreenShareGrid: (props: HarnessProps) => {
+    const override = harness.record('ScreenShareGrid', props);
+    return override ? override(props) : <div data-testid="screen-share-grid" />;
+  },
+}));
+
+vi.mock('../components/NeonD/NeonDGame', () => ({ NeonDGame: () => null }));
+
+vi.mock('../components/SettingsModal/SettingsModal', () => ({
+  DEFAULT_SCREEN_SHARE: { captureAudio: false, resolution: '1080p', fps: 30, systemAudio: false, viewerMode: 'in-app' },
+  SettingsModal: () => null,
+}));
+
+vi.mock('../hooks/useMatrixClient', () => ({ useMatrixClient: () => harness.matrixClient }));
+vi.mock('../hooks/useChatStore', () => ({
+  useChatStore: () => ({ messages: [], addMessage: vi.fn() }),
+  addMessageToStore: vi.fn(),
+  clearChatStorage: vi.fn(),
+  purgeEphemeralMessages: vi.fn(),
+}));
+vi.mock('../hooks/useDMStore', () => ({
+  useDMStore: (options: HarnessProps) => {
+    harness.captured.set('useDMStore', options);
+    return harness.dmStore;
+  },
+}));
+vi.mock('../hooks/useUnreadTracker', () => ({
+  resetMarkersCache: vi.fn(),
+  useUnreadTracker: () => harness.unreadTracker,
+}));
+vi.mock('../hooks/useBrmbleIdle', () => ({ useBrmbleIdle: () => 0 }));
+vi.mock('../hooks/useIdleStatus', () => ({ useIdleStatus: () => ({ voiceIdle: {}, systemIdle: 0, isLocked: false }) }));
+vi.mock('../hooks/useIdleActions', () => ({ AFK_THRESHOLD_SEC: 600, useIdleActions: () => harness.idleActions }));
+vi.mock('../hooks/useServerHealth', () => ({ useServerHealth: () => undefined }));
+vi.mock('../hooks/useCompanionOverlayPublisher', () => ({ useCompanionOverlayPublisher: () => undefined }));
+vi.mock('../hooks/useLeaveVoiceCooldown', () => ({ useLeaveVoiceCooldown: () => ({ isOnCooldown: false, trigger: vi.fn() }) }));
+vi.mock('../hooks/useNotificationQueue', () => ({ useNotificationQueue: () => harness.notificationQueue }));
+vi.mock('../hooks/useScreenShare', () => ({ useScreenShare: () => harness.screenShare }));
+
+export interface HarnessChannel {
+  id: number;
+  name: string;
+  [extra: string]: unknown;
+}
+
+export interface HarnessUser {
+  session: number;
+  name: string;
+  channelId?: number;
+  self?: boolean;
+  [extra: string]: unknown;
+}
+
+export interface HarnessDmContact {
+  id: string;
+  name: string;
+  unreadCount?: number;
+  [extra: string]: unknown;
+}
+
+export interface HarnessShare {
+  roomName: string;
+  userId: number;
+  userName: string;
+}
+
+export interface RenderConnectedAppOptions {
+  /** `'7'` for channel 7, `'server-root'` for the root, `null` for no presence. */
+  joinedChannelId?: string | null;
+  channels?: HarnessChannel[];
+  /**
+   * Matrix room ids by channel id. Defaults to one room per channel; pass `{}` for a
+   * server whose channels have no Matrix rooms at all.
+   */
+  matrixRoomMap?: Record<string, string>;
+  users?: HarnessUser[];
+  dmContacts?: HarnessDmContact[];
+  /** Shares the local user is watching; each one also gets a fake remote video element. */
+  watchedShares?: HarnessShare[];
+  /** Opens a paint session through the real `onOpenPaint` entry point after connecting. */
+  paintSessionId?: string | null;
+  /** Conversation tabs seeded into storage before the first render. */
+  persistedTabs?: Conversation[];
+  /** Per-channel unread counts, keyed by channel id. */
+  unreads?: Record<string, { notificationCount: number; highlightCount: number }>;
+  serverLabel?: string;
+}
+
+export interface ConnectedAppHandles extends RenderResult {
+  emit: (event: string, data?: unknown) => void;
+  screenShare: typeof harness.screenShare;
+  matrixClient: typeof harness.matrixClient;
+  dmStore: typeof harness.dmStore;
+  unreadTracker: typeof harness.unreadTracker;
+  notificationQueue: typeof harness.notificationQueue;
+  /** Emits a presence reset that puts the local user in another voice channel. */
+  moveSelfToChannel: (channelId: number) => void;
+  /** Last props seen by a captured component, e.g. `'ChatPanel:channel'`. */
+  props: (name: string) => HarnessProps | undefined;
+  /** Re-renders the same `<App />` tree, for asserting on freshly captured props. */
+  rerenderApp: () => void;
+}
+
+const SERVER_HOST = 'voice.example.com';
+const SERVER_PORT = 64738;
+export const HARNESS_SERVER_ADDRESS = `${SERVER_HOST}:${SERVER_PORT}`;
+
+/** Replaces a component with a stub for the current test file. */
+export function overrideComponent(
+  name: OverridableComponent,
+  render: (props: HarnessProps) => ReactNode,
+): void {
+  harness.overrides.set(name, render as (props: HarnessProps) => unknown);
+}
+
+/** Drops every component override and captured prop set. */
+export function resetAppHarness(): void {
+  harness.overrides.clear();
+  harness.captured.clear();
+  harness.roomUnreads.clear();
+  harness.screenShare.watchingShares = [];
+  harness.screenShare.remoteVideoEls = new Map();
+  harness.screenShare.focusedShare = null;
+  harness.dmStore.contacts = [];
+  harness.dmStore.selectedContact = null;
+  (bridge as unknown as { __reset: () => void }).__reset();
+}
+
+export { harness as appHarnessMocks };
+
+function emit(event: string, data?: unknown): void {
+  (bridge as unknown as { __emit: (event: string, data?: unknown) => void }).__emit(event, data);
+}
+
+/** Renders `App` without connecting it, for suites that drive the connection themselves. */
+export function renderDisconnectedApp(): RenderResult {
+  return render(
+    <ServiceStatusProvider>
+      <App />
+    </ServiceStatusProvider>,
+  );
+}
+
+export { emit as emitBridgeEvent };
+
+function channelIdNumber(joinedChannelId: string | null): number | undefined {
+  if (joinedChannelId === null) return undefined;
+  if (joinedChannelId === 'server-root') return 0;
+  return Number(joinedChannelId);
+}
+
+/**
+ * Renders `App` and drives it to the connected state.
+ *
+ * The connection is emitted the way the client does it: `voice.autoConnect` (which is
+ * what establishes the server address the tab store is keyed by), then
+ * `server.credentials`, then `voice.connected` carrying presence.
+ */
+export function renderConnectedApp(options: RenderConnectedAppOptions = {}): ConnectedAppHandles {
+  const joinedChannelId = options.joinedChannelId === undefined ? '7' : options.joinedChannelId;
+  const selfChannelId = channelIdNumber(joinedChannelId);
+  const channels: HarnessChannel[] = options.channels
+    ?? (selfChannelId && selfChannelId > 0 ? [{ id: selfChannelId, name: 'General' }] : [{ id: 7, name: 'General' }]);
+
+  const users: HarnessUser[] = options.users
+    ?? [{ session: 1, name: 'Me', self: true, ...(selfChannelId === undefined ? {} : { channelId: selfChannelId }) }];
+
+  const roomMap: Record<string, string> = options.matrixRoomMap ?? {};
+  if (!options.matrixRoomMap) {
+    for (const channel of channels) roomMap[String(channel.id)] = `!channel-${channel.id}:example.com`;
+  }
+
+  for (const [channelId, unread] of Object.entries(options.unreads ?? {})) {
+    harness.roomUnreads.set(roomMap[channelId] ?? `!channel-${channelId}:example.com`, {
+      ...unread,
+      fullyReadEventId: null,
+    });
+  }
+
+  harness.dmStore.contacts = (options.dmContacts ?? []).map(contact => ({
+    ...contact,
+    id: contact.id,
+    displayName: contact.name,
+    unreadCount: contact.unreadCount ?? 0,
+  }));
+
+  const shares = options.watchedShares ?? [];
+  harness.screenShare.watchingShares = shares;
+  harness.screenShare.remoteVideoEls = new Map(
+    shares.map(share => [share.userId, document.createElement('video')]),
+  );
+
+  if (options.persistedTabs) {
+    saveConversationTabs(HARNESS_SERVER_ADDRESS, options.persistedTabs);
+  }
+
+  const view = render(
+    <ServiceStatusProvider>
+      <App />
+    </ServiceStatusProvider>,
+  );
+
+  act(() => {
+    emit('voice.autoConnect', {
+      id: 'harness-server',
+      label: options.serverLabel ?? 'Brmble',
+      host: SERVER_HOST,
+      port: SERVER_PORT,
+    });
+    emit('server.credentials', {
+      matrix: {
+        homeserverUrl: 'https://example.com',
+        accessToken: 'token',
+        userId: '@me:example.com',
+        roomMap,
+      },
+    });
+    emit('voice.connected', {
+      username: 'Me',
+      channelId: selfChannelId ?? 0,
+      channels,
+      users,
+    });
+  });
+
+  if (options.paintSessionId) {
+    const channelProps = harness.captured.get('ChatPanel:channel');
+    const onOpenPaint = channelProps?.onOpenPaint as ((sessionId: string) => void) | undefined;
+    if (!onOpenPaint) {
+      throw new Error('renderConnectedApp: paintSessionId requires a rendered channel ChatPanel');
+    }
+    act(() => { onOpenPaint(options.paintSessionId!); });
+  }
+
+  return {
+    ...view,
+    emit,
+    screenShare: harness.screenShare,
+    matrixClient: harness.matrixClient,
+    dmStore: harness.dmStore,
+    unreadTracker: harness.unreadTracker,
+    notificationQueue: harness.notificationQueue,
+    moveSelfToChannel: (channelId: number) => {
+      act(() => {
+        emit('voice.usersReset', {
+          users: users.map(user => (user.self ? { ...user, channelId } : user)),
+        });
+      });
+    },
+    props: (name: string) => harness.captured.get(name),
+    rerenderApp: () => {
+      view.rerender(
+        <ServiceStatusProvider>
+          <App />
+        </ServiceStatusProvider>,
+      );
+    },
+  };
+}

--- a/src/Brmble.Web/src/workspace/activityPresence.test.ts
+++ b/src/Brmble.Web/src/workspace/activityPresence.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  activityChannelMatchesPresence,
+  channelActivityRoomName,
+  parseChannelActivityRoomName,
+} from './activityPresence';
+import { SERVER_ROOT_CHANNEL_ID } from './presence';
+
+describe('activityChannelMatchesPresence', () => {
+  it('matches when the activity belongs to the joined channel', () => {
+    expect(activityChannelMatchesPresence('7', '7')).toBe(true);
+  });
+
+  it('rejects an activity owned by a different channel', () => {
+    expect(activityChannelMatchesPresence('7', '12')).toBe(false);
+  });
+
+  it('rejects when not standing in any channel', () => {
+    expect(activityChannelMatchesPresence(null, '7')).toBe(false);
+  });
+
+  it('rejects server-root because it owns no activities', () => {
+    expect(activityChannelMatchesPresence(SERVER_ROOT_CHANNEL_ID, SERVER_ROOT_CHANNEL_ID)).toBe(false);
+    expect(activityChannelMatchesPresence(SERVER_ROOT_CHANNEL_ID, '7')).toBe(false);
+  });
+
+  it('rejects an activity with no owning channel', () => {
+    expect(activityChannelMatchesPresence('7', null)).toBe(false);
+    expect(activityChannelMatchesPresence('7', undefined)).toBe(false);
+  });
+});
+
+describe('channelActivityRoomName', () => {
+  it('encodes a channel id as a livekit room name', () => {
+    expect(channelActivityRoomName('7')).toBe('channel-7');
+  });
+
+  it('round-trips through the parser', () => {
+    for (const id of ['7', '12', '0', SERVER_ROOT_CHANNEL_ID]) {
+      expect(parseChannelActivityRoomName(channelActivityRoomName(id))).toBe(id);
+    }
+  });
+});
+
+describe('parseChannelActivityRoomName', () => {
+  it('extracts the channel id', () => {
+    expect(parseChannelActivityRoomName('channel-7')).toBe('7');
+  });
+
+  it('preserves ids that themselves contain hyphens', () => {
+    expect(parseChannelActivityRoomName('channel-server-root')).toBe(SERVER_ROOT_CHANNEL_ID);
+    expect(parseChannelActivityRoomName('channel-7-extra')).toBe('7-extra');
+  });
+
+  it('rejects an empty channel id', () => {
+    expect(parseChannelActivityRoomName('channel-')).toBeNull();
+  });
+
+  it('rejects a non-matching prefix', () => {
+    expect(parseChannelActivityRoomName('room-7')).toBeNull();
+    expect(parseChannelActivityRoomName('channel7')).toBeNull();
+    expect(parseChannelActivityRoomName('')).toBeNull();
+    expect(parseChannelActivityRoomName('xchannel-7')).toBeNull();
+  });
+});

--- a/src/Brmble.Web/src/workspace/activityPresence.ts
+++ b/src/Brmble.Web/src/workspace/activityPresence.ts
@@ -1,0 +1,34 @@
+import { SERVER_ROOT_CHANNEL_ID } from './presence';
+
+const CHANNEL_ROOM_PREFIX = 'channel-';
+
+/**
+ * An activity (paint session, screen share, ...) is alive only while you are standing
+ * in the channel that owns it. Server-root owns nothing.
+ */
+export function activityChannelMatchesPresence(
+  joinedChannelId: string | null,
+  activityChannelId: string | null | undefined,
+): boolean {
+  if (joinedChannelId === null || joinedChannelId === SERVER_ROOT_CHANNEL_ID) return false;
+  if (activityChannelId === null || activityChannelId === undefined) return false;
+  return activityChannelId === joinedChannelId;
+}
+
+/** Encodes a channel id as the LiveKit room name used for that channel's activities. */
+export function channelActivityRoomName(channelId: string): string {
+  return `${CHANNEL_ROOM_PREFIX}${channelId}`;
+}
+
+/**
+ * Inverse of {@link channelActivityRoomName}. Returns null when the name is not a
+ * channel activity room.
+ *
+ * Everything after the first `channel-` is treated as the id, so ids that themselves
+ * contain hyphens (notably `server-root`) round-trip. An empty id is rejected.
+ */
+export function parseChannelActivityRoomName(roomName: string): string | null {
+  if (!roomName.startsWith(CHANNEL_ROOM_PREFIX)) return null;
+  const channelId = roomName.slice(CHANNEL_ROOM_PREFIX.length);
+  return channelId.length > 0 ? channelId : null;
+}

--- a/src/Brmble.Web/src/workspace/channelActivity.test.ts
+++ b/src/Brmble.Web/src/workspace/channelActivity.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { selectStage } from './channelActivity';
+
+describe('selectStage', () => {
+  it('returns nothing when the channel is quiet', () => {
+    expect(selectStage({ available: [], explicit: null, previous: null })).toBeNull();
+  });
+
+  it('stages the first activity to appear', () => {
+    expect(selectStage({ available: ['screen-share'], explicit: null, previous: null })).toBe('screen-share');
+  });
+
+  it('does not let a later activity steal the stage', () => {
+    expect(selectStage({ available: ['screen-share', 'paint'], explicit: null, previous: 'screen-share' })).toBe('screen-share');
+  });
+
+  it('honours an explicit choice', () => {
+    expect(selectStage({ available: ['screen-share', 'paint'], explicit: 'paint', previous: 'screen-share' })).toBe('paint');
+  });
+
+  it('ignores an explicit choice that is no longer available', () => {
+    expect(selectStage({ available: ['screen-share'], explicit: 'paint', previous: null })).toBe('screen-share');
+  });
+
+  it('hands over when the staged activity ends', () => {
+    expect(selectStage({ available: ['paint'], explicit: null, previous: 'screen-share' })).toBe('paint');
+  });
+
+  it('returns nothing when the last activity ends', () => {
+    expect(selectStage({ available: [], explicit: 'paint', previous: 'paint' })).toBeNull();
+  });
+});

--- a/src/Brmble.Web/src/workspace/channelActivity.test.ts
+++ b/src/Brmble.Web/src/workspace/channelActivity.test.ts
@@ -14,6 +14,10 @@ describe('selectStage', () => {
     expect(selectStage({ available: ['screen-share', 'paint'], explicit: null, previous: 'screen-share' })).toBe('screen-share');
   });
 
+  it('keeps the staged activity even when it is not first in the list', () => {
+    expect(selectStage({ available: ['screen-share', 'paint'], explicit: null, previous: 'paint' })).toBe('paint');
+  });
+
   it('honours an explicit choice', () => {
     expect(selectStage({ available: ['screen-share', 'paint'], explicit: 'paint', previous: 'screen-share' })).toBe('paint');
   });

--- a/src/Brmble.Web/src/workspace/channelActivity.ts
+++ b/src/Brmble.Web/src/workspace/channelActivity.ts
@@ -1,0 +1,12 @@
+export type ChannelActivityKind = 'screen-share' | 'paint';
+
+export function selectStage(input: {
+  available: ChannelActivityKind[];
+  explicit: ChannelActivityKind | null;
+  previous: ChannelActivityKind | null;
+}): ChannelActivityKind | null {
+  if (input.available.length === 0) return null;
+  if (input.explicit && input.available.includes(input.explicit)) return input.explicit;
+  if (input.previous && input.available.includes(input.previous)) return input.previous;
+  return input.available[0];
+}

--- a/src/Brmble.Web/src/workspace/conversation.test.ts
+++ b/src/Brmble.Web/src/workspace/conversation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { conversationKey, isChannelConversation, sameConversation, type Conversation } from './conversation';
+
+describe('conversation identity', () => {
+  it('keys channels and dms into disjoint namespaces', () => {
+    expect(conversationKey({ kind: 'channel', channelId: '7' })).toBe('channel:7');
+    expect(conversationKey({ kind: 'dm', contactId: '@val:example.com' })).toBe('dm:@val:example.com');
+    expect(conversationKey({ kind: 'channel', channelId: 'server-root' })).toBe('channel:server-root');
+  });
+
+  it('never collides a channel id with a contact id', () => {
+    const channel: Conversation = { kind: 'channel', channelId: '7' };
+    const dm: Conversation = { kind: 'dm', contactId: '7' };
+    expect(conversationKey(channel)).not.toBe(conversationKey(dm));
+    expect(sameConversation(channel, dm)).toBe(false);
+  });
+
+  it('compares by value, not reference', () => {
+    expect(sameConversation({ kind: 'channel', channelId: '7' }, { kind: 'channel', channelId: '7' })).toBe(true);
+    expect(sameConversation({ kind: 'channel', channelId: '7' }, { kind: 'channel', channelId: '8' })).toBe(false);
+  });
+
+  it('narrows channel conversations', () => {
+    const c: Conversation = { kind: 'channel', channelId: '7' };
+    expect(isChannelConversation(c)).toBe(true);
+    expect(isChannelConversation({ kind: 'dm', contactId: 'a' })).toBe(false);
+  });
+});

--- a/src/Brmble.Web/src/workspace/conversation.ts
+++ b/src/Brmble.Web/src/workspace/conversation.ts
@@ -1,0 +1,19 @@
+export type Conversation =
+  | { kind: 'channel'; channelId: string }
+  | { kind: 'dm'; contactId: string };
+
+export function conversationKey(conversation: Conversation): string {
+  return conversation.kind === 'channel'
+    ? `channel:${conversation.channelId}`
+    : `dm:${conversation.contactId}`;
+}
+
+export function sameConversation(a: Conversation, b: Conversation): boolean {
+  return conversationKey(a) === conversationKey(b);
+}
+
+export function isChannelConversation(
+  conversation: Conversation,
+): conversation is { kind: 'channel'; channelId: string } {
+  return conversation.kind === 'channel';
+}

--- a/src/Brmble.Web/src/workspace/conversationStorage.test.ts
+++ b/src/Brmble.Web/src/workspace/conversationStorage.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Conversation } from './conversation';
+import {
+  conversationStorageKey,
+  loadConversationTabs,
+  saveConversationTabs,
+} from './conversationStorage';
+
+const channel = (id: string): Conversation => ({ kind: 'channel', channelId: id });
+const dm = (id: string): Conversation => ({ kind: 'dm', contactId: id });
+const always = () => true;
+
+describe('conversation tab persistence', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('round-trips tabs for a server', () => {
+    saveConversationTabs('server-a', [channel('9'), dm('@val:example.com')]);
+    expect(loadConversationTabs('server-a', always)).toEqual([channel('9'), dm('@val:example.com')]);
+  });
+
+  it('scopes storage per server', () => {
+    saveConversationTabs('server-a', [channel('9')]);
+    saveConversationTabs('server-b', [channel('4')]);
+    expect(loadConversationTabs('server-a', always)).toEqual([channel('9')]);
+    expect(loadConversationTabs('server-b', always)).toEqual([channel('4')]);
+    expect(conversationStorageKey('server-a')).not.toBe(conversationStorageKey('server-b'));
+  });
+
+  it('returns an empty list when nothing is stored', () => {
+    expect(loadConversationTabs('server-a', always)).toEqual([]);
+  });
+
+  it('drops conversations the validator rejects', () => {
+    saveConversationTabs('server-a', [channel('9'), channel('404'), dm('gone')]);
+    const restored = loadConversationTabs('server-a', c =>
+      c.kind === 'channel' ? c.channelId === '9' : false);
+    expect(restored).toEqual([channel('9')]);
+  });
+
+  it('resets to empty on malformed json', () => {
+    localStorage.setItem(conversationStorageKey('server-a'), '{not json');
+    expect(loadConversationTabs('server-a', always)).toEqual([]);
+  });
+
+  it('resets to empty on an unexpected version', () => {
+    localStorage.setItem(conversationStorageKey('server-a'), JSON.stringify({ version: 99, tabs: [channel('9')] }));
+    expect(loadConversationTabs('server-a', always)).toEqual([]);
+  });
+
+  it('discards structurally invalid entries without discarding valid ones', () => {
+    localStorage.setItem(conversationStorageKey('server-a'), JSON.stringify({
+      version: 1,
+      tabs: [channel('9'), { kind: 'channel' }, { kind: 'wormhole', id: 1 }, null, dm('a')],
+    }));
+    expect(loadConversationTabs('server-a', always)).toEqual([channel('9'), dm('a')]);
+  });
+
+  it('deduplicates repeated keys', () => {
+    saveConversationTabs('server-a', [channel('9'), channel('9'), dm('a')]);
+    expect(loadConversationTabs('server-a', always)).toEqual([channel('9'), dm('a')]);
+  });
+
+  it('survives a storage write failure without throwing', () => {
+    // Patch the prototype of the *live* localStorage object. Under jsdom that is
+    // Storage.prototype; under the Map-backed shim in test-setup.ts (Node 25 path) it is
+    // StorageShim.prototype. Patching Storage.prototype unconditionally, or spying on the
+    // localStorage object itself, silently fails in one of the two environments and would
+    // make this test pass vacuously. toHaveBeenCalled() proves the throw was reached.
+    const setItem = vi
+      .spyOn(Object.getPrototypeOf(localStorage) as Storage, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('quota');
+      });
+    try {
+      expect(() => saveConversationTabs('server-a', [channel('9')])).not.toThrow();
+      expect(setItem).toHaveBeenCalled();
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+});

--- a/src/Brmble.Web/src/workspace/conversationStorage.ts
+++ b/src/Brmble.Web/src/workspace/conversationStorage.ts
@@ -1,0 +1,65 @@
+import { conversationKey, type Conversation } from './conversation';
+
+const STORAGE_VERSION = 1;
+const STORAGE_PREFIX = 'brmble-conversation-tabs';
+
+export function conversationStorageKey(serverId: string): string {
+  return `${STORAGE_PREFIX}:${serverId}`;
+}
+
+function isConversation(value: unknown): value is Conversation {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as { kind?: unknown; channelId?: unknown; contactId?: unknown };
+  if (candidate.kind === 'channel') return typeof candidate.channelId === 'string';
+  if (candidate.kind === 'dm') return typeof candidate.contactId === 'string';
+  return false;
+}
+
+function dedupe(conversations: Conversation[]): Conversation[] {
+  const seen = new Set<string>();
+  const result: Conversation[] = [];
+  for (const conversation of conversations) {
+    const key = conversationKey(conversation);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(conversation);
+  }
+  return result;
+}
+
+export function saveConversationTabs(serverId: string, tabs: Conversation[]): void {
+  try {
+    localStorage.setItem(
+      conversationStorageKey(serverId),
+      JSON.stringify({ version: STORAGE_VERSION, tabs: dedupe(tabs) }),
+    );
+  } catch {
+    // Persistence is best-effort; a full or unavailable store must never break the UI.
+  }
+}
+
+export function loadConversationTabs(
+  serverId: string,
+  isValid: (conversation: Conversation) => boolean,
+): Conversation[] {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(conversationStorageKey(serverId));
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return [];
+  const payload = parsed as { version?: unknown; tabs?: unknown };
+  if (payload.version !== STORAGE_VERSION || !Array.isArray(payload.tabs)) return [];
+
+  return dedupe(payload.tabs.filter(isConversation)).filter(isValid);
+}

--- a/src/Brmble.Web/src/workspace/conversationStorage.ts
+++ b/src/Brmble.Web/src/workspace/conversationStorage.ts
@@ -3,8 +3,14 @@ import { conversationKey, type Conversation } from './conversation';
 const STORAGE_VERSION = 1;
 const STORAGE_PREFIX = 'brmble-conversation-tabs';
 
-export function conversationStorageKey(serverId: string): string {
-  return `${STORAGE_PREFIX}:${serverId}`;
+/**
+ * Key under which one server's conversation tabs are persisted. `serverAddress` is the
+ * address the workspace is connected to — the same value used to key the rest of the
+ * per-server storage helpers. The `brmble-conversation-tabs:<serverAddress>` format is
+ * load-bearing for existing users' saved tabs and must not change.
+ */
+export function conversationStorageKey(serverAddress: string): string {
+  return `${STORAGE_PREFIX}:${serverAddress}`;
 }
 
 function isConversation(value: unknown): value is Conversation {
@@ -27,10 +33,10 @@ function dedupe(conversations: Conversation[]): Conversation[] {
   return result;
 }
 
-export function saveConversationTabs(serverId: string, tabs: Conversation[]): void {
+export function saveConversationTabs(serverAddress: string, tabs: Conversation[]): void {
   try {
     localStorage.setItem(
-      conversationStorageKey(serverId),
+      conversationStorageKey(serverAddress),
       JSON.stringify({ version: STORAGE_VERSION, tabs: dedupe(tabs) }),
     );
   } catch {
@@ -39,12 +45,12 @@ export function saveConversationTabs(serverId: string, tabs: Conversation[]): vo
 }
 
 export function loadConversationTabs(
-  serverId: string,
+  serverAddress: string,
   isValid: (conversation: Conversation) => boolean,
 ): Conversation[] {
   let raw: string | null = null;
   try {
-    raw = localStorage.getItem(conversationStorageKey(serverId));
+    raw = localStorage.getItem(conversationStorageKey(serverAddress));
   } catch {
     return [];
   }

--- a/src/Brmble.Web/src/workspace/mainPanelMode.test.ts
+++ b/src/Brmble.Web/src/workspace/mainPanelMode.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { selectMainPanelMode } from './mainPanelMode';
+
+describe('selectMainPanelMode', () => {
+  it('splits when nothing is being played', () => {
+    expect(selectMainPanelMode({ idleGameOpen: false, participatingMatchId: null })).toBe('split');
+  });
+
+  it('takes the panel for the idle game', () => {
+    expect(selectMainPanelMode({ idleGameOpen: true, participatingMatchId: null })).toBe('game');
+  });
+
+  it('takes the panel while participating in a match', () => {
+    expect(selectMainPanelMode({ idleGameOpen: false, participatingMatchId: 'match-1' })).toBe('game');
+  });
+
+  it('prefers the match when both are somehow set', () => {
+    expect(selectMainPanelMode({ idleGameOpen: true, participatingMatchId: 'match-1' })).toBe('game');
+  });
+});

--- a/src/Brmble.Web/src/workspace/mainPanelMode.ts
+++ b/src/Brmble.Web/src/workspace/mainPanelMode.ts
@@ -1,0 +1,8 @@
+export type MainPanelMode = 'game' | 'split';
+
+export function selectMainPanelMode(input: {
+  idleGameOpen: boolean;
+  participatingMatchId: string | null;
+}): MainPanelMode {
+  return input.participatingMatchId !== null || input.idleGameOpen ? 'game' : 'split';
+}

--- a/src/Brmble.Web/src/workspace/presence.test.ts
+++ b/src/Brmble.Web/src/workspace/presence.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { selectJoinedChannelId } from './presence';
+
+describe('selectJoinedChannelId', () => {
+  it('returns the stringified channel of the self user', () => {
+    expect(selectJoinedChannelId([
+      { channelId: 3 },
+      { self: true, channelId: 7 },
+    ])).toBe('7');
+  });
+
+  it('maps the root channel to server-root', () => {
+    expect(selectJoinedChannelId([{ self: true, channelId: 0 }])).toBe('server-root');
+  });
+
+  it('returns null when there is no self user', () => {
+    expect(selectJoinedChannelId([{ channelId: 7 }])).toBeNull();
+    expect(selectJoinedChannelId([])).toBeNull();
+  });
+
+  it('returns null when the self user has no channel', () => {
+    expect(selectJoinedChannelId([{ self: true }])).toBeNull();
+  });
+});

--- a/src/Brmble.Web/src/workspace/presence.ts
+++ b/src/Brmble.Web/src/workspace/presence.ts
@@ -1,0 +1,12 @@
+export interface PresenceUser {
+  self?: boolean;
+  channelId?: number;
+}
+
+export const SERVER_ROOT_CHANNEL_ID = 'server-root';
+
+export function selectJoinedChannelId(users: PresenceUser[]): string | null {
+  const self = users.find(user => user.self);
+  if (!self || self.channelId == null) return null;
+  return self.channelId === 0 ? SERVER_ROOT_CHANNEL_ID : String(self.channelId);
+}

--- a/src/Brmble.Web/src/workspace/unreadOwnership.test.ts
+++ b/src/Brmble.Web/src/workspace/unreadOwnership.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { suppressOpenConversations } from './unreadOwnership';
+
+describe('suppressOpenConversations', () => {
+  const keyOf = (id: string) => `channel:${id}`;
+
+  it('removes entries whose conversation is open', () => {
+    const result = suppressOpenConversations(new Map([['7', 3], ['9', 1]]), new Set(['channel:7']), keyOf);
+    expect([...result.keys()]).toEqual(['9']);
+  });
+
+  it('leaves everything when nothing is open', () => {
+    const result = suppressOpenConversations(new Map([['7', 3]]), new Set<string>(), keyOf);
+    expect([...result.keys()]).toEqual(['7']);
+  });
+
+  it('does not mutate the input', () => {
+    const input = new Map([['7', 3]]);
+    suppressOpenConversations(input, new Set(['channel:7']), keyOf);
+    expect(input.size).toBe(1);
+  });
+
+  it('returns an empty map when every conversation is open', () => {
+    const result = suppressOpenConversations(new Map([['7', 3]]), new Set(['channel:7']), keyOf);
+    expect(result.size).toBe(0);
+  });
+});

--- a/src/Brmble.Web/src/workspace/unreadOwnership.ts
+++ b/src/Brmble.Web/src/workspace/unreadOwnership.ts
@@ -1,0 +1,21 @@
+/**
+ * An unread conversation is announced in exactly one place. Once a conversation is open
+ * as a tab, the tab owns its badge and the sidebar row / contact entry goes quiet.
+ *
+ * Returns a NEW map with every entry whose conversation is open removed; the input is
+ * never mutated. Aggregate counts (the OS/taskbar badge, total DM unread) must be
+ * computed from the UNSUPPRESSED values — otherwise activity in a background tab would
+ * be hidden while the window is unfocused.
+ */
+export function suppressOpenConversations<T>(
+  entries: Map<string, T>,
+  openKeys: Set<string>,
+  keyOf: (id: string) => string,
+): Map<string, T> {
+  const result = new Map<string, T>();
+  for (const [id, value] of entries) {
+    if (openKeys.has(keyOf(id))) continue;
+    result.set(id, value);
+  }
+  return result;
+}

--- a/src/Brmble.Web/src/workspace/workspaceState.test.ts
+++ b/src/Brmble.Web/src/workspace/workspaceState.test.ts
@@ -1,147 +1,164 @@
 import { describe, expect, it } from 'vitest';
+import { conversationKey, type Conversation } from './conversation';
 import {
   createWorkspaceState,
-  getForegroundConversation,
-  isMessagesPanelExpanded,
+  isHomeKey,
+  selectActiveConversation,
+  selectHomeKey,
   workspaceReducer,
+  type WorkspaceState,
 } from './workspaceState';
 
-describe('workspace state machine', () => {
-  it('creates the channel-first workspace', () => {
-    const state = createWorkspaceState();
+const channel = (id: string): Conversation => ({ kind: 'channel', channelId: id });
+const dm = (id: string): Conversation => ({ kind: 'dm', contactId: id });
+const keys = (state: WorkspaceState) => state.tabs.map(conversationKey);
 
-    expect(state).toEqual({
-      messagesPanelExpanded: true,
-      foreground: { kind: 'channel' },
-      previousContent: { messagesPanelExpanded: true },
-      remoteWatchCount: 0,
+const joined = (id: string | null, base = createWorkspaceState()) =>
+  workspaceReducer(base, { type: 'JOINED_CHANNEL_CHANGED', channelId: id });
+
+describe('workspace conversation tabs', () => {
+  it('starts empty and disconnected', () => {
+    const state = createWorkspaceState();
+    expect(state).toEqual({ joinedChannelId: null, tabs: [], activeKey: null });
+    expect(selectHomeKey(state)).toBeNull();
+    expect(selectActiveConversation(state)).toBeNull();
+  });
+
+  it('creates a pinned home tab when joining a channel', () => {
+    const state = joined('7');
+    expect(keys(state)).toEqual(['channel:7']);
+    expect(state.activeKey).toBe('channel:7');
+    expect(isHomeKey(state, 'channel:7')).toBe(true);
+  });
+
+  it('keeps a home tab at server root', () => {
+    const state = joined('server-root');
+    expect(keys(state)).toEqual(['channel:server-root']);
+    expect(selectHomeKey(state)).toBe('channel:server-root');
+  });
+
+  it('appends and activates an opened conversation', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('@val:example.com') });
+    expect(keys(state)).toEqual(['channel:7', 'channel:9', 'dm:@val:example.com']);
+    expect(state.activeKey).toBe('dm:@val:example.com');
+  });
+
+  it('activates rather than duplicating an already open conversation', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    expect(keys(state)).toEqual(['channel:7', 'channel:9', 'dm:a']);
+    expect(state.activeKey).toBe('channel:9');
+  });
+
+  it('replaces the home tab when the joined channel changes and leaves browsed tabs alone', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '12' });
+    expect(keys(state)).toEqual(['channel:12', 'channel:9']);
+    expect(selectHomeKey(state)).toBe('channel:12');
+  });
+
+  it('absorbs a browsed tab that becomes the new home instead of showing it twice', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '9' });
+    expect(keys(state)).toEqual(['channel:9', 'dm:a']);
+    expect(state.activeKey).toBe('dm:a');
+  });
+
+  it('follows the absorbed tab into home when it was the active tab', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '9' });
+    expect(keys(state)).toEqual(['channel:9']);
+    expect(state.activeKey).toBe('channel:9');
+  });
+
+  it('moves activation to the new home when the old home was active', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'ACTIVATE_CONVERSATION', key: 'channel:7' });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '12' });
+    expect(state.activeKey).toBe('channel:12');
+  });
+
+  it('keeps activation on a browsed tab across a channel move', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '12' });
+    expect(state.activeKey).toBe('channel:9');
+  });
+
+  it('refuses to close the home tab', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'channel:7' });
+    expect(keys(state)).toEqual(['channel:7']);
+  });
+
+  it('activates the right neighbour when closing the active tab', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'ACTIVATE_CONVERSATION', key: 'channel:9' });
+    state = workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'channel:9' });
+    expect(keys(state)).toEqual(['channel:7', 'dm:a']);
+    expect(state.activeKey).toBe('dm:a');
+  });
+
+  it('falls back to the left neighbour when closing the last tab', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'dm:a' });
+    expect(state.activeKey).toBe('channel:9');
+  });
+
+  it('leaves activation alone when closing an inactive tab', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: channel('9') });
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'channel:9' });
+    expect(state.activeKey).toBe('dm:a');
+  });
+
+  it('treats invalidation as a close', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'CONVERSATION_INVALIDATED', key: 'dm:a' });
+    expect(keys(state)).toEqual(['channel:7']);
+    expect(state.activeKey).toBe('channel:7');
+  });
+
+  it('restores non-home tabs and activates home', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, {
+      type: 'RESTORE_CONVERSATIONS',
+      conversations: [channel('9'), dm('a'), channel('7')],
     });
-    expect(isMessagesPanelExpanded(state)).toBe(true);
-    expect(getForegroundConversation(state)).toBe(state.foreground);
+    expect(keys(state)).toEqual(['channel:7', 'channel:9', 'dm:a']);
+    expect(state.activeKey).toBe('channel:7');
   });
 
-  it('closes once when the first remote watch starts and restores the previous visibility when the final one ends', () => {
-    let state = createWorkspaceState();
-    state = workspaceReducer(state, { type: 'TOGGLE_MESSAGES_PANEL' });
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 1 });
-    expect(state.messagesPanelExpanded).toBe(false);
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 0 });
-    expect(state.messagesPanelExpanded).toBe(false);
+  it('drops every tab and the home tab on disconnect', () => {
+    let state = joined('7');
+    state = workspaceReducer(state, { type: 'OPEN_CONVERSATION', conversation: dm('a') });
+    state = workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: null });
+    expect(selectHomeKey(state)).toBeNull();
+    expect(keys(state)).toEqual(['dm:a']);
+    state = workspaceReducer(state, { type: 'WORKSPACE_RESET' });
+    expect(keys(state)).toEqual([]);
+    expect(state.activeKey).toBeNull();
   });
 
-  it('changes only Messages-panel visibility when remote watching starts or ends', () => {
-    let state = workspaceReducer(createWorkspaceState(), { type: 'SELECT_DM', contactId: '@val:example.com' });
-    const foreground = state.foreground;
-    const previousContent = state.previousContent;
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 1 });
-    expect(state.messagesPanelExpanded).toBe(false);
-    expect(state.foreground).toBe(foreground);
-    expect(state.previousContent).toEqual(previousContent);
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 0 });
-    expect(state.messagesPanelExpanded).toBe(true);
-    expect(state.foreground).toBe(foreground);
-    expect(state.previousContent).toEqual(previousContent);
-  });
-
-  it('keeps a manually reopened panel open until the watch set becomes empty', () => {
-    let state = workspaceReducer(createWorkspaceState(), { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 1 });
-    state = workspaceReducer(state, { type: 'TOGGLE_MESSAGES_PANEL' });
-    expect(state.messagesPanelExpanded).toBe(true);
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 2 });
-    expect(state.messagesPanelExpanded).toBe(true);
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 0 });
-    expect(state.messagesPanelExpanded).toBe(true);
-  });
-
-  it('reopens the panel when the final watch ends after a manual close during watching', () => {
-    let state = workspaceReducer(createWorkspaceState(), { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 1 });
-    state = workspaceReducer(state, { type: 'TOGGLE_MESSAGES_PANEL' });
-    state = workspaceReducer(state, { type: 'TOGGLE_MESSAGES_PANEL' });
-    expect(state.messagesPanelExpanded).toBe(false);
-
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 0 });
-
-    expect(state.messagesPanelExpanded).toBe(true);
-  });
-
-  it('clamps remote-watch counts at zero and changes visibility only at zero edges', () => {
-    const initialState = createWorkspaceState();
-    let state = initialState;
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: -2 });
-    expect(state).toBe(initialState);
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 2 });
-    const watchingState = state;
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 4 });
-    expect(state.remoteWatchCount).toBe(4);
-    expect(state.messagesPanelExpanded).toBe(false);
-    expect(state.foreground).toBe(watchingState.foreground);
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: -1 });
-    expect(state.remoteWatchCount).toBe(0);
-    expect(state.messagesPanelExpanded).toBe(true);
-  });
-
-  it('resets a reconnecting session to the channel-first workspace without clearing retained panel data', () => {
-    let state = workspaceReducer(createWorkspaceState(), { type: 'SELECT_DM', contactId: '@val:example.com' });
-    const previousContent = state.previousContent;
-    state = workspaceReducer(state, { type: 'SELECT_CHANNEL' });
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 2 });
-    state = workspaceReducer(state, { type: 'CONNECTION_WORKSPACE_READY' });
-    expect(state).toMatchObject({ messagesPanelExpanded: true, remoteWatchCount: 0 });
-    expect(state.foreground).toEqual({ kind: 'channel' });
-    expect(state.previousContent).toEqual(previousContent);
-  });
-
-  it('falls back to the channel while watching when the selected DM is invalidated', () => {
-    let state = workspaceReducer(createWorkspaceState(), { type: 'SELECT_DM', contactId: '@val:example.com' });
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 1 });
-    state = workspaceReducer(state, { type: 'SELECTED_DM_INVALIDATED' });
-    expect(state.foreground).toEqual({ kind: 'channel' });
-  });
-
-  it('falls back to the empty DM workspace when an invalidated DM is not being watched', () => {
-    let state = workspaceReducer(createWorkspaceState(), { type: 'SELECT_DM', contactId: '@val:example.com' });
-    state = workspaceReducer(state, { type: 'SELECTED_DM_INVALIDATED' });
-    expect(state.foreground).toEqual({ kind: 'dm', contactId: '' });
-  });
-
-  it('keeps the foreground channel when a background DM is invalidated', () => {
-    let state = workspaceReducer(createWorkspaceState(), { type: 'SELECT_DM', contactId: '@val:example.com' });
-    state = workspaceReducer(state, { type: 'SELECT_CHANNEL' });
-    const channelState = state;
-
-    state = workspaceReducer(state, { type: 'SELECTED_DM_INVALIDATED' });
-
-    expect(state).toBe(channelState);
-    expect(state.foreground).toEqual({ kind: 'channel' });
-  });
-
-  it('updates previous panel visibility before switching into a remote watch', () => {
-    let state = workspaceReducer(createWorkspaceState(), { type: 'TOGGLE_MESSAGES_PANEL' });
-    state = workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 1 });
-
-    expect(state.previousContent).toEqual({ messagesPanelExpanded: false });
-  });
-
-  it('preserves previous content when opening or toggling the Messages panel', () => {
-    let state = workspaceReducer(createWorkspaceState(), { type: 'SELECT_DM', contactId: '@val:example.com' });
-    const previousContent = state.previousContent;
-    state = workspaceReducer(state, { type: 'TOGGLE_MESSAGES_PANEL' });
-    state = workspaceReducer(state, { type: 'OPEN_MESSAGES_PANEL' });
-    expect(state.previousContent).toBe(previousContent);
-  });
-
-  it('returns the original state for idempotent events', () => {
-    const state = createWorkspaceState();
-
-    expect(workspaceReducer(state, { type: 'REMOTE_WATCH_COUNT_CHANGED', count: 0 })).toBe(state);
-    expect(workspaceReducer(state, { type: 'OPEN_MESSAGES_PANEL' })).toBe(state);
-    expect(workspaceReducer(state, { type: 'CONNECTION_WORKSPACE_READY' })).toBe(state);
-  });
-
-  it('uses one toggle action for both successive visibility changes', () => {
-    let state = createWorkspaceState();
-    state = workspaceReducer(state, { type: 'TOGGLE_MESSAGES_PANEL' });
-    state = workspaceReducer(state, { type: 'TOGGLE_MESSAGES_PANEL' });
-    expect(state.messagesPanelExpanded).toBe(true);
+  it('returns the same state object when nothing changes', () => {
+    const state = joined('7');
+    expect(workspaceReducer(state, { type: 'JOINED_CHANNEL_CHANGED', channelId: '7' })).toBe(state);
+    expect(workspaceReducer(state, { type: 'ACTIVATE_CONVERSATION', key: 'channel:7' })).toBe(state);
+    expect(workspaceReducer(state, { type: 'CLOSE_CONVERSATION', key: 'channel:404' })).toBe(state);
   });
 });

--- a/src/Brmble.Web/src/workspace/workspaceState.ts
+++ b/src/Brmble.Web/src/workspace/workspaceState.ts
@@ -1,114 +1,121 @@
-export type ForegroundConversation =
-  | { kind: 'channel' }
-  | { kind: 'dm'; contactId: string };
+import { conversationKey, type Conversation } from './conversation';
 
 export interface WorkspaceState {
-  messagesPanelExpanded: boolean;
-  foreground: ForegroundConversation;
-  previousContent: { messagesPanelExpanded: boolean };
-  remoteWatchCount: number;
+  joinedChannelId: string | null;
+  tabs: Conversation[];
+  activeKey: string | null;
 }
 
 export type WorkspaceEvent =
-  | { type: 'REMOTE_WATCH_COUNT_CHANGED'; count: number }
-  | { type: 'CONNECTION_WORKSPACE_READY' }
-  | { type: 'TOGGLE_MESSAGES_PANEL' }
-  | { type: 'OPEN_MESSAGES_PANEL' }
-  | { type: 'SELECT_CHANNEL' }
-  | { type: 'SELECT_DM'; contactId: string }
-  | { type: 'SELECTED_DM_INVALIDATED' };
+  | { type: 'JOINED_CHANNEL_CHANGED'; channelId: string | null }
+  | { type: 'OPEN_CONVERSATION'; conversation: Conversation }
+  | { type: 'CLOSE_CONVERSATION'; key: string }
+  | { type: 'ACTIVATE_CONVERSATION'; key: string }
+  | { type: 'CONVERSATION_INVALIDATED'; key: string }
+  | { type: 'RESTORE_CONVERSATIONS'; conversations: Conversation[] }
+  | { type: 'WORKSPACE_RESET' };
 
 export const createWorkspaceState = (): WorkspaceState => ({
-  messagesPanelExpanded: true,
-  foreground: { kind: 'channel' },
-  previousContent: { messagesPanelExpanded: true },
-  remoteWatchCount: 0,
+  joinedChannelId: null,
+  tabs: [],
+  activeKey: null,
 });
 
-export const isMessagesPanelExpanded = (state: WorkspaceState): boolean =>
-  state.messagesPanelExpanded;
+export const selectHomeKey = (state: WorkspaceState): string | null =>
+  state.joinedChannelId === null ? null : `channel:${state.joinedChannelId}`;
 
-export const getForegroundConversation = (
-  state: WorkspaceState,
-): ForegroundConversation => state.foreground;
+export const isHomeKey = (state: WorkspaceState, key: string): boolean =>
+  selectHomeKey(state) === key;
+
+export const selectActiveConversation = (state: WorkspaceState): Conversation | null =>
+  state.tabs.find(tab => conversationKey(tab) === state.activeKey) ?? null;
+
+function withoutKey(tabs: Conversation[], key: string | null): Conversation[] {
+  if (key === null) return tabs;
+  return tabs.filter(tab => conversationKey(tab) !== key);
+}
+
+function closeTab(state: WorkspaceState, key: string): WorkspaceState {
+  if (isHomeKey(state, key)) return state;
+  const index = state.tabs.findIndex(tab => conversationKey(tab) === key);
+  if (index === -1) return state;
+
+  const tabs = state.tabs.filter((_, position) => position !== index);
+  if (state.activeKey !== key) return { ...state, tabs };
+
+  const neighbour = tabs[index] ?? tabs[index - 1] ?? null;
+  const fallback = neighbour ? conversationKey(neighbour) : selectHomeKey(state);
+  return { ...state, tabs, activeKey: fallback };
+}
 
 export const workspaceReducer = (
   state: WorkspaceState,
   event: WorkspaceEvent,
 ): WorkspaceState => {
   switch (event.type) {
-    case 'REMOTE_WATCH_COUNT_CHANGED': {
-      const count = Math.max(0, event.count);
-      const wasWatching = state.remoteWatchCount > 0;
-      const isWatching = count > 0;
-      const previousContent = !wasWatching && isWatching
-        ? { messagesPanelExpanded: state.messagesPanelExpanded }
-        : state.previousContent;
-      const messagesPanelExpanded =
-        wasWatching === isWatching
-          ? state.messagesPanelExpanded
-          : isWatching
-            ? false
-            : state.previousContent.messagesPanelExpanded;
+    case 'JOINED_CHANNEL_CHANGED': {
+      if (event.channelId === state.joinedChannelId) return state;
 
-      if (
-        count === state.remoteWatchCount &&
-        messagesPanelExpanded === state.messagesPanelExpanded &&
-        previousContent === state.previousContent
-      ) {
-        return state;
+      const previousHomeKey = selectHomeKey(state);
+      const rest = withoutKey(state.tabs, previousHomeKey);
+
+      if (event.channelId === null) {
+        const activeKey = state.activeKey === previousHomeKey
+          ? (rest[0] ? conversationKey(rest[0]) : null)
+          : state.activeKey;
+        return { joinedChannelId: null, tabs: rest, activeKey };
       }
 
-      return { ...state, remoteWatchCount: count, messagesPanelExpanded, previousContent };
+      const home: Conversation = { kind: 'channel', channelId: event.channelId };
+      const homeKey = conversationKey(home);
+      const absorbed = rest.some(tab => conversationKey(tab) === homeKey);
+      const tabs = [home, ...withoutKey(rest, homeKey)];
+      const activeKey = state.activeKey === previousHomeKey || state.activeKey === null || absorbed && state.activeKey === homeKey
+        ? homeKey
+        : tabs.some(tab => conversationKey(tab) === state.activeKey)
+          ? state.activeKey
+          : homeKey;
+
+      return { joinedChannelId: event.channelId, tabs, activeKey };
     }
-    case 'CONNECTION_WORKSPACE_READY':
-      if (
-        state.messagesPanelExpanded &&
-        state.remoteWatchCount === 0 &&
-        state.foreground.kind === 'channel'
-      ) {
-        return state;
+
+    case 'OPEN_CONVERSATION': {
+      const key = conversationKey(event.conversation);
+      if (state.tabs.some(tab => conversationKey(tab) === key)) {
+        return state.activeKey === key ? state : { ...state, activeKey: key };
       }
-      return {
-        ...state,
-        messagesPanelExpanded: true,
-        foreground: { kind: 'channel' },
-        remoteWatchCount: 0,
-      };
-    case 'TOGGLE_MESSAGES_PANEL':
-      return { ...state, messagesPanelExpanded: !state.messagesPanelExpanded };
-    case 'OPEN_MESSAGES_PANEL':
-      return state.messagesPanelExpanded
-        ? state
-        : { ...state, messagesPanelExpanded: true };
-    case 'SELECT_CHANNEL':
-      return state.foreground.kind === 'channel'
-        ? state
-        : { ...state, foreground: { kind: 'channel' } };
-    case 'SELECT_DM': {
-      if (
-        state.foreground.kind === 'dm' &&
-        state.foreground.contactId === event.contactId
-      ) {
-        return state;
-      }
-      const foreground = { kind: 'dm' as const, contactId: event.contactId };
-      return { ...state, foreground };
+      return { ...state, tabs: [...state.tabs, event.conversation], activeKey: key };
     }
-    case 'SELECTED_DM_INVALIDATED': {
-      if (state.foreground.kind !== 'dm') {
-        return state;
-      }
 
-      if (state.remoteWatchCount > 0) {
-        return { ...state, foreground: { kind: 'channel' } };
-      }
+    case 'ACTIVATE_CONVERSATION': {
+      if (state.activeKey === event.key) return state;
+      if (!state.tabs.some(tab => conversationKey(tab) === event.key)) return state;
+      return { ...state, activeKey: event.key };
+    }
 
-      if (state.foreground.contactId === '') {
-        return state;
-      }
+    case 'CLOSE_CONVERSATION':
+    case 'CONVERSATION_INVALIDATED':
+      return closeTab(state, event.key);
 
-      return { ...state, foreground: { kind: 'dm', contactId: '' } };
+    case 'RESTORE_CONVERSATIONS': {
+      const homeKey = selectHomeKey(state);
+      const home = state.tabs.find(tab => conversationKey(tab) === homeKey);
+      const seen = new Set<string>(homeKey ? [homeKey] : []);
+      const restored: Conversation[] = [];
+      for (const conversation of event.conversations) {
+        const key = conversationKey(conversation);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        restored.push(conversation);
+      }
+      const tabs = home ? [home, ...restored] : restored;
+      return { ...state, tabs, activeKey: homeKey ?? (tabs[0] ? conversationKey(tabs[0]) : null) };
+    }
+
+    case 'WORKSPACE_RESET': {
+      const homeKey = selectHomeKey(state);
+      const home = state.tabs.find(tab => conversationKey(tab) === homeKey);
+      return { ...state, tabs: home ? [home] : [], activeKey: home ? homeKey : null };
     }
   }
 };


### PR DESCRIPTION
Gives the Brmble main panel a single owner, built on an explicit split between **presence** (the channel you are in) and **conversation** (what you are reading).

Implements `docs/superpowers/plans/2026-08-19-main-panel-regions-and-conversation-tabs.md` against `docs/superpowers/specs/2026-08-19-main-panel-regions-and-conversation-tabs-design.md`.

## What changes

Participating in a game fills the whole main panel. Otherwise the panel splits: channel activity on top (screen share or paint, exactly one staged, chips to switch) and a tabbed chat region below. The leftmost chat tab is always the channel you are in via voice, is not closable, and is *replaced* rather than duplicated when you move channels. DMs share that same tab strip.

- Replaced the overloaded `currentChannelId` with `joinedChannelId` (presence) plus an explicit tab list in the workspace reducer.
- Two nested splitters collapsed into one `VerticalSplitPane` (`brmble-main-split`). `brmble-paint-split` and `brmble-screenshare-split` are retired.
- The two-slide `.content-slider` collapsed into one `ChatPanel` driven by the active tab, removing the 400ms slide transition.
- `DMContactList` is permanently visible, with a width-driven rail below 60rem.
- Backgrounded remote shares stay subscribed for a 10s grace period, then unsubscribe.

## Four live defects fixed

All four were the same underlying bug — a presence-bound feature gated on the *viewed* channel:

| Defect | Was |
|---|---|
| Paint closed when you browsed another channel | Survival guard compared against the viewed channel |
| Your own channel's share became unwatchable after clicking elsewhere | Watch + discovery gated on viewed, publishing on joined |
| Duel Challenge offered where the server rejects it | Client gated on viewed; `DuelOrchestrator.cs:124` requires same voice channel |
| Nothing indicated which channel you were in | Sidebar highlight followed the viewed channel |

Rather than three bespoke predicates, the shared rule lives in `workspace/activityPresence.ts`, so the server-root exclusion and the `channel-${id}` room-name encoding exist in exactly one place.

## Where the plan was wrong

Verified against the codebase rather than followed literally:

- `activeGameMatch` does not exist — it is `activeMatch`, `matchId` is a number, and there is no `.state === 'complete'`. Completion is structural, so the plan's exit effect was unnecessary.
- `intentionalPublicationGenerationRef` **never existed**. The plan presented an invented mechanism as pre-existing; following it literally would have caused the exact stale-generation hazard it was meant to prevent. Suppression is presence-based instead, and mutation-tested.
- The Task 3 reducer failed its own test — the test contradicted the plan's prose contract and its own sample implementation.
- The Task 5 restore effect was self-contradictory (guard on a non-empty channel list *and* keep `channels` out of the deps). Replaced with a restore-once latch.
- `serverId` does not exist; tab persistence is scoped by `serverAddress` (host:port), never the user-editable label.
- `getChannelMatrixRoomId` does not exist; the real function is `getPermittedMatrixChannelId`.

## Manual testing

Exercised with four concurrent clients. Four bugs found and fixed in-branch:

- `55bfa374` — DM tabs were never validated on restore, leaving a permanent unresolvable ghost tab (a spec violation: the spec requires dropping a DM tab whose contact no longer resolves)
- `95dc2360` — screen-share availability was derived from `remoteVideoEls`, which the hide path wipes, so after the 10s grace the chip unmounted and the stage could never return
- `51868e28` — the conversation region still read the legacy `currentChannelId`, so the header went stale and root chat rendered empty with a disabled composer
- `71b00732` — removed the dead toggle-DM-screen keybinding (web + C# `InputRouter` + settings record)

## Verification

`npx tsc -b --noEmit` 0 errors · `npm test -- --run` 155 files / 1874 tests · `npm run build` ✓ · `dotnet build` 0 warnings 0 errors · `dotnet test` 1352 passed

`npm run lint` reports 205 pre-existing problems, verified identical on clean `main`; this branch adds none.

## Reviewer attention

- **The test harness is too permissive.** Three of the four manually-found bugs were masked by inert mocks (`setRemoteScreenSharesHidden`, `setSubscribed`, and a `useChatStore` returning `[]` for every key). The pattern is tests asserting *calls* rather than user-visible outcomes. A hardening pass is worthwhile.
- The narrow-width DM rail has **no automated coverage** — jsdom cannot evaluate media queries.
- Ephemeral Mumble DM tabs are now dropped when that user goes offline. Those conversations are already session-scoped, but it is a behaviour change.

## Follow-ups, deliberately not in scope

- DM contact identity is inconsistent across three open sites (`matrixUserId` vs `certHash`), which is how divergent tabs get created.
- `AuthEndpoints.cs:162` keys the user directory by `DisplayName` and silently drops duplicate accounts — the original cause of the unresolvable DM id.
- `docs/superpowers/plans/2026-07-25-generic-spectator-and-foreground-activity.md` **must not be executed as written** — its client half is superseded by this work. It needs a superseded header before anyone picks it up.
- The spectator / duel-chip / Arena project has no executable plan; those documents predate both collaborative paint and this region model.
